### PR TITLE
Set cargo clippy version to 1.83.0 and resolved new warnings

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install specific Rust version
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable-1.82.0 # Pin to a specific Rust version
+          toolchain: 1.82.0 # Pin to a specific Rust version
           override: true
 
       - name: Install Clippy

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install specific Rust version
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.82.0 # Pin to a specific Rust version
+          toolchain: 1.83.0 # Pin to a specific Rust version
           override: true
 
       - name: Install Clippy

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -31,6 +31,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install specific Rust version
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable-1.82.0 # Pin to a specific Rust version
+          override: true
+
+      - name: Install Clippy
+        run: rustup component add clippy
+
       - name: Run Cargo Clippy
         run: cargo clippy --all-targets --all-features
 

--- a/core/src/evaluation/variable_value/float.rs
+++ b/core/src/evaluation/variable_value/float.rs
@@ -132,7 +132,7 @@ impl<'de> Deserialize<'de> for Float {
     {
         struct NumberVisitor;
 
-        impl<'de> Visitor<'de> for NumberVisitor {
+        impl Visitor<'_> for NumberVisitor {
             type Value = Float;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/core/src/evaluation/variable_value/index.rs
+++ b/core/src/evaluation/variable_value/index.rs
@@ -102,7 +102,7 @@ impl Index for String {
     }
 }
 
-impl<'a, T> Index for &'a T
+impl<T> Index for &T
 where
     T: ?Sized + Index,
 {
@@ -123,12 +123,12 @@ mod private {
     impl Sealed for usize {}
     impl Sealed for str {}
     impl Sealed for String {}
-    impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
+    impl<T> Sealed for &T where T: ?Sized + Sealed {}
 }
 
 struct Type<'a>(&'a VariableValue);
 
-impl<'a> Display for Type<'a> {
+impl Display for Type<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self.0 {
             VariableValue::Null => f.write_str("null"),

--- a/core/src/evaluation/variable_value/integer.rs
+++ b/core/src/evaluation/variable_value/integer.rs
@@ -206,7 +206,7 @@ impl<'de> Deserialize<'de> for Integer {
     {
         struct NumberVisitor;
 
-        impl<'de> Visitor<'de> for NumberVisitor {
+        impl Visitor<'_> for NumberVisitor {
             type Value = Integer;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/core/src/evaluation/variable_value/partial_eq.rs
+++ b/core/src/evaluation/variable_value/partial_eq.rs
@@ -63,7 +63,7 @@ impl PartialEq<str> for VariableValue {
     }
 }
 
-impl<'a> PartialEq<&'a str> for VariableValue {
+impl PartialEq<&str> for VariableValue {
     fn eq(&self, other: &&str) -> bool {
         eq_str(self, other)
     }
@@ -75,7 +75,7 @@ impl PartialEq<VariableValue> for str {
     }
 }
 
-impl<'a> PartialEq<VariableValue> for &'a str {
+impl PartialEq<VariableValue> for &str {
     fn eq(&self, other: &VariableValue) -> bool {
         eq_str(other, self)
     }

--- a/query-perf/src/scenario.rs
+++ b/query-perf/src/scenario.rs
@@ -54,7 +54,7 @@ impl<'a> SrcChangeStreamIter<'a> {
     }
 }
 
-impl<'a> Iterator for SrcChangeStreamIter<'a> {
+impl Iterator for SrcChangeStreamIter<'_> {
     type Item = SourceChange;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/shared-tests/src/use_cases/crosses_above_a_threshold/queries.rs
+++ b/shared-tests/src/use_cases/crosses_above_a_threshold/queries.rs
@@ -51,7 +51,6 @@ spec:
             property: id
   query: > … Cypher Query …
 */
-
 pub fn crosses_above_a_threshold_metadata() -> Vec<QueryJoin> {
     vec![
         QueryJoin {

--- a/shared-tests/src/use_cases/crosses_above_and_stays_above/queries.rs
+++ b/shared-tests/src/use_cases/crosses_above_and_stays_above/queries.rs
@@ -43,7 +43,6 @@ spec:
             property: sensor_id
   query: > … Cypher Query …
 */
-
 pub fn crosses_above_and_stays_above_metadata() -> Vec<QueryJoin> {
     vec![
         QueryJoin {

--- a/shared-tests/src/use_cases/crosses_above_three_times_in_an_hour/queries.rs
+++ b/shared-tests/src/use_cases/crosses_above_three_times_in_an_hour/queries.rs
@@ -43,7 +43,6 @@ spec:
             property: sensor_id
   query: > … Cypher Query …
 */
-
 pub fn crosses_above_three_times_in_an_hour_metadata() -> Vec<QueryJoin> {
     vec![
         QueryJoin {

--- a/shared-tests/src/use_cases/decrease_by_ten/queries.rs
+++ b/shared-tests/src/use_cases/decrease_by_ten/queries.rs
@@ -43,7 +43,6 @@ spec:
             property: id
   query: > … Cypher Query …
 */
-
 pub fn decrease_by_ten_metadata() -> Vec<QueryJoin> {
     vec![
         QueryJoin {

--- a/shared-tests/src/use_cases/exceeds_one_standard_deviation/queries.rs
+++ b/shared-tests/src/use_cases/exceeds_one_standard_deviation/queries.rs
@@ -43,7 +43,6 @@ spec:
             property: sensor_id
   query: > … Cypher Query …
  */
-
 pub fn exceeds_one_standard_deviation_metadata() -> Vec<QueryJoin> {
     vec![
         QueryJoin {

--- a/shared-tests/src/use_cases/greater_than_a_threshold/queries.rs
+++ b/shared-tests/src/use_cases/greater_than_a_threshold/queries.rs
@@ -43,7 +43,6 @@ spec:
             property: cust_id
   query: > … Cypher Query …
 */
-
 pub fn greater_than_a_threshold_metadata() -> Vec<QueryJoin> {
     vec![
         QueryJoin {

--- a/shared-tests/src/use_cases/logical_conditions/queries.rs
+++ b/shared-tests/src/use_cases/logical_conditions/queries.rs
@@ -43,7 +43,6 @@ spec:
             property: sensor_id
   query: > … Cypher Query …
 */
-
 pub fn logical_conditions_metadata() -> Vec<QueryJoin> {
     vec![
         QueryJoin {

--- a/shared-tests/src/use_cases/rolling_average_decrease_by_ten/queries.rs
+++ b/shared-tests/src/use_cases/rolling_average_decrease_by_ten/queries.rs
@@ -43,7 +43,6 @@ spec:
             property: sensor_id
   query: > … Cypher Query …
  */
-
 pub fn rolling_average_decrease_by_ten_metadata() -> Vec<QueryJoin> {
     vec![
         QueryJoin {

--- a/shared-tests/src/use_cases/steps_happen_in_any_order/queries.rs
+++ b/shared-tests/src/use_cases/steps_happen_in_any_order/queries.rs
@@ -43,7 +43,6 @@ spec:
             property: step_id
   query: > … Cypher Query …
 */
-
 pub fn steps_happen_in_any_order_metadata() -> Vec<QueryJoin> {
     vec![
         QueryJoin {


### PR DESCRIPTION
# Description

- Set cargo clippy version to be fixed at 1.83.0
- Resolved new lint warnings

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
