### PR TITLE
True now or later

### DIFF
--- a/core/src/evaluation/functions/future/mod.rs
+++ b/core/src/evaluation/functions/future/mod.rs
@@ -28,6 +28,7 @@ mod future_element;
 mod true_for;
 mod true_later;
 mod true_until;
+mod true_now_or_later;
 
 pub trait RegisterFutureFunctions {
     fn register_future_functions(
@@ -72,6 +73,11 @@ impl RegisterFutureFunctions for FunctionRegistry {
         self.register_function(
             "drasi.trueLater",
             Function::Scalar(Arc::new(true_later::TrueLater::new(future_queue.clone()))),
+        );
+
+        self.register_function(
+            "drasi.trueNowOrLater",
+            Function::Scalar(Arc::new(true_now_or_later::TrueNowOrLater::new(future_queue.clone()))),
         );
     }
 }

--- a/core/src/evaluation/functions/future/true_now_or_later.rs
+++ b/core/src/evaluation/functions/future/true_now_or_later.rs
@@ -49,12 +49,10 @@ impl ScalarFunction for TrueNowOrLater {
                 error: FunctionEvaluationError::InvalidArgumentCount,
             });
         }
-        println!("TrueNowOrLater called:");
 
         let anchor_ref = match context.get_anchor_element() {
             Some(anchor) => anchor.get_reference().clone(),
             None => {
-                println!("No anchor element found");
                 return Ok(VariableValue::Null);
             }
         };
@@ -70,10 +68,7 @@ impl ScalarFunction for TrueNowOrLater {
             }
         };
 
-        println!("Condition: {}", condition);
-
         if *condition {
-            println!("Condition is true now");
             return Ok(VariableValue::Bool(true));
         }
 
@@ -101,19 +96,13 @@ impl ScalarFunction for TrueNowOrLater {
             }
         };
 
-        println!("Due time: {}", due_time);
-
         let group_signature = context.get_input_grouping_hash();
 
-        println!("Group signature: {}", group_signature);
-
         if due_time <= context.get_realtime() {
-            println!("Due time is in the past");
             return Ok(VariableValue::Bool(*condition));
         }
 
         if let SideEffects::Apply = context.get_side_effects() {
-            println!("Adding to future queue");
             match self
                 .future_queue
                 .push(
@@ -135,8 +124,6 @@ impl ScalarFunction for TrueNowOrLater {
                 }
             }
         }
-
-        println!("Returning Awaiting");
 
         Ok(VariableValue::Awaiting)
     }

--- a/core/src/evaluation/functions/future/true_now_or_later.rs
+++ b/core/src/evaluation/functions/future/true_now_or_later.rs
@@ -1,0 +1,143 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::evaluation::context::SideEffects;
+use crate::evaluation::functions::ScalarFunction;
+use crate::evaluation::variable_value::VariableValue;
+use crate::evaluation::ExpressionEvaluationContext;
+use crate::evaluation::{FunctionError, FunctionEvaluationError};
+use crate::interface::{FutureQueue, PushType};
+use async_trait::async_trait;
+use chrono::NaiveTime;
+use drasi_query_ast::ast;
+
+pub struct TrueNowOrLater {
+    future_queue: Arc<dyn FutureQueue>,
+}
+
+impl TrueNowOrLater {
+    pub fn new(future_queue: Arc<dyn FutureQueue>) -> Self {
+        TrueNowOrLater { future_queue }
+    }
+}
+
+#[allow(clippy::print_stdout, clippy::unwrap_used)]
+#[async_trait]
+impl ScalarFunction for TrueNowOrLater {
+    async fn call(
+        &self,
+        context: &ExpressionEvaluationContext,
+        expression: &ast::FunctionExpression,
+        args: Vec<VariableValue>,
+    ) -> Result<VariableValue, FunctionError> {
+        if args.len() != 2 {
+            return Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgumentCount,
+            });
+        }
+        println!("TrueNowOrLater called:");
+
+        let anchor_ref = match context.get_anchor_element() {
+            Some(anchor) => anchor.get_reference().clone(),
+            None => {
+                println!("No anchor element found");
+                return Ok(VariableValue::Null);
+            }
+        };
+
+        let condition = match &args[0] {
+            VariableValue::Bool(b) => b,
+            VariableValue::Null => return Ok(VariableValue::Null),
+            _ => {
+                return Err(FunctionError {
+                    function_name: expression.name.to_string(),
+                    error: FunctionEvaluationError::InvalidArgument(0),
+                })
+            }
+        };
+
+        println!("Condition: {}", condition);
+
+        if *condition {
+            println!("Condition is true now");
+            return Ok(VariableValue::Bool(true));
+        }
+
+        let due_time = match &args[1] {
+            VariableValue::Date(d) => {
+                d.and_time(NaiveTime::MIN).and_utc().timestamp_millis() as u64
+            }
+            VariableValue::LocalDateTime(d) => d.and_utc().timestamp_millis() as u64,
+            VariableValue::ZonedDateTime(d) => d.datetime().timestamp_millis() as u64,
+            VariableValue::Integer(n) => match n.as_u64() {
+                Some(u) => u,
+                None => {
+                    return Err(FunctionError {
+                        function_name: expression.name.to_string(),
+                        error: FunctionEvaluationError::OverflowError,
+                    })
+                }
+            },
+            VariableValue::Null => return Ok(VariableValue::Null),
+            _ => {
+                return Err(FunctionError {
+                    function_name: expression.name.to_string(),
+                    error: FunctionEvaluationError::InvalidArgument(1),
+                })
+            }
+        };
+
+        println!("Due time: {}", due_time);
+
+        let group_signature = context.get_input_grouping_hash();
+
+        println!("Group signature: {}", group_signature);
+
+        if due_time <= context.get_realtime() {
+            println!("Due time is in the past");
+            return Ok(VariableValue::Bool(*condition));
+        }
+
+        if let SideEffects::Apply = context.get_side_effects() {
+            println!("Adding to future queue");
+            match self
+                .future_queue
+                .push(
+                    PushType::Overwrite,
+                    expression.position_in_query,
+                    group_signature,
+                    &anchor_ref,
+                    context.get_transaction_time(),
+                    due_time,
+                )
+                .await
+            {
+                Ok(_) => (),
+                Err(e) => {
+                    return Err(FunctionError {
+                        function_name: expression.name.to_string(),
+                        error: FunctionEvaluationError::IndexError(e),
+                    })
+                }
+            }
+        }
+
+        println!("Returning Awaiting");
+
+        Ok(VariableValue::Awaiting)
+    }
+}

--- a/shared-tests/src/in_memory/mod.rs
+++ b/shared-tests/src/in_memory/mod.rs
@@ -150,6 +150,12 @@ mod sensor_heartbeat {
     }
 
     #[tokio::test]
+    pub async fn not_reported_with_true_now_or_later() {
+        let test_config = InMemoryQueryConfig::new();
+        sensor_heartbeat::not_reported_with_true_now_or_later(&test_config).await;
+    }
+
+    #[tokio::test]
     pub async fn percent_not_reported() {
         let test_config = InMemoryQueryConfig::new();
         sensor_heartbeat::percent_not_reported(&test_config).await;

--- a/shared-tests/src/use_cases/sensor_heartbeat/queries.rs
+++ b/shared-tests/src/use_cases/sensor_heartbeat/queries.rs
@@ -31,6 +31,22 @@ pub fn not_reported_query() -> &'static str {
     "
 }
 
+pub fn not_reported_query_v2() -> &'static str {
+    "
+    MATCH
+        (e:Equipment)-[:HAS_SENSOR]->(s:Sensor)-[:HAS_VALUE]->(v:SensorValue)
+    WITH
+        e,
+        s,
+        max(drasi.changeDateTime(v)) AS last_ts
+    WHERE drasi.trueNowOrLater(last_ts <= (datetime.realtime() - duration( { minutes: 60 } )), last_ts + duration( { minutes: 60 } ))
+    RETURN
+        e.name AS equipment,
+        s.type AS sensor,
+        last_ts AS last_ts
+    "
+}
+
 pub fn percent_not_reported_query() -> &'static str {
     "
     MATCH


### PR DESCRIPTION
This pull request introduces a new future function, `trueNowOrLater`. The function evaluates a condition immediately or schedules it for future evaluation, depending on the provided arguments. A common pattern with the existing `trueLater` function emerged where one often needs to couple the function with an `or` clause of the same condition that is passed to the function in order to avoid the future function being scheduled in perpetuity under some conditions. This relieves some nuanced / non-obvious complexities when using the `trueLater` function. 

The following expression:
```cypher
WHERE
    last_ts <= (datetime.realtime() - duration( { minutes: 60 } )) 
OR
    drasi.trueLater(last_ts <= (datetime.realtime() - duration( { minutes: 60 } )), last_ts + duration( { minutes: 60 } ))   
```

can become:
```cypher
WHERE drasi.trueNowOrLater(last_ts <= (datetime.realtime() - duration( { minutes: 60 } )), last_ts + duration( { minutes: 60 } ))
```