### PR TITLE
Middleware validation tests

### DIFF
--- a/index-garnet/src/element_index.rs
+++ b/index-garnet/src/element_index.rs
@@ -533,7 +533,7 @@ impl ElementIndex for GarnetElementIndex {
 
         let mut pipeline = redis::pipe();
         pipeline.atomic();
-        println!("deleting element: {:?}", stored_element_ref);
+        log::debug!("deleting element: {:?}", stored_element_ref);
         self.delete_element_internal(&mut pipeline, &stored_element_ref)
             .await?;
 

--- a/shared-tests/src/in_memory/mod.rs
+++ b/shared-tests/src/in_memory/mod.rs
@@ -120,6 +120,18 @@ mod remap {
         let test_config = InMemoryQueryConfig::new();
         remap::remap(&test_config).await;
     }
+
+    #[tokio::test]
+    pub async fn remap_invalid_middleware_config() {
+        let test_config = InMemoryQueryConfig::new();
+        remap::remap_invalid_config_fails(&test_config).await;
+    }
+
+    #[tokio::test]
+    pub async fn remap_incorrect_middleware_structure() {
+        let test_config = InMemoryQueryConfig::new();
+        remap::remap_incorrect_structure_fails(&test_config).await;
+    }
 }
 
 mod overdue_invoice {
@@ -363,6 +375,18 @@ mod unwind {
     async fn unwind() {
         let test_config = InMemoryQueryConfig::new();
         unwind::unwind(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn unwind_invalid_middleware_config() {
+        let test_config = InMemoryQueryConfig::new();
+        unwind::unwind_invalid_config_fails(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn unwind_incorrect_middleware_structure() {
+        let test_config = InMemoryQueryConfig::new();
+        unwind::unwind_incorrect_structure_fails(&test_config).await;
     }
 }
 

--- a/shared-tests/src/use_cases/remap/mod.rs
+++ b/shared-tests/src/use_cases/remap/mod.rs
@@ -225,11 +225,22 @@ pub async fn remap_invalid_config_fails(config: &(impl QueryTestConfig + Send)) 
         builder.try_build().await
     };
 
-    assert!(result.is_err(), "expected invalid map middleware config to fail build");
+    assert!(
+        result.is_err(),
+        "expected invalid map middleware config to fail build"
+    );
     let err = result.err().unwrap();
     let err_str = err.to_string();
-    assert!(err_str.contains("Middleware setup error"), "unexpected error: {}", err_str);
-    assert!(err_str.contains("Invalid configuration"), "unexpected error: {}", err_str);
+    assert!(
+        err_str.contains("Middleware setup error"),
+        "unexpected error: {}",
+        err_str
+    );
+    assert!(
+        err_str.contains("Invalid configuration"),
+        "unexpected error: {}",
+        err_str
+    );
 }
 
 #[allow(clippy::unwrap_used)]
@@ -250,9 +261,20 @@ pub async fn remap_incorrect_structure_fails(config: &(impl QueryTestConfig + Se
         builder.try_build().await
     };
 
-    assert!(result.is_err(), "expected incorrect map middleware JSON structure to fail build");
+    assert!(
+        result.is_err(),
+        "expected incorrect map middleware JSON structure to fail build"
+    );
     let err = result.err().unwrap();
     let err_str = err.to_string();
-    assert!(err_str.contains("Middleware setup error"), "unexpected error: {}", err_str);
-    assert!(err_str.contains("Invalid configuration"), "unexpected error: {}", err_str);
+    assert!(
+        err_str.contains("Middleware setup error"),
+        "unexpected error: {}",
+        err_str
+    );
+    assert!(
+        err_str.contains("Invalid configuration"),
+        "unexpected error: {}",
+        err_str
+    );
 }

--- a/shared-tests/src/use_cases/remap/mod.rs
+++ b/shared-tests/src/use_cases/remap/mod.rs
@@ -244,6 +244,8 @@ pub async fn remap_invalid_config_fails(config: &(impl QueryTestConfig + Send)) 
         err_str
     );
 }
+
+#[allow(clippy::unwrap_used)]
 pub async fn remap_incorrect_structure_fails(config: &(impl QueryTestConfig + Send)) {
     // Register MapFactory and attempt to build with incorrect JSON structure
     let mut middleware_registry = MiddlewareTypeRegistry::new();

--- a/shared-tests/src/use_cases/remap/mod.rs
+++ b/shared-tests/src/use_cases/remap/mod.rs
@@ -215,7 +215,9 @@ pub async fn remap_invalid_config_fails(config: &(impl QueryTestConfig + Send)) 
     let middleware_registry = Arc::new(middleware_registry);
 
     let result = {
-        let mut builder = QueryBuilder::new(queries::remap_query());
+        let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+        let parser = Arc::new(CypherParser::new(function_registry.clone()));
+        let mut builder = QueryBuilder::new(queries::remap_query(), parser);
         builder = config.config_query(builder).await;
         builder = builder.with_middleware_registry(middleware_registry);
         for mw in queries::invalid_middlewares() {
@@ -242,8 +244,6 @@ pub async fn remap_invalid_config_fails(config: &(impl QueryTestConfig + Send)) 
         err_str
     );
 }
-
-#[allow(clippy::unwrap_used)]
 pub async fn remap_incorrect_structure_fails(config: &(impl QueryTestConfig + Send)) {
     // Register MapFactory and attempt to build with incorrect JSON structure
     let mut middleware_registry = MiddlewareTypeRegistry::new();
@@ -251,7 +251,9 @@ pub async fn remap_incorrect_structure_fails(config: &(impl QueryTestConfig + Se
     let middleware_registry = Arc::new(middleware_registry);
 
     let result = {
-        let mut builder = QueryBuilder::new(queries::remap_query());
+        let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+        let parser = Arc::new(CypherParser::new(function_registry.clone()));
+        let mut builder = QueryBuilder::new(queries::remap_query(), parser);
         builder = config.config_query(builder).await;
         builder = builder.with_middleware_registry(middleware_registry);
         for mw in queries::incorrect_structure_middlewares() {

--- a/shared-tests/src/use_cases/unwind/mod.rs
+++ b/shared-tests/src/use_cases/unwind/mod.rs
@@ -276,7 +276,9 @@ pub async fn unwind_invalid_config_fails(config: &(impl QueryTestConfig + Send))
     let middleware_registry = Arc::new(middleware_registry);
 
     let result = {
-        let mut builder = QueryBuilder::new(queries::unwind_query());
+        let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+        let parser = Arc::new(CypherParser::new(function_registry.clone()));
+        let mut builder = QueryBuilder::new(queries::unwind_query(), parser);
         builder = config.config_query(builder).await;
         builder = builder.with_middleware_registry(middleware_registry);
         for mw in queries::invalid_middlewares() {
@@ -314,7 +316,9 @@ pub async fn unwind_incorrect_structure_fails(config: &(impl QueryTestConfig + S
     let middleware_registry = Arc::new(middleware_registry);
 
     let result = {
-        let mut builder = QueryBuilder::new(queries::unwind_query());
+        let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+        let parser = Arc::new(CypherParser::new(function_registry.clone()));
+        let mut builder = QueryBuilder::new(queries::unwind_query(), parser);
         builder = config.config_query(builder).await;
         builder = builder.with_middleware_registry(middleware_registry);
         for mw in queries::incorrect_structure_middlewares() {

--- a/shared-tests/src/use_cases/unwind/mod.rs
+++ b/shared-tests/src/use_cases/unwind/mod.rs
@@ -267,3 +267,56 @@ pub async fn unwind(config: &(impl QueryTestConfig + Send)) {
         }));
     }
 }
+
+#[allow(clippy::unwrap_used)]
+pub async fn unwind_invalid_config_fails(config: &(impl QueryTestConfig + Send)) {
+    // Prepare registry with UnwindFactory and build a query using an invalid selector
+    let mut middleware_registry = MiddlewareTypeRegistry::new();
+    middleware_registry.register(Arc::new(UnwindFactory::new()));
+    let middleware_registry = Arc::new(middleware_registry);
+
+    let result = {
+        let mut builder = QueryBuilder::new(queries::unwind_query());
+        builder = config.config_query(builder).await;
+        builder = builder.with_middleware_registry(middleware_registry);
+        for mw in queries::invalid_middlewares() {
+            builder = builder.with_source_middleware(mw);
+        }
+        builder = builder.with_source_pipeline("test", &queries::source_pipeline());
+        builder.try_build().await
+    };
+
+    // Expect an error during build due to invalid middleware configuration
+    assert!(result.is_err(), "expected invalid middleware config to fail build");
+    let err = result.err().unwrap();
+    let err_str = err.to_string();
+    // Surface should indicate Middleware setup/Invalid configuration
+    assert!(err_str.contains("Middleware setup error"), "unexpected error: {}", err_str);
+    assert!(err_str.contains("Invalid configuration"), "unexpected error: {}", err_str);
+}
+
+#[allow(clippy::unwrap_used)]
+pub async fn unwind_incorrect_structure_fails(config: &(impl QueryTestConfig + Send)) {
+    // Prepare registry with UnwindFactory and build a query using incorrect JSON structure
+    let mut middleware_registry = MiddlewareTypeRegistry::new();
+    middleware_registry.register(Arc::new(UnwindFactory::new()));
+    let middleware_registry = Arc::new(middleware_registry);
+
+    let result = {
+        let mut builder = QueryBuilder::new(queries::unwind_query());
+        builder = config.config_query(builder).await;
+        builder = builder.with_middleware_registry(middleware_registry);
+        for mw in queries::incorrect_structure_middlewares() {
+            builder = builder.with_source_middleware(mw);
+        }
+        builder = builder.with_source_pipeline("test", &queries::source_pipeline());
+        builder.try_build().await
+    };
+
+    // Expect an error during build due to incorrect JSON structure
+    assert!(result.is_err(), "expected incorrect middleware JSON structure to fail build");
+    let err = result.err().unwrap();
+    let err_str = err.to_string();
+    assert!(err_str.contains("Middleware setup error"), "unexpected error: {}", err_str);
+    assert!(err_str.contains("Invalid configuration"), "unexpected error: {}", err_str);
+}

--- a/shared-tests/src/use_cases/unwind/mod.rs
+++ b/shared-tests/src/use_cases/unwind/mod.rs
@@ -287,12 +287,23 @@ pub async fn unwind_invalid_config_fails(config: &(impl QueryTestConfig + Send))
     };
 
     // Expect an error during build due to invalid middleware configuration
-    assert!(result.is_err(), "expected invalid middleware config to fail build");
+    assert!(
+        result.is_err(),
+        "expected invalid middleware config to fail build"
+    );
     let err = result.err().unwrap();
     let err_str = err.to_string();
     // Surface should indicate Middleware setup/Invalid configuration
-    assert!(err_str.contains("Middleware setup error"), "unexpected error: {}", err_str);
-    assert!(err_str.contains("Invalid configuration"), "unexpected error: {}", err_str);
+    assert!(
+        err_str.contains("Middleware setup error"),
+        "unexpected error: {}",
+        err_str
+    );
+    assert!(
+        err_str.contains("Invalid configuration"),
+        "unexpected error: {}",
+        err_str
+    );
 }
 
 #[allow(clippy::unwrap_used)]
@@ -314,9 +325,20 @@ pub async fn unwind_incorrect_structure_fails(config: &(impl QueryTestConfig + S
     };
 
     // Expect an error during build due to incorrect JSON structure
-    assert!(result.is_err(), "expected incorrect middleware JSON structure to fail build");
+    assert!(
+        result.is_err(),
+        "expected incorrect middleware JSON structure to fail build"
+    );
     let err = result.err().unwrap();
     let err_str = err.to_string();
-    assert!(err_str.contains("Middleware setup error"), "unexpected error: {}", err_str);
-    assert!(err_str.contains("Invalid configuration"), "unexpected error: {}", err_str);
+    assert!(
+        err_str.contains("Middleware setup error"),
+        "unexpected error: {}",
+        err_str
+    );
+    assert!(
+        err_str.contains("Invalid configuration"),
+        "unexpected error: {}",
+        err_str
+    );
 }


### PR DESCRIPTION
This pull request adds negative tests for middleware configuration validation in both the remap and unwind use cases. The new tests ensure that invalid middleware configurations and incorrect JSON structures are properly detected and result in expected errors during query building. Supporting helper functions generate these invalid configurations for testing purposes.

**Negative middleware configuration tests:**

* Added async tests in `shared-tests/src/in_memory/mod.rs` to verify that invalid middleware configs and incorrect JSON structures for both remap and unwind fail as expected. [[1]](diffhunk://#diff-ad71c9d2af7ad16067cf3b2a048d831860c2a831deeec63417217b8f043e3387R123-R134) [[2]](diffhunk://#diff-ad71c9d2af7ad16067cf3b2a048d831860c2a831deeec63417217b8f043e3387R379-R390)

**Remap use case enhancements:**

* Implemented `remap_invalid_config_fails` and `remap_incorrect_structure_fails` functions in `shared-tests/src/use_cases/remap/mod.rs` to check error handling for bad middleware configs.
* Added helper functions `invalid_middlewares` and `incorrect_structure_middlewares` in `shared-tests/src/use_cases/remap/queries.rs` to generate invalid configs for testing.

**Unwind use case enhancements:**

* Implemented `unwind_invalid_config_fails` and `unwind_incorrect_structure_fails` functions in `shared-tests/src/use_cases/unwind/mod.rs` to check error handling for bad middleware configs.
* Added helper functions `invalid_middlewares` and `incorrect_structure_middlewares` in `shared-tests/src/use_cases/unwind/queries.rs` to generate invalid configs for testing.