### PR TITLE
Implemented FILTER, LET, and YIELD keywords

### DIFF
--- a/query-gql/Cargo.toml
+++ b/query-gql/Cargo.toml
@@ -16,6 +16,3 @@ drasi-query-ast = { path = "../query-ast" }
 peg = "0.8.1"
 serde = "1.0.164"
 serde_json = "1.0.96"
-
-[dev-dependencies]
-drasi-query-cypher = { path = "../query-cypher" }

--- a/query-gql/Cargo.toml
+++ b/query-gql/Cargo.toml
@@ -16,3 +16,6 @@ drasi-query-ast = { path = "../query-ast" }
 peg = "0.8.1"
 serde = "1.0.164"
 serde_json = "1.0.96"
+
+[dev-dependencies]
+drasi-query-cypher = { path = "../query-cypher" }

--- a/query-gql/src/lib.rs
+++ b/query-gql/src/lib.rs
@@ -405,7 +405,7 @@ peg::parser! {
         rule match_with_where() -> (Vec<MatchClause>, Vec<Expression>)
             = ms:(match_clause() ++ (__+)) __*
             w:where_clause()? { (ms.into_iter().flatten().collect(), w.into_iter().collect()) }
-        
+
         rule part(config: &dyn GQLConfiguration) -> Vec<QueryPart>
               = __*
                 match_and_where:(match_with_where() ** (__+))
@@ -418,8 +418,8 @@ peg::parser! {
                       QueryParseError::MissingGroupByKey => "Non-grouped RETURN expressions must appear in GROUP BY clause",
                       QueryParseError::ParserError(_) => "Parser error",
                   }) }
-          
-          
+
+
 
         pub rule query(config: &dyn GQLConfiguration) -> Query
             = __*
@@ -433,7 +433,7 @@ peg::parser! {
 
 }
 
-pub enum StatementClause {
+enum StatementClause {
     Let(Vec<(Arc<str>, Expression)>),
     Yield(Vec<(Expression, Option<Arc<str>>)>),
     Filter(Expression),
@@ -591,7 +591,6 @@ fn get_starting_scope(match_clauses: &[MatchClause]) -> Vec<Expression> {
 
     expressions
 }
-
 
 fn handle_explicit_group_by(
     match_clauses: Vec<MatchClause>,

--- a/query-gql/src/lib.rs
+++ b/query-gql/src/lib.rs
@@ -51,6 +51,9 @@ peg::parser! {
         rule kw_exists()    = ("EXISTS" / "exists")
         rule kw_group()     = ("GROUP" / "group")
         rule kw_by()        = ("BY" / "by")
+        rule kw_let()       = ("LET" / "let")
+        rule kw_yield()     = ("YIELD" / "yield")
+        rule kw_filter()    = ("FILTER" / "filter")
 
         rule _()
             = quiet!{[' ']}
@@ -200,6 +203,32 @@ peg::parser! {
 
         rule else_expression() -> Expression
             = kw_else() __+ else_:expression() __+ { else_ }
+
+        rule let_assign() -> (Arc<str>, Expression)
+            = name:ident() __* "=" __* expr:expression() { (name, expr) }
+
+        rule let_statement() -> Vec<(Arc<str>,Expression)>
+            = __* kw_let() __+
+            assigns:(let_assign() ** (__* "," __*))
+            __*
+            { assigns }
+
+        rule yield_assign() -> (Expression, Option<Arc<str>>)
+            = expr:expression() __* kw_as() __* alias:ident() { (expr, Some(alias)) }
+            / expr:expression() { (expr, None) }
+
+        rule yield_statement() -> Vec<(Expression, Option<Arc<str>>)>
+            = __* kw_yield() __+
+              assigns:(yield_assign() ** (__* "," __*))
+              __* { assigns }
+
+        rule filter_statement() -> Expression
+            = __* kw_filter() __+ expr:expression() { expr }
+
+        rule statement_clause() -> StatementClause
+            = l:let_statement()    { StatementClause::Let(l) }
+            / y:yield_statement()  { StatementClause::Yield(y) }
+            / f:filter_statement() { StatementClause::Filter(vec![f]) }
 
             #[cache_left_rec]
         pub rule expression() -> Expression
@@ -379,12 +408,13 @@ peg::parser! {
         rule part(config: &dyn GQLConfiguration) -> Vec<QueryPart>
             = match_clauses:( __* m:(match_clause() ** (__+) )? { m.unwrap_or_default().into_iter().flatten().collect() } )
               where_clauses:( __* w:(where_clause() ** (__+) )? { w.unwrap_or_default() } )
+              statement_clauses:( __* s:statement_clause() __* { s } )*
               __*
               return_clause:(with_or_return())
               group_by_exprs:( __* g:group_by_clause()? { g } )
               __*
               // Will return full expected set in addition to the error message
-                {? build_query_parts(match_clauses, where_clauses, return_clause, group_by_exprs, config).map_err(|e| match e {
+                {? build_query_parts(match_clauses, where_clauses, statement_clauses, return_clause, group_by_exprs, config).map_err(|e| match e {
                     QueryParseError::MissingGroupByKey => "Non-grouped RETURN expressions must appear in GROUP BY clause",
                     QueryParseError::ParserError(_) => "Parser error",
                 }) }
@@ -399,6 +429,12 @@ peg::parser! {
             }
     }
 
+}
+
+pub enum StatementClause {
+    Let(Vec<(Arc<str>, Expression)>),
+    Yield(Vec<(Expression, Option<Arc<str>>)>),
+    Filter(Vec<Expression>),
 }
 
 pub fn parse(
@@ -416,22 +452,134 @@ pub trait GQLConfiguration: Send + Sync {
     fn get_aggregating_function_names(&self) -> HashSet<String>;
 }
 
-pub fn build_query_parts(
-    match_clauses: Vec<MatchClause>,
-    where_clauses: Vec<Expression>,
-    final_return: Vec<Expression>,
-    group_by_keys: Option<Vec<Expression>>,
+fn build_query_parts(
+    mut match_clauses: Vec<MatchClause>,
+    mut where_clauses: Vec<Expression>,
+    statement_clauses: Vec<StatementClause>,
+    final_return_expressions: Vec<Expression>,
+    group_by_expressions: Option<Vec<Expression>>,
     config: &dyn GQLConfiguration,
 ) -> Result<Vec<QueryPart>, QueryParseError> {
-    if let Some(keys) = group_by_keys {
-        handle_explicit_group_by(match_clauses, where_clauses, final_return, keys, config)
-    } else {
-        Ok(vec![QueryPart {
+    let mut query_parts = Vec::new();
+
+    if !statement_clauses.is_empty() {
+        let starting_scope = get_starting_scope(&match_clauses);
+        query_parts.extend(build_parts_for_statements(
+            std::mem::take(&mut match_clauses),
+            std::mem::take(&mut where_clauses),
+            statement_clauses,
+            starting_scope,
+            config,
+        ));
+    }
+
+    let final_projection_parts = if let Some(group_keys) = group_by_expressions {
+        handle_explicit_group_by(
             match_clauses,
             where_clauses,
-            return_clause: final_return.into_projection_clause(config),
-        }])
+            final_return_expressions,
+            group_keys,
+            config,
+        )?
+    } else {
+        vec![QueryPart {
+            match_clauses,
+            where_clauses,
+            return_clause: final_return_expressions.into_projection_clause(config),
+        }]
+    };
+
+    query_parts.extend(final_projection_parts);
+    Ok(query_parts)
+}
+
+fn build_parts_for_statements(
+    mut match_clauses: Vec<MatchClause>,
+    mut where_clauses: Vec<Expression>,
+    statements: Vec<StatementClause>,
+    mut scope: Vec<Expression>,
+    config: &dyn GQLConfiguration,
+) -> Vec<QueryPart> {
+    let mut parts = Vec::new();
+
+    for statement in statements {
+        let match_clause = std::mem::take(&mut match_clauses);
+        let where_clause = std::mem::take(&mut where_clauses);
+
+        match statement {
+            StatementClause::Let(bindings) => {
+                let mut projection = scope.clone();
+                for (alias, expr) in bindings {
+                    projection.push(UnaryExpression::alias(expr.clone(), alias.clone()));
+                    scope.push(UnaryExpression::ident(alias.as_ref()));
+                }
+                parts.push(QueryPart {
+                    match_clauses: match_clause,
+                    where_clauses: where_clause,
+                    return_clause: projection.into_projection_clause(config),
+                });
+            }
+
+            StatementClause::Yield(yields) => {
+                let mut projection = Vec::new();
+                let mut new_scope = Vec::new();
+                for (expr, alias_opt) in yields {
+                    if let Some(alias) = alias_opt {
+                        projection.push(UnaryExpression::alias(expr.clone(), alias.clone()));
+                        new_scope.push(UnaryExpression::ident(alias.as_ref()));
+                    } else {
+                        projection.push(expr.clone());
+                        if let Expression::UnaryExpression(UnaryExpression::Identifier(id)) = &expr
+                        {
+                            new_scope.push(UnaryExpression::ident(id));
+                        }
+                    }
+                }
+                scope = new_scope;
+                parts.push(QueryPart {
+                    match_clauses: match_clause,
+                    where_clauses: where_clause,
+                    return_clause: projection.into_projection_clause(config),
+                });
+            }
+
+            StatementClause::Filter(filters) => {
+                if !match_clause.is_empty() || !where_clause.is_empty() {
+                    parts.push(QueryPart {
+                        match_clauses: match_clause,
+                        where_clauses: where_clause,
+                        return_clause: scope.clone().into_projection_clause(config),
+                    });
+                }
+                for filter_expr in filters {
+                    parts.push(QueryPart {
+                        match_clauses: Vec::new(),
+                        where_clauses: vec![filter_expr],
+                        return_clause: scope.clone().into_projection_clause(config),
+                    });
+                }
+            }
+        }
     }
+
+    parts
+}
+
+fn get_starting_scope(match_clauses: &[MatchClause]) -> Vec<Expression> {
+    let mut expressions = Vec::new();
+
+    for clause in match_clauses {
+        if let Some(name) = &clause.start.annotation.name {
+            expressions.push(UnaryExpression::ident(name.as_ref()));
+        }
+        for (_rel, node) in &clause.path {
+            if let Some(name) = &node.annotation.name {
+                expressions.push(UnaryExpression::ident(name.as_ref()));
+            }
+        }
+    }
+
+    expressions
 }
 
 fn handle_explicit_group_by(

--- a/query-gql/src/tests.rs
+++ b/query-gql/src/tests.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 
 use super::*;
 use ast::*;
+use drasi_query_cypher::{parse, CypherConfiguration};
 
 struct TestConfig {}
 
@@ -32,8 +33,7 @@ static TEST_CONFIG: TestConfig = TestConfig {};
 // GROUP BY tests
 #[test]
 fn implicit_grouping_with_one_key() {
-    // 1. Implicit Grouping with One Key
-    // Expected: Groups by z.type (zone_type), counts vehicles.
+    // Implicit Grouping with One Key
     let query = gql::query(
         "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone {type:'Parking Lot'})
         RETURN z.type AS zone_type, count(v) AS vehicle_count",
@@ -58,8 +58,7 @@ fn implicit_grouping_with_one_key() {
 
 #[test]
 fn implicit_grouping_with_two_keys() {
-    // 2. Implicit Grouping with Two Keys
-    // Checks that multiple non-aggregated expressions in RETURN are all treated as grouping keys.
+    // Implicit Grouping with Two Keys
     let query = gql::query(
         "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone {type:'Parking Lot'})
          RETURN z.type AS zone_type, v.color AS vehicle_color, count(v) AS vehicle_count",
@@ -100,7 +99,7 @@ fn implicit_grouping_with_two_keys() {
 
 #[test]
 fn explicit_group_by_all_keys_projected() {
-    // 3. Explicit GROUP BY: All Keys Projected
+    // Explicit GROUP BY: All Keys Projected
     // Ensures explicit GROUP BY behaves identically to implicit grouping.
     let query = gql::query(
         "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
@@ -143,8 +142,8 @@ fn explicit_group_by_all_keys_projected() {
 
 #[test]
 fn explicit_group_by_subset_of_keys_projected() {
-    // 4. Explicit GROUP BY: Subset of Keys Projected
-    // Creates a multi-part query (like Cypher's WITH) in the AST.
+    // Explicit GROUP BY: Subset of Keys Projected
+    // Creates a multi-part query
     let query = gql::query(
         "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
          RETURN z.type AS zone_type, count(v) AS vehicle_count
@@ -216,8 +215,7 @@ fn explicit_group_by_subset_of_keys_projected() {
 
 #[test]
 fn group_by_with_function_expression() {
-    // 5. GROUP BY with Function Expression
-    // Verifies that functions can be used as grouping keys.
+    // GROUP BY with Function Expression
     let query = gql::query(
         "MATCH (a)-[t:Transfers]->(b)
          RETURN FLOOR(t.amount) AS amount_group, count(t) AS number_of_transfers
@@ -250,8 +248,7 @@ fn group_by_with_function_expression() {
 
 #[test]
 fn group_by_with_binary_expression() {
-    // 6. GROUP BY with Binary Expression
-    // Ensures that binary expressions can serve as grouping keys.
+    // GROUP BY with Binary Expression
     let query = gql::query(
         "MATCH (a)-[t:Transfers]->(b)
          RETURN t.amount + 100, count(t) AS number_of_transfers
@@ -277,8 +274,7 @@ fn group_by_with_binary_expression() {
 
 #[test]
 fn group_by_with_aliased_column() {
-    // 8. GROUP BY with Aliased Column
-    // Tests that aliases specified in RETURN can be referenced in the GROUP BY clause.
+    // GROUP BY with Aliased Column
     let query = gql::query(
         "MATCH (a)-[t:Transfers]->(b)
          RETURN t.account_id AS account, count(t) AS number_of_transfers
@@ -307,8 +303,7 @@ fn group_by_with_aliased_column() {
 
 #[test]
 fn group_by_with_account_id_and_count() {
-    // 9. GROUP BY with Account ID and Count
-    // Tests grouping by account_id and returning both the grouping key and aggregate count.
+    // GROUP BY with Account ID and Count
     let query = gql::query(
         "MATCH (a)-[t:Transfers]->(b)
             RETURN t.account_id, count(t) AS number_of_transfers
@@ -356,7 +351,7 @@ fn group_by_with_account_id_and_count() {
 
 #[test]
 fn group_by_empty() {
-    // 10. GROUP BY ()
+    // GROUP BY ()
     // Tests the special case where GROUP BY () groups all rows into a single group.
     let query = gql::query(
         "MATCH (v:Vehicle) RETURN count(v) AS total_rows GROUP BY ()",
@@ -378,9 +373,8 @@ fn group_by_empty() {
 
 #[test]
 fn implicit_grouping_with_only_aggregates() {
-    // 12. Implicit Grouping with Only Aggregates
+    // Implicit Grouping with Only Aggregates
     // Tests that when RETURN contains only aggregate functions with no explicit GROUP BY,
-    // it should infer a single-group aggregation (empty grouping key set) just like GROUP BY ().
     let query = gql::query(
         "MATCH (v:Vehicle) 
          RETURN count(v) AS total",
@@ -402,8 +396,7 @@ fn implicit_grouping_with_only_aggregates() {
 
 #[test]
 fn grouping_on_raw_identifiers() {
-    // 13. Grouping on Raw Identifiers (No Alias)
-    // Tests that GROUP BY can reference un-aliased expressions from the RETURN clause.
+    // Grouping on Raw Identifiers (No Alias)
     let query = gql::query(
         "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone) 
          RETURN z.type, count(v) AS vehicle_count 
@@ -429,8 +422,7 @@ fn grouping_on_raw_identifiers() {
 
 #[test]
 fn grouping_on_non_aliased_function() {
-    // 14. Grouping on Non-aliased Function
-    // Tests that GROUP BY can reference un-aliased function expressions from the RETURN clause.
+    // Grouping on Non-aliased Function
     let query = gql::query(
         "MATCH (a)-[t:Transfers]->(b) 
          RETURN floor(t.amount), count(t) 
@@ -524,5 +516,2595 @@ fn group_by_and_where_on_vehicles() {
                 },
             },],
         }
+    );
+}
+
+// LET and YIELD Tests
+
+// Shared Cypher test config for AST comparison
+struct TestCypherConfig {}
+impl CypherConfiguration for TestCypherConfig {
+    fn get_aggregating_function_names(&self) -> std::collections::HashSet<String> {
+        let mut set = std::collections::HashSet::new();
+        set.insert("count".into());
+        set
+    }
+}
+
+#[test]
+fn simple_let_assignment() {
+    let gql_query = "MATCH (v:Vehicle)
+         LET isRed = v.color = 'Red'
+         RETURN v.color, isRed";
+    let cypher_query = "MATCH (v:Vehicle)
+        WITH v, v.color = 'Red' AS isRed
+        RETURN v.color, isRed";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+    let cypher_ast = parse(cypher_query, &TestCypherConfig {}).unwrap();
+
+    assert_eq!(gql_ast, cypher_ast, "GQL and Cypher ASTs should be equal");
+}
+
+#[test]
+fn multiple_let_variables_in_one_clause() {
+    let gql_query = "MATCH (a:Account)
+         LET active = a.is_blocked = false, nameLength = LENGTH(a.nick_name)
+         RETURN a.nick_name, active, nameLength";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("a".into()),
+                        },
+                        labels: vec!["Account".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("a"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("a"),
+                                "is_blocked".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Boolean(false)),
+                        ),
+                        "active".into(),
+                    ),
+                    UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "LENGTH".into(),
+                            vec![UnaryExpression::expression_property(
+                                UnaryExpression::ident("a"),
+                                "nick_name".into(),
+                            )],
+                            75,
+                        ),
+                        "nameLength".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("a"),
+                        "nick_name".into(),
+                    ),
+                    UnaryExpression::ident("active"),
+                    UnaryExpression::ident("nameLength"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+#[test]
+fn chained_let_clauses_preserving_all_variables() {
+    let gql_query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         LET isRed = v.color = 'Red'
+         LET inGarage = z.type = 'Garage'
+         RETURN v.color, z.type, isRed, inGarage";
+    let cypher_query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+        WITH v, z, v.color = 'Red' AS isRed
+        WITH v, z, isRed, z.type = 'Garage' AS inGarage
+        RETURN v.color, z.type, isRed, inGarage";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+    let cypher_ast = parse(cypher_query, &TestCypherConfig {}).unwrap();
+
+    assert_eq!(gql_ast, cypher_ast, "GQL and Cypher ASTs should be equal");
+}
+
+#[test]
+fn test_let_with_where_clause() {
+    let gql_query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+    WHERE z.type = 'Garage'
+    LET color = v.color
+    RETURN color";
+    let cypher_query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+    WHERE z.type = 'Garage'
+    WITH v, z, v.color as color
+    RETURN color";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+    let cypher_ast = parse(cypher_query, &TestCypherConfig {}).unwrap();
+
+    assert_eq!(gql_ast, cypher_ast, "GQL and Cypher ASTs should be equal");
+}
+
+#[test]
+fn let_with_conditionals() {
+    let gql_query = "MATCH (a:Account)
+         LET status = CASE WHEN a.is_blocked THEN 'Blocked' ELSE 'Active' END
+         RETURN a.nick_name, status";
+    let cypher_query = "MATCH (a:Account)
+        WITH a, CASE WHEN a.is_blocked THEN 'Blocked' ELSE 'Active' END AS status
+        RETURN a.nick_name, status";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+    let cypher_ast = parse(cypher_query, &TestCypherConfig {}).unwrap();
+
+    assert_eq!(gql_ast, cypher_ast, "GQL and Cypher ASTs should be equal");
+}
+
+#[test]
+fn chained_lets_with_multiple_new_variables() {
+    let gql_query = "MATCH (p:Person)
+         LET nameLength = LENGTH(p.name)
+         LET isShortName = nameLength < 5, isLongName = nameLength > 7
+         RETURN p.name, isShortName, isLongName";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("p".into()),
+                        },
+                        labels: vec!["Person".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("p"),
+                    UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "LENGTH".into(),
+                            vec![UnaryExpression::expression_property(
+                                UnaryExpression::ident("p"),
+                                "name".into(),
+                            )],
+                            43,
+                        ),
+                        "nameLength".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("p"),
+                    UnaryExpression::ident("nameLength"),
+                    UnaryExpression::alias(
+                        BinaryExpression::lt(
+                            UnaryExpression::ident("nameLength"),
+                            UnaryExpression::literal(Literal::Integer(5)),
+                        ),
+                        "isShortName".into(),
+                    ),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::ident("nameLength"),
+                            UnaryExpression::literal(Literal::Integer(7)),
+                        ),
+                        "isLongName".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("p"),
+                        "name".into(),
+                    ),
+                    UnaryExpression::ident("isShortName"),
+                    UnaryExpression::ident("isLongName"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+// GROUP BY with LET tests
+
+#[test]
+fn group_by_let_defined_variable() {
+    // Example 1: Group by LET-Defined Variable
+    // MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+    // WITH v, z, v.color = 'Red' AS isRed
+    // RETURN z.type AS zone_type, isRed, count(v) AS vehicle_count
+
+    let query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         LET isRed = v.color = 'Red'
+         RETURN z.type AS zone_type, isRed, count(v) AS vehicle_count
+         GROUP BY zone_type, isRed";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch::right(
+                            Annotation::empty(),
+                            vec!["LOCATED_IN".into()],
+                            vec![],
+                            None,
+                        ),
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Text("Red".into())),
+                        ),
+                        "isRed".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![
+                        UnaryExpression::alias(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("z"),
+                                "type".into(),
+                            ),
+                            "zone_type".into(),
+                        ),
+                        UnaryExpression::ident("isRed"),
+                    ],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::ident("v")],
+                            123,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+#[test]
+fn multiple_let_variables_in_group_by() {
+    // Example 2: Multiple LET Variables in GROUP BY
+    // MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+    // WITH v, z, v.color = 'Red' AS isRed
+    // WITH v, z, isRed, v.color = 'Blue' AS isBlue
+    // RETURN zone_type, isRed, isBlue, count(v) AS vehicle_count
+
+    let query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         LET isRed = v.color = 'Red'
+         LET isBlue = v.color = 'Blue'
+         RETURN z.type AS zone_type, isRed, isBlue, count(v) AS vehicle_count
+         GROUP BY zone_type, isRed, isBlue";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch::right(
+                            Annotation::empty(),
+                            vec!["LOCATED_IN".into()],
+                            vec![],
+                            None,
+                        ),
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Text("Red".into())),
+                        ),
+                        "isRed".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::ident("isRed"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Text("Blue".into())),
+                        ),
+                        "isBlue".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![
+                        UnaryExpression::alias(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("z"),
+                                "type".into(),
+                            ),
+                            "zone_type".into(),
+                        ),
+                        UnaryExpression::ident("isRed"),
+                        UnaryExpression::ident("isBlue"),
+                    ],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::ident("v")],
+                            170,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+#[test]
+fn group_by_let_defined_variable_with_less_projected_columns() {
+    // Example 3: Group by LET-Defined Variable with less Projected Columns
+    // MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+    // WITH v, z, v.color = 'Red' AS isRed
+    // WITH z.type AS zone_type, isRed, count(v) AS vehicle_count
+    // RETURN zone_type, vehicle_count
+    let query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         LET isRed = v.color = 'Red'
+         RETURN z.type AS zone_type, count(v) AS vehicle_count
+         GROUP BY zone_type, isRed";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch::right(
+                            Annotation::empty(),
+                            vec!["LOCATED_IN".into()],
+                            vec![],
+                            None,
+                        ),
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Text("Red".into())),
+                        ),
+                        "isRed".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![
+                        UnaryExpression::alias(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("z"),
+                                "type".into(),
+                            ),
+                            "zone_type".into(),
+                        ),
+                        UnaryExpression::ident("isRed"),
+                    ],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::ident("v")],
+                            116,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("zone_type"),
+                    UnaryExpression::ident("vehicle_count"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+#[test]
+fn implicit_grouping_with_let() {
+    // Implicit grouping with LET
+    // MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+    // WITH v, z, v.color = 'Red' AS isRed
+    // RETURN z.type AS zone_type, isRed, count(v) AS vehicle_count
+    let query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         LET isRed = v.color = 'Red'
+         RETURN z.type AS zone_type, isRed, count(v) AS vehicle_count";
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch::right(
+                            Annotation::empty(),
+                            vec!["LOCATED_IN".into()],
+                            vec![],
+                            None,
+                        ),
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Text("Red".into())),
+                        ),
+                        "isRed".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![
+                        UnaryExpression::alias(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("z"),
+                                "type".into(),
+                            ),
+                            "zone_type".into(),
+                        ),
+                        UnaryExpression::ident("isRed"),
+                    ],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::ident("v")],
+                            123,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+        ],
+    };
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+#[test]
+fn implicit_grouping_with_multiple_let() {
+    // Implicit grouping with multiple LET
+    // MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+    // WITH v, z, v.color = 'Red' AS isRed
+    // WITH v, z, isRed, v.color = 'Blue' AS isBlue
+    // RETURN z.type AS zone_type, isRed, isBlue, count(v) AS vehicle_count
+    let query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         LET isRed = v.color = 'Red'
+         LET isBlue = v.color = 'Blue'
+         RETURN z.type AS zone_type, isRed, isBlue, count(v) AS vehicle_count";
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch::right(
+                            Annotation::empty(),
+                            vec!["LOCATED_IN".into()],
+                            vec![],
+                            None,
+                        ),
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Text("Red".into())),
+                        ),
+                        "isRed".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::ident("isRed"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Text("Blue".into())),
+                        ),
+                        "isBlue".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![
+                        UnaryExpression::alias(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("z"),
+                                "type".into(),
+                            ),
+                            "zone_type".into(),
+                        ),
+                        UnaryExpression::ident("isRed"),
+                        UnaryExpression::ident("isBlue"),
+                    ],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::ident("v")],
+                            170,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+        ],
+    };
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+#[test]
+fn let_variable_not_used_in_group_by_or_return() {
+    // LET Variable Not Used in GROUP BY or RETURN
+    // MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+    // WITH v, z, v.color = 'Red' AS isRed
+    // RETURN z.type AS zone_type, count(v) AS vehicle_count
+
+    let query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         LET isRed = v.color = 'Red'
+         RETURN z.type AS zone_type, count(v) AS vehicle_count
+         GROUP BY zone_type";
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch::right(
+                            Annotation::empty(),
+                            vec!["LOCATED_IN".into()],
+                            vec![],
+                            None,
+                        ),
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Text("Red".into())),
+                        ),
+                        "isRed".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("z"),
+                            "type".into(),
+                        ),
+                        "zone_type".into(),
+                    )],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::ident("v")],
+                            116,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+        ],
+    };
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+// YIELD tests
+#[test]
+fn simple_yield() {
+    let gql_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+         YIELD v.color AS vehicleColor, z.type AS location
+         RETURN vehicleColor, location";
+    let cypher_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+        WITH v.color AS vehicleColor, z.type AS location
+        RETURN vehicleColor, location";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+    let cypher_ast = parse(cypher_query, &TestCypherConfig {}).unwrap();
+
+    assert_eq!(gql_ast, cypher_ast, "GQL and Cypher ASTs should be equal");
+}
+
+#[test]
+fn simple_yield_on_property() {
+    let gql_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+         YIELD v.color
+         RETURN v.color";
+    let cypher_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+        WITH v.color
+        RETURN v.color";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+    let cypher_ast = parse(cypher_query, &TestCypherConfig {}).unwrap();
+
+    assert_eq!(gql_ast, cypher_ast, "GQL and Cypher ASTs should be equal");
+}
+
+#[test]
+fn yield_single_identifier() {
+    let gql_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+         YIELD v
+         RETURN v.color";
+    let cypher_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+        WITH v
+        RETURN v.color";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+    let cypher_ast = parse(cypher_query, &TestCypherConfig {}).unwrap();
+
+    assert_eq!(gql_ast, cypher_ast, "GQL and Cypher ASTs should be equal");
+}
+
+#[test]
+fn yield_with_let_and_chained_yield() {
+    let gql_query = "MATCH (p:Product)
+         LET productName = p.name, cost = p.price
+         YIELD productName, cost
+         LET total = cost * 1.2
+         YIELD total AS finalPrice
+         RETURN finalPrice";
+    let cypher_query = "MATCH (p:Product)
+        WITH p, p.name AS productName, p.price AS cost
+        WITH productName, cost
+        WITH productName, cost, cost * 1.2 AS total
+        WITH total AS finalPrice
+        RETURN finalPrice";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+    let cypher_ast = parse(cypher_query, &TestCypherConfig {}).unwrap();
+
+    assert_eq!(gql_ast, cypher_ast, "GQL and Cypher ASTs should be equal");
+}
+
+#[test]
+fn yield_with_where() {
+    let gql_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+         WHERE v.color = 'Red'
+         YIELD v.color AS vehicleColor, z.type AS location
+         RETURN vehicleColor, location";
+    let cypher_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+        WHERE v.color = 'Red'
+        WITH v.color AS vehicleColor, z.type AS location
+        RETURN vehicleColor, location";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+    let cypher_ast = parse(cypher_query, &TestCypherConfig {}).unwrap();
+
+    assert_eq!(gql_ast, cypher_ast, "GQL and Cypher ASTs should be equal");
+}
+
+#[test]
+fn yield_with_group_by() {
+    // MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+    // WITH z.type AS zone_type, v.color AS vehicle_color
+    // RETURN zone_type, vehicle_color, count(1) AS vehicle_count
+    let gql_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+         YIELD z.type AS zone_type, v.color AS vehicle_color
+         RETURN zone_type, vehicle_color, count(1) AS vehicle_count
+         GROUP BY zone_type, vehicle_color";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch {
+                            direction: Direction::Right,
+                            annotation: Annotation {
+                                name: Some("e".into()),
+                            },
+                            variable_length: None,
+                            labels: vec!["LOCATED_IN".into()],
+                            property_predicates: vec![],
+                        },
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("z"),
+                            "type".into(),
+                        ),
+                        "zone_type".into(),
+                    ),
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "vehicle_color".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![
+                        UnaryExpression::ident("zone_type"),
+                        UnaryExpression::ident("vehicle_color"),
+                    ],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::literal(Literal::Integer(1))],
+                            146,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+#[test]
+fn yield_with_group_by_fewer_columns_projected() {
+    // MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+    // WITH z.type AS zone_type, v.color AS vehicle_color
+    // WITH zone_type, vehicle_color, count(1) AS vehicle_count
+    // RETURN zone_type, vehicle_count
+
+    let gql_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+         YIELD z.type AS zone_type, v.color AS vehicle_color
+         RETURN zone_type, count(1) AS vehicle_count
+         GROUP BY zone_type, vehicle_color";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch {
+                            direction: Direction::Right,
+                            annotation: Annotation {
+                                name: Some("e".into()),
+                            },
+                            variable_length: None,
+                            labels: vec!["LOCATED_IN".into()],
+                            property_predicates: vec![],
+                        },
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("z"),
+                            "type".into(),
+                        ),
+                        "zone_type".into(),
+                    ),
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "vehicle_color".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![
+                        UnaryExpression::ident("zone_type"),
+                        UnaryExpression::ident("vehicle_color"),
+                    ],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::literal(Literal::Integer(1))],
+                            131,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("zone_type"),
+                    UnaryExpression::ident("vehicle_count"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure"
+    );
+}
+
+#[test]
+fn yield_let_and_group_by_together() {
+    // Equivalent Cypher:
+    // MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+    // WHERE v.color = 'Red'
+    // WITH v, z, v.color = 'Red' AS isRed
+    // WITH v, z, isRed, v.price > 50000 AS isExpensive
+    // WITH z.type AS zone_type, v.color AS vehicle_color, isRed, isExpensive
+    // WITH zone_type, isRed, isExpensive, count(1) AS vehicle_count
+    // RETURN zone_type, isRed, vehicle_count
+    let gql_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+         WHERE v.color = 'Red'
+         LET isRed = v.color = 'Red'
+         LET isExpensive = v.price > 50000
+         YIELD z.type AS zone_type, v.color AS vehicle_color, isRed, isExpensive
+         RETURN zone_type, isRed, count(1) AS vehicle_count
+         GROUP BY zone_type, isRed, isExpensive";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch {
+                            direction: Direction::Right,
+                            annotation: Annotation {
+                                name: Some("e".into()),
+                            },
+                            variable_length: None,
+                            labels: vec!["LOCATED_IN".into()],
+                            property_predicates: vec![],
+                        },
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![BinaryExpression::eq(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Text("Red".into())),
+                )],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "color".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Text("Red".into())),
+                        ),
+                        "isRed".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::ident("isRed"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "price".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Integer(50000)),
+                        ),
+                        "isExpensive".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("z"),
+                            "type".into(),
+                        ),
+                        "zone_type".into(),
+                    ),
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "vehicle_color".into(),
+                    ),
+                    UnaryExpression::ident("isRed"),
+                    UnaryExpression::ident("isExpensive"),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![
+                        UnaryExpression::ident("zone_type"),
+                        UnaryExpression::ident("isRed"),
+                        UnaryExpression::ident("isExpensive"),
+                    ],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::literal(Literal::Integer(1))],
+                            269,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("zone_type"),
+                    UnaryExpression::ident("isRed"),
+                    UnaryExpression::ident("vehicle_count"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure with YIELD, LET, and GROUP BY combined"
+    );
+}
+
+#[test]
+fn yield_then_let() {
+    // Equivalent Cypher:
+    // MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+    // WITH v.color AS vehicleColor, z.type AS location
+    // WITH vehicleColor, location, vehicleColor = 'Red' AS isRed
+    // RETURN vehicleColor, location, isRed
+    let gql_query = "MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
+         YIELD v.color AS vehicleColor, z.type AS location
+         LET isRed = vehicleColor = 'Red'
+         RETURN vehicleColor, location, isRed";
+
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch {
+                            direction: Direction::Right,
+                            annotation: Annotation {
+                                name: Some("e".into()),
+                            },
+                            variable_length: None,
+                            labels: vec!["LOCATED_IN".into()],
+                            property_predicates: vec![],
+                        },
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "vehicleColor".into(),
+                    ),
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("z"),
+                            "type".into(),
+                        ),
+                        "location".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("vehicleColor"),
+                    UnaryExpression::ident("location"),
+                    UnaryExpression::alias(
+                        BinaryExpression::eq(
+                            UnaryExpression::ident("vehicleColor"),
+                            UnaryExpression::literal(Literal::Text("Red".into())),
+                        ),
+                        "isRed".into(),
+                    ),
+                ]),
+            },
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("vehicleColor"),
+                    UnaryExpression::ident("location"),
+                    UnaryExpression::ident("isRed"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for YIELD then LET"
+    );
+}
+
+// FILTER Tests
+#[test]
+fn simple_filter() {
+    // MATCH (v:Vehicle)
+    // FILTER v.miles > 60000
+    // RETURN v.color, v.miles
+    let query = "MATCH (v:Vehicle)
+         FILTER v.miles > 60000
+         RETURN v.color, v.miles";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Second query part: Filter by miles
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Integer(60000)),
+                )],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Third query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into(),
+                    ),
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for simple FILTER"
+    );
+}
+
+#[test]
+fn multiple_filters() {
+    // MATCH (v:Vehicle)
+    // FILTER v.color = 'Red'
+    // FILTER v.miles > 60000
+    // RETURN v.color, v.miles
+    let query = "MATCH (v:Vehicle)
+         FILTER v.color = 'Red'
+         FILTER v.miles > 60000
+         RETURN v.color, v.miles";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Second query part: Filter by color
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::eq(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Text("Red".into())),
+                )],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Third query part: Filter by miles
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Integer(60000)),
+                )],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Fourth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into(),
+                    ),
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for multiple FILTERs"
+    );
+}
+
+#[test]
+fn filter_with_let() {
+    // MATCH (v:Vehicle)
+    // LET isHighMileage = v.miles >= 60000
+    // FILTER isHighMileage
+    // RETURN v.color
+    let query = "MATCH (v:Vehicle)
+         LET isHighMileage = v.miles >= 60000
+         FILTER isHighMileage
+         RETURN v.color";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles and define LET variable
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::alias(
+                        BinaryExpression::ge(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "miles".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Integer(60000)),
+                        ),
+                        "isHighMileage".into(),
+                    ),
+                ]),
+            },
+            // Second query part: Filter by LET variable
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![UnaryExpression::ident("isHighMileage")],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("isHighMileage"),
+                ]),
+            },
+            // Third query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::expression_property(
+                    UnaryExpression::ident("v"),
+                    "color".into(),
+                )]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for FILTER with LET"
+    );
+}
+
+#[test]
+fn filter_let_return_vehicle() {
+    let query = "MATCH (v:Vehicle)
+         FILTER v.miles > 60000
+         LET highMileage = v.miles > 60000
+         RETURN v.color, highMileage";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Second query part: Filter by miles
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Integer(60000)),
+                )],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Third query part: Define LET variable
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "miles".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Integer(60000)),
+                        ),
+                        "highMileage".into(),
+                    ),
+                ]),
+            },
+            // Fourth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into(),
+                    ),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for FILTER, LET, and RETURN"
+    );
+}
+
+#[test]
+fn filter_yield_return_color() {
+    let query = "MATCH (v:Vehicle)
+         FILTER v.miles > 60000
+         YIELD v.color AS color
+         RETURN color";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Second query part: Filter by miles
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Integer(60000)),
+                )],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Third query part: Yield v.color as color
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::alias(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into(),
+                    ),
+                    "color".into(),
+                )]),
+            },
+            // Fourth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("color")]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for FILTER, YIELD, and RETURN"
+    );
+}
+
+#[test]
+fn yield_filter_return_color() {
+    let query = "MATCH (v:Vehicle)
+         YIELD v.color AS color, v.miles AS miles
+         FILTER miles > 60000
+         RETURN color";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles and yield color/miles
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "color".into(),
+                    ),
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "miles".into(),
+                        ),
+                        "miles".into(),
+                    ),
+                ]),
+            },
+            // Second query part: Filter miles > 60000
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::ident("miles"),
+                    UnaryExpression::literal(Literal::Integer(60000)),
+                )],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("miles"),
+                ]),
+            },
+            // Third query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("color")]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for YIELD, FILTER, and RETURN"
+    );
+}
+
+#[test]
+fn filter_let_yield_return_color_highmileage() {
+    let query = "MATCH (v:Vehicle)
+         FILTER v.miles > 60000
+         LET highMileage = v.miles > 60000
+         YIELD v.color AS color, highMileage
+         RETURN color, highMileage";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Second query part: Filter by miles
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Integer(60000)),
+                )],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Third query part: Define LET variable
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "miles".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Integer(60000)),
+                        ),
+                        "highMileage".into(),
+                    ),
+                ]),
+            },
+            // Fourth query part: Yield v.color as color, highMileage
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "color".into(),
+                    ),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+            // Fifth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for FILTER, LET, YIELD, and RETURN"
+    );
+}
+
+#[test]
+fn filter_yield_let_return_color_highmileage() {
+    let query = "MATCH (v:Vehicle)
+         FILTER v.miles > 60000
+         YIELD v.color AS color, v.miles AS miles
+         LET highMileage = miles > 60000
+         RETURN color, highMileage";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Second query part: Filter by miles
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Integer(60000)),
+                )],
+                return_clause: ProjectionClause::Item(vec![UnaryExpression::ident("v")]),
+            },
+            // Third query part: Yield v.color as color, v.miles as miles
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "color".into(),
+                    ),
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "miles".into(),
+                        ),
+                        "miles".into(),
+                    ),
+                ]),
+            },
+            // Fourth query part: Define LET variable
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("miles"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::ident("miles"),
+                            UnaryExpression::literal(Literal::Integer(60000)),
+                        ),
+                        "highMileage".into(),
+                    ),
+                ]),
+            },
+            // Fifth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for FILTER, YIELD, LET, and RETURN"
+    );
+}
+
+#[test]
+fn let_filter_yield_return_color_highmileage() {
+    let query = "MATCH (v:Vehicle)
+         LET highMileage = v.miles > 60000
+         FILTER highMileage
+         YIELD v.color AS color, highMileage
+         RETURN color, highMileage";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles and define LET variable
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "miles".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Integer(60000)),
+                        ),
+                        "highMileage".into(),
+                    ),
+                ]),
+            },
+            // Second query part: Filter by highMileage
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![UnaryExpression::ident("highMileage")],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+            // Third query part: Yield v.color as color, highMileage
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "color".into(),
+                    ),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+            // Fourth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for LET, FILTER, YIELD, and RETURN"
+    );
+}
+
+#[test]
+fn let_yield_filter_return_color_highmileage() {
+    let query = "MATCH (v:Vehicle)
+         LET highMileage = v.miles > 60000
+         YIELD v.color AS color, highMileage
+         FILTER highMileage
+         RETURN color, highMileage";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles and define LET variable
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "miles".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Integer(60000)),
+                        ),
+                        "highMileage".into(),
+                    ),
+                ]),
+            },
+            // Second query part: Yield v.color as color, highMileage
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "color".into(),
+                    ),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+            // Third query part: Filter by highMileage
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![UnaryExpression::ident("highMileage")],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+            // Fourth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for LET, YIELD, FILTER, and RETURN"
+    );
+}
+
+#[test]
+fn yield_filter_let_return_color_highmileage() {
+    let query = "MATCH (v:Vehicle)
+         YIELD v.color AS color, v.miles AS miles
+         FILTER miles > 60000
+         LET highMileage = miles > 60000
+         RETURN color, highMileage";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles and yield color/miles
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "color".into(),
+                    ),
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "miles".into(),
+                        ),
+                        "miles".into(),
+                    ),
+                ]),
+            },
+            // Second query part: Filter miles > 60000
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::ident("miles"),
+                    UnaryExpression::literal(Literal::Integer(60000)),
+                )],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("miles"),
+                ]),
+            },
+            // Fourth query part: Define LET variable
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("miles"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::ident("miles"),
+                            UnaryExpression::literal(Literal::Integer(60000)),
+                        ),
+                        "highMileage".into(),
+                    ),
+                ]),
+            },
+            // Fifth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for YIELD, FILTER, LET, and RETURN"
+    );
+}
+
+#[test]
+fn yield_let_filter_return_color_highmileage() {
+    let query = "MATCH (v:Vehicle)
+         YIELD v.color AS color, v.miles AS miles
+         LET highMileage = miles > 60000
+         FILTER highMileage
+         RETURN color, highMileage";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles and yield color/miles
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "color".into(),
+                    ),
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "miles".into(),
+                        ),
+                        "miles".into(),
+                    ),
+                ]),
+            },
+            // Second query part: Define LET variable
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("miles"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::ident("miles"),
+                            UnaryExpression::literal(Literal::Integer(60000)),
+                        ),
+                        "highMileage".into(),
+                    ),
+                ]),
+            },
+            // Third query part: Filter by highMileage
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![UnaryExpression::ident("highMileage")],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("miles"),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+            // Fifth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("highMileage"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for YIELD, LET, FILTER, and RETURN"
+    );
+}
+
+#[test]
+fn where_and_filter_together() {
+    // Test combining WHERE and FILTER clauses
+    // WHERE filters during the MATCH phase, FILTER filters after projection
+    let query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         WHERE v.color = 'Red'
+         FILTER v.miles > 60000
+         RETURN v.color, v.miles, z.type";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles with WHERE clause
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch::right(
+                            Annotation::empty(),
+                            vec!["LOCATED_IN".into()],
+                            vec![],
+                            None,
+                        ),
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![BinaryExpression::eq(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Text("Red".into())),
+                )],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                ]),
+            },
+            // Second query part: FILTER by miles
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::literal(Literal::Integer(60000)),
+                )],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                ]),
+            },
+            // Third query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "color".into(),
+                    ),
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("z"),
+                        "type".into(),
+                    ),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for WHERE and FILTER together"
+    );
+}
+
+#[test]
+fn let_filter_group_by_together() {
+    // Test combining LET, FILTER, and GROUP BY clauses
+    // This tests the interaction between variable definition, filtering, and aggregation
+    let query = "MATCH (v:Vehicle)-[:LOCATED_IN]->(z:Zone)
+         LET isHighMileage = v.miles > 60000
+         LET isExpensive = v.price > 50000
+         FILTER isHighMileage
+         RETURN z.type AS zone_type, isExpensive, count(v) AS vehicle_count
+         GROUP BY zone_type, isExpensive";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles and define LET variables
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![(
+                        RelationMatch::right(
+                            Annotation::empty(),
+                            vec!["LOCATED_IN".into()],
+                            vec![],
+                            None,
+                        ),
+                        NodeMatch {
+                            annotation: Annotation {
+                                name: Some("z".into()),
+                            },
+                            labels: vec!["Zone".into()],
+                            property_predicates: vec![],
+                        },
+                    )],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "miles".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Integer(60000)),
+                        ),
+                        "isHighMileage".into(),
+                    ),
+                ]),
+            },
+            // Second query part: Define second LET variable
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::ident("isHighMileage"),
+                    UnaryExpression::alias(
+                        BinaryExpression::gt(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("v"),
+                                "price".into(),
+                            ),
+                            UnaryExpression::literal(Literal::Integer(50000)),
+                        ),
+                        "isExpensive".into(),
+                    ),
+                ]),
+            },
+            // Third query part: Filter by isHighMileage
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![UnaryExpression::ident("isHighMileage")],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("z"),
+                    UnaryExpression::ident("isHighMileage"),
+                    UnaryExpression::ident("isExpensive"),
+                ]),
+            },
+            // Fourth query part: Group by zone_type and isExpensive
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::GroupBy {
+                    grouping: vec![
+                        UnaryExpression::alias(
+                            UnaryExpression::expression_property(
+                                UnaryExpression::ident("z"),
+                                "type".into(),
+                            ),
+                            "zone_type".into(),
+                        ),
+                        UnaryExpression::ident("isExpensive"),
+                    ],
+                    aggregates: vec![UnaryExpression::alias(
+                        FunctionExpression::function(
+                            "count".into(),
+                            vec![UnaryExpression::ident("v")],
+                            210,
+                        ),
+                        "vehicle_count".into(),
+                    )],
+                },
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for LET, FILTER, and GROUP BY together"
+    );
+}
+
+#[test]
+fn let_filter_yield_with_param() {
+    // Test LET, FILTER, YIELD, and $param usage
+    let query = "MATCH (v:Vehicle)
+         LET threshold = $param
+         FILTER v.miles > threshold
+         YIELD v.color AS color, v.miles AS miles, threshold
+         RETURN color, miles, threshold";
+
+    let gql_ast = gql::query(query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![
+            // First query part: Match vehicles and define LET variable
+            QueryPart {
+                match_clauses: vec![MatchClause {
+                    start: NodeMatch {
+                        annotation: Annotation {
+                            name: Some("v".into()),
+                        },
+                        labels: vec!["Vehicle".into()],
+                        property_predicates: vec![],
+                    },
+                    path: vec![],
+                    optional: false,
+                }],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::alias(
+                        UnaryExpression::parameter("param".into()),
+                        "threshold".into(),
+                    ),
+                ]),
+            },
+            // Second query part: Filter by v.miles > threshold
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![BinaryExpression::gt(
+                    UnaryExpression::expression_property(
+                        UnaryExpression::ident("v"),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::ident("threshold"),
+                )],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("v"),
+                    UnaryExpression::ident("threshold"),
+                ]),
+            },
+            // Third query part: Yield v.color as color, v.miles as miles, threshold
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "color".into(),
+                        ),
+                        "color".into(),
+                    ),
+                    UnaryExpression::alias(
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("v"),
+                            "miles".into(),
+                        ),
+                        "miles".into(),
+                    ),
+                    UnaryExpression::ident("threshold"),
+                ]),
+            },
+            // Fourth query part: Final projection
+            QueryPart {
+                match_clauses: vec![],
+                where_clauses: vec![],
+                return_clause: ProjectionClause::Item(vec![
+                    UnaryExpression::ident("color"),
+                    UnaryExpression::ident("miles"),
+                    UnaryExpression::ident("threshold"),
+                ]),
+            },
+        ],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for LET, FILTER, YIELD, and $param"
     );
 }


### PR DESCRIPTION
# GQL FILTER, LET, and YIELD Implementation

## Overview
This pull request introduces support for `FILTER`, `LET`, and `YIELD` from Graph Query Language (GQL), enabling variable creation, scoped column selection/aliasing, and table filtering.

## LET Statement
The `LET` statement allows users to define new variables or computed fields for every row in the current working table. Each `LET` expression can reference all existing columns in scope, and the resulting variables are added as new columns. Aggregates are not allowed in `LET`.

**Implementation Details:** 
If `LET` directly follows a `MATCH` (optionally with `WHERE`), a single query part is formed that includes the match and where conditions, and the entire scope is projected along with the new variable. Otherwise, a `LET` is a single query part with an empty `MATCH` and `WHERE` that projects the new variables and current scope.

**Example:**
```cypher
MATCH (v:Vehicle)
LET isRed = v.color = 'Red'
RETURN v.color, isRed
```
_Equivalent Cypher:_
```cypher
MATCH (v:Vehicle)
WITH v, v.color = 'Red' AS isRed
RETURN v.color, isRed
```
## YIELD Clause
The `YIELD` clause projects and optionally renames columns from the working table, limiting the set of columns available to subsequent clauses. Only specified columns remain in scope after `YIELD`.

**Implementation Details:** 
If `YIELD` directly follows a `MATCH` (optionally with a `WHERE` clause), a single query part is formed that includes the match and where conditions, and the projection contains only the columns defined in `YIELD`. Otherwise, YIELD forms a separate query part with an empty MATCH and WHERE, projecting only the expressions defined in YIELD.

**Example:**
```cypher
MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
YIELD v.color AS vehicleColor, z.type AS location
RETURN vehicleColor, location
```
_Equivalent Cypher:_
```cypher
MATCH (v:Vehicle)-[e:LOCATED_IN]->(z:Zone)
WITH v.color AS vehicleColor, z.type AS location
RETURN vehicleColor, location
```

## FILTER Statement
`FILTER` is a standalone statement that filters the current working table after previous steps. It does not create a new table, and it updates the working table.

**Implementation Details:** 
If `FILTER` directly follows a `MATCH` (optionally with a `WHERE` clause), a single query part is formed that includes the match and where conditions and projects the current scope. Then, a separate query part is created where the `FILTER` condition is applied as a `WHERE` clause in the query part, and the current scope is projected. Regardless of its position, `FILTER` always produces a separate query part. 

`FILTER` is implemented by introducing a new query part where the filter expression is placed in the `WHERE` clause of the query part.

**Example:**
```cypher
MATCH (n:Person)
FILTER n.age > 30
RETURN n.name, n.age
```