### PR TITLE
Add GQL CAST Function Support

### DIFF
--- a/core/src/evaluation/functions/mod.rs
+++ b/core/src/evaluation/functions/mod.rs
@@ -18,10 +18,10 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use async_trait::async_trait;
+pub use async_trait::async_trait;
 
 pub use drasi_query_ast::api::QueryConfiguration;
-use drasi_query_ast::ast;
+pub use drasi_query_ast::ast;
 
 use super::{ExpressionEvaluationContext, FunctionError};
 use crate::evaluation::variable_value::VariableValue;

--- a/core/src/evaluation/mod.rs
+++ b/core/src/evaluation/mod.rs
@@ -54,8 +54,8 @@ pub enum EvaluationError {
 
 #[derive(Debug)]
 pub struct FunctionError {
-    function_name: String,
-    error: FunctionEvaluationError,
+    pub function_name: String,
+    pub error: FunctionEvaluationError,
 }
 
 impl PartialEq for FunctionError {

--- a/functions-gql/Cargo.toml
+++ b/functions-gql/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 drasi-core = { path = "../core" }
+
+[dev-dependencies]
+tokio = { version = "1.29.1", features = ["full"] }

--- a/functions-gql/src/gql_scalar/cast.rs
+++ b/functions-gql/src/gql_scalar/cast.rs
@@ -1,0 +1,83 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use drasi_core::evaluation::functions::ast;
+use drasi_core::evaluation::functions::async_trait;
+use drasi_core::evaluation::functions::{ScalarFunction, ToBoolean, ToFloat, ToInteger, ToString};
+use drasi_core::evaluation::variable_value::VariableValue;
+use drasi_core::evaluation::{ExpressionEvaluationContext, FunctionError, FunctionEvaluationError};
+
+#[derive(Debug)]
+pub struct Cast {}
+
+#[async_trait]
+impl ScalarFunction for Cast {
+    async fn call(
+        &self,
+        context: &ExpressionEvaluationContext,
+        expression: &ast::FunctionExpression,
+        args: Vec<VariableValue>,
+    ) -> Result<VariableValue, FunctionError> {
+        if args.len() != 2 {
+            return Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgumentCount,
+            });
+        }
+
+        let value = &args[0];
+        let target_type = match &args[1] {
+            VariableValue::String(s) => s.to_uppercase(),
+            _ => {
+                return Err(FunctionError {
+                    function_name: expression.name.to_string(),
+                    error: FunctionEvaluationError::InvalidArgument(1),
+                })
+            }
+        };
+
+        match target_type.as_str() {
+            "STRING" => {
+                let to_string = ToString {};
+                to_string
+                    .call(context, expression, vec![value.clone()])
+                    .await
+            }
+            "INTEGER" | "INT" => {
+                let to_integer = ToInteger {};
+                to_integer
+                    .call(context, expression, vec![value.clone()])
+                    .await
+            }
+            "FLOAT" => {
+                let to_float = ToFloat {};
+                to_float
+                    .call(context, expression, vec![value.clone()])
+                    .await
+            }
+            "BOOLEAN" | "BOOL" => {
+                let to_boolean = ToBoolean {};
+                to_boolean
+                    .call(context, expression, vec![value.clone()])
+                    .await
+            }
+            _ => Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidType {
+                    expected: "STRING, INTEGER/INT, FLOAT, or BOOLEAN/BOOL".to_string(),
+                },
+            }),
+        }
+    }
+}

--- a/functions-gql/src/gql_scalar/cast_tests.rs
+++ b/functions-gql/src/gql_scalar/cast_tests.rs
@@ -1,0 +1,234 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use drasi_core::evaluation::context::QueryVariables;
+use drasi_core::evaluation::functions::ScalarFunction;
+use drasi_core::evaluation::variable_value::VariableValue;
+use drasi_core::evaluation::{
+    ExpressionEvaluationContext, FunctionError, FunctionEvaluationError, InstantQueryClock,
+};
+
+use crate::gql_scalar::Cast;
+
+fn get_func_expr() -> drasi_core::evaluation::functions::ast::FunctionExpression {
+    drasi_core::evaluation::functions::ast::FunctionExpression {
+        name: Arc::from("cast"),
+        args: vec![],
+        position_in_query: 10,
+    }
+}
+
+#[tokio::test]
+async fn test_cast_to_string() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Integer(123.into()),
+        VariableValue::String("STRING".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert_eq!(result.unwrap(), VariableValue::String("123".to_string()));
+}
+
+#[tokio::test]
+async fn test_cast_to_integer() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::String("456".to_string()),
+        VariableValue::String("INTEGER".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert_eq!(result.unwrap(), VariableValue::Integer(456.into()));
+}
+
+#[tokio::test]
+async fn test_cast_to_int() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::String("789".to_string()),
+        VariableValue::String("INT".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert_eq!(result.unwrap(), VariableValue::Integer(789.into()));
+}
+
+#[tokio::test]
+async fn test_cast_to_float() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::String("3.14".to_string()),
+        VariableValue::String("FLOAT".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert_eq!(result.unwrap(), VariableValue::Float(3.14.into()));
+}
+
+#[tokio::test]
+async fn test_cast_to_boolean() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::String("true".to_string()),
+        VariableValue::String("BOOLEAN".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert_eq!(result.unwrap(), VariableValue::Bool(true));
+}
+
+#[tokio::test]
+async fn test_cast_to_bool() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::String("false".to_string()),
+        VariableValue::String("BOOL".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert_eq!(result.unwrap(), VariableValue::Bool(false));
+}
+
+#[tokio::test]
+async fn test_cast_case_insensitive() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Integer(42.into()),
+        VariableValue::String("string".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert_eq!(result.unwrap(), VariableValue::String("42".to_string()));
+}
+
+#[tokio::test]
+async fn test_cast_invalid_type() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Integer(123.into()),
+        VariableValue::String("INVALID".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidType { .. }
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_cast_too_many_args() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Integer(123.into()),
+        VariableValue::String("STRING".to_string()),
+        VariableValue::String("EXTRA".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_cast_too_few_args() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Integer(123.into())];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_cast_invalid_target_type_arg() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Integer(123.into()),
+        VariableValue::Integer(456.into()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgument(1)
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_cast_null_value() {
+    let cast = Cast {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Null,
+        VariableValue::String("STRING".to_string()),
+    ];
+    let result = cast.call(&context, &get_func_expr(), args).await;
+    assert_eq!(result.unwrap(), VariableValue::Null);
+}

--- a/functions-gql/src/gql_scalar/cast_tests.rs
+++ b/functions-gql/src/gql_scalar/cast_tests.rs
@@ -84,11 +84,11 @@ async fn test_cast_to_float() {
         ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
 
     let args = vec![
-        VariableValue::String("3.14".to_string()),
+        VariableValue::String("2.5".to_string()),
         VariableValue::String("FLOAT".to_string()),
     ];
     let result = cast.call(&context, &get_func_expr(), args).await;
-    assert_eq!(result.unwrap(), VariableValue::Float(3.14.into()));
+    assert_eq!(result.unwrap(), VariableValue::Float(2.5.into()));
 }
 
 #[tokio::test]

--- a/functions-gql/src/gql_scalar/mod.rs
+++ b/functions-gql/src/gql_scalar/mod.rs
@@ -1,0 +1,20 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod cast;
+
+pub use cast::Cast;
+
+#[cfg(test)]
+mod cast_tests;

--- a/functions-gql/src/lib.rs
+++ b/functions-gql/src/lib.rs
@@ -20,6 +20,9 @@ use drasi_core::evaluation::functions::FunctionRegistry;
 #[cfg(test)]
 mod tests;
 
+mod gql_scalar;
+use gql_scalar::Cast;
+
 pub trait GQLFunctionSet {
     fn with_gql_function_set(self) -> Arc<FunctionRegistry>;
 }
@@ -70,6 +73,7 @@ fn register_gql_scalar_functions(registry: &FunctionRegistry) {
     registry.register_function("size", Function::Scalar(Arc::new(Size {})));
     registry.register_function("coalesce", Function::Scalar(Arc::new(Coalesce {})));
     registry.register_function("last", Function::Scalar(Arc::new(CypherLast {})));
+    registry.register_function("cast", Function::Scalar(Arc::new(Cast {})));
 }
 
 fn register_list_functions(registry: &FunctionRegistry) {

--- a/query-gql/src/lib.rs
+++ b/query-gql/src/lib.rs
@@ -264,6 +264,10 @@ peg::parser! {
                 e:(@) __+ kw_is() _+ kw_not() _+ kw_null() { UnaryExpression::is_not_null(e) }
                 kw_case() __* mtch:expression()? __* when:when_expression()+ __* else_:else_expression()? __* kw_end() { CaseExpression::case(mtch, when, else_) }
                 kw_case() __* when:when_expression()+ __* else_:else_expression()? __* kw_end() { CaseExpression::case(None, when, else_) }
+                pos: position!() ("CAST" / "cast") _* "(" __* value:expression() __+ kw_as() __+ target_type:ident() __* ")" {
+                    let params = vec![value, UnaryExpression::literal(Literal::Text(target_type))];
+                    FunctionExpression::function(Arc::from("cast"), params, pos )
+                }
                 pos: position!() func:function_name() _* "(" __* params:(expression() ** (__* "," __*))? __* ")" "." key:ident() {
                     let params = params.unwrap_or_else(Vec::new);
                     UnaryExpression::expression_property(FunctionExpression::function(func, params, pos ), key)

--- a/query-gql/src/tests.rs
+++ b/query-gql/src/tests.rs
@@ -4065,3 +4065,46 @@ fn match_with_where_inside_match() {
         "GQL AST should match expected structure for MATCH with inline WHEREs"
     );
 }
+
+// CAST function test
+#[test]
+fn test_cast_function_parsing() {
+    let gql_query = "MATCH (p:Person) RETURN CAST(p.age AS STRING) AS age_str";
+    let gql_ast = gql::query(gql_query, &TEST_CONFIG).unwrap();
+
+    let expected_ast = Query {
+        parts: vec![QueryPart {
+            match_clauses: vec![MatchClause {
+                start: NodeMatch {
+                    annotation: Annotation {
+                        name: Some("p".into()),
+                    },
+                    labels: vec!["Person".into()],
+                    property_predicates: vec![],
+                },
+                path: vec![],
+                optional: false,
+            }],
+            where_clauses: vec![],
+            return_clause: ProjectionClause::Item(vec![UnaryExpression::alias(
+                FunctionExpression::function(
+                    Arc::from("cast"),
+                    vec![
+                        UnaryExpression::expression_property(
+                            UnaryExpression::ident("p"),
+                            "age".into(),
+                        ),
+                        UnaryExpression::literal(Literal::Text("STRING".into())),
+                    ],
+                    24,
+                ),
+                "age_str".into(),
+            )]),
+        }],
+    };
+
+    assert_eq!(
+        gql_ast, expected_ast,
+        "GQL AST should match expected structure for CAST function"
+    );
+}


### PR DESCRIPTION
## Summary

This PR implements the `CAST` function for GQL, enabling type conversion operations in GQL queries. The implementation follows the GQL standard for scalar type casting and integrates with Drasi's existing type conversion infrastructure.

## Changes

### Core Implementation
- Added `CAST` function in `functions-gql/src/gql_scalar/cast.rs`
- Supports casting to:
  - `BOOLEAN` - Converts values to boolean type
  - `INTEGER` - Converts values to integer type  
  - `FLOAT` - Converts values to floating-point type
  - `STRING` - Converts values to string type
- Leverages existing Drasi type conversion traits (`ToBoolean`, `ToInteger`, `ToFloat`, `ToString`)

### Testing
- Tests cover all supported type conversions and edge cases
- Validates proper error handling for invalid casts

### Integration
- Registered CAST function in the GQL function registry
- Updated module exports in `functions-gql/src/lib.rs` and `query-gql/src/lib.rs`

## Usage Example

```gql
CAST(42 AS STRING)
CAST(3.14 AS FLOAT)
CAST(1 AS BOOLEAN)
CAST(100 AS INTEGER)
```

## Technical Details

- The function accepts two arguments: the value to cast and the target type name
- Target type names are case-insensitive ("INTEGER", "integer", "Integer" all work)
- Returns appropriate errors for invalid argument counts or unsupported type names

## Limitations

- **Temporal type conversions are not supported**: The current implementation does not support casting to or from date, time, datetime, or duration types 
- Only basic scalar type conversions (BOOLEAN, INTEGER, FLOAT, STRING) are implemented in this PR
