### PR TITLE
Implemented GQL GROUP BY

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - feature/*
-      - release/*
       - feature-gql
 
 jobs:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches: ['*']
   pull_request:
-    branches: [ "main" ]
-  
+    branches:
+      - main
+      - feature/*
+      - release/*
+      - feature-gql
 
 jobs:
   clippy_check:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -21,7 +21,6 @@ on:
   pull_request:
     branches:
       - main
-      - release/*
       - feature/*
       - feature-gql
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches:
       - main
+      - release/*
+      - feature/*
+      - feature-gql
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/readme.md
+++ b/.github/workflows/readme.md
@@ -14,11 +14,11 @@ This document describes the GitHub Actions workflows in the `.github/workflows` 
 ### [ci-lint.yml](ci-lint.yml)
 - **Purpose**: Runs linting checks to ensure code quality and adherence to coding standards.
 - **Trigger**: 
-  - Automatically triggered on pull requests to the `main` branch and any pushes.
+  - Automatically triggered on pull requests to the `main`, `feature/*`, or `release/*` branches and any pushes.
 
 ### [coverage.yaml](coverage.yaml)
 - **Purpose**: Generates and uploads code coverage reports to Codecov.
-- **Trigger**: Automatically triggered on pull requests to the `main` branch and pushes to the `codecov-test` branch.
+- **Trigger**: Automatically triggered on pull requests to the `main`, `feature/*`, or `release/*` branches and pushes to the `codecov-test` branch.
 
 ### [devskim.yml](devskim.yml)
 - **Purpose**: Performs security analysis using DevSkim to detect potential vulnerabilities.
@@ -35,7 +35,7 @@ This document describes the GitHub Actions workflows in the `.github/workflows` 
 
 ### [test.yml](test.yml)
 - **Purpose**: Executes `cargo test` to run unit tests.
-- **Trigger**: Automatically triggered on pull requests and pushes to the `main` branch.
+- **Trigger**: Automatically triggered on pull requests to the `main`, `feature/*`, or `release/*` branches and pushes to the `main` branch.
 
 
 ## Viewing Workflow Status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,19 @@
 name: Run Tests
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - release/*
+    tags:
+      - v*
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+      - feature/*
+      - release/*
+      - feature-gql
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "core",
   "query-ast",
   "query-cypher",
+  "query-gql",
   "index-rocksdb",
   "index-garnet",
   "middleware",

--- a/query-ast/src/api.rs
+++ b/query-ast/src/api.rs
@@ -24,4 +24,7 @@ pub trait QueryParser: Send + Sync {
 pub enum QueryParseError {
     #[error("parser error: {0}")]
     ParserError(Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Non-grouped RETURN expressions must appear in GROUP BY clause")]
+    MissingGroupByKey,
 }

--- a/query-ast/src/ast.rs
+++ b/query-ast/src/ast.rs
@@ -511,6 +511,10 @@ impl FunctionExpression {
             position_in_query,
         })
     }
+
+    pub fn eq_ignore_position_in_query(&self, other: &Self) -> bool {
+        self.name == other.name && self.args == other.args
+    }
 }
 
 impl ParentExpression for FunctionExpression {

--- a/query-gql/Cargo.toml
+++ b/query-gql/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "drasi-query-gql"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Drasi Core GQL Parser"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi"]
+categories = ["database"]
+readme = "../readme.md"    
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+drasi-query-ast = { path = "../query-ast" }
+peg = "0.8.1"
+serde = "1.0.164"
+serde_json = "1.0.96"

--- a/query-gql/src/lib.rs
+++ b/query-gql/src/lib.rs
@@ -1,0 +1,626 @@
+#![allow(clippy::redundant_closure_call)]
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use drasi_query_ast::{
+    api::{QueryParseError, QueryParser},
+    ast::{
+        self, Expression, MatchClause, ParentExpression, ProjectionClause, QueryPart,
+        UnaryExpression,
+    },
+};
+use peg::{error::ParseError, str::LineCol};
+use std::{collections::HashSet, sync::Arc};
+
+#[cfg(test)]
+mod tests;
+
+peg::parser! {
+    grammar gql() for str {
+        use drasi_query_ast::ast::*;
+
+        rule kw_match()     = ("MATCH" / "match")
+        rule kw_optional()  = ("OPTIONAL" / "optional")
+        rule kw_where()     = ("WHERE" / "where")
+        rule kw_return()    = ("RETURN" / "return")
+        rule kw_true()      = ("TRUE" / "true")
+        rule kw_false()     = ("FALSE" / "false")
+        rule kw_null()      = ("NULL" / "null")
+        rule kw_and()       = ("AND" / "and")
+        rule kw_or()        = ("OR" / "or")
+        rule kw_not()       = ("NOT" / "not")
+        rule kw_is()        = ("IS" / "is")
+        rule kw_as()        = ("AS" / "as")
+        rule kw_case()      = ("CASE" / "case")
+        rule kw_when()      = ("WHEN" / "when")
+        rule kw_then()      = ("THEN" / "then")
+        rule kw_else()      = ("ELSE" / "else")
+        rule kw_end()       = ("END" / "end")
+        rule kw_in()        = ("IN" / "in")
+        rule kw_exists()    = ("EXISTS" / "exists")
+        rule kw_group()     = ("GROUP" / "group")
+        rule kw_by()        = ("BY" / "by")
+
+        rule _()
+            = quiet!{[' ']}
+
+        rule __()
+            = quiet!{[' ' | '\n' | '\t']}
+            / comment()
+
+        rule comment()
+            = quiet!{ "//" (!"\n" [_])* ("\n" / ![_])}
+
+        rule alpha()
+            = ['a'..='z' | 'A'..='Z']
+
+        rule num()
+            = quiet! {
+                ['0'..='9']
+            }
+            / expected!("a number")
+
+        rule alpha_num()
+            = ['a'..='z' | 'A'..='Z' | '0'..='9' | '_']
+
+
+        // e.g. '42', '-1'
+        rule integer() -> i64
+            = integer:$("-"?num()+) {? integer.parse().or(Err("invalid integer")) }
+
+        // e.g. '-0.53', '34346.245', '236.0'
+        rule real() -> f64
+            = real:$("-"? num()+ "." num()+) {? real.parse().or(Err("invalid real"))}
+
+        // e.g. 'TRUE', 'FALSE'
+        rule boolean() -> bool
+            = kw_true() { true } / kw_false() { false }
+
+        // e.g. 'hello world'
+        rule text() -> Arc<str>
+            = quiet! {
+                "'" text:$((date_for_date_time() "T" time_format() timezone())) "'"{ Arc::from(text) }
+            }
+            / quiet! {
+                "'" text:$((date_for_date_time() "T" time_format())) "'"{ Arc::from(text) }
+            }
+            / quiet! {
+                "'" text:$(date_format()) "'" { Arc::from(text) }
+            }
+            / quiet! {
+                "'" text:$(time_format() timezone()) "'" { Arc::from(text) }
+            }
+            / quiet! {
+                "'" text:$(time_format()) "'" { Arc::from(text) }
+            }
+            /quiet!{
+                "'" text:$(duration()) "'" { Arc::from(text) }
+            }
+            /quiet! {
+                "'" text:$([^ '\'' | '\n' | '\r']*) "'" { Arc::from(text) }
+            }
+            / expected!("a quoted string")
+
+        // e.g. 'TRUE', '42', 'hello world'
+        rule literal() -> Literal
+            = r:real() { Literal::Real(r) }
+            / i:integer() { Literal::Integer(i) }
+            / b:boolean() { Literal::Boolean(b) }
+            / t:text() { Literal::Text(t) }
+            / kw_null() { Literal::Null }
+
+        rule year() -> Arc<str>
+            = year:$(['0'..='9']*<4>) { Arc::from(year) }
+
+        rule month() -> Arc<str>
+            = month:$(['0'..='1']['0'..='9']) { Arc::from(month) }
+
+        rule day() -> Arc<str>
+            = day:$(['0'..='9']*<2>) { Arc::from(day) }
+
+        rule week() -> Arc<str>
+            = week:$("W" ['0'..='9']*<0,2>) { Arc::from(week) }
+
+        rule quarter() -> Arc<str>
+            = quarter:$("Q" ['1'..='4']) { Arc::from(quarter)}
+
+        rule date_format() -> Arc<str>
+            = date_format:$(year() "-"? month() "-"? day()) { Arc::from(date_format) }
+            / date_format:$(year() "-"? week() "-"? ['0'..='7']) { Arc::from(date_format) }
+            / date_format:$(year() "-"? week()) { Arc::from(date_format) }
+            / date_format:$(year() "-"? quarter() "-"? day()) { Arc::from(date_format) }
+            / date_format:$(year() "-"? month()) { Arc::from(date_format) }
+            / date_format:$(year() "-"? ['0'..='9']*<3>) { Arc::from(date_format) }
+            / date_format:$(year()) { Arc::from(date_format) }
+
+
+        rule hour() -> Arc<str>
+            = hour:$(['0'..='2']['0'..='9']) { Arc::from(hour) }
+
+        rule minute() -> Arc<str>
+            = minute:$(['0'..='5']['0'..='9']) { Arc::from(minute) }
+
+        rule second() -> Arc<str>
+            = second:$(['0'..='5']['0'..='9']) { Arc::from(second) }
+
+        rule time_fraction() -> Arc<str>
+            = time_fraction:$("." ['0'..='9']*<0,9>) { Arc::from(time_fraction) }
+
+        rule time_format() ->  Arc<str>
+            = time_format:$(hour() ":"? minute() ":"? second()? time_fraction()?) { Arc::from(time_format) }
+            / time_format:$(hour() ":"? minute() ":"? second()) { Arc::from(time_format) }
+            / time_format:$(hour() ":"? minute()) { Arc::from(time_format) }
+            / time_format:$(hour()) { Arc::from(time_format) }
+
+        rule date_for_date_time() -> Arc<str>
+            = date_for_date_time:$(year() "-"? month() "-"? day()) { Arc::from(date_for_date_time) }
+            / date_for_date_time:$(year() "-"? week() "-"? ['0'..='7']) { Arc::from(date_for_date_time) }
+            / date_for_date_time:$(year() "-"? quarter() "-"? day() ) { Arc::from(date_for_date_time) }
+            / date_for_date_time:$(year() "-"? ['0'..='9']*<3>) { Arc::from(date_for_date_time) }
+
+
+
+        rule timezone() -> Arc<str>
+            = timezone:$("Z") { Arc::from(timezone) }
+            / timezone:$("[" ['a'..='z' | 'A'..='Z' | '_']+ "/" ['a'..='z' | 'A'..='Z' | '_']+  "]") { Arc::from(timezone) }
+            / timezone:$("+" hour() ":"? minute()?) { Arc::from(timezone) }
+            / timezone:$("-" hour() ":"? minute()?) { Arc::from(timezone) }
+            / timezone:$("+" hour() "[" ['a'..='z' | 'A'..='Z' | '_']+ "/" ['a'..='z' | 'A'..='Z' | '_']+ "]" ) { Arc::from(timezone) }
+            / timezone:$("-" hour() "[" ['a'..='z' | 'A'..='Z' | '_']+ "/" ['a'..='z' | 'A'..='Z' | '_']+  "]" ) { Arc::from(timezone) }
+            //specific timezone (IANA timezone database)
+
+
+        rule space() = [' ']*
+
+        rule duration() -> Arc<str>
+            = duration:$("P" date_for_date_time()? "T" time_format()?) "\"" ")" { Arc::from(duration) } //"P2012-02-02T14:37:21.545"
+            / duration:$("P" (['0'..='9']*<0,19> "Y")? ( ['0'..='9']*<0,19> "M")? ( ['0'..='9']*<0,19> "W")? ( ['0'..='9']*<0,19>  time_fraction()?"D")? ("T" ( ['0'..='9']*<0,19> "H")? ( ['0'..='9']*<0,19> "M")? ( ['0'..='9']*<0,19> time_fraction()?  "S")?)?) { Arc::from(duration) }
+            / duration:$("P" (['0'..='9']*<0,19> "Y")? ( ['0'..='9']*<0,19> "M")? ( ['0'..='9']*<0,19> "W")? ( ['0'..='9']*<0,19>  time_fraction()?"D")? ){ Arc::from(duration) }
+            / duration:$("P" ("T" ( ['0'..='9']*<0,19> "H")? ( ['0'..='9']*<0,19>"M")? ( ['0'..='9']*<0,19>  time_fraction()? "S")?)?){ Arc::from(duration) }
+
+
+
+        rule projection_expression() -> Expression
+            = z:expression() _* kw_as() _* a:ident() { UnaryExpression::alias(z, a) }
+            / expression()
+
+        rule when_expression() -> (Expression, Expression)
+            = kw_when() __+ when:expression() __+ kw_then() __+ then:expression() __+ { (when, then) }
+
+        rule else_expression() -> Expression
+            = kw_else() __+ else_:expression() __+ { else_ }
+
+            #[cache_left_rec]
+        pub rule expression() -> Expression
+            = precedence!{
+                a:(@) __* kw_and() __* b:@ { BinaryExpression::and(a, b) }
+                a:(@) __* kw_or() __* b:@ { BinaryExpression::or(a, b) }
+                --
+                kw_not() __* c:(@) { UnaryExpression::not(c) }
+                --
+                it:iterator() { it }
+                --
+                a:(@) __* kw_in() __* b:@ { BinaryExpression::in_(a, b) }
+                a:(@) __* "="  __* b:@ { BinaryExpression::eq(a, b) }
+                a:(@) __* ("<>" / "!=") __* b:@ { BinaryExpression::ne(a, b) }
+                a:(@) __* "<"  __* b:@ { BinaryExpression::lt(a, b) }
+                a:(@) __* "<=" __* b:@ { BinaryExpression::le(a, b) }
+                a:(@) __* ">"  __* b:@ { BinaryExpression::gt(a, b) }
+                a:(@) __* ">=" __* b:@ { BinaryExpression::ge(a, b) }
+                --
+                a:(@) __* "+" __* b:@ { BinaryExpression::add(a, b) }
+                a:(@) __* "-" __* b:@ { BinaryExpression::subtract(a, b) }
+                --
+                a:(@) __* "*" __* b:@ { BinaryExpression::multiply(a, b) }
+                a:(@) __* "/" __* b:@ { BinaryExpression::divide(a, b) }
+                --
+                a:(@) __* "%" __* b:@ { BinaryExpression::modulo(a, b) }
+                a:(@) __* "^" __* b:@ { BinaryExpression::exponent(a, b) }
+                --
+                parent:@ "." key:ident() { UnaryExpression::expression_property(parent, key) }
+                --
+                list:expression() "[" index:expression() "]" { BinaryExpression::index(list, index)}
+                e:(@) __+ kw_is() _+ kw_null() { UnaryExpression::is_null(e) }
+                e:(@) __+ kw_is() _+ kw_not() _+ kw_null() { UnaryExpression::is_not_null(e) }
+                kw_case() __* mtch:expression()? __* when:when_expression()+ __* else_:else_expression()? __* kw_end() { CaseExpression::case(mtch, when, else_) }
+                kw_case() __* when:when_expression()+ __* else_:else_expression()? __* kw_end() { CaseExpression::case(None, when, else_) }
+                pos: position!() func:function_name() _* "(" __* params:(expression() ** (__* "," __*))? __* ")" "." key:ident() {
+                    let params = params.unwrap_or_else(Vec::new);
+                    UnaryExpression::expression_property(FunctionExpression::function(func, params, pos ), key)
+                }
+                pos: position!() func:function_name() _* "(" __* params:(expression() ** (__* "," __*))? __* ")" {
+                    let params = params.unwrap_or_else(Vec::new);
+                    FunctionExpression::function(func, params, pos )
+                }
+                "$" name:ident() { UnaryExpression::parameter(name) }
+                start:expression()? ".." end:expression()? { UnaryExpression::list_range(start, end) }
+                l:literal() { UnaryExpression::literal(l) }
+                i:ident() { UnaryExpression::ident(&i) } // UnaryExpression::ident(i)
+
+                --
+                "(" __* c:expression() __* ")" { c }
+                c: component() { ObjectExpression::object_from_vec(c)  } //ObjectExpression
+                "[" __* c:expression() ** (__* "," __*) __* "]" { ListExpression::list(c) }
+            }
+
+            #[cache_left_rec]
+        rule iterator() -> Expression
+            = "[" __* item:ident() __* kw_in() __* list:expression() __* kw_where() __* filter:expression() __* "|" __* map:expression()__* "]"
+                { IteratorExpression::map_with_filter(item, list, map, filter) }
+
+            / "[" __* item:ident() __* kw_in() __* list:expression() __*  "|" __* map:expression()__* "]"
+                { IteratorExpression::map(item, list, map) }
+
+            / "[" __* item:ident() __* kw_in() __* list:expression() __* kw_where() __* filter:expression()__* "]"
+                { IteratorExpression::iterator_with_filter(item, list, filter) }
+
+            / "[" __* item:ident() __* kw_in() __* list:expression()__* "]"
+                { IteratorExpression::iterator(item, list) }
+
+            / item:ident() __* kw_in() __* list:expression() __* kw_where() __* filter:expression() __* "|" __* map:expression()
+                { IteratorExpression::map_with_filter(item, list, map, filter) }
+
+            / item:ident() __* kw_in() __* list:expression() __*  "|" __* map:expression()
+                { IteratorExpression::map(item, list, map) }
+
+            / item:ident() __* kw_in() __* list:expression() __* kw_where() __* filter:expression()
+                { IteratorExpression::iterator_with_filter(item, list, filter) }
+
+            / item:ident() __* kw_in() __* list:expression()
+                { IteratorExpression::iterator(item, list) }
+
+
+        // e.g. 'hello_world', 'Rust', 'HAS_PROPERTY'
+        rule ident() -> Arc<str>
+            = quiet!{ident:$(alpha()alpha_num()*) { Arc::from(ident) }}
+            / "`" ident:$([^ '`' | '\n' | '\r']*) "`" { Arc::from(ident) }
+            / expected!("an identifier")
+
+        // e.g. 'sign', 'duration_between'
+        rule function_name()  -> Arc<str>
+            = quiet!{func:$(alpha()alpha_num()* ("." alpha_num()+)?) { Arc::from(func) }}
+            / expected!("function name")
+
+        rule component() -> Vec<(Arc<str>, Expression)>
+            = "{" __* entries:( (k:ident() __* ":" __* v:expression() { (k, v) }) ++ (__* "," __*) ) __* "}" { entries }
+
+        // e.g. 'a', 'a : PERSON', ': KNOWS'
+        rule annotation() -> Annotation
+            = name:ident()? { Annotation { name } }
+
+
+        // e.g. '{answer: 42, book: 'Hitchhikers Guide'}'
+        rule property_map() -> Vec<(Arc<str>, Expression)>
+            = "{" __* entries:( (k:ident() __* ":" __* v:expression() { (k, v) }) ++ (__* "," __*) ) __* "}" { entries }
+
+        rule property_map_predicate() -> Vec<Expression>
+            = "{" __* entries:( (k:ident() __* ":" __* v:expression() { BinaryExpression::eq(UnaryExpression::property("".into(), k), v) }) ++ (__* "," __*) ) __* "}" { entries }
+
+        rule element_match() -> (Annotation, Vec<Arc<str>>, Vec<Expression>)
+            = a:annotation() labels:(":" label:ident() ** "|" { label })? _* p:(pm:property_map_predicate() { pm } / ( w:(where_clause() ** (__+) )? { w.unwrap_or_else(Vec::new) } ) ) {
+                (a, labels.unwrap_or_else(Vec::new), p)
+            }
+
+        // e.g. '()', '( a:PERSON )', '(b)', '(a : OTHER_THING)'
+        rule node() -> NodeMatch
+            = "(" _* element:element_match() _* ")" {
+                NodeMatch::new(element.0, element.1, element.2)
+              }
+            / expected!("node match pattern, e.g. '()', '( a:PERSON )', '(b)', '(a : OTHER_THING)'")
+
+        // e.g. '-', '<-', '-[ name:KIND ]-', '<-[name]-'
+        rule relation() -> RelationMatch
+            =  "-[" _* element:element_match() _* vl:variable_length()? _* "]->" {
+                RelationMatch::right(element.0, element.1, element.2, vl)
+            }
+            /  "-[" _* element:element_match() _* vl:variable_length()? _* "]-"  {
+                RelationMatch::either(element.0, element.1, element.2, vl)
+            }
+            / "<-[" _* element:element_match() _* vl:variable_length()? _* "]-"  {
+                RelationMatch::left(element.0, element.1, element.2, vl)
+            }
+            / "<-" { RelationMatch::left(Annotation::empty(), Vec::new(), Vec::new(), None) }
+            / "->" { RelationMatch::right(Annotation::empty(), Vec::new(), Vec::new(), None) }
+            / "-" { RelationMatch::either(Annotation::empty(), Vec::new(), Vec::new(), None) }
+            / expected!("relation match pattern, e.g. '-', '<-', '-[ name:KIND ]-', '<-[name]-'")
+
+
+        rule variable_length() -> VariableLengthMatch
+            = quiet!{
+                "*" min_hops:integer()? max_hops:(".." r:integer() {r})? { VariableLengthMatch{ min_hops, max_hops } }
+            }
+            / expected!("variable length match pattern, e.g. '*', '*2', '*..3'")
+
+        rule property() -> (Arc<str>, Arc<str>)
+            = name:ident() "." key:ident() { (name, key) }
+            / "$" name:ident() "." key:ident() { (name, key) }
+
+            #[cache_left_rec]
+        rule nested_property() -> Expression
+            = parent:expression() "." key:ident() { UnaryExpression::expression_property(parent, key) }
+
+        // e.g. 'MATCH (a)', 'MATCH (a) -> (b) <- (c)', ...
+        rule match_clause() -> Vec<MatchClause>
+            = kw_match() __+ items:( (start:node()
+                    path:( (__* e:relation() __* n:node() { (e, n) }) ** "" ) {
+                    MatchClause { start, path, optional: false }
+                }) ++ (__* "," __*) ) { items }
+            / kw_optional() __+ kw_match() __+ items:( (start:node()
+                path:( (__* e:relation() __* n:node() { (e, n) }) ** "" ) {
+                    MatchClause { start, path, optional: true }
+                }) ++ (__* "," __*) ) { items }
+
+        // e.g. 'WHERE a.name <> b.name', 'WHERE a.age > b.age AND a.age <= 42'
+        rule where_clause() -> Expression
+            = kw_where() __+ c:expression() { c }
+
+        // e.g. 'RETURN a, b'
+        rule return_clause() -> Vec<Expression>
+            = kw_return() __+ items:( projection_expression() ++ (__* "," __*) ) { items }
+
+        rule group_by_clause() -> Vec<Expression>
+            = kw_group() __+ kw_by() __+ "(" __* ")" { Vec::new() }  // Handle GROUP BY ()
+            / kw_group() __+ kw_by() __+ items:( expression() ++ (__* "," __*) ) { items }
+
+        rule with_or_return() -> Vec<Expression>
+            = r:return_clause() { r }
+
+        rule part(config: &dyn GQLConfiguration) -> Vec<QueryPart>
+            = match_clauses:( __* m:(match_clause() ** (__+) )? { m.unwrap_or_default().into_iter().flatten().collect() } )
+              where_clauses:( __* w:(where_clause() ** (__+) )? { w.unwrap_or_default() } )
+              __*
+              return_clause:(with_or_return())
+              group_by_exprs:( __* g:group_by_clause()? { g } )
+              __*
+              // Will return full expected set in addition to the error message
+                {? build_query_parts(match_clauses, where_clauses, return_clause, group_by_exprs, config).map_err(|e| match e {
+                    QueryParseError::MissingGroupByKey => "Non-grouped RETURN expressions must appear in GROUP BY clause",
+                    QueryParseError::ParserError(_) => "Parser error",
+                }) }
+
+        pub rule query(config: &dyn GQLConfiguration) -> Query
+            = __*
+                parts:(w:( part(config)+ ) { w.into_iter().flatten().collect() } )
+                __* {
+                Query {
+                    parts,
+                }
+            }
+    }
+
+}
+
+pub fn parse(
+    input: &str,
+    config: &dyn GQLConfiguration,
+) -> Result<ast::Query, ParseError<LineCol>> {
+    gql::query(input, config)
+}
+
+pub fn parse_expression(input: &str) -> Result<ast::Expression, ParseError<LineCol>> {
+    gql::expression(input)
+}
+
+pub trait GQLConfiguration: Send + Sync {
+    fn get_aggregating_function_names(&self) -> HashSet<String>;
+}
+
+pub fn build_query_parts(
+    match_clauses: Vec<MatchClause>,
+    where_clauses: Vec<Expression>,
+    final_return: Vec<Expression>,
+    group_by_keys: Option<Vec<Expression>>,
+    config: &dyn GQLConfiguration,
+) -> Result<Vec<QueryPart>, QueryParseError> {
+    if let Some(keys) = group_by_keys {
+        handle_explicit_group_by(match_clauses, where_clauses, final_return, keys, config)
+    } else {
+        Ok(vec![QueryPart {
+            match_clauses,
+            where_clauses,
+            return_clause: final_return.into_projection_clause(config),
+        }])
+    }
+}
+
+fn handle_explicit_group_by(
+    match_clauses: Vec<MatchClause>,
+    where_clauses: Vec<Expression>,
+    return_expressions: Vec<Expression>,
+    group_by_keys: Vec<Expression>,
+    config: &dyn GQLConfiguration,
+) -> Result<Vec<QueryPart>, QueryParseError> {
+    let mut return_non_aggs = Vec::new();
+    let mut return_aggs = Vec::new();
+    for expr in &return_expressions {
+        if contains_aggregating_function(expr, config) {
+            return_aggs.push(expr.clone());
+        } else {
+            return_non_aggs.push(expr.clone());
+        }
+    }
+
+    if return_non_aggs.iter().any(|expr| {
+        group_by_keys
+            .iter()
+            .all(|key| !matches_group_by_key(expr, key))
+    }) {
+        return Err(QueryParseError::MissingGroupByKey);
+    }
+
+    // All GROUP BY keys appear in the RETURN non-aggregates
+    if group_by_keys
+        .iter()
+        .all(|k| return_non_aggs.iter().any(|e| matches_group_by_key(e, k)))
+    {
+        return Ok(vec![QueryPart {
+            match_clauses,
+            where_clauses,
+            return_clause: return_expressions.into_projection_clause(config),
+        }]);
+    }
+
+    // Fewer keys are projected in the RETURN than are in the GROUP BY clause.
+    let full_keys: Vec<_> = group_by_keys
+        .into_iter()
+        .map(|key| {
+            return_expressions
+                .iter()
+                .find(|e| matches_group_by_key(e, &key))
+                .cloned()
+                .unwrap_or(key)
+        })
+        .collect();
+
+    Ok(group_all_keys_then_project_return(
+        &match_clauses,
+        &where_clauses,
+        full_keys,
+        return_aggs,
+        &return_expressions,
+    ))
+}
+
+fn matches_group_by_key(expr: &Expression, key: &Expression) -> bool {
+    if expr == key {
+        return true;
+    }
+
+    match (expr, key) {
+        (Expression::FunctionExpression(f1), Expression::FunctionExpression(f2)) => {
+            f1.eq_ignore_position_in_query(f2)
+        }
+
+        // If the RETURN expression is an alias (a.name AS person_name) and the GROUP BY references the alias name (person_name), it is a match.
+        (
+            Expression::UnaryExpression(UnaryExpression::Alias { alias, .. }),
+            Expression::UnaryExpression(UnaryExpression::Identifier(id)),
+        ) => id == alias,
+        _ => false,
+    }
+}
+
+fn group_all_keys_then_project_return(
+    match_clauses: &[MatchClause],
+    where_clauses: &[Expression],
+    grouping: Vec<Expression>,
+    aggregates: Vec<Expression>,
+    original_return: &[Expression],
+) -> Vec<QueryPart> {
+    let initial_projection = if aggregates.is_empty() {
+        ProjectionClause::Item(grouping.clone())
+    } else {
+        ProjectionClause::GroupBy {
+            grouping: grouping.clone(),
+            aggregates: aggregates.clone(),
+        }
+    };
+
+    let perform_grouping_part = QueryPart {
+        match_clauses: match_clauses.to_owned(),
+        where_clauses: where_clauses.to_owned(),
+        return_clause: initial_projection,
+    };
+
+    let project_return_part = QueryPart {
+        match_clauses: vec![],
+        where_clauses: vec![],
+        return_clause: ProjectionClause::Item(
+            original_return
+                .iter()
+                .map(expression_to_alias_ident)
+                .collect(),
+        ),
+    };
+
+    vec![perform_grouping_part, project_return_part]
+}
+
+// Converts an expression (x + 1 AS sum) to just the alias ident (sum).
+fn expression_to_alias_ident(expr: &Expression) -> Expression {
+    if let Expression::UnaryExpression(UnaryExpression::Alias { alias, .. }) = expr {
+        UnaryExpression::ident(alias)
+    } else {
+        expr.clone()
+    }
+}
+
+pub trait IntoProjectionClause {
+    fn into_projection_clause(self, config: &dyn GQLConfiguration) -> ProjectionClause;
+}
+
+impl IntoProjectionClause for Vec<Expression> {
+    fn into_projection_clause(self, config: &dyn GQLConfiguration) -> ProjectionClause {
+        let mut keys = Vec::new();
+        let mut aggs = Vec::new();
+
+        for expr in self {
+            if contains_aggregating_function(&expr, config) {
+                aggs.push(expr);
+            } else {
+                keys.push(expr);
+            }
+        }
+
+        if aggs.is_empty() {
+            ProjectionClause::Item(keys)
+        } else {
+            ProjectionClause::GroupBy {
+                grouping: keys,
+                aggregates: aggs,
+            }
+        }
+    }
+}
+
+pub fn contains_aggregating_function(
+    expression: &Expression,
+    config: &dyn GQLConfiguration,
+) -> bool {
+    let stack = &mut vec![expression];
+    let aggr_funcs = config.get_aggregating_function_names();
+
+    while let Some(expr) = stack.pop() {
+        if let Expression::FunctionExpression(ref function) = expr {
+            if aggr_funcs.contains(&function.name.to_string()) {
+                return true;
+            }
+        }
+
+        for c in expr.get_children() {
+            stack.push(c);
+        }
+    }
+
+    false
+}
+
+pub struct GQLParser {
+    config: Arc<dyn GQLConfiguration>,
+}
+
+impl GQLParser {
+    pub fn new(config: Arc<dyn GQLConfiguration>) -> Self {
+        GQLParser { config }
+    }
+}
+
+impl QueryParser for GQLParser {
+    fn parse(&self, input: &str) -> Result<ast::Query, QueryParseError> {
+        match parse(input, &*self.config) {
+            Ok(query) => Ok(query),
+            Err(e) => Err(QueryParseError::ParserError(Box::new(e))),
+        }
+    }
+}

--- a/query-gql/src/tests.rs
+++ b/query-gql/src/tests.rs
@@ -1,0 +1,528 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use super::*;
+use ast::*;
+
+struct TestConfig {}
+
+impl GQLConfiguration for TestConfig {
+    fn get_aggregating_function_names(&self) -> HashSet<String> {
+        let mut set = HashSet::new();
+        set.insert("count".into());
+        set
+    }
+}
+
+static TEST_CONFIG: TestConfig = TestConfig {};
+
+// GROUP BY tests
+#[test]
+fn implicit_grouping_with_one_key() {
+    // 1. Implicit Grouping with One Key
+    // Expected: Groups by z.type (zone_type), counts vehicles.
+    let query = gql::query(
+        "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone {type:'Parking Lot'})
+        RETURN z.type AS zone_type, count(v) AS vehicle_count",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![UnaryExpression::alias(
+                UnaryExpression::expression_property(UnaryExpression::ident("z"), "type".into()),
+                "zone_type".into()
+            )],
+            aggregates: vec![UnaryExpression::alias(
+                FunctionExpression::function("count".into(), vec![UnaryExpression::ident("v")], 99),
+                "vehicle_count".into()
+            )]
+        }
+    );
+}
+
+#[test]
+fn implicit_grouping_with_two_keys() {
+    // 2. Implicit Grouping with Two Keys
+    // Checks that multiple non-aggregated expressions in RETURN are all treated as grouping keys.
+    let query = gql::query(
+        "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone {type:'Parking Lot'})
+         RETURN z.type AS zone_type, v.color AS vehicle_color, count(v) AS vehicle_count",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![
+                UnaryExpression::alias(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("z"),
+                        "type".into()
+                    ),
+                    "zone_type".into()
+                ),
+                UnaryExpression::alias(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into()
+                    ),
+                    "vehicle_color".into()
+                )
+            ],
+            aggregates: vec![UnaryExpression::alias(
+                FunctionExpression::function(
+                    "count".into(),
+                    vec![UnaryExpression::ident("v")],
+                    126
+                ),
+                "vehicle_count".into()
+            )]
+        }
+    );
+}
+
+#[test]
+fn explicit_group_by_all_keys_projected() {
+    // 3. Explicit GROUP BY: All Keys Projected
+    // Ensures explicit GROUP BY behaves identically to implicit grouping.
+    let query = gql::query(
+        "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         RETURN z.type AS zone_type, v.color AS vehicle_color, count(v) AS vehicle_count
+         GROUP BY zone_type, vehicle_color",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![
+                UnaryExpression::alias(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("z"),
+                        "type".into()
+                    ),
+                    "zone_type".into()
+                ),
+                UnaryExpression::alias(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into()
+                    ),
+                    "vehicle_color".into()
+                )
+            ],
+            aggregates: vec![UnaryExpression::alias(
+                FunctionExpression::function(
+                    "count".into(),
+                    vec![UnaryExpression::ident("v")],
+                    105
+                ),
+                "vehicle_count".into()
+            )]
+        }
+    );
+}
+
+#[test]
+fn explicit_group_by_subset_of_keys_projected() {
+    // 4. Explicit GROUP BY: Subset of Keys Projected
+    // Creates a multi-part query (like Cypher's WITH) in the AST.
+    let query = gql::query(
+        "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         RETURN z.type AS zone_type, count(v) AS vehicle_count
+         GROUP BY zone_type, v.color",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query,
+        Query {
+            parts: vec![
+                // First part: Group by all specified keys
+                QueryPart {
+                    match_clauses: vec![MatchClause {
+                        start: NodeMatch::with_annotation(
+                            Annotation::new("v".into()),
+                            "Vehicle".into()
+                        ),
+                        path: vec![(
+                            RelationMatch::right(
+                                Annotation::empty(),
+                                vec!["LOCATED_IN".into()],
+                                vec![],
+                                None
+                            ),
+                            NodeMatch::with_annotation(Annotation::new("z".into()), "Zone".into())
+                        )],
+                        optional: false,
+                    }],
+                    where_clauses: vec![],
+                    return_clause: ProjectionClause::GroupBy {
+                        grouping: vec![
+                            UnaryExpression::alias(
+                                UnaryExpression::expression_property(
+                                    UnaryExpression::ident("z"),
+                                    "type".into()
+                                ),
+                                "zone_type".into()
+                            ),
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into()
+                            )
+                        ],
+                        aggregates: vec![UnaryExpression::alias(
+                            FunctionExpression::function(
+                                "count".into(),
+                                vec![UnaryExpression::ident("v")],
+                                79
+                            ),
+                            "vehicle_count".into()
+                        )]
+                    }
+                },
+                // Second part: Final projection with only subset of keys
+                QueryPart {
+                    match_clauses: vec![],
+                    where_clauses: vec![],
+                    return_clause: ProjectionClause::Item(vec![
+                        UnaryExpression::ident("zone_type"),
+                        UnaryExpression::ident("vehicle_count")
+                    ])
+                }
+            ]
+        }
+    );
+}
+
+#[test]
+fn group_by_with_function_expression() {
+    // 5. GROUP BY with Function Expression
+    // Verifies that functions can be used as grouping keys.
+    let query = gql::query(
+        "MATCH (a)-[t:Transfers]->(b)
+         RETURN FLOOR(t.amount) AS amount_group, count(t) AS number_of_transfers
+         GROUP BY amount_group",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![UnaryExpression::alias(
+                FunctionExpression::function(
+                    "FLOOR".into(),
+                    vec![UnaryExpression::expression_property(
+                        UnaryExpression::ident("t"),
+                        "amount".into()
+                    )],
+                    45
+                ),
+                "amount_group".into()
+            )],
+            aggregates: vec![UnaryExpression::alias(
+                FunctionExpression::function("count".into(), vec![UnaryExpression::ident("t")], 78),
+                "number_of_transfers".into()
+            )]
+        }
+    );
+}
+
+#[test]
+fn group_by_with_binary_expression() {
+    // 6. GROUP BY with Binary Expression
+    // Ensures that binary expressions can serve as grouping keys.
+    let query = gql::query(
+        "MATCH (a)-[t:Transfers]->(b)
+         RETURN t.amount + 100, count(t) AS number_of_transfers
+         GROUP BY t.amount + 100",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![BinaryExpression::add(
+                UnaryExpression::expression_property(UnaryExpression::ident("t"), "amount".into()),
+                UnaryExpression::literal(Literal::Integer(100))
+            )],
+            aggregates: vec![UnaryExpression::alias(
+                FunctionExpression::function("count".into(), vec![UnaryExpression::ident("t")], 61),
+                "number_of_transfers".into()
+            )]
+        }
+    );
+}
+
+#[test]
+fn group_by_with_aliased_column() {
+    // 8. GROUP BY with Aliased Column
+    // Tests that aliases specified in RETURN can be referenced in the GROUP BY clause.
+    let query = gql::query(
+        "MATCH (a)-[t:Transfers]->(b)
+         RETURN t.account_id AS account, count(t) AS number_of_transfers
+         GROUP BY account",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![UnaryExpression::alias(
+                UnaryExpression::expression_property(
+                    UnaryExpression::ident("t"),
+                    "account_id".into()
+                ),
+                "account".into()
+            )],
+            aggregates: vec![UnaryExpression::alias(
+                FunctionExpression::function("count".into(), vec![UnaryExpression::ident("t")], 70),
+                "number_of_transfers".into()
+            )]
+        }
+    );
+}
+
+#[test]
+fn group_by_with_account_id_and_count() {
+    // 9. GROUP BY with Account ID and Count
+    // Tests grouping by account_id and returning both the grouping key and aggregate count.
+    let query = gql::query(
+        "MATCH (a)-[t:Transfers]->(b)
+            RETURN t.account_id, count(t) AS number_of_transfers
+            GROUP BY t.account_id",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query,
+        Query {
+            parts: vec![QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch::new(Annotation::new("a".into()), vec![], vec![]),
+                    path: vec![(
+                        RelationMatch::right(
+                            Annotation::new("t".into()),
+                            vec!["Transfers".into()],
+                            vec![],
+                            None
+                        ),
+                        NodeMatch::new(Annotation::new("b".into()), vec![], vec![])
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![UnaryExpression::expression_property(
+                        UnaryExpression::ident("t"),
+                        "account_id".into()
+                    )],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::ident("t")],
+                            62
+                        ),
+                        "number_of_transfers".into()
+                    )]
+                }
+            }]
+        }
+    );
+}
+
+#[test]
+fn group_by_empty() {
+    // 10. GROUP BY ()
+    // Tests the special case where GROUP BY () groups all rows into a single group.
+    let query = gql::query(
+        "MATCH (v:Vehicle) RETURN count(v) AS total_rows GROUP BY ()",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![],
+            aggregates: vec![UnaryExpression::alias(
+                FunctionExpression::function("count".into(), vec![UnaryExpression::ident("v")], 25),
+                "total_rows".into()
+            )]
+        }
+    );
+}
+
+#[test]
+fn implicit_grouping_with_only_aggregates() {
+    // 12. Implicit Grouping with Only Aggregates
+    // Tests that when RETURN contains only aggregate functions with no explicit GROUP BY,
+    // it should infer a single-group aggregation (empty grouping key set) just like GROUP BY ().
+    let query = gql::query(
+        "MATCH (v:Vehicle) 
+         RETURN count(v) AS total",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![],
+            aggregates: vec![UnaryExpression::alias(
+                FunctionExpression::function("count".into(), vec![UnaryExpression::ident("v")], 35),
+                "total".into()
+            )]
+        }
+    );
+}
+
+#[test]
+fn grouping_on_raw_identifiers() {
+    // 13. Grouping on Raw Identifiers (No Alias)
+    // Tests that GROUP BY can reference un-aliased expressions from the RETURN clause.
+    let query = gql::query(
+        "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone) 
+         RETURN z.type, count(v) AS vehicle_count 
+         GROUP BY z.type",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![UnaryExpression::expression_property(
+                UnaryExpression::ident("z"),
+                "type".into()
+            )],
+            aggregates: vec![UnaryExpression::alias(
+                FunctionExpression::function("count".into(), vec![UnaryExpression::ident("v")], 67),
+                "vehicle_count".into()
+            )]
+        }
+    );
+}
+
+#[test]
+fn grouping_on_non_aliased_function() {
+    // 14. Grouping on Non-aliased Function
+    // Tests that GROUP BY can reference un-aliased function expressions from the RETURN clause.
+    let query = gql::query(
+        "MATCH (a)-[t:Transfers]->(b) 
+         RETURN floor(t.amount), count(t) 
+         GROUP BY floor(t.amount)",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query.parts[0].return_clause,
+        ProjectionClause::GroupBy {
+            grouping: vec![FunctionExpression::function(
+                "floor".into(),
+                vec![UnaryExpression::expression_property(
+                    UnaryExpression::ident("t"),
+                    "amount".into()
+                )],
+                46
+            )],
+            aggregates: vec![FunctionExpression::function(
+                "count".into(),
+                vec![UnaryExpression::ident("t")],
+                63
+            )]
+        }
+    );
+}
+#[test]
+fn group_by_and_where_on_vehicles() {
+    // This test checks GROUP BY and WHERE together
+    let query = gql::query(
+        "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         WHERE v.color = 'Red'
+         RETURN z.type, count(v) AS vehicle_count
+         GROUP BY z.type
+        ",
+        &TEST_CONFIG,
+    )
+    .unwrap();
+
+    assert_eq!(
+        query,
+        Query {
+            parts: vec![QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch {
+                            direction: Direction::Right,
+                            annotation: Annotation { name: None },
+                            variable_length: None,
+                            labels: vec!["LOCATED_IN".into()],
+                            property_predicates: vec![],
+                        },
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    ),],
+                    optional: false,
+                },],
+                where_clauses: vec![BinaryExpression::eq(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into()
+                    ),
+                    UnaryExpression::literal(Literal::Text("Red".into()))
+                ),],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![UnaryExpression::expression_property(
+                        UnaryExpression::ident("z"),
+                        "type".into()
+                    ),],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::ident("v")],
+                            97
+                        ),
+                        "vehicle_count".into()
+                    ),],
+                },
+            },],
+        }
+    );
+}


### PR DESCRIPTION
# Pull Request: GQL GROUP BY Implementation

## Overview

This pull request introduces GROUP BY from Graph Query Language (GQL). The implementation ensures that queries without an explicit GROUP BY are grouped implicitly (like Cypher), while queries with an explicit GROUP BY behave as described in the standard.

## GROUP BY Implementation
### 1. Implicit Grouping (No GROUP BY clause)
- If no `GROUP BY` clause is specified, all non-aggregated expressions in the RETURN clause automatically become grouping keys. This follows Cypher's behavior. 

### 2. Explicit GROUP BY
- If a `GROUP BY` clause is present, only the listed expressions/columns are used as grouping keys.
- Any non-aggregated column in `RETURN` that is not in the `GROUP BY` clause is **invalid**.

### 3. Grouping Keys
- **Grouping keys must NOT be aggregate functions or their aliases.**
- You may use an alias from the `RETURN` clause as a grouping key if:
  - The alias refers to a non-aggregate expression.
  - The alias is unique among projected columns.
  - The alias is actually defined in the `RETURN` clause.

### 4. RETURN Clause Requirements
- Every projected column in the `RETURN` clause must either:
  - Appear in the `GROUP BY` clause, or
  - Be the result of an aggregate function.

### 6. Two-Stage Plan
- If `GROUP BY` specifies more keys than are projected, the engine uses a **two-stage plan**:
  - First, group by all keys.
  - Then, further project only the keys in the RETURN.

## Example Cases

#### 1. Every grouping key listed in GROUP BY is present in the output (single-stage plan)
```cypher
MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
RETURN z.type AS zone_type, v.color AS vehicle_color, count(v) AS vehicle_count
GROUP BY zone_type, vehicle_color
```
- `GROUP BY` keys exactly match non-aggregate columns in `RETURN`.

#### 2. Fewer Projected Keys Than GROUP BY Keys (two-stage plan)
```cypher
MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
RETURN z.type AS zone_type, count(v) AS vehicle_count
GROUP BY zone_type, v.color
```
- Engine groups by both `zone_type` and `v.color`, then projects only `zone_type` and aggregates.

#### 3. More Projected Keys Than GROUP BY Keys (error)
```cypher
MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
RETURN z.type AS zone_type, v.color AS vehicle_color, count(v) AS vehicle_count
GROUP BY vehicle_color
```
- `zone_type` is not in `GROUP BY` and is not an aggregate—**this is an error**.

## Implementation Details

The explicit GROUP BY logic is handled in the function handle_explicit_group_by. It works as follows:

1. Partition the RETURN expressions into aggregates (A) and non-aggregates (K).
2. Build a lookup set from for the expressions in GROUP BY (G).
3. For each expression in K:
    - If the expression is in G: the query is valid.
    - Else: Error (must be grouped or aggregated).
4. If all G are present in K: 
    - Single-stage plan, emit original RETURN clause.
5. Else: 
    - Two-stage plan:
        - Stage 1: GROUP BY the full set G and compute all A.
        - Stage 2: Project the original RETURN expressions.

## Two-stage plan
When the `GROUP BY` clause contains more keys than are present in the projected output (`RETURN`), the engine uses a **two-stage plan**. 

In stage 1, group by all keys specified in the `GROUP BY` clause. The result set at this stage includes all grouping keys and aggregate columns. The second stage projects only the columns requested in the original `RETURN` clause.

## Caveats
Grouping without aggregation functions is not supported. This is similar to RETURN DISTINCT, which is also currently unsupported.
