### PR TITLE
Enable LTO in Rust release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ version = "0.2.0"
 
 [profile.release]
 codegen-units = 1
-lto = "thin"
+lto = true


### PR DESCRIPTION
# Description

Enabling Link Time Optimization (LTO) will reduce the binary size. By setting `lto` to be `true` in the release profile, LTO will only be enabled in our release build, as we use the command `cargo install` in our dockerfiles. When we do a local `cargo build`, LTO will not be enabled. To enable LTO in `cargo build`, run with the `--release` flag

Results from running the `query-perf` tests with and without LTO: 
Without LTO:  https://gist.github.com/ruokun-niu/70c0252f4a36bdf5f4d52febf35a9226
With LTO: https://gist.github.com/ruokun-niu/08de253ef74ae4b6fede0effcb695b48

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: [#97](https://github.com/drasi-project/drasi-platform/issues/97)
