### PR TITLE
Update code coverage tool to use 'Code Coverage Summary' instead of Codecov

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,6 +17,11 @@ jobs:
   core_code_coverage:
     name: Generate Code Coverage for drasi-core
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -50,6 +55,8 @@ jobs:
           cargo install cargo-tarpaulin
       
       - name: Generate Code Coverage
+        env:
+          REDIS_URL: redis://localhost:6379
         run: |
           cargo tarpaulin --out Xml
           mv tarpaulin-report.xml drasi-core-tarpaulin-report.xml

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,7 +2,7 @@ name: Generate Rust Code Coverage
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     branches:
       - "main"
 
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
     services:
       redis:
         image: redis:7-alpine
@@ -80,6 +81,8 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Write to Job Summary
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,6 +17,8 @@ jobs:
   core_code_coverage:
     name: Generate Code Coverage for drasi-core
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     services:
       redis:
         image: redis:7-alpine

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,8 +1,13 @@
 name: Generate Rust Code Coverage
 
 on:
-  pull_request_target:
-    types: [assigned, opened, synchronize, reopened]
+  pull_request:
+    branches:
+      - main
+  # pull_request_target:
+  #   branches:
+  #     - main
+  #   types: [assigned, opened, synchronize, reopened]
 
 env:
   CARGO_TERM_COLOR: always
@@ -73,12 +78,12 @@ jobs:
           indicators: true
           output: both
 
-      - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
-        with:
-          recreate: true
-          path: code-coverage-results.md
+      # - name: Add Coverage PR Comment
+      #   uses: marocchino/sticky-pull-request-comment@v2
+      #   if: github.event_name == 'pull_request'
+      #   with:
+      #     recreate: true
+      #     path: code-coverage-results.md
 
       - name: Write to Job Summary
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -81,8 +81,6 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Write to Job Summary
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -78,3 +78,6 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
+
+      - name: Write to Job Summary
+        run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -59,7 +59,7 @@ jobs:
           REDIS_URL: redis://localhost:6379
         run: |
           cargo tarpaulin --out Xml
-          mv tarpaulin-report.xml drasi-core-tarpaulin-report.xml
+          mv cobertura.xml drasi-core-tarpaulin-report.xml
           echo "Code coverage report generated"
 
       - name: Code Coverage Report

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -14,16 +14,13 @@ permissions:
 
   
 jobs:
-  coverage_with_code_cov: 
+  core_code_coverage:
+    name: Generate Code Coverage for drasi-core
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - name: Cache Cargo registry
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
@@ -47,20 +44,30 @@ jobs:
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-
-      - name: Install Rust
-        run: rustup update stable
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@981088406945bfd239b6fcdeb9a73f24b463e426 # cargo-llvm-cov
-      - name: Generate code coverage
-        env:
-          REDIS_URL: redis://localhost:6379
+      - name: Install Rust and Cargo tarpaulin
         run: |
-          cd core
-          cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} 
-          files: core/lcov.info
-          fail_ci_if_error: true
+          rustup update stable
+          cargo install cargo-tarpaulin
       
+      - name: Generate Code Coverage
+        run: |
+          cargo tarpaulin --out Xml
+          mv tarpaulin-report.xml drasi-core-tarpaulin-report.xml
+          echo "Code coverage report generated"
+
+      - name: Code Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: drasi-core-tarpaulin-report.xml
+          badge: true
+          fail_below_min: true
+          format: markdown
+          indicators: true
+          output: both
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,10 +1,8 @@
 name: Generate Rust Code Coverage
 
 on:
-  workflow_dispatch:
   pull_request_target:
-    branches:
-      - "main"
+    types: [assigned, opened, synchronize, reopened]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  # pull_request_target:
-  #   branches:
-  #     - main
-  #   types: [assigned, opened, synchronize, reopened]
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,7 +17,6 @@ jobs:
     name: Generate Code Coverage for drasi-core
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       contents: read
     services:
       redis:
@@ -77,13 +72,6 @@ jobs:
           format: markdown
           indicators: true
           output: both
-
-      # - name: Add Coverage PR Comment
-      #   uses: marocchino/sticky-pull-request-comment@v2
-      #   if: github.event_name == 'pull_request'
-      #   with:
-      #     recreate: true
-      #     path: code-coverage-results.md
 
       - name: Write to Job Summary
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
# Description

We were using Codecov as code coverage report platform earlier. However, when we erased the history of the repository, Codecov stopped working as it was pointing at an old commit (this commit does not belong to any repository). 

I have attempted to configure Codecov to point to the correct commit, but I was not able to do so. After investigating further, seems like the best approach right now is to just ditch Codecov and use an alternative. Specifically, I found a popular tool called ['Code Coverage Summary'](https://github.com/marketplace/actions/code-coverage-summary) and it is much easier to use.

Why we should use Code Coverage Summary:
- Easy to use. We do not need to configure any Github apps. A coverage report is generated on PRs that target the main branch of `drasi-core` repository, and the report can be viewed in Github Actions (for example https://github.com/drasi-project/drasi-core/actions/runs/11262449528/attempts/1#summary-31318162846)
- No need to configure any sorts of token/secrets. The github action runner will handle everything. This also means that PRs from forked repos has the sufficient permissions to run this
- Has the ability to create coverage report comments in PR _(This is not enabled at the moment. Adding this feature means that we need to grant additional permissions to the workflow)_
- Has the ability to create/update a coverage badge on our readme page (Not a feature of 'Code Coverage Summary', but can be achieved by using another action like this one https://github.com/marketplace/actions/coverage-badge)
- Easier to ignore parts of the code as we are using tarpaulin (See https://github.com/xd009642/tarpaulin?tab=readme-ov-file#ignoring-code-in-files)

Some tradeoffs from not using Codecov:
- Code coverage summary does not have a dashboard (we still have a pretty good report)
- Difficult to compare the code coverage changes between the current run and the previous ones

Overall, I think this code coverage report tool is just a lot easier to use and maintain and less error prone.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
