### PR TITLE
Add conditional option to map/unwind middleware

### DIFF
--- a/middleware/src/unwind/mod.rs
+++ b/middleware/src/unwind/mod.rs
@@ -39,6 +39,7 @@ pub struct UnwindMapping {
     label: String,
     key: Option<JsonPathExpression>,
     relation: Option<String>,
+    condition: Option<JsonPathExpression>,
 }
 
 #[derive(Clone)]
@@ -137,6 +138,13 @@ impl SourceMiddleware for Unwind {
                 let mut change_map = HashMap::new();
 
                 if let Some(new_obj) = &new_element_obj {
+                    if let Some(condition) = &mapping.condition {
+                        let condition_result = condition.execute_one(new_obj);
+                        if condition_result.is_none() {
+                            continue; // Skip this mapping if the condition is not met
+                        }
+                    }
+
                     let selected = mapping.selector.execute(new_obj);
 
                     for (index, obj) in selected.iter().enumerate() {
@@ -225,6 +233,13 @@ impl SourceMiddleware for Unwind {
                 }
 
                 if let Some(old_obj) = &old_element_obj {
+                    if let Some(condition) = &mapping.condition {
+                        let condition_result = condition.execute_one(old_obj);
+                        if condition_result.is_none() {
+                            continue; // Skip this mapping if the condition is not met
+                        }
+                    }
+
                     let selected = mapping.selector.execute(old_obj);
 
                     for (index, obj) in selected.iter().enumerate() {


### PR DESCRIPTION
# Description

This PR adds a `condition` field to the configuration of the `map` and `unwind` middleware implementations. This field takes a JSONPath expression, and can be used to filter out changes that should not be mapped.

for example, the GitHub webhook payload includes an `action` field:

```json
{
"action": "opened",
  "issue": {
  }
}
```

Where one may want a different mapping depending on the action, they can now use the `condition` field to filter out the changes that should not be mapped.
