### PR TITLE
DateTime with Timezone parsing

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,9 +34,9 @@ caches = "0.2.4"
 log = "0.4.20"
 tracing = "0.1.37"
 opentelemetry = "0.20"
-chrono = { version = "0.4.31", features = ["serde"] }
+chrono = { version = "0.4.41", features = ["serde"] }
 dateparser = "0.2.0"
-chrono-tz = "0.8.3"
+chrono-tz = {version = "0.10.3", features = ["serde"] }
 regex = "1.9.5"
 iso8601-duration = "0.2.0"
 round = "0.1.2"
@@ -46,3 +46,5 @@ statistical = "1.0.0"
 approx = "0.5.1"
 lazy_static = "1.4.0"
 once_cell = "1.19.0"
+time = { version = "0.3.41", features = ["std", "parsing", "macros", "serde"] }
+time-macros = { version = "0.2.6", features = ["serde"] }

--- a/core/src/evaluation/expressions/mod.rs
+++ b/core/src/evaluation/expressions/mod.rs
@@ -1246,7 +1246,7 @@ impl ExpressionEvaluator {
                         .map_or(VariableValue::Null, |new_zdt| {
                             VariableValue::ZonedDateTime(ZonedDateTime::new(
                                 new_zdt,
-                                zdt.timezone().clone(),
+                                zdt.timezone_name().clone(),
                             ))
                         }),
                     (VariableValue::Duration(duration1), VariableValue::Duration(duration2)) => {
@@ -1305,7 +1305,7 @@ impl ExpressionEvaluator {
                         .map_or(VariableValue::Null, |new_zdt| {
                             VariableValue::ZonedDateTime(ZonedDateTime::new(
                                 new_zdt,
-                                zdt.timezone().clone(),
+                                zdt.timezone_name().clone(),
                             ))
                         }),
                     (VariableValue::Duration(duration1), VariableValue::Duration(duration2)) => {
@@ -2072,7 +2072,7 @@ async fn get_datetime_property(zoned_datetime: ZonedDateTime, property: String) 
     let date = datetime.date_naive();
     let time = datetime.time();
     let offset = datetime.offset();
-    let timezone = zoned_datetime.timezone();
+    let timezone = zoned_datetime.timezone_name();
 
     match property.as_str() {
         "year" => Some(date.year().to_string()),

--- a/core/src/evaluation/expressions/tests/datetime.rs
+++ b/core/src/evaluation/expressions/tests/datetime.rs
@@ -1658,7 +1658,10 @@ async fn test_zoned_datetime_truncate() {
         NaiveDateTime::and_local_timezone(&naive_date_time, FixedOffset::east_opt(3600).unwrap())
             .unwrap();
     assert_eq!(*result.datetime(), date_time);
-    assert_eq!(*result.timezone_name(), Some("Europe/Stockholm".to_string()));
+    assert_eq!(
+        *result.timezone_name(),
+        Some("Europe/Stockholm".to_string())
+    );
 
     let expr = "datetime.truncate('year', $param1, {day: 5})";
     let expr = drasi_query_cypher::parse_expression(expr).unwrap();

--- a/core/src/evaluation/expressions/tests/datetime.rs
+++ b/core/src/evaluation/expressions/tests/datetime.rs
@@ -355,7 +355,7 @@ async fn evaluate_zoned_date_time_yy_mm_dd_timezone() {
         let date_time =
             NaiveDateTime::and_local_timezone(&naive_date_time, FixedOffset::east_opt(0).unwrap())
                 .unwrap();
-        let zoned_date_time = ZonedDateTime::new(date_time, Some("[America/New_York]".to_string()));
+        let zoned_date_time = ZonedDateTime::new(date_time, Some("America/New_York".to_string()));
         assert_eq!(
             evaluator
                 .evaluate_expression(&context, &expr)
@@ -386,7 +386,7 @@ async fn evaluate_zoned_date_time_yy_ww_dd_timezone() {
         let date_time =
             NaiveDateTime::and_local_timezone(&naive_date_time, FixedOffset::east_opt(0).unwrap())
                 .unwrap();
-        let zoned_date_time = ZonedDateTime::new(date_time, Some("[Europe/London]".to_string()));
+        let zoned_date_time = ZonedDateTime::new(date_time, Some("Europe/London".to_string()));
         assert_eq!(
             evaluator
                 .evaluate_expression(&context, &expr)
@@ -445,7 +445,7 @@ async fn evaluate_zoned_date_time_yy_ww_dd_timezone_with_frac() {
         let date_time =
             NaiveDateTime::and_local_timezone(&naive_date_time, FixedOffset::east_opt(0).unwrap())
                 .unwrap();
-        let zoned_date_time = ZonedDateTime::new(date_time, Some("[Europe/London]".to_string()));
+        let zoned_date_time = ZonedDateTime::new(date_time, Some("Europe/London".to_string()));
         assert_eq!(
             evaluator
                 .evaluate_expression(&context, &expr)
@@ -1658,7 +1658,7 @@ async fn test_zoned_datetime_truncate() {
         NaiveDateTime::and_local_timezone(&naive_date_time, FixedOffset::east_opt(3600).unwrap())
             .unwrap();
     assert_eq!(*result.datetime(), date_time);
-    assert_eq!(*result.timezone(), Some("Europe/Stockholm".to_string()));
+    assert_eq!(*result.timezone_name(), Some("Europe/Stockholm".to_string()));
 
     let expr = "datetime.truncate('year', $param1, {day: 5})";
     let expr = drasi_query_cypher::parse_expression(expr).unwrap();

--- a/core/src/evaluation/functions/aggregation/max.rs
+++ b/core/src/evaluation/functions/aggregation/max.rs
@@ -150,7 +150,7 @@ impl AggregatingFunction for Max {
                 accumulator.insert(value * -1.0).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::ZonedDateTime(
-                        ZonedDateTime::from_epoch_millis((head * -1.0) as u64),
+                        ZonedDateTime::from_epoch_millis((head * -1.0) as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -352,7 +352,7 @@ impl AggregatingFunction for Max {
                 accumulator.remove(value * -1.0).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::ZonedDateTime(
-                        ZonedDateTime::from_epoch_millis((head * -1.0) as u64),
+                        ZonedDateTime::from_epoch_millis((head * -1.0) as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -512,7 +512,7 @@ impl AggregatingFunction for Max {
             })),
             VariableValue::Integer(_) => Ok(VariableValue::Integer((value as i64).into())),
             VariableValue::ZonedDateTime(_) => Ok(VariableValue::ZonedDateTime(
-                ZonedDateTime::from_epoch_millis(value as u64),
+                ZonedDateTime::from_epoch_millis(value as i64),
             )),
             VariableValue::Duration(_) => Ok(VariableValue::Duration(Duration::new(
                 ChronoDuration::milliseconds(value as i64),

--- a/core/src/evaluation/functions/aggregation/min.rs
+++ b/core/src/evaluation/functions/aggregation/min.rs
@@ -139,7 +139,7 @@ impl AggregatingFunction for Min {
                 accumulator.insert(value).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::ZonedDateTime(
-                        ZonedDateTime::from_epoch_millis(head as u64),
+                        ZonedDateTime::from_epoch_millis(head as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -330,7 +330,7 @@ impl AggregatingFunction for Min {
                 accumulator.remove(value).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::ZonedDateTime(
-                        ZonedDateTime::from_epoch_millis(head as u64),
+                        ZonedDateTime::from_epoch_millis(head as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -489,7 +489,7 @@ impl AggregatingFunction for Min {
             })),
             VariableValue::Integer(_) => Ok(VariableValue::Integer((value as i64).into())),
             VariableValue::ZonedDateTime(_) => Ok(VariableValue::ZonedDateTime(
-                ZonedDateTime::from_epoch_millis(value as u64),
+                ZonedDateTime::from_epoch_millis(value as i64),
             )),
             VariableValue::Duration(_) => Ok(VariableValue::Duration(Duration::new(
                 ChronoDuration::milliseconds(value as i64),

--- a/core/src/evaluation/functions/metadata.rs
+++ b/core/src/evaluation/functions/metadata.rs
@@ -84,7 +84,7 @@ impl ScalarFunction for ChangeDateTime {
         }
         match &args[0] {
             VariableValue::Element(e) => Ok(VariableValue::ZonedDateTime(
-                ZonedDateTime::from_epoch_millis(e.get_effective_from()),
+                ZonedDateTime::from_epoch_millis(e.get_effective_from() as i64),
             )),
             _ => Err(FunctionError {
                 function_name: expression.name.to_string(),

--- a/core/src/evaluation/functions/temporal_instant/temporal_instant.rs
+++ b/core/src/evaluation/functions/temporal_instant/temporal_instant.rs
@@ -106,7 +106,7 @@ impl ScalarFunction for Date {
             _ => Err(FunctionError {
                 function_name: expression.name.to_string(),
                 error: FunctionEvaluationError::InvalidArgument(0),
-            }),            
+            }),
         }
     }
 }

--- a/core/src/evaluation/functions/temporal_instant/tests/mod.rs
+++ b/core/src/evaluation/functions/temporal_instant/tests/mod.rs
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 use super::temporal_instant;
+mod parse_tests;
 mod truncate_date_tests;
 mod truncate_datetime_tests;
 mod truncate_localdatetime_tests;
 mod truncate_localtime_tests;
 mod truncate_time_tests;
-mod parse_tests;
-
-

--- a/core/src/evaluation/functions/temporal_instant/tests/mod.rs
+++ b/core/src/evaluation/functions/temporal_instant/tests/mod.rs
@@ -18,3 +18,6 @@ mod truncate_datetime_tests;
 mod truncate_localdatetime_tests;
 mod truncate_localtime_tests;
 mod truncate_time_tests;
+mod parse_tests;
+
+

--- a/core/src/evaluation/functions/temporal_instant/tests/parse_tests.rs
+++ b/core/src/evaluation/functions/temporal_instant/tests/parse_tests.rs
@@ -1,0 +1,100 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::temporal_instant;
+use crate::evaluation::context::QueryVariables;
+use crate::evaluation::functions::ScalarFunction;
+use crate::evaluation::variable_value::zoned_datetime::ZonedDateTime;
+use crate::evaluation::variable_value::VariableValue;
+use crate::evaluation::{ExpressionEvaluationContext, InstantQueryClock};
+use chrono::NaiveDate;
+use drasi_query_ast::ast;
+use std::sync::Arc;
+
+fn get_func_expr() -> ast::FunctionExpression {
+    ast::FunctionExpression {
+        name: Arc::from("function"),
+        args: vec![],
+        position_in_query: 10,
+    }
+}
+
+#[tokio::test]
+async fn test_parse_date() {
+    let subject = temporal_instant::Date {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::String("2025-01-01".to_string()),
+    ];
+    let result = subject
+        .call(&context, &get_func_expr(), args.clone())
+        .await;
+    assert_eq!(
+        result.unwrap(),
+        VariableValue::Date(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap())
+    );
+}
+
+
+#[tokio::test]
+async fn test_parse_zoned_datetime() {
+    let subject = temporal_instant::DateTime {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let result = subject
+        .call(&context, &get_func_expr(), vec![
+        //VariableValue::String("2025-01-01T12:00:00".to_string()),
+        VariableValue::String("2015-07-21T21:40:32.142+01:00".to_string()),
+    ])
+        .await;
+
+    assert_eq!(
+        result.unwrap(),
+        VariableValue::ZonedDateTime(ZonedDateTime::new(
+            chrono::DateTime::parse_from_rfc3339("2015-07-21T21:40:32.142+01:00").unwrap(),
+            None,
+        ))
+    );
+
+    let result = subject
+        .call(&context, &get_func_expr(), vec![
+        VariableValue::String("2025-01-01T12:00:00Z".to_string()),        
+    ])
+        .await;
+    assert_eq!(
+        result.unwrap(),
+        VariableValue::ZonedDateTime(ZonedDateTime::new(
+            chrono::DateTime::parse_from_rfc3339("2025-01-01T12:00:00+00:00").unwrap(),
+            None,
+        ))
+    );
+
+    let result = subject
+        .call(&context, &get_func_expr(), vec![
+        VariableValue::String("2025-01-01T12:00Z".to_string()),        
+    ])
+        .await;
+    assert_eq!(
+        result.unwrap(),
+        VariableValue::ZonedDateTime(ZonedDateTime::new(
+            chrono::DateTime::parse_from_rfc3339("2025-01-01T12:00:00+00:00").unwrap(),
+            None,
+        ))
+    );
+}

--- a/core/src/evaluation/functions/temporal_instant/tests/parse_tests.rs
+++ b/core/src/evaluation/functions/temporal_instant/tests/parse_tests.rs
@@ -37,18 +37,13 @@ async fn test_parse_date() {
     let context =
         ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
 
-    let args = vec![
-        VariableValue::String("2025-01-01".to_string()),
-    ];
-    let result = subject
-        .call(&context, &get_func_expr(), args.clone())
-        .await;
+    let args = vec![VariableValue::String("2025-01-01".to_string())];
+    let result = subject.call(&context, &get_func_expr(), args.clone()).await;
     assert_eq!(
         result.unwrap(),
         VariableValue::Date(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap())
     );
 }
-
 
 #[tokio::test]
 async fn test_parse_zoned_datetime() {
@@ -58,10 +53,14 @@ async fn test_parse_zoned_datetime() {
         ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
 
     let result = subject
-        .call(&context, &get_func_expr(), vec![
-        //VariableValue::String("2025-01-01T12:00:00".to_string()),
-        VariableValue::String("2015-07-21T21:40:32.142+01:00".to_string()),
-    ])
+        .call(
+            &context,
+            &get_func_expr(),
+            vec![
+                //VariableValue::String("2025-01-01T12:00:00".to_string()),
+                VariableValue::String("2015-07-21T21:40:32.142+01:00".to_string()),
+            ],
+        )
         .await;
 
     assert_eq!(
@@ -73,9 +72,11 @@ async fn test_parse_zoned_datetime() {
     );
 
     let result = subject
-        .call(&context, &get_func_expr(), vec![
-        VariableValue::String("2025-01-01T12:00:00Z".to_string()),        
-    ])
+        .call(
+            &context,
+            &get_func_expr(),
+            vec![VariableValue::String("2025-01-01T12:00:00Z".to_string())],
+        )
         .await;
     assert_eq!(
         result.unwrap(),
@@ -86,9 +87,11 @@ async fn test_parse_zoned_datetime() {
     );
 
     let result = subject
-        .call(&context, &get_func_expr(), vec![
-        VariableValue::String("2025-01-01T12:00Z".to_string()),        
-    ])
+        .call(
+            &context,
+            &get_func_expr(),
+            vec![VariableValue::String("2025-01-01T12:00Z".to_string())],
+        )
         .await;
     assert_eq!(
         result.unwrap(),

--- a/core/src/evaluation/mod.rs
+++ b/core/src/evaluation/mod.rs
@@ -49,6 +49,7 @@ pub enum EvaluationError {
     CorruptData,
     InvalidArgument,
     UnknownProperty { property_name: String },
+    FormatError { expected: String },
 }
 
 #[derive(Debug)]

--- a/core/src/evaluation/temporal_constants.rs
+++ b/core/src/evaluation/temporal_constants.rs
@@ -38,8 +38,8 @@ pub const INVALID_LOCAL_DATETIME_FORMAT_ERROR: &str = "A valid string representa
 pub const INVALID_ZONED_TIME_FORMAT_ERROR: &str = "A valid string representation of a zoned time or a map of zoned time components. \n\
                                 Examples include: time('214032.142Z'), time('21:40:32+01:00'), time('214032-0100'), time({hour: 12, minute: 31, second: 14, microsecond: 645876, timezone: '+01:00'})";
 
-pub const INVALID_ZONED_DATETIME_FORMAT_ERROR: &str = "A valid string representation of a zoned datetime or a map of zoned datetime components.\n\
-                                Examples include: datetime('20150721T21:40-01:30'), datetime('2015-07-21T21:40:32.142+0100'), datetime({year: 1984, ordinalDay: 202, hour: 12, minute: 31, second: 14, timezone: '+01:00'})";
+pub const INVALID_ZONED_DATETIME_FORMAT_ERROR: &str = "A valid string representation of an RFC 3339 datetime or a map of zoned datetime components.\n\
+                                Examples include: datetime('20150721T21:40-01:30'), datetime('2015-07-21T21:40:32.142+01:00'), datetime({year: 1984, ordinalDay: 202, hour: 12, minute: 31, second: 14, timezone: '+01:00'})";
 
 pub const INVALID_LOCAL_TIME_FORMAT_ERROR: &str = "A valid string representation of a local time or a map of local time components.\n\
                                 Examples include: localtime('21:40:32.142'), localtime('214032.142'), localtime({hour: 12, minute: 31, second: 14, nanosecond: 789, millisecond: 123, microsecond: 456})";

--- a/core/src/evaluation/variable_value/zoned_datetime.rs
+++ b/core/src/evaluation/variable_value/zoned_datetime.rs
@@ -12,38 +12,94 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::evaluation::temporal_constants::UTC_FIXED_OFFSET;
+use crate::evaluation::{temporal_constants::{self, UTC_FIXED_OFFSET}, EvaluationError};
 use chrono::{DateTime, FixedOffset, TimeZone};
+use chrono_tz::Tz;
 use core::fmt::{self, Display};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
-#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ZonedDateTime {
     datetime: DateTime<FixedOffset>,
-    timezone: Option<String>, // timezone is optional; depending on the input
+    timezone_name: Option<String>, // timezone name is optional; depending on the input
 }
 
 impl ZonedDateTime {
-    pub fn new(datetime: DateTime<FixedOffset>, timezone: Option<String>) -> Self {
-        ZonedDateTime { datetime, timezone }
+    pub fn new(datetime: DateTime<FixedOffset>, timezone_name: Option<String>) -> Self {
+        ZonedDateTime { datetime, timezone_name }
     }
 
-    pub fn from_epoch_millis(epoch_millis: u64) -> Self {
+    pub fn from_epoch_millis(epoch_millis: i64) -> Self {
         let offset = *UTC_FIXED_OFFSET;
-        let datetime = offset.timestamp_millis_opt(epoch_millis as i64).unwrap();
+        let datetime = offset.timestamp_millis_opt(epoch_millis).unwrap();
         ZonedDateTime {
             datetime,
-            timezone: None,
+            timezone_name: None,
         }
+    }
+
+    pub fn from_string(input : &str) -> Result<Self, EvaluationError> {
+        if let Some(bracket_pos) = input.find('[') {
+            let base_str = &input[..bracket_pos];
+            let end_bracket = match input.find(']') {
+                Some(pos) => pos,
+                None => {
+                    return Err(EvaluationError::FormatError {
+                        expected: temporal_constants::INVALID_ZONED_DATETIME_FORMAT_ERROR.to_string(),
+                    })
+                }
+            };
+            let tz_str = &input[bracket_pos + 1..end_bracket];
+            let tz = match extract_iana_timezone(tz_str) {
+                Some(tz) => tz,
+                None => {
+                    return Err(EvaluationError::FormatError {
+                        expected: temporal_constants::INVALID_ZONED_DATETIME_FORMAT_ERROR.to_string(),
+                    })
+                }
+            };
+
+            let base_dt = match time::PrimitiveDateTime::parse(base_str, &time::format_description::well_known::Iso8601::DEFAULT) {
+                Ok(dt) => {
+                    DateTime::from_timestamp_nanos(dt.assume_utc().unix_timestamp_nanos() as i64).naive_utc()
+                },
+                Err(e) => {
+                    return Err(EvaluationError::FormatError {
+                        expected: e.to_string(),
+                    })
+                }
+            };
+            
+            let dt2 = match tz.from_local_datetime(&base_dt) {
+                chrono::offset::LocalResult::Single(d) => d,
+                chrono::offset::LocalResult::Ambiguous(d1, _) => d1,
+                chrono::offset::LocalResult::None => {
+                    return Err(EvaluationError::FormatError {
+                        expected: temporal_constants::INVALID_ZONED_DATETIME_FORMAT_ERROR.to_string(),
+                    })
+                }
+            };            
+            
+            return Ok(ZonedDateTime::new(dt2.fixed_offset(), Some(tz.name().to_string())));
+        }
+        
+        match time::OffsetDateTime::parse(input, &time::format_description::well_known::Iso8601::DEFAULT) {
+            Ok(dt) => return Ok(Self::from_epoch_millis((dt.unix_timestamp_nanos() / 1_000_000) as i64)),
+            Err(e) => {
+                return Err(EvaluationError::FormatError {
+                    expected: e.to_string(),
+                })
+            }
+        };
     }
 
     pub fn datetime(&self) -> &DateTime<FixedOffset> {
         &self.datetime
     }
 
-    pub fn timezone(&self) -> &Option<String> {
-        &self.timezone
+    pub fn timezone_name(&self) -> &Option<String> {
+        &self.timezone_name
     }
 }
 
@@ -51,4 +107,17 @@ impl Display for ZonedDateTime {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         self.datetime.fmt(formatter)
     }
+}
+
+
+fn extract_iana_timezone(input: &str) -> Option<Tz> {
+    let timezone_str = input.replace(' ', "_").replace(['[', ']'], "");
+    if timezone_str == "Z" || timezone_str.contains('+') || timezone_str.contains('-') {
+        return Some(Tz::UTC);
+    }
+    let tz: Tz = match timezone_str.parse() {
+        Ok(tz) => tz,
+        Err(_) => return None,
+    };
+    Some(tz)
 }

--- a/core/src/evaluation/variable_value/zoned_datetime.rs
+++ b/core/src/evaluation/variable_value/zoned_datetime.rs
@@ -105,16 +105,16 @@ impl ZonedDateTime {
             &time::format_description::well_known::Iso8601::DEFAULT,
         ) {
             Ok(dt) => {
-                return Ok(Self::from_epoch_millis(
+                Ok(Self::from_epoch_millis(
                     (dt.unix_timestamp_nanos() / 1_000_000) as i64,
                 ))
             }
             Err(e) => {
-                return Err(EvaluationError::FormatError {
+                Err(EvaluationError::FormatError {
                     expected: e.to_string(),
                 })
             }
-        };
+        }
     }
 
     pub fn datetime(&self) -> &DateTime<FixedOffset> {

--- a/core/src/evaluation/variable_value/zoned_datetime.rs
+++ b/core/src/evaluation/variable_value/zoned_datetime.rs
@@ -104,16 +104,12 @@ impl ZonedDateTime {
             input,
             &time::format_description::well_known::Iso8601::DEFAULT,
         ) {
-            Ok(dt) => {
-                Ok(Self::from_epoch_millis(
-                    (dt.unix_timestamp_nanos() / 1_000_000) as i64,
-                ))
-            }
-            Err(e) => {
-                Err(EvaluationError::FormatError {
-                    expected: e.to_string(),
-                })
-            }
+            Ok(dt) => Ok(Self::from_epoch_millis(
+                (dt.unix_timestamp_nanos() / 1_000_000) as i64,
+            )),
+            Err(e) => Err(EvaluationError::FormatError {
+                expected: e.to_string(),
+            }),
         }
     }
 

--- a/shared-tests/src/use_cases/sensor_heartbeat/mod.rs
+++ b/shared-tests/src/use_cases/sensor_heartbeat/mod.rs
@@ -130,7 +130,7 @@ pub async fn not_reported(config: &(impl QueryTestConfig + Send)) {
             after: variablemap!(
                 "equipment" => VariableValue::String("Turbine 1".into()),
                 "sensor" => VariableValue::String("Temp".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0))
+                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
             ),
         }));
 
@@ -138,7 +138,7 @@ pub async fn not_reported(config: &(impl QueryTestConfig + Send)) {
             after: variablemap!(
                 "equipment" => VariableValue::String("Turbine 2".into()),
                 "sensor" => VariableValue::String("Temp".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0))
+                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
             ),
         }));
 
@@ -146,7 +146,7 @@ pub async fn not_reported(config: &(impl QueryTestConfig + Send)) {
             after: variablemap!(
                 "equipment" => VariableValue::String("Turbine 2".into()),
                 "sensor" => VariableValue::String("RPM".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0))
+                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
             ),
         }));
     }
@@ -189,7 +189,7 @@ pub async fn not_reported(config: &(impl QueryTestConfig + Send)) {
             before: variablemap!(
                 "equipment" => VariableValue::String("Turbine 2".into()),
                 "sensor" => VariableValue::String("RPM".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(init_time.and_utc().timestamp_millis() as u64))
+                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(init_time.and_utc().timestamp_millis()))
             ),
         }));
     }
@@ -205,7 +205,7 @@ pub async fn not_reported(config: &(impl QueryTestConfig + Send)) {
             after: variablemap!(
                 "equipment" => VariableValue::String("Turbine 1".into()),
                 "sensor" => VariableValue::String("RPM".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time1))
+                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time1 as i64))
             ),
         }));
     }


### PR DESCRIPTION
# Description

Date time strings with timezone were not parsing valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) strings.
Added the [time](https://docs.rs/time/latest/time/) crate to handle the parsing.

