### PR TITLE
Relabel Middleware

### DIFF
--- a/core/src/evaluation/expressions/tests/cypher_scalar.rs
+++ b/core/src/evaluation/expressions/tests/cypher_scalar.rs
@@ -264,7 +264,7 @@ async fn evaluate_timestamp() {
 
     let result = match evaluator.evaluate_expression(&context, &expr).await {
         Ok(result) => result,
-        Err(e) => panic!("Error: {:?}", e),
+        Err(e) => panic!("Error: {e:?}"),
     };
 
     let time_since_epoch = std::time::SystemTime::now()

--- a/core/src/evaluation/functions/aggregation/max.rs
+++ b/core/src/evaluation/functions/aggregation/max.rs
@@ -95,19 +95,17 @@ impl AggregatingFunction for Max {
                         })
                     }
                 };
-                accumulator.insert(value * -1.0).await;
+                accumulator.insert(-value).await;
                 match accumulator.get_head().await {
-                    Ok(Some(head)) => {
-                        Ok(VariableValue::Float(match Float::from_f64(head * -1.0) {
-                            Some(f) => f,
-                            None => {
-                                return Err(FunctionError {
-                                    function_name: "Max".to_string(),
-                                    error: FunctionEvaluationError::CorruptData,
-                                })
-                            }
-                        }))
-                    }
+                    Ok(Some(head)) => Ok(VariableValue::Float(match Float::from_f64(-head) {
+                        Some(f) => f,
+                        None => {
+                            return Err(FunctionError {
+                                function_name: "Max".to_string(),
+                                error: FunctionEvaluationError::CorruptData,
+                            })
+                        }
+                    })),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
                         function_name: "Max".to_string(),
@@ -125,19 +123,17 @@ impl AggregatingFunction for Max {
                         })
                     }
                 };
-                accumulator.insert((value as f64) * -1.0).await;
+                accumulator.insert(-(value as f64)).await;
                 match accumulator.get_head().await {
-                    Ok(Some(head)) => {
-                        Ok(VariableValue::Float(match Float::from_f64(head * -1.0) {
-                            Some(f) => f,
-                            None => {
-                                return Err(FunctionError {
-                                    function_name: "Max".to_string(),
-                                    error: FunctionEvaluationError::CorruptData,
-                                })
-                            }
-                        }))
-                    }
+                    Ok(Some(head)) => Ok(VariableValue::Float(match Float::from_f64(-head) {
+                        Some(f) => f,
+                        None => {
+                            return Err(FunctionError {
+                                function_name: "Max".to_string(),
+                                error: FunctionEvaluationError::CorruptData,
+                            })
+                        }
+                    })),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
                         function_name: "Max".to_string(),
@@ -147,10 +143,10 @@ impl AggregatingFunction for Max {
             }
             VariableValue::ZonedDateTime(zdt) => {
                 let value = zdt.datetime().timestamp_millis() as f64;
-                accumulator.insert(value * -1.0).await;
+                accumulator.insert(-value).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::ZonedDateTime(
-                        ZonedDateTime::from_epoch_millis((head * -1.0) as i64),
+                        ZonedDateTime::from_epoch_millis(-head as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -161,10 +157,10 @@ impl AggregatingFunction for Max {
             }
             VariableValue::Duration(d) => {
                 let value = d.duration().num_milliseconds() as f64;
-                accumulator.insert(value * -1.0).await;
+                accumulator.insert(-value).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::Duration(Duration::new(
-                        ChronoDuration::milliseconds((head * -1.0) as i64),
+                        ChronoDuration::milliseconds(-head as i64),
                         0,
                         0,
                     ))),
@@ -179,10 +175,10 @@ impl AggregatingFunction for Max {
                 // For date (Chrono::NaiveDate), we can store the number of days since the epoch
                 let reference_date = *temporal_constants::EPOCH_NAIVE_DATE;
                 let days_since_epoch = d.signed_duration_since(reference_date).num_days() as f64;
-                accumulator.insert(days_since_epoch * -1.0).await;
+                accumulator.insert(-days_since_epoch).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::Date(
-                        reference_date + ChronoDuration::days((head * -1.0) as i64),
+                        reference_date + ChronoDuration::days(-head as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -195,11 +191,11 @@ impl AggregatingFunction for Max {
                 let reference_time = *temporal_constants::MIDNIGHT_NAIVE_TIME;
                 let duration_since_midnight =
                     t.signed_duration_since(reference_time).num_milliseconds() as f64;
-                accumulator.insert(duration_since_midnight * -1.0).await;
+                accumulator.insert(-duration_since_midnight).await;
 
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::LocalTime(
-                        reference_time + ChronoDuration::milliseconds((head * -1.0) as i64),
+                        reference_time + ChronoDuration::milliseconds(-head as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -210,7 +206,7 @@ impl AggregatingFunction for Max {
             }
             VariableValue::LocalDateTime(dt) => {
                 let duration_since_epoch = dt.and_utc().timestamp_millis() as f64;
-                accumulator.insert(duration_since_epoch * -1.0).await;
+                accumulator.insert(-duration_since_epoch).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::LocalDateTime(
                         DateTime::from_timestamp_millis(head as i64 * -1.0 as i64)
@@ -242,11 +238,10 @@ impl AggregatingFunction for Max {
                     }
                 };
                 let duration_since_epoch = epoch_datetime.timestamp_millis() as f64;
-                accumulator.insert(duration_since_epoch * -1.0).await;
+                accumulator.insert(-duration_since_epoch).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::ZonedTime(ZonedTime::new(
-                        (epoch_datetime + ChronoDuration::milliseconds((head * -1.0) as i64))
-                            .time(),
+                        (epoch_datetime + ChronoDuration::milliseconds(-head as i64)).time(),
                         *temporal_constants::UTC_FIXED_OFFSET,
                     ))),
                     Ok(None) => Ok(VariableValue::Null),
@@ -297,19 +292,17 @@ impl AggregatingFunction for Max {
                         })
                     }
                 };
-                accumulator.remove(value * -1.0).await;
+                accumulator.remove(-value).await;
                 match accumulator.get_head().await {
-                    Ok(Some(head)) => {
-                        Ok(VariableValue::Float(match Float::from_f64(head * -1.0) {
-                            Some(f) => f,
-                            None => {
-                                return Err(FunctionError {
-                                    function_name: "Max".to_string(),
-                                    error: FunctionEvaluationError::CorruptData,
-                                })
-                            }
-                        }))
-                    }
+                    Ok(Some(head)) => Ok(VariableValue::Float(match Float::from_f64(-head) {
+                        Some(f) => f,
+                        None => {
+                            return Err(FunctionError {
+                                function_name: "Max".to_string(),
+                                error: FunctionEvaluationError::CorruptData,
+                            })
+                        }
+                    })),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
                         function_name: "Max".to_string(),
@@ -327,19 +320,17 @@ impl AggregatingFunction for Max {
                         })
                     }
                 };
-                accumulator.remove((value as f64) * -1.0).await;
+                accumulator.remove(-(value as f64)).await;
                 match accumulator.get_head().await {
-                    Ok(Some(head)) => {
-                        Ok(VariableValue::Float(match Float::from_f64(head * -1.0) {
-                            Some(f) => f,
-                            None => {
-                                return Err(FunctionError {
-                                    function_name: "Max".to_string(),
-                                    error: FunctionEvaluationError::CorruptData,
-                                })
-                            }
-                        }))
-                    }
+                    Ok(Some(head)) => Ok(VariableValue::Float(match Float::from_f64(-head) {
+                        Some(f) => f,
+                        None => {
+                            return Err(FunctionError {
+                                function_name: "Max".to_string(),
+                                error: FunctionEvaluationError::CorruptData,
+                            })
+                        }
+                    })),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
                         function_name: "Max".to_string(),
@@ -349,10 +340,10 @@ impl AggregatingFunction for Max {
             }
             VariableValue::ZonedDateTime(zdt) => {
                 let value = zdt.datetime().timestamp_millis() as f64;
-                accumulator.remove(value * -1.0).await;
+                accumulator.remove(-value).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::ZonedDateTime(
-                        ZonedDateTime::from_epoch_millis((head * -1.0) as i64),
+                        ZonedDateTime::from_epoch_millis(-head as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -363,10 +354,10 @@ impl AggregatingFunction for Max {
             }
             VariableValue::Duration(d) => {
                 let value = d.duration().num_milliseconds() as f64;
-                accumulator.remove(value * -1.0).await;
+                accumulator.remove(-value).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::Duration(Duration::new(
-                        ChronoDuration::milliseconds((head * -1.0) as i64),
+                        ChronoDuration::milliseconds(-head as i64),
                         0,
                         0,
                     ))),
@@ -381,10 +372,10 @@ impl AggregatingFunction for Max {
                 // For date (Chrono::NaiveDate), we can store the number of days since the epoch
                 let reference_date = *temporal_constants::EPOCH_NAIVE_DATE;
                 let days_since_epoch = d.signed_duration_since(reference_date).num_days() as f64;
-                accumulator.remove(days_since_epoch * -1.0).await;
+                accumulator.remove(-days_since_epoch).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::Date(
-                        reference_date + ChronoDuration::days((head * -1.0) as i64),
+                        reference_date + ChronoDuration::days(-head as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -397,11 +388,11 @@ impl AggregatingFunction for Max {
                 let reference_time = *temporal_constants::MIDNIGHT_NAIVE_TIME;
                 let duration_since_midnight =
                     t.signed_duration_since(reference_time).num_milliseconds() as f64;
-                accumulator.remove(duration_since_midnight * -1.0).await;
+                accumulator.remove(-duration_since_midnight).await;
 
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::LocalTime(
-                        reference_time + ChronoDuration::milliseconds((head * -1.0) as i64),
+                        reference_time + ChronoDuration::milliseconds(-head as i64),
                     )),
                     Ok(None) => Ok(VariableValue::Null),
                     Err(e) => Err(FunctionError {
@@ -412,7 +403,7 @@ impl AggregatingFunction for Max {
             }
             VariableValue::LocalDateTime(dt) => {
                 let duration_since_epoch = dt.and_utc().timestamp_millis() as f64;
-                accumulator.remove(duration_since_epoch * -1.0).await;
+                accumulator.remove(-duration_since_epoch).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::LocalDateTime(
                         DateTime::from_timestamp_millis(head as i64 * -1.0 as i64)
@@ -444,11 +435,10 @@ impl AggregatingFunction for Max {
                     }
                 };
                 let duration_since_epoch = epoch_datetime.timestamp_millis() as f64;
-                accumulator.remove(duration_since_epoch * -1.0).await;
+                accumulator.remove(-duration_since_epoch).await;
                 match accumulator.get_head().await {
                     Ok(Some(head)) => Ok(VariableValue::ZonedTime(ZonedTime::new(
-                        (epoch_datetime + ChronoDuration::milliseconds((head * -1.0) as i64))
-                            .time(),
+                        (epoch_datetime + ChronoDuration::milliseconds(-head as i64)).time(),
                         *temporal_constants::UTC_FIXED_OFFSET,
                     ))),
                     Ok(None) => Ok(VariableValue::Null),
@@ -490,7 +480,7 @@ impl AggregatingFunction for Max {
         };
 
         let value = match accumulator.get_head().await {
-            Ok(Some(head)) => head * -1.0,
+            Ok(Some(head)) => -head,
             Ok(None) => return Ok(VariableValue::Null),
             Err(e) => {
                 return Err(FunctionError {

--- a/core/src/evaluation/functions/cypher_scalar/tests/timestamp_tests.rs
+++ b/core/src/evaluation/functions/cypher_scalar/tests/timestamp_tests.rs
@@ -43,7 +43,7 @@ async fn test_timestamp() {
         .await
     {
         Ok(result) => result,
-        Err(e) => panic!("Error: {:?}", e),
+        Err(e) => panic!("Error: {e:?}"),
     };
 
     let time_since_epoch = std::time::SystemTime::now()

--- a/core/src/evaluation/functions/temporal_duration/temporal_duration.rs
+++ b/core/src/evaluation/functions/temporal_duration/temporal_duration.rs
@@ -999,7 +999,7 @@ async fn parse_duration_input(duration_str: &str) -> Result<Duration, FunctionEr
     let date_duration = duration.split('T').next();
     let mut time_duration = None;
     if duration.contains('T') {
-        time_duration = duration.split('T').last();
+        time_duration = duration.split('T').next_back();
     }
 
     let mut duration_years = 0;
@@ -1096,7 +1096,7 @@ async fn parse_duration_input(duration_str: &str) -> Result<Duration, FunctionEr
     }
 
     if let Some(time_duration) = time_duration {
-        let time_duration_string = format!("PT{}", time_duration);
+        let time_duration_string = format!("PT{time_duration}");
 
         let iso_duration = match time_duration_string.parse::<IsoDuration>() {
             Ok(iso_duration) => iso_duration,
@@ -1122,7 +1122,7 @@ async fn parse_duration_input(duration_str: &str) -> Result<Duration, FunctionEr
         };
 
         if time_duration_string.contains('.') {
-            let mut fract_string = match time_duration_string.split('.').last() {
+            let mut fract_string = match time_duration_string.split('.').next_back() {
                 Some(fract_string) => fract_string,
                 None => {
                     return Err(FunctionError {

--- a/core/src/evaluation/functions/temporal_instant/temporal_instant.rs
+++ b/core/src/evaluation/functions/temporal_instant/temporal_instant.rs
@@ -1506,7 +1506,7 @@ async fn truncate_date(
         }),
         "weekyear" => {
             // First day of the first week of the year
-            let date_string = format!("{}-1-1", year);
+            let date_string = format!("{year}-1-1");
             let date = match NaiveDate::parse_from_str(&date_string, "%Y-%W-%u") {
                 Ok(date) => date,
                 Err(_) => {
@@ -1666,7 +1666,7 @@ async fn truncate_date_with_map(
         }
         "weekyear" => {
             // First day of the first week of the year
-            let date_string = format!("{}-1-1", year);
+            let date_string = format!("{year}-1-1");
             let date = match NaiveDate::parse_from_str(&date_string, "%Y-%W-%u") {
                 Ok(date) => date,
                 Err(_) => {
@@ -2030,7 +2030,7 @@ async fn date_str_formatter(input: &str) -> Result<String, FunctionEvaluationErr
     // NaiveDate parser does not support date in the format of YYYYMM
     // Changing this to YYYYMM01 (as suggested by Neo4j)
     if date_str.len() == 6 && !date_str.contains('Q') && !date_str.contains('W') {
-        return Ok(format!("{}01", date_str));
+        return Ok(format!("{date_str}01"));
     }
 
     // YYYYWwwD, YYYYWww
@@ -2068,7 +2068,7 @@ async fn date_str_formatter(input: &str) -> Result<String, FunctionEvaluationErr
 
     // YYYY
     if date_str.len() == 4 {
-        let formatted_input = format!("{}0101", date_str);
+        let formatted_input = format!("{date_str}0101");
         return Ok(formatted_input);
     }
 
@@ -2213,7 +2213,7 @@ async fn parse_local_date_time_input(
         }
     };
 
-    let time_string = match input_string.split('T').last() {
+    let time_string = match input_string.split('T').next_back() {
         Some(time) => time,
         None => {
             return Err(FunctionEvaluationError::InvalidFormat {

--- a/core/src/evaluation/mod.rs
+++ b/core/src/evaluation/mod.rs
@@ -111,17 +111,17 @@ impl PartialEq for FunctionEvaluationError {
 impl fmt::Display for FunctionEvaluationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FunctionEvaluationError::InvalidArgument(arg) => write!(f, "Invalid argument: {}", arg),
+            FunctionEvaluationError::InvalidArgument(arg) => write!(f, "Invalid argument: {arg}"),
             FunctionEvaluationError::InvalidArgumentCount => write!(f, "Invalid argument count"),
-            FunctionEvaluationError::IndexError(err) => write!(f, "Index error: {}", err),
+            FunctionEvaluationError::IndexError(err) => write!(f, "Index error: {err}"),
             FunctionEvaluationError::OverflowError => write!(f, "Overflow error"),
             FunctionEvaluationError::OutofRange => write!(f, "Out of range"),
             FunctionEvaluationError::InvalidFormat { expected } => {
-                write!(f, "Invalid format, expected: {}", expected)
+                write!(f, "Invalid format, expected: {expected}")
             }
             FunctionEvaluationError::CorruptData => write!(f, "Invalid accumulator"),
             FunctionEvaluationError::InvalidType { expected } => {
-                write!(f, "Invalid type, expected: {}", expected)
+                write!(f, "Invalid type, expected: {expected}")
             }
         }
     }
@@ -161,7 +161,7 @@ impl From<MiddlewareError> for EvaluationError {
 impl Display for EvaluationError {
     // Match the variant and handle the display differently for each variant
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        format!("{:?}", self).fmt(f)
+        format!("{self:?}").fmt(f)
     }
 }
 

--- a/core/src/evaluation/parts/tests/multi_part.rs
+++ b/core/src/evaluation/parts/tests/multi_part.rs
@@ -1404,7 +1404,7 @@ async fn aggregating_part_to_scalar_part_add_solution_emit_remove() {
     )
     .await;
 
-    println!("{:?}", result);
+    println!("{result:?}");
 
     assert_eq!(
         result,

--- a/core/src/evaluation/variable_value/float.rs
+++ b/core/src/evaluation/variable_value/float.rs
@@ -111,7 +111,7 @@ impl From<Float> for Number {
 
 impl Debug for Float {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "Float({})", self)
+        write!(formatter, "Float({self})")
     }
 }
 

--- a/core/src/evaluation/variable_value/index.rs
+++ b/core/src/evaluation/variable_value/index.rs
@@ -50,10 +50,7 @@ impl Index for usize {
             VariableValue::List(list) => {
                 let len = list.len();
                 list.get_mut(*self).unwrap_or_else(|| {
-                    panic!(
-                        "cannot access index {} of JSON array of length {}",
-                        self, len
-                    )
+                    panic!("cannot access index {self} of JSON array of length {len}")
                 })
             }
             _ => panic!("cannot access index {} of JSON {}", self, Type(value)),

--- a/core/src/evaluation/variable_value/integer.rs
+++ b/core/src/evaluation/variable_value/integer.rs
@@ -120,7 +120,7 @@ impl Display for Integer {
 
 impl Debug for Integer {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "Integer({})", self)
+        write!(formatter, "Integer({self})")
     }
 }
 

--- a/core/src/evaluation/variable_value/mod.rs
+++ b/core/src/evaluation/variable_value/mod.rs
@@ -75,7 +75,7 @@ impl From<VariableValue> for Value {
             VariableValue::LocalDateTime(t) => Value::String(t.to_string()),
             VariableValue::ZonedDateTime(t) => Value::String(t.to_string()),
             VariableValue::Duration(d) => Value::String(d.to_string()),
-            VariableValue::Expression(e) => Value::String(format!("{:?}", e)),
+            VariableValue::Expression(e) => Value::String(format!("{e:?}")),
             VariableValue::ListRange(r) => Value::String(r.to_string()),
             VariableValue::Element(e) => e.as_ref().into(),
             VariableValue::ElementMetadata(m) => Value::String(m.to_string()),
@@ -106,7 +106,7 @@ pub enum RangeBound {
 impl Display for RangeBound {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            RangeBound::Index(i) => write!(f, "{}", i),
+            RangeBound::Index(i) => write!(f, "{i}"),
             RangeBound::Unbounded => write!(f, "..."),
         }
     }
@@ -384,10 +384,10 @@ impl Debug for VariableValue {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
             VariableValue::Null => formatter.write_str("Null"),
-            VariableValue::Bool(boolean) => write!(formatter, "Bool({})", boolean),
-            VariableValue::Integer(integer) => write!(formatter, "Integer({})", integer),
-            VariableValue::Float(float) => write!(formatter, "Float({})", float),
-            VariableValue::String(string) => write!(formatter, "String({:?})", string),
+            VariableValue::Bool(boolean) => write!(formatter, "Bool({boolean})"),
+            VariableValue::Integer(integer) => write!(formatter, "Integer({integer})"),
+            VariableValue::Float(float) => write!(formatter, "Float({float})"),
+            VariableValue::String(string) => write!(formatter, "String({string:?})"),
             VariableValue::List(vec) => {
                 let _ = formatter.write_str("List ");
                 Debug::fmt(vec, formatter)
@@ -396,22 +396,22 @@ impl Debug for VariableValue {
                 let _ = formatter.write_str("Object ");
                 Debug::fmt(map, formatter)
             }
-            VariableValue::Date(date) => write!(formatter, "Date({})", date),
-            VariableValue::LocalTime(time) => write!(formatter, "LocalTime({})", time),
-            VariableValue::ZonedTime(time) => write!(formatter, "Time({})", time),
-            VariableValue::LocalDateTime(time) => write!(formatter, "LocalDateTime({})", time),
-            VariableValue::ZonedDateTime(time) => write!(formatter, "ZonedDateTime({})", time),
-            VariableValue::Duration(duration) => write!(formatter, "Duration({})", duration),
+            VariableValue::Date(date) => write!(formatter, "Date({date})"),
+            VariableValue::LocalTime(time) => write!(formatter, "LocalTime({time})"),
+            VariableValue::ZonedTime(time) => write!(formatter, "Time({time})"),
+            VariableValue::LocalDateTime(time) => write!(formatter, "LocalDateTime({time})"),
+            VariableValue::ZonedDateTime(time) => write!(formatter, "ZonedDateTime({time})"),
+            VariableValue::Duration(duration) => write!(formatter, "Duration({duration})"),
             VariableValue::Expression(expression) => {
-                write!(formatter, "Expression({:?})", expression)
+                write!(formatter, "Expression({expression:?})")
             }
-            VariableValue::ListRange(range) => write!(formatter, "ListRange({:?})", range),
-            VariableValue::Element(element) => write!(formatter, "Element({:?})", element),
+            VariableValue::ListRange(range) => write!(formatter, "ListRange({range:?})"),
+            VariableValue::Element(element) => write!(formatter, "Element({element:?})"),
             VariableValue::ElementMetadata(metadata) => {
-                write!(formatter, "ElementMetadata({:?})", metadata)
+                write!(formatter, "ElementMetadata({metadata:?})")
             }
             VariableValue::ElementReference(reference) => {
-                write!(formatter, "ElementReference({:?})", reference)
+                write!(formatter, "ElementReference({reference:?})")
             }
             VariableValue::Awaiting => write!(formatter, "Awaiting"),
         }
@@ -422,10 +422,10 @@ impl Display for VariableValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
             VariableValue::Null => write!(f, "null"),
-            VariableValue::Bool(b) => write!(f, "{}", b),
-            VariableValue::Integer(i) => write!(f, "{}", i),
-            VariableValue::Float(fl) => write!(f, "{}", fl),
-            VariableValue::String(s) => write!(f, "{}", s),
+            VariableValue::Bool(b) => write!(f, "{b}"),
+            VariableValue::Integer(i) => write!(f, "{i}"),
+            VariableValue::Float(fl) => write!(f, "{fl}"),
+            VariableValue::String(s) => write!(f, "{s}"),
             VariableValue::List(l) => {
                 let mut first = true;
                 write!(f, "[")?;
@@ -435,7 +435,7 @@ impl Display for VariableValue {
                     } else {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}", item)?;
+                    write!(f, "{item}")?;
                 }
                 write!(f, "]")
             }
@@ -448,21 +448,21 @@ impl Display for VariableValue {
                     } else {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", key, value)?;
+                    write!(f, "{key}: {value}")?;
                 }
                 write!(f, "}}")
             }
-            VariableValue::Date(d) => write!(f, "{}", d),
-            VariableValue::LocalTime(t) => write!(f, "{}", t),
-            VariableValue::ZonedTime(t) => write!(f, "{}", t),
-            VariableValue::LocalDateTime(t) => write!(f, "{}", t),
-            VariableValue::ZonedDateTime(t) => write!(f, "{}", t),
-            VariableValue::Duration(d) => write!(f, "{}", d),
-            VariableValue::Expression(e) => write!(f, "{:?}", e),
-            VariableValue::ListRange(r) => write!(f, "{}", r),
-            VariableValue::Element(e) => write!(f, "{:?}", e),
-            VariableValue::ElementMetadata(m) => write!(f, "{}", m),
-            VariableValue::ElementReference(r) => write!(f, "{}", r),
+            VariableValue::Date(d) => write!(f, "{d}"),
+            VariableValue::LocalTime(t) => write!(f, "{t}"),
+            VariableValue::ZonedTime(t) => write!(f, "{t}"),
+            VariableValue::LocalDateTime(t) => write!(f, "{t}"),
+            VariableValue::ZonedDateTime(t) => write!(f, "{t}"),
+            VariableValue::Duration(d) => write!(f, "{d}"),
+            VariableValue::Expression(e) => write!(f, "{e:?}"),
+            VariableValue::ListRange(r) => write!(f, "{r}"),
+            VariableValue::Element(e) => write!(f, "{e:?}"),
+            VariableValue::ElementMetadata(m) => write!(f, "{m}"),
+            VariableValue::ElementReference(r) => write!(f, "{r}"),
             VariableValue::Awaiting => write!(f, "Awaiting"),
         }
     }

--- a/core/src/evaluation/variable_value/partial_eq.rs
+++ b/core/src/evaluation/variable_value/partial_eq.rs
@@ -19,42 +19,42 @@ use chrono::{NaiveDate, NaiveTime};
 
 fn eq_i64(value: &VariableValue, other: i64) -> bool {
     match value {
-        VariableValue::Integer(n) => n.as_i64().map_or(false, |n| n == other),
-        VariableValue::Float(n) => n.as_f64().map_or(false, |n| n == other as f64),
+        VariableValue::Integer(n) => n.as_i64() == Some(other),
+        VariableValue::Float(n) => n.as_f64() == Some(other as f64),
         _ => false,
     }
 }
 
 fn eq_u64(value: &VariableValue, other: u64) -> bool {
     match value {
-        VariableValue::Integer(n) => n.as_u64().map_or(false, |n| n == other),
-        VariableValue::Float(n) => n.as_f64().map_or(false, |n| n == other as f64),
+        VariableValue::Integer(n) => n.as_u64() == Some(other),
+        VariableValue::Float(n) => n.as_f64() == Some(other as f64),
         _ => false,
     }
 }
 
 fn eq_f32(value: &VariableValue, other: f32) -> bool {
     match value {
-        VariableValue::Float(n) => n.as_f32().map_or(false, |n| n == other),
-        VariableValue::Integer(n) => n.as_i64().map_or(false, |n| n as f64 == other as f64),
+        VariableValue::Float(n) => n.as_f32() == Some(other),
+        VariableValue::Integer(n) => n.as_i64().is_some_and(|n| n as f64 == other as f64),
         _ => false,
     }
 }
 
 fn eq_f64(value: &VariableValue, other: f64) -> bool {
     match value {
-        VariableValue::Float(n) => n.as_f64().map_or(false, |n| n == other),
-        VariableValue::Integer(n) => n.as_i64().map_or(false, |n| n as f64 == other),
+        VariableValue::Float(n) => n.as_f64() == Some(other),
+        VariableValue::Integer(n) => n.as_i64().is_some_and(|n| n as f64 == other),
         _ => false,
     }
 }
 
 fn eq_bool(value: &VariableValue, other: bool) -> bool {
-    value.as_bool().map_or(false, |n| n == other)
+    value.as_bool() == Some(other)
 }
 
 fn eq_str(value: &VariableValue, other: &str) -> bool {
-    value.as_str().map_or(false, |n| n == other)
+    value.as_str() == Some(other)
 }
 
 impl PartialEq<str> for VariableValue {
@@ -137,14 +137,14 @@ impl PartialEq<VariableValue> for VariableValue {
         match (self, other) {
             (VariableValue::Integer(n), VariableValue::Integer(m)) => n == m,
             (VariableValue::Float(n), VariableValue::Float(m)) => n == m,
-            (VariableValue::Integer(n), VariableValue::Float(m)) => n.as_i64().map_or(false, |n| {
+            (VariableValue::Integer(n), VariableValue::Float(m)) => n.as_i64().is_some_and(|n| {
                 n as f64
                     == match m.as_f64() {
                         Some(m) => m,
                         None => unreachable!(),
                     }
             }),
-            (VariableValue::Float(n), VariableValue::Integer(m)) => m.as_i64().map_or(false, |m| {
+            (VariableValue::Float(n), VariableValue::Integer(m)) => m.as_i64().is_some_and(|m| {
                 m as f64
                     == match n.as_f64() {
                         Some(n) => n,

--- a/core/src/in_memory_index/in_memory_element_index.rs
+++ b/core/src/in_memory_index/in_memory_element_index.rs
@@ -628,7 +628,7 @@ impl ElementArchive {
             .data
             .range((Bound::Included(&0), Bound::Included(&time)))
             .map(|x| *x.0)
-            .last()
+            .next_back()
         {
             None => Some(0),
             Some(v) => Some(v),

--- a/core/src/interface/mod.rs
+++ b/core/src/interface/mod.rs
@@ -79,7 +79,7 @@ impl PartialEq for IndexError {
 
 impl Display for IndexError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        format!("{:?}", self).fmt(f)
+        format!("{self:?}").fmt(f)
     }
 }
 

--- a/core/src/middleware/mod.rs
+++ b/core/src/middleware/mod.rs
@@ -93,8 +93,7 @@ impl SourceMiddlewarePipeline {
                 container
                     .get(name)
                     .ok_or(MiddlewareSetupError::InvalidConfiguration(format!(
-                        "Unknown middleware: {}",
-                        name
+                        "Unknown middleware: {name}"
                     )))
             })
             .collect::<Result<Vec<Arc<dyn SourceMiddleware>>, MiddlewareSetupError>>()?;

--- a/core/src/path_solver/mod.rs
+++ b/core/src/path_solver/mod.rs
@@ -163,7 +163,7 @@ async fn create_solution_stream(
                     break;
                 },
                 SolutionStreamCommand::Panic(e) => {
-                    panic!("Error in solution task: {:?}", e);
+                    panic!("Error in solution task: {e:?}");
                 },
                 SolutionStreamCommand::Unsolvable => {
                     inflight -= 1;

--- a/examples/process_monitor.rs
+++ b/examples/process_monitor.rs
@@ -65,13 +65,13 @@ async fn process_change(query: &ContinuousQuery, change: SourceChange) {
     for context in result {
         match context {
             QueryPartEvaluationContext::Adding { after } => {
-                println!("Adding: {:?}", after);
+                println!("Adding: {after:?}");
             }
             QueryPartEvaluationContext::Removing { before } => {
-                println!("Removing: {:?}", before);
+                println!("Removing: {before:?}");
             }
             QueryPartEvaluationContext::Updating { before, after } => {
-                println!("Updating: {:?} -> {:?}", before, after);
+                println!("Updating: {before:?} -> {after:?}");
             }
             _ => {}
         }

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -62,7 +62,7 @@ async fn main() {
                 let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis() as u64;
 
                 let new_temp: usize = rng.gen_range(0..31);
-                println!("Component1 - temperature: {}", new_temp);
+                println!("Component1 - temperature: {new_temp}");
                 process_change(&query, SourceChange::Update {
                     element: Element::Node {
                         metadata: ElementMetadata {
@@ -77,7 +77,7 @@ async fn main() {
                 }).await;
 
                 let new_temp: usize = rng.gen_range(0..31);
-                println!("Component2 - temperature: {}", new_temp);
+                println!("Component2 - temperature: {new_temp}");
                 process_change(&query, SourceChange::Update {
                     element: Element::Node {
                         metadata: ElementMetadata {
@@ -103,13 +103,13 @@ async fn process_change(query: &ContinuousQuery, change: SourceChange) {
     for context in result {
         match context {
             QueryPartEvaluationContext::Adding { after } => {
-                println!("Adding: {:?}", after);
+                println!("Adding: {after:?}");
             }
             QueryPartEvaluationContext::Removing { before } => {
-                println!("Removing: {:?}", before);
+                println!("Removing: {before:?}");
             }
             QueryPartEvaluationContext::Updating { before, after } => {
-                println!("Updating: {:?} -> {:?}", before, after);
+                println!("Updating: {before:?} -> {after:?}");
             }
             _ => {}
         }

--- a/functions-gql/src/lib.rs
+++ b/functions-gql/src/lib.rs
@@ -118,7 +118,18 @@ fn register_aggregation_functions(registry: &FunctionRegistry) {
 }
 
 fn register_temporal_instant_functions(registry: &FunctionRegistry) {
-    registry.register_function("duration.between", Function::Scalar(Arc::new(Between {})));
+    registry.register_function("date", Function::Scalar(Arc::new(Date {})));
+    registry.register_function("zoned_time", Function::Scalar(Arc::new(Time {})));
+    registry.register_function("local_time", Function::Scalar(Arc::new(LocalTime {})));
+    registry.register_function("zoned_datetime", Function::Scalar(Arc::new(DateTime {})));
+    registry.register_function(
+        "local_datetime",
+        Function::Scalar(Arc::new(LocalDateTime {})),
+    );
+}
+
+fn register_temporal_duration_functions(registry: &FunctionRegistry) {
+    registry.register_function("duration_between", Function::Scalar(Arc::new(Between {})));
     registry.register_function("duration.inMonths", Function::Scalar(Arc::new(InMonths {})));
     registry.register_function("duration.inDays", Function::Scalar(Arc::new(InDays {})));
     registry.register_function(
@@ -126,8 +137,4 @@ fn register_temporal_instant_functions(registry: &FunctionRegistry) {
         Function::Scalar(Arc::new(InSeconds {})),
     );
     registry.register_function("duration", Function::Scalar(Arc::new(DurationFunc {})));
-}
-
-fn register_temporal_duration_functions(registry: &FunctionRegistry) {
-    registry.register_function("dateDiff", Function::Scalar(Arc::new(Between {})));
 }

--- a/index-garnet/src/element_index.rs
+++ b/index-garnet/src/element_index.rs
@@ -533,7 +533,7 @@ impl ElementIndex for GarnetElementIndex {
 
         let mut pipeline = redis::pipe();
         pipeline.atomic();
-        println!("deleting element: {:?}", stored_element_ref);
+        log::debug!("deleting element: {:?}", stored_element_ref);
         self.delete_element_internal(&mut pipeline, &stored_element_ref)
             .await?;
 

--- a/middleware/src/decoder/mod.rs
+++ b/middleware/src/decoder/mod.rs
@@ -250,10 +250,10 @@ impl Decoder {
     pub fn decode_base64(&self, encoded: &str) -> Result<String, String> {
         base64::engine::general_purpose::STANDARD
             .decode(encoded.as_bytes())
-            .map_err(|e| format!("Invalid base64 encoding: {}", e))
+            .map_err(|e| format!("Invalid base64 encoding: {e}"))
             .and_then(|bytes| {
                 String::from_utf8(bytes)
-                    .map_err(|e| format!("Decoded bytes are not valid UTF-8: {}", e))
+                    .map_err(|e| format!("Decoded bytes are not valid UTF-8: {e}"))
             })
     }
 
@@ -261,20 +261,20 @@ impl Decoder {
     pub fn decode_base64url(&self, encoded: &str) -> Result<String, String> {
         base64::engine::general_purpose::URL_SAFE_NO_PAD
             .decode(encoded.as_bytes())
-            .map_err(|e| format!("Invalid base64url encoding: {}", e))
+            .map_err(|e| format!("Invalid base64url encoding: {e}"))
             .and_then(|bytes| {
                 String::from_utf8(bytes)
-                    .map_err(|e| format!("Decoded bytes are not valid UTF-8: {}", e))
+                    .map_err(|e| format!("Decoded bytes are not valid UTF-8: {e}"))
             })
     }
 
     /// Decodes a hex encoded string.
     pub fn decode_hex(&self, encoded: &str) -> Result<String, String> {
         hex::decode(encoded)
-            .map_err(|e| format!("Invalid hex encoding: {}", e))
+            .map_err(|e| format!("Invalid hex encoding: {e}"))
             .and_then(|bytes| {
                 String::from_utf8(bytes)
-                    .map_err(|e| format!("Decoded bytes are not valid UTF-8: {}", e))
+                    .map_err(|e| format!("Decoded bytes are not valid UTF-8: {e}"))
             })
     }
 
@@ -282,14 +282,14 @@ impl Decoder {
     pub fn decode_url(&self, encoded: &str) -> Result<String, String> {
         urlencoding::decode(encoded)
             .map(|cow| cow.into_owned())
-            .map_err(|e| format!("Invalid URL encoding: {}", e))
+            .map_err(|e| format!("Invalid URL encoding: {e}"))
     }
 
     /// Decodes a JSON escaped string.
     pub fn decode_json_escape(&self, encoded: &str) -> Result<String, String> {
-        let json_value_str = format!("\"{}\"", encoded);
+        let json_value_str = format!("\"{encoded}\"");
         serde_json::from_str::<String>(&json_value_str)
-            .map_err(|e| format!("Invalid JSON escape sequence: {}", e))
+            .map_err(|e| format!("Invalid JSON escape sequence: {e}"))
     }
 }
 

--- a/middleware/src/decoder/tests.rs
+++ b/middleware/src/decoder/tests.rs
@@ -1134,8 +1134,7 @@ mod factory {
             let mw_config = create_mw_config(config);
             assert!(
                 subject.create(&mw_config).is_ok(),
-                "Failed for encoding_type: {}",
-                enc_type
+                "Failed for encoding_type: {enc_type}"
             );
         }
     }
@@ -1153,8 +1152,7 @@ mod factory {
             let mw_config = create_mw_config(config);
             assert!(
                 subject.create(&mw_config).is_ok(),
-                "Failed for on_error: {}",
-                val
+                "Failed for on_error: {val}"
             );
         }
         // Test default (fail) by omitting the field

--- a/middleware/src/lib.rs
+++ b/middleware/src/lib.rs
@@ -17,4 +17,5 @@ pub mod decoder;
 pub mod map;
 pub mod parse_json;
 pub mod promote;
+pub mod relabel;
 pub mod unwind;

--- a/middleware/src/map/mod.rs
+++ b/middleware/src/map/mod.rs
@@ -325,8 +325,7 @@ impl SourceMiddlewareFactory for MapFactory {
             Ok(mappings) => mappings,
             Err(e) => {
                 return Err(MiddlewareSetupError::InvalidConfiguration(format!(
-                    "Invalid configuration: {}",
-                    e
+                    "Invalid configuration: {e}"
                 )))
             }
         };

--- a/middleware/src/parse_json/mod.rs
+++ b/middleware/src/parse_json/mod.rs
@@ -193,8 +193,7 @@ impl ParseJson {
                 return self.handle_error(
                     ParseJsonErrorType::InvalidType,
                     format!(
-                        "Target property '{}' is not a String (Type: {}). Cannot parse JSON.",
-                        target_prop_name, type_name
+                        "Target property '{target_prop_name}' is not a String (Type: {type_name}). Cannot parse JSON."
                     ),
                 );
             }
@@ -202,8 +201,7 @@ impl ParseJson {
                 return self.handle_error(
                     ParseJsonErrorType::MissingProperty,
                     format!(
-                        "Target property '{}' not found in element. Cannot parse JSON.",
-                        target_prop_name
+                        "Target property '{target_prop_name}' not found in element. Cannot parse JSON."
                     ),
                 );
             }
@@ -265,10 +263,7 @@ impl ParseJson {
             }
             Err(e) => self.handle_error(
                 ParseJsonErrorType::ParseError,
-                format!(
-                    "Failed to parse JSON string in property '{}': {}",
-                    target_prop_name, e
-                ),
+                format!("Failed to parse JSON string in property '{target_prop_name}': {e}"),
             ),
         }
     }

--- a/middleware/src/parse_json/tests.rs
+++ b/middleware/src/parse_json/tests.rs
@@ -94,8 +94,7 @@ fn assert_property(props: &ElementPropertyMap, property: &str, expected: &Elemen
     assert_eq!(
         props.get(property),
         Some(expected),
-        "Property '{}' doesn't match expected value",
-        property
+        "Property '{property}' doesn't match expected value"
     );
 }
 
@@ -503,7 +502,7 @@ mod process {
         }));
         let middleware = factory.create(&config).unwrap();
         let index = InMemoryElementIndex::new();
-        let deep_json = (0..25).fold("null".to_string(), |acc, _| format!(r#"{{"k":{}}}"#, acc));
+        let deep_json = (0..25).fold("null".to_string(), |acc, _| format!(r#"{{"k":{acc}}}"#));
         let input_change = create_node_insert_change(json!({ "deep_json": deep_json }));
         let original_change_clone = input_change.clone();
 
@@ -605,7 +604,7 @@ mod process {
         }));
         let middleware = factory.create(&config).unwrap();
         let index = InMemoryElementIndex::new();
-        let deep_json = (0..25).fold("null".to_string(), |acc, _| format!(r#"{{"k":{}}}"#, acc));
+        let deep_json = (0..25).fold("null".to_string(), |acc, _| format!(r#"{{"k":{acc}}}"#));
         let input_change = create_node_insert_change(json!({ "deep_json": deep_json }));
 
         let result = middleware.process(input_change, &index).await;

--- a/middleware/src/promote/mod.rs
+++ b/middleware/src/promote/mod.rs
@@ -72,7 +72,7 @@ impl FromStr for JsonPathExpression {
                 expression: s.to_string(),
                 path,
             }),
-            Err(e) => Err(format!("Failed to parse rule: {}", e)),
+            Err(e) => Err(format!("Failed to parse rule: {e}")),
         }
     }
 }

--- a/middleware/src/promote/tests.rs
+++ b/middleware/src/promote/tests.rs
@@ -930,7 +930,7 @@ mod factory {
         match result {
             Err(MiddlewareSetupError::InvalidConfiguration(msg)) => {
                 // Check for the specific error message from the custom deserializer
-                assert!(msg.contains("Empty JSONPath"), "Error message was: {}", msg);
+                assert!(msg.contains("Empty JSONPath"), "Error message was: {msg}");
             }
             _ => panic!("Expected InvalidConfiguration error"),
         }
@@ -956,8 +956,7 @@ mod factory {
                 // Check for a message indicating a parse failure
                 assert!(
                     msg.contains("Failed to parse rule"),
-                    "Error message was: {}",
-                    msg
+                    "Error message was: {msg}"
                 );
             }
             _ => panic!("Expected InvalidConfiguration error for invalid JSONPath syntax"),
@@ -1152,8 +1151,7 @@ mod factory {
             let mw_config = create_mw_config(config);
             assert!(
                 subject.create(&mw_config).is_ok(),
-                "Failed for on_conflict: {}",
-                strategy
+                "Failed for on_conflict: {strategy}"
             );
         }
     }
@@ -1176,8 +1174,7 @@ mod factory {
             let mw_config = create_mw_config(config);
             assert!(
                 subject.create(&mw_config).is_ok(),
-                "Failed for on_error: {}",
-                value
+                "Failed for on_error: {value}"
             );
         }
     }

--- a/middleware/src/relabel/mod.rs
+++ b/middleware/src/relabel/mod.rs
@@ -1,0 +1,182 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use drasi_core::{
+    interface::{
+        ElementIndex, MiddlewareError, MiddlewareSetupError, SourceMiddleware,
+        SourceMiddlewareFactory,
+    },
+    models::{Element, ElementMetadata, SourceChange, SourceMiddlewareConfig},
+};
+use serde::Deserialize;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RelabelMiddlewareConfig {
+    #[serde(rename = "labelMappings")]
+    pub label_mappings: HashMap<String, String>,
+}
+
+pub struct RelabelMiddleware {
+    label_mappings: HashMap<String, String>,
+}
+
+impl RelabelMiddleware {
+    pub fn new(config: RelabelMiddlewareConfig) -> Self {
+        RelabelMiddleware {
+            label_mappings: config.label_mappings,
+        }
+    }
+
+    fn relabel_element(&self, element: Element) -> Element {
+        let metadata = element.get_metadata();
+        let new_labels: Vec<Arc<str>> = metadata
+            .labels
+            .iter()
+            .map(|label| {
+                self.label_mappings
+                    .get(label.as_ref())
+                    .map(|new_label| Arc::from(new_label.as_str()))
+                    .unwrap_or_else(|| label.clone())
+            })
+            .collect();
+
+        let new_metadata = ElementMetadata {
+            reference: metadata.reference.clone(),
+            labels: Arc::from(new_labels),
+            effective_from: metadata.effective_from,
+        };
+
+        match element {
+            Element::Node { properties, .. } => Element::Node {
+                metadata: new_metadata,
+                properties,
+            },
+            Element::Relation {
+                in_node,
+                out_node,
+                properties,
+                ..
+            } => Element::Relation {
+                metadata: new_metadata,
+                in_node,
+                out_node,
+                properties,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl SourceMiddleware for RelabelMiddleware {
+    async fn process(
+        &self,
+        source_change: SourceChange,
+        _element_index: &dyn ElementIndex,
+    ) -> Result<Vec<SourceChange>, MiddlewareError> {
+        match source_change {
+            SourceChange::Insert { element } => {
+                let relabeled_element = self.relabel_element(element);
+                Ok(vec![SourceChange::Insert {
+                    element: relabeled_element,
+                }])
+            }
+            SourceChange::Update { element } => {
+                let relabeled_element = self.relabel_element(element);
+                Ok(vec![SourceChange::Update {
+                    element: relabeled_element,
+                }])
+            }
+            SourceChange::Delete { metadata } => {
+                let new_labels: Vec<Arc<str>> = metadata
+                    .labels
+                    .iter()
+                    .map(|label| {
+                        self.label_mappings
+                            .get(label.as_ref())
+                            .map(|new_label| Arc::from(new_label.as_str()))
+                            .unwrap_or_else(|| label.clone())
+                    })
+                    .collect();
+
+                let new_metadata = ElementMetadata {
+                    reference: metadata.reference.clone(),
+                    labels: Arc::from(new_labels),
+                    effective_from: metadata.effective_from,
+                };
+
+                Ok(vec![SourceChange::Delete {
+                    metadata: new_metadata,
+                }])
+            }
+            SourceChange::Future { .. } => Ok(vec![source_change]),
+        }
+    }
+}
+
+pub struct RelabelMiddlewareFactory {}
+
+impl RelabelMiddlewareFactory {
+    pub fn new() -> Self {
+        RelabelMiddlewareFactory {}
+    }
+}
+
+impl Default for RelabelMiddlewareFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SourceMiddlewareFactory for RelabelMiddlewareFactory {
+    fn name(&self) -> String {
+        "relabel".to_string()
+    }
+
+    fn create(
+        &self,
+        config: &SourceMiddlewareConfig,
+    ) -> Result<Arc<dyn SourceMiddleware>, MiddlewareSetupError> {
+        let relabel_config: RelabelMiddlewareConfig =
+            match serde_json::from_value(serde_json::Value::Object(config.config.clone())) {
+                Ok(cfg) => cfg,
+                Err(e) => {
+                    return Err(MiddlewareSetupError::InvalidConfiguration(format!(
+                        "[{}] Invalid configuration: {}",
+                        config.name, e
+                    )))
+                }
+            };
+
+        if relabel_config.label_mappings.is_empty() {
+            return Err(MiddlewareSetupError::InvalidConfiguration(format!(
+                "[{}] At least one label mapping must be specified",
+                config.name
+            )));
+        }
+
+        log::info!(
+            "[{}] Creating Relabel middleware with {} label mappings",
+            config.name,
+            relabel_config.label_mappings.len()
+        );
+
+        Ok(Arc::new(RelabelMiddleware::new(relabel_config)))
+    }
+}

--- a/middleware/src/relabel/tests.rs
+++ b/middleware/src/relabel/tests.rs
@@ -1,0 +1,530 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::relabel::RelabelMiddlewareFactory;
+use drasi_core::{
+    in_memory_index::in_memory_element_index::InMemoryElementIndex,
+    interface::{FutureElementRef, MiddlewareSetupError, SourceMiddlewareFactory},
+    models::{
+        Element, ElementMetadata, ElementReference, ElementTimestamp, ElementValue, SourceChange,
+        SourceMiddlewareConfig,
+    },
+};
+use serde_json::{json, Value};
+
+// --- Test Helpers ---
+
+fn create_mw_config(config_json: Value) -> SourceMiddlewareConfig {
+    SourceMiddlewareConfig {
+        name: "test_relabel".into(),
+        kind: "relabel".into(),
+        config: config_json
+            .as_object()
+            .expect("Config JSON must be an object")
+            .clone(),
+    }
+}
+
+fn create_node_insert_change(labels: Vec<&str>, props: Value) -> SourceChange {
+    let labels: Vec<Arc<str>> = labels.into_iter().map(|s| Arc::from(s)).collect();
+    SourceChange::Insert {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("test_source", "node1"),
+                labels: Arc::from(labels),
+                effective_from: 0,
+            },
+            properties: props.into(),
+        },
+    }
+}
+
+fn create_node_update_change(labels: Vec<&str>, props: Value) -> SourceChange {
+    let labels: Vec<Arc<str>> = labels.into_iter().map(|s| Arc::from(s)).collect();
+    SourceChange::Update {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("test_source", "node1"),
+                labels: Arc::from(labels),
+                effective_from: 1,
+            },
+            properties: props.into(),
+        },
+    }
+}
+
+fn create_relation_insert_change(labels: Vec<&str>, props: Value) -> SourceChange {
+    let labels: Vec<Arc<str>> = labels.into_iter().map(|s| Arc::from(s)).collect();
+    SourceChange::Insert {
+        element: Element::Relation {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("test_source", "rel1"),
+                labels: Arc::from(labels),
+                effective_from: 0,
+            },
+            properties: props.into(),
+            in_node: ElementReference::new("test_source", "node1"),
+            out_node: ElementReference::new("test_source", "node2"),
+        },
+    }
+}
+
+fn create_delete_change(labels: Vec<&str>) -> SourceChange {
+    let labels: Vec<Arc<str>> = labels.into_iter().map(|s| Arc::from(s)).collect();
+    SourceChange::Delete {
+        metadata: ElementMetadata {
+            reference: ElementReference::new("test_source", "node1"),
+            labels: Arc::from(labels),
+            effective_from: 2,
+        },
+    }
+}
+
+fn create_future_change() -> SourceChange {
+    SourceChange::Future {
+        future_ref: FutureElementRef {
+            element_ref: ElementReference::new("test_source", "node1"),
+            original_time: 0 as ElementTimestamp,
+            due_time: 100 as ElementTimestamp,
+            group_signature: 0,
+        },
+    }
+}
+
+mod process {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_basic_label_relabeling() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "Person": "User",
+                "Company": "Organization"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let subject = factory.create(&mw_config).unwrap();
+        let element_index = Arc::new(InMemoryElementIndex::new());
+
+        let source_change =
+            create_node_insert_change(vec!["Person", "Employee"], json!({"name": "John Doe"}));
+
+        let result = subject
+            .process(source_change, element_index.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            SourceChange::Insert { element } => {
+                let metadata = element.get_metadata();
+                assert_eq!(metadata.labels.len(), 2);
+                assert!(metadata.labels.contains(&Arc::from("User")));
+                assert!(metadata.labels.contains(&Arc::from("Employee")));
+                assert!(!metadata.labels.contains(&Arc::from("Person")));
+            }
+            _ => panic!("Expected Insert change"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_partial_label_relabeling() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "OldLabel": "NewLabel"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let subject = factory.create(&mw_config).unwrap();
+        let element_index = Arc::new(InMemoryElementIndex::new());
+
+        let source_change =
+            create_node_insert_change(vec!["OldLabel", "UnchangedLabel"], json!({"data": "test"}));
+
+        let result = subject
+            .process(source_change, element_index.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            SourceChange::Insert { element } => {
+                let metadata = element.get_metadata();
+                assert_eq!(metadata.labels.len(), 2);
+                assert!(metadata.labels.contains(&Arc::from("NewLabel")));
+                assert!(metadata.labels.contains(&Arc::from("UnchangedLabel")));
+                assert!(!metadata.labels.contains(&Arc::from("OldLabel")));
+            }
+            _ => panic!("Expected Insert change"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_no_matching_labels() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "NonExistentLabel": "NewLabel"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let subject = factory.create(&mw_config).unwrap();
+        let element_index = Arc::new(InMemoryElementIndex::new());
+
+        let source_change = create_node_insert_change(
+            vec!["ExistingLabel", "AnotherLabel"],
+            json!({"data": "test"}),
+        );
+
+        let result = subject
+            .process(source_change, element_index.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            SourceChange::Insert { element } => {
+                let metadata = element.get_metadata();
+                assert_eq!(metadata.labels.len(), 2);
+                assert!(metadata.labels.contains(&Arc::from("ExistingLabel")));
+                assert!(metadata.labels.contains(&Arc::from("AnotherLabel")));
+            }
+            _ => panic!("Expected Insert change"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_multiple_label_mappings() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "Person": "User",
+                "Company": "Organization",
+                "Employee": "Staff"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let subject = factory.create(&mw_config).unwrap();
+        let element_index = Arc::new(InMemoryElementIndex::new());
+
+        let source_change = create_node_insert_change(
+            vec!["Person", "Company", "Employee", "Manager"],
+            json!({"data": "test"}),
+        );
+
+        let result = subject
+            .process(source_change, element_index.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            SourceChange::Insert { element } => {
+                let metadata = element.get_metadata();
+                assert_eq!(metadata.labels.len(), 4);
+                assert!(metadata.labels.contains(&Arc::from("User")));
+                assert!(metadata.labels.contains(&Arc::from("Organization")));
+                assert!(metadata.labels.contains(&Arc::from("Staff")));
+                assert!(metadata.labels.contains(&Arc::from("Manager")));
+
+                // Original labels should be replaced
+                assert!(!metadata.labels.contains(&Arc::from("Person")));
+                assert!(!metadata.labels.contains(&Arc::from("Company")));
+                assert!(!metadata.labels.contains(&Arc::from("Employee")));
+            }
+            _ => panic!("Expected Insert change"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_change_relabeling() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "TempLabel": "FinalLabel"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let subject = factory.create(&mw_config).unwrap();
+        let element_index = Arc::new(InMemoryElementIndex::new());
+
+        let source_change = create_node_update_change(vec!["TempLabel"], json!({"updated": true}));
+
+        let result = subject
+            .process(source_change, element_index.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            SourceChange::Update { element } => {
+                let metadata = element.get_metadata();
+                assert_eq!(metadata.labels.len(), 1);
+                assert!(metadata.labels.contains(&Arc::from("FinalLabel")));
+                assert!(!metadata.labels.contains(&Arc::from("TempLabel")));
+            }
+            _ => panic!("Expected Update change"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_relation_relabeling() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "KNOWS": "CONNECTED_TO",
+                "WORKS_FOR": "EMPLOYED_BY"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let subject = factory.create(&mw_config).unwrap();
+        let element_index = Arc::new(InMemoryElementIndex::new());
+
+        let source_change = create_relation_insert_change(
+            vec!["KNOWS", "SOCIAL_LINK"],
+            json!({"since": "2020-01-01"}),
+        );
+
+        let result = subject
+            .process(source_change, element_index.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            SourceChange::Insert { element } => {
+                let metadata = element.get_metadata();
+                assert_eq!(metadata.labels.len(), 2);
+                assert!(metadata.labels.contains(&Arc::from("CONNECTED_TO")));
+                assert!(metadata.labels.contains(&Arc::from("SOCIAL_LINK")));
+                assert!(!metadata.labels.contains(&Arc::from("KNOWS")));
+            }
+            _ => panic!("Expected Insert change with Relation"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_change_relabeling() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "OldLabel": "NewLabel"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let subject = factory.create(&mw_config).unwrap();
+        let element_index = Arc::new(InMemoryElementIndex::new());
+
+        let source_change = create_delete_change(vec!["OldLabel", "KeepLabel"]);
+
+        let result = subject
+            .process(source_change, element_index.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            SourceChange::Delete { metadata } => {
+                assert_eq!(metadata.labels.len(), 2);
+                assert!(metadata.labels.contains(&Arc::from("NewLabel")));
+                assert!(metadata.labels.contains(&Arc::from("KeepLabel")));
+                assert!(!metadata.labels.contains(&Arc::from("OldLabel")));
+            }
+            _ => panic!("Expected Delete change"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_future_change_passthrough() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "AnyLabel": "NewLabel"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let subject = factory.create(&mw_config).unwrap();
+        let element_index = Arc::new(InMemoryElementIndex::new());
+
+        let source_change = create_future_change();
+
+        let result = subject
+            .process(source_change.clone(), element_index.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], source_change);
+    }
+
+    #[tokio::test]
+    async fn test_properties_preserved() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "TestLabel": "NewTestLabel"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let subject = factory.create(&mw_config).unwrap();
+        let element_index = Arc::new(InMemoryElementIndex::new());
+
+        let properties = json!({
+            "name": "Test Node",
+            "value": 42,
+            "active": true
+        });
+
+        let source_change = create_node_insert_change(vec!["TestLabel"], properties.clone());
+
+        let result = subject
+            .process(source_change, element_index.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            SourceChange::Insert { element } => {
+                let props = element.get_properties();
+                assert_eq!(
+                    props.get("name"),
+                    Some(&ElementValue::String("Test Node".into()))
+                );
+                assert_eq!(props.get("value"), Some(&ElementValue::Integer(42)));
+                assert_eq!(props.get("active"), Some(&ElementValue::Bool(true)));
+            }
+            _ => panic!("Expected Insert change"),
+        }
+    }
+}
+
+mod factory {
+    use super::*;
+
+    #[test]
+    fn test_create_relabel_middleware_success() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "Person": "User",
+                "Company": "Organization"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let result = factory.create(&mw_config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_empty_label_mappings_fails() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {}
+        });
+        let mw_config = create_mw_config(config);
+        let result = factory.create(&mw_config);
+        assert!(result.is_err());
+        match result {
+            Err(MiddlewareSetupError::InvalidConfiguration(msg)) => {
+                assert!(msg.contains("At least one label mapping must be specified"));
+            }
+            _ => panic!("Expected InvalidConfiguration error"),
+        }
+    }
+
+    #[test]
+    fn test_missing_label_mappings_fails() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            // Missing label_mappings field
+        });
+        let mw_config = create_mw_config(config);
+        let result = factory.create(&mw_config);
+        assert!(result.is_err());
+        match result {
+            Err(MiddlewareSetupError::InvalidConfiguration(msg)) => {
+                assert!(msg.contains("missing field `labelMappings`"));
+            }
+            _ => panic!("Expected InvalidConfiguration error"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_config_format() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": "invalid_format" // Should be an object, not string
+        });
+        let mw_config = create_mw_config(config);
+        let result = factory.create(&mw_config);
+        assert!(result.is_err());
+        match result {
+            Err(MiddlewareSetupError::InvalidConfiguration(msg)) => {
+                assert!(msg.contains("Invalid configuration"));
+            }
+            _ => panic!("Expected InvalidConfiguration error"),
+        }
+    }
+
+    #[test]
+    fn test_factory_name() {
+        let factory = RelabelMiddlewareFactory::new();
+        assert_eq!(factory.name(), "relabel");
+    }
+
+    #[test]
+    fn test_factory_default() {
+        let factory = RelabelMiddlewareFactory::default();
+        let config = json!({
+            "labelMappings": {
+                "Test": "NewTest"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let result = factory.create(&mw_config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_single_label_mapping() {
+        let factory = RelabelMiddlewareFactory::new();
+        let config = json!({
+            "labelMappings": {
+                "OnlyLabel": "SingleLabel"
+            }
+        });
+        let mw_config = create_mw_config(config);
+        let result = factory.create(&mw_config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_many_label_mappings() {
+        let factory = RelabelMiddlewareFactory::new();
+        let mut mappings = serde_json::Map::new();
+        for i in 1..=100 {
+            mappings.insert(format!("Label{}", i), json!(format!("NewLabel{}", i)));
+        }
+        let config = json!({
+            "labelMappings": mappings
+        });
+        let mw_config = create_mw_config(config);
+        let result = factory.create(&mw_config);
+        assert!(result.is_ok());
+    }
+}

--- a/middleware/src/relabel/tests.rs
+++ b/middleware/src/relabel/tests.rs
@@ -39,7 +39,7 @@ fn create_mw_config(config_json: Value) -> SourceMiddlewareConfig {
 }
 
 fn create_node_insert_change(labels: Vec<&str>, props: Value) -> SourceChange {
-    let labels: Vec<Arc<str>> = labels.into_iter().map(|s| Arc::from(s)).collect();
+    let labels: Vec<Arc<str>> = labels.into_iter().map(Arc::from).collect();
     SourceChange::Insert {
         element: Element::Node {
             metadata: ElementMetadata {
@@ -53,7 +53,7 @@ fn create_node_insert_change(labels: Vec<&str>, props: Value) -> SourceChange {
 }
 
 fn create_node_update_change(labels: Vec<&str>, props: Value) -> SourceChange {
-    let labels: Vec<Arc<str>> = labels.into_iter().map(|s| Arc::from(s)).collect();
+    let labels: Vec<Arc<str>> = labels.into_iter().map(Arc::from).collect();
     SourceChange::Update {
         element: Element::Node {
             metadata: ElementMetadata {
@@ -67,7 +67,7 @@ fn create_node_update_change(labels: Vec<&str>, props: Value) -> SourceChange {
 }
 
 fn create_relation_insert_change(labels: Vec<&str>, props: Value) -> SourceChange {
-    let labels: Vec<Arc<str>> = labels.into_iter().map(|s| Arc::from(s)).collect();
+    let labels: Vec<Arc<str>> = labels.into_iter().map(Arc::from).collect();
     SourceChange::Insert {
         element: Element::Relation {
             metadata: ElementMetadata {
@@ -83,7 +83,7 @@ fn create_relation_insert_change(labels: Vec<&str>, props: Value) -> SourceChang
 }
 
 fn create_delete_change(labels: Vec<&str>) -> SourceChange {
-    let labels: Vec<Arc<str>> = labels.into_iter().map(|s| Arc::from(s)).collect();
+    let labels: Vec<Arc<str>> = labels.into_iter().map(Arc::from).collect();
     SourceChange::Delete {
         metadata: ElementMetadata {
             reference: ElementReference::new("test_source", "node1"),
@@ -518,7 +518,7 @@ mod factory {
         let factory = RelabelMiddlewareFactory::new();
         let mut mappings = serde_json::Map::new();
         for i in 1..=100 {
-            mappings.insert(format!("Label{}", i), json!(format!("NewLabel{}", i)));
+            mappings.insert(format!("Label{i}"), json!(format!("NewLabel{}", i)));
         }
         let config = json!({
             "labelMappings": mappings

--- a/middleware/src/unwind/mod.rs
+++ b/middleware/src/unwind/mod.rs
@@ -306,11 +306,11 @@ impl SourceMiddleware for Unwind {
 }
 
 fn format_item_id(expression: &str, parent_id: &str, item_id: &str) -> String {
-    format!("$unwind-{}-{}-{}", expression, parent_id, item_id)
+    format!("$unwind-{expression}-{parent_id}-{item_id}")
 }
 
 fn format_relation_id(child_id: &str) -> String {
-    format!("{}$rel", child_id)
+    format!("{child_id}$rel")
 }
 
 pub struct UnwindFactory {}
@@ -341,8 +341,7 @@ impl SourceMiddlewareFactory for UnwindFactory {
             Ok(mappings) => mappings,
             Err(e) => {
                 return Err(MiddlewareSetupError::InvalidConfiguration(format!(
-                    "Invalid configuration: {}",
-                    e
+                    "Invalid configuration: {e}"
                 )))
             }
         };

--- a/middleware/src/unwind/tests.rs
+++ b/middleware/src/unwind/tests.rs
@@ -232,7 +232,7 @@ mod process {
         assert!(result.is_ok());
         let result = result.unwrap();
 
-        println!("Result: {:#?}", result);
+        println!("Result: {result:#?}");
 
         assert!(result.contains(&SourceChange::Delete {
             metadata: ElementMetadata {

--- a/query-gql/src/lib.rs
+++ b/query-gql/src/lib.rs
@@ -502,8 +502,7 @@ fn get_scope_from_projection(
                     }
                     _ => {
                         return Err(QueryParseError::UnaliasedComplexExpression(format!(
-                            "{:?}",
-                            expr
+                            "{expr:?}"
                         )))
                     }
                 }
@@ -525,8 +524,7 @@ fn get_scope_from_projection(
                     }
                     _ => {
                         return Err(QueryParseError::UnaliasedComplexExpression(format!(
-                            "{:?}",
-                            expr
+                            "{expr:?}"
                         )))
                     }
                 }
@@ -631,8 +629,7 @@ fn build_parts_for_statements(
                     } else {
                         // Complex expression in YIELD is invalid: (YIELD x + 100)
                         return Err(QueryParseError::UnaliasedComplexExpression(format!(
-                            "{:?}",
-                            expr
+                            "{expr:?}"
                         )));
                     }
                 }

--- a/query-perf/src/main.rs
+++ b/query-perf/src/main.rs
@@ -59,7 +59,7 @@ async fn main() {
     println!("--------------------------------");
     println!("Drasi Query Component Perf Tests");
     println!("--------------------------------");
-    println!("Test Run Config: \n{:?}\n", test_run_config);
+    println!("Test Run Config: \n{test_run_config:?}\n");
 
     for scenario in scenarios {
         let mut result: TestRunResult = TestRunResult::new(
@@ -72,7 +72,7 @@ async fn main() {
         println!("--------------------------------");
         println!("Scenario - {}", scenario_config.name);
         println!("--------------------------------");
-        println!(" - Scenario Config: \n{:?}\n", scenario_config);
+        println!(" - Scenario Config: \n{scenario_config:?}\n");
         println!(" - Initializing Scenario...");
 
         let query_id = format!("test-{}", Uuid::new_v4());
@@ -165,6 +165,6 @@ async fn main() {
             // println!("change_result: {:#?}", _change_result);
         }
         result.end_run();
-        println!(" - Result: {:#?}", result);
+        println!(" - Result: {result:#?}");
     }
 }

--- a/query-perf/src/scenario/building_comfort_scenarios/building_comfort_model.rs
+++ b/query-perf/src/scenario/building_comfort_scenarios/building_comfort_model.rs
@@ -173,12 +173,12 @@ impl PartialEq for Location {
 impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Location::Building(building_idx) => write!(f, "b_{}", building_idx),
+            Location::Building(building_idx) => write!(f, "b_{building_idx}"),
             Location::Floor(building_idx, floor_idx) => {
-                write!(f, "f_{}_{}", building_idx, floor_idx)
+                write!(f, "f_{building_idx}_{floor_idx}")
             }
             Location::Room(building_idx, floor_idx, room_idx) => {
-                write!(f, "r_{}_{}_{}", building_idx, floor_idx, room_idx)
+                write!(f, "r_{building_idx}_{floor_idx}_{room_idx}")
             }
         }
     }
@@ -563,8 +563,7 @@ impl BuildingComfortModel {
             node_result = graph.add_node(floor.to_domain_graph_node());
             if node_result.is_err() {
                 panic!(
-                    "Error returned from DomainModelGraph::add_node() adding floor_idx: {}.",
-                    floor_idx
+                    "Error returned from DomainModelGraph::add_node() adding floor_idx: {floor_idx}."
                 );
             }
 
@@ -592,8 +591,7 @@ impl BuildingComfortModel {
                 node_result = graph.add_node(room.to_domain_graph_node());
                 if node_result.is_err() {
                     panic!(
-                        "Error returned from DomainModelGraph::add_node() adding room_idx: {}.",
-                        room_idx
+                        "Error returned from DomainModelGraph::add_node() adding room_idx: {room_idx}."
                     );
                 }
 

--- a/query-perf/src/test_run.rs
+++ b/query-perf/src/test_run.rs
@@ -61,7 +61,7 @@ impl FromStr for IndexType {
             "memory" => Ok(IndexType::Memory),
             "redis" => Ok(IndexType::Redis),
             "rocksdb" => Ok(IndexType::RocksDB),
-            _ => Err(format!("Unknown index type: {}", s)),
+            _ => Err(format!("Unknown index type: {s}")),
         }
     }
 }

--- a/shared-tests/src/in_memory/mod.rs
+++ b/shared-tests/src/in_memory/mod.rs
@@ -422,6 +422,17 @@ mod promote {
     }
 }
 
+mod relabel {
+    use super::InMemoryQueryConfig;
+    use crate::use_cases::*;
+
+    #[tokio::test]
+    async fn relabel() {
+        let test_config = InMemoryQueryConfig::new();
+        relabel::relabel(&test_config).await;
+    }
+}
+
 mod dapr_state_store {
     use super::InMemoryQueryConfig;
     use crate::use_cases::*;

--- a/shared-tests/src/use_cases/crosses_above_three_times_in_an_hour/mod.rs
+++ b/shared-tests/src/use_cases/crosses_above_three_times_in_an_hour/mod.rs
@@ -246,10 +246,7 @@ pub async fn crosses_above_three_times_in_an_hour(config: &(impl QueryTestConfig
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Update sensor value ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 1);
 
         assert!(result.contains(&QueryPartEvaluationContext::Updating {

--- a/shared-tests/src/use_cases/dapr_state_store/mod.rs
+++ b/shared-tests/src/use_cases/dapr_state_store/mod.rs
@@ -73,7 +73,7 @@ fn create_middleware_registry() -> Arc<MiddlewareTypeRegistry> {
 fn create_dapr_value(data: &JsonValue) -> ElementValue {
     let json_string = data.to_string();
     let base64_encoded = base64_engine.encode(json_string.as_bytes());
-    let quoted_base64 = format!("\"{}\"", base64_encoded);
+    let quoted_base64 = format!("\"{base64_encoded}\"");
     ElementValue::String(Arc::from(quoted_base64.as_str()))
 }
 
@@ -141,9 +141,9 @@ async fn setup_query(
     builder = builder.with_middleware_registry(registry);
 
     // Create unique names for middleware instances per test
-    let decoder_mw_name = format!("{}_decoder", test_name);
-    let parser_mw_name = format!("{}_parser", test_name);
-    let promoter_mw_name = format!("{}_promoter", test_name);
+    let decoder_mw_name = format!("{test_name}_decoder");
+    let parser_mw_name = format!("{test_name}_parser");
+    let promoter_mw_name = format!("{test_name}_promoter");
 
     // Add middleware configs using helpers from queries.rs
     builder = builder.with_source_middleware(queries::create_decoder_config(
@@ -218,8 +218,7 @@ async fn test_insert_basic_flow(config: &(impl QueryTestConfig + Send)) {
         result.contains(&QueryPartEvaluationContext::Adding {
             after: expected_vars
         }),
-        "Result did not contain expected Adding context. Got: {:?}",
-        result
+        "Result did not contain expected Adding context. Got: {result:?}"
     );
 }
 
@@ -287,8 +286,7 @@ async fn test_update_basic_flow(config: &(impl QueryTestConfig + Send)) {
             before: expected_vars_before,
             after: expected_vars_after
         }),
-        "Result did not contain expected Updating context. Got: {:?}",
-        update_result
+        "Result did not contain expected Updating context. Got: {update_result:?}"
     );
 }
 
@@ -343,8 +341,7 @@ async fn test_delete_passthrough(config: &(impl QueryTestConfig + Send)) {
         delete_result.contains(&QueryPartEvaluationContext::Removing {
             before: expected_vars_before_delete
         }),
-        "Result did not contain expected Removing context. Got: {:?}",
-        delete_result
+        "Result did not contain expected Removing context. Got: {delete_result:?}"
     );
 }
 

--- a/shared-tests/src/use_cases/dapr_state_store/queries.rs
+++ b/shared-tests/src/use_cases/dapr_state_store/queries.rs
@@ -22,18 +22,17 @@ use super::{ELEMENT_LABEL, PARSED_DATA_PROP, RAW_DATA_PROP};
 pub fn observer_query() -> String {
     format!(
         "
-        MATCH (n:{})
+        MATCH (n:{ELEMENT_LABEL})
         RETURN
-            n.`{}` as rawData,        // Original (overwritten by decoder)
-            n.`{}` as parsedData,    // Parsed structure from parse_json
+            n.`{RAW_DATA_PROP}` as rawData,        // Original (overwritten by decoder)
+            n.`{PARSED_DATA_PROP}` as parsedData,    // Parsed structure from parse_json
             // --- Promoted fields from various tests ---
             n.userId as userId,
             n.orderTotal as orderTotal,
             n.orderStatus as orderStatus,
             n.promotedValue as promotedValue,
             n.promotedTag as promotedTag
-        ",
-        ELEMENT_LABEL, RAW_DATA_PROP, PARSED_DATA_PROP
+        "
     )
 }
 

--- a/shared-tests/src/use_cases/decoder/mod.rs
+++ b/shared-tests/src/use_cases/decoder/mod.rs
@@ -93,7 +93,7 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result1 = query1.process_source_change(insert1).await.unwrap();
-    println!("Result 1 (Insert): {:?}", result1);
+    println!("Result 1 (Insert): {result1:?}");
     assert_eq!(result1.len(), 1);
     assert!(result1.contains(&QueryPartEvaluationContext::Adding {
         after: variablemap!(
@@ -146,7 +146,7 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result2 = query2.process_source_change(insert2).await.unwrap();
-    println!("Result 2 (Insert): {:?}", result2);
+    println!("Result 2 (Insert): {result2:?}");
     assert_eq!(result2.len(), 1);
     assert!(result2.contains(&QueryPartEvaluationContext::Adding {
         after: variablemap!(
@@ -199,7 +199,7 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result3 = query3.process_source_change(insert3).await.unwrap();
-    println!("Result 3 (Insert - Invalid URL, Skip): {:?}", result3);
+    println!("Result 3 (Insert - Invalid URL, Skip): {result3:?}");
     // Middleware should not modify the element
     assert_eq!(result3.len(), 1);
     assert!(result3.contains(&QueryPartEvaluationContext::Adding {
@@ -252,7 +252,7 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result4 = query4.process_source_change(insert4).await.unwrap();
-    println!("Result 4 (Insert - JSON Escape): {:?}", result4);
+    println!("Result 4 (Insert - JSON Escape): {result4:?}");
     assert_eq!(result4.len(), 1);
     assert!(result4.contains(&QueryPartEvaluationContext::Adding {
         after: variablemap!(
@@ -304,7 +304,7 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result5 = query5.process_source_change(insert5).await;
-    println!("Result 5 (Insert - Missing Prop, Fail): {:?}", result5);
+    println!("Result 5 (Insert - Missing Prop, Fail): {result5:?}");
     // Expect an error because on_error is fail
     assert!(result5.is_err());
     assert!(result5
@@ -352,7 +352,7 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result6 = query6.process_source_change(insert6).await.unwrap();
-    println!("Result 6 (Insert - Wrong Type, Skip): {:?}", result6);
+    println!("Result 6 (Insert - Wrong Type, Skip): {result6:?}");
     // Because on_error is skip, the element is added but not modified by middleware
     assert_eq!(result6.len(), 1);
     assert!(result6.contains(&QueryPartEvaluationContext::Adding {
@@ -404,7 +404,7 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result7 = query7.process_source_change(insert7).await;
-    println!("Result 7 (Insert - Size Limit, Fail): {:?}", result7);
+    println!("Result 7 (Insert - Size Limit, Fail): {result7:?}");
     // Expect an error because on_error is fail and size limit exceeded
     assert!(result7.is_err());
     assert!(result7
@@ -458,7 +458,7 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result8_update = query1.process_source_change(update8).await.unwrap();
-    println!("Result 8 (Update): {:?}", result8_update);
+    println!("Result 8 (Update): {result8_update:?}");
     assert_eq!(result8_update.len(), 1);
     assert!(
         result8_update.contains(&QueryPartEvaluationContext::Updating {
@@ -489,7 +489,7 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result9_delete = query1.process_source_change(delete9).await.unwrap();
-    println!("Result 9 (Delete): {:?}", result9_delete);
+    println!("Result 9 (Delete): {result9_delete:?}");
     assert_eq!(result9_delete.len(), 1);
     assert!(
         result9_delete.contains(&QueryPartEvaluationContext::Removing {

--- a/shared-tests/src/use_cases/document/mod.rs
+++ b/shared-tests/src/use_cases/document/mod.rs
@@ -145,7 +145,7 @@ pub async fn document(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!("Node Result - Add t1: {:?}", result);
+        println!("Node Result - Add t1: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Adding {
             after: variablemap!(
                 "name" => VariableValue::from(json!("pod-1")),

--- a/shared-tests/src/use_cases/incident_alert/mod.rs
+++ b/shared-tests/src/use_cases/incident_alert/mod.rs
@@ -355,7 +355,7 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!("getting result {:?}", result);
+        println!("getting result {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
             default_before: true,
             default_after: false,
@@ -557,7 +557,7 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 2);
-        println!("getting result {:?}", result);
+        println!("getting result {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
             default_before: false,
             default_after: false,

--- a/shared-tests/src/use_cases/linear_regression/mod.rs
+++ b/shared-tests/src/use_cases/linear_regression/mod.rs
@@ -138,7 +138,7 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
 
         assert_eq!(result.len(), 1);
-        println!("Node Result - Add p6: {:?}", result);
+        println!("Node Result - Add p6: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
             grouping_keys: vec![],
             default_before: true,
@@ -166,7 +166,7 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
 
         assert_eq!(result.len(), 1);
-        println!("Node Result - Remove p2: {:?}", result);
+        println!("Node Result - Remove p2: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
             grouping_keys: vec![],
             default_before: false,
@@ -194,7 +194,7 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
 
         assert_eq!(result.len(), 1);
-        println!("Node Result - Remove p6: {:?}", result);
+        println!("Node Result - Remove p6: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
             grouping_keys: vec![],
             default_before: false,
@@ -220,7 +220,7 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
             })
             .await
             .unwrap();
-        println!("Node Result - Remove p1: {:?}", result);
+        println!("Node Result - Remove p1: {result:?}");
 
         let result = lg_query
             .process_source_change(SourceChange::Delete {
@@ -232,7 +232,7 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
             })
             .await
             .unwrap();
-        println!("Node Result - Remove p3: {:?}", result);
+        println!("Node Result - Remove p3: {result:?}");
 
         let result = lg_query
             .process_source_change(SourceChange::Delete {
@@ -244,7 +244,7 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
             })
             .await
             .unwrap();
-        println!("Node Result - Remove p4: {:?}", result);
+        println!("Node Result - Remove p4: {result:?}");
 
         let result = lg_query
             .process_source_change(SourceChange::Delete {
@@ -256,7 +256,7 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
             })
             .await
             .unwrap();
-        println!("Node Result - Remove p5: {:?}", result);
+        println!("Node Result - Remove p5: {result:?}");
     }
 
     //re-add initial values
@@ -346,7 +346,7 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
 
         assert_eq!(result.len(), 1);
-        println!("Node Result - Add p6: {:?}", result);
+        println!("Node Result - Add p6: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
             grouping_keys: vec![],
             default_before: true,

--- a/shared-tests/src/use_cases/logical_conditions/mod.rs
+++ b/shared-tests/src/use_cases/logical_conditions/mod.rs
@@ -85,10 +85,7 @@ pub async fn logical_conditions(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Update sensor value ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 0);
 
         timestamp += 60;
@@ -113,10 +110,7 @@ pub async fn logical_conditions(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Update sensor value ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 0);
 
         timestamp += 60;
@@ -141,10 +135,7 @@ pub async fn logical_conditions(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Update sensor value ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 0);
 
         timestamp += 60;
@@ -169,10 +160,7 @@ pub async fn logical_conditions(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Update sensor value ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 1);
 
         assert!(result.contains(&QueryPartEvaluationContext::Adding {
@@ -203,10 +191,7 @@ pub async fn logical_conditions(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Update sensor value ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 1);
 
         assert!(result.contains(&QueryPartEvaluationContext::Removing {
@@ -237,10 +222,7 @@ pub async fn logical_conditions(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Update sensor value ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 0);
     }
 }

--- a/shared-tests/src/use_cases/mod.rs
+++ b/shared-tests/src/use_cases/mod.rs
@@ -29,6 +29,7 @@ pub mod optional_match;
 pub mod overdue_invoice;
 pub mod parse_json;
 pub mod promote;
+pub mod relabel;
 pub mod remap;
 pub mod sensor_heartbeat;
 pub mod unwind;

--- a/shared-tests/src/use_cases/overdue_invoice/mod.rs
+++ b/shared-tests/src/use_cases/overdue_invoice/mod.rs
@@ -220,7 +220,7 @@ pub async fn overdue_count_persistent(config: &(impl QueryTestConfig + Send)) {
         let result = result.unwrap();
 
         assert_eq!(result.len(), 1);
-        println!("later: {:?}", result);
+        println!("later: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Adding {
             after: variablemap!(
                 "count" => VariableValue::Integer(3.into())

--- a/shared-tests/src/use_cases/parse_json/mod.rs
+++ b/shared-tests/src/use_cases/parse_json/mod.rs
@@ -128,7 +128,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:1", "target_prop": r#"{"key": "value", "num": 123}"# }),
     );
     let result1 = query1.process_source_change(insert1).await.unwrap();
-    println!("Result 1 (Insert): {:?}", result1);
+    println!("Result 1 (Insert): {result1:?}");
     assert_eq!(result1.len(), 1);
     let expected_vv_map1 = variablemap!(
         "key" => VariableValue::String("value".to_string()),
@@ -171,7 +171,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:2", "target_prop": r#"[1, "two", true, null, 1.234]"# }),
     );
     let result2 = query2.process_source_change(insert2).await.unwrap();
-    println!("Result 2 (Insert): {:?}", result2);
+    println!("Result 2 (Insert): {result2:?}");
     assert_eq!(result2.len(), 1);
     let expected_vv_list2 = vec![
         VariableValue::Integer(Integer::from(1)),
@@ -201,7 +201,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         }),
     );
     let result3 = query2.process_source_change(insert3).await.unwrap();
-    println!("Result 3 (Insert - Collision): {:?}", result3);
+    println!("Result 3 (Insert - Collision): {result3:?}");
     assert_eq!(result3.len(), 1);
     let expected_vv_map3 = variablemap!(
         "new" => VariableValue::Bool(true)
@@ -242,7 +242,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:4", "target_prop": r#"{"status": "updated"}"# }),
     );
     let result4_update = query1.process_source_change(update4).await.unwrap();
-    println!("Result 4 (Update): {:?}", result4_update);
+    println!("Result 4 (Update): {result4_update:?}");
     assert_eq!(result4_update.len(), 1);
     let updated_vv_map4 = variablemap!(
         "status" => VariableValue::String("updated".to_string())
@@ -269,7 +269,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
     // Use query1 setup
     let delete5 = create_node_delete_change("node:4"); // Delete the node from previous step
     let result5_delete = query1.process_source_change(delete5).await.unwrap();
-    println!("Result 5 (Delete): {:?}", result5_delete);
+    println!("Result 5 (Delete): {result5_delete:?}");
     assert_eq!(result5_delete.len(), 1);
     let deleted_vv_map5 = updated_vv_map4;
     assert!(
@@ -310,7 +310,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:6", "target_prop": r#"{"key": "value""# }),
     );
     let result6 = query6.process_source_change(insert6).await.unwrap();
-    println!("Result 6 (Skip Invalid): {:?}", result6);
+    println!("Result 6 (Skip Invalid): {result6:?}");
     assert_eq!(result6.len(), 1);
     assert!(result6.contains(&QueryPartEvaluationContext::Adding {
         after: variablemap!(
@@ -348,7 +348,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:7", "target_prop": r#"{"key": "value""# }),
     );
     let result7 = query7.process_source_change(insert7).await;
-    println!("Result 7 (Fail Invalid): {:?}", result7);
+    println!("Result 7 (Fail Invalid): {result7:?}");
     assert!(result7.is_err());
     assert!(result7.unwrap_err().to_string().contains("ParseError"));
 
@@ -360,7 +360,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:8", "other_prop": "some_value" }),
     );
     let result8 = query6.process_source_change(insert8).await.unwrap();
-    println!("Result 8 (Skip Missing): {:?}", result8);
+    println!("Result 8 (Skip Missing): {result8:?}");
     assert_eq!(result8.len(), 1);
     assert!(result8.contains(&QueryPartEvaluationContext::Adding {
         after: variablemap!(
@@ -379,7 +379,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:9", "other_prop": "another_value" }),
     );
     let result9 = query7.process_source_change(insert9).await;
-    println!("Result 9 (Fail Missing): {:?}", result9);
+    println!("Result 9 (Fail Missing): {result9:?}");
     assert!(result9.is_err());
     assert!(result9.unwrap_err().to_string().contains("MissingProperty"));
 
@@ -411,7 +411,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:10", "target_prop": large_json_str }),
     );
     let result10 = query10.process_source_change(insert10).await.unwrap();
-    println!("Result 10 (Skip Size): {:?}", result10);
+    println!("Result 10 (Skip Size): {result10:?}");
     assert_eq!(result10.len(), 1);
     assert!(result10.contains(&QueryPartEvaluationContext::Adding {
         after: variablemap!(
@@ -449,7 +449,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:11", "target_prop": large_json_str }),
     );
     let result11 = query11.process_source_change(insert11).await;
-    println!("Result 11 (Fail Size): {:?}", result11);
+    println!("Result 11 (Fail Size): {result11:?}");
     assert!(result11.is_err());
     assert!(result11.unwrap_err().to_string().contains("SizeExceeded"));
 
@@ -481,7 +481,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:12", "target_prop": deep_json_str }),
     );
     let result12 = query12.process_source_change(insert12).await.unwrap();
-    println!("Result 12 (Skip Depth): {:?}", result12);
+    println!("Result 12 (Skip Depth): {result12:?}");
     assert_eq!(result12.len(), 1);
     assert!(result12.contains(&QueryPartEvaluationContext::Adding {
         after: variablemap!(
@@ -519,7 +519,7 @@ pub async fn parse_json_test(config: &(impl QueryTestConfig + Send)) {
         json!({ "id": "node:13", "target_prop": deep_json_str }),
     );
     let result13 = query13.process_source_change(insert13).await;
-    println!("Result 13 (Fail Depth): {:?}", result13);
+    println!("Result 13 (Fail Depth): {result13:?}");
     assert!(result13.is_err());
     assert!(result13.unwrap_err().to_string().contains("DeepNesting"));
 }

--- a/shared-tests/src/use_cases/relabel/mod.rs
+++ b/shared-tests/src/use_cases/relabel/mod.rs
@@ -83,7 +83,7 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!("Node Result - Add Person (should be User): {:?}", result);
+        println!("Node Result - Add Person (should be User): {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Adding {
             after: variablemap!(
                 "userName" => VariableValue::from(json!("John Doe")),
@@ -116,10 +116,7 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 0);
-        println!(
-            "Node Result - Add Employee (should be Staff, no match): {:?}",
-            result
-        );
+        println!("Node Result - Add Employee (should be Staff, no match): {result:?}");
     }
 
     // Update the Person node
@@ -144,7 +141,7 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!("Node Result - Update Person: {:?}", result);
+        println!("Node Result - Update Person: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Updating {
             before: variablemap!(
                 "userName" => VariableValue::from(json!("John Doe")),
@@ -182,10 +179,7 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!(
-            "Node Result - Add Person+Employee (becomes User+Staff): {:?}",
-            result
-        );
+        println!("Node Result - Add Person+Employee (becomes User+Staff): {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Adding {
             after: variablemap!(
                 "userName" => VariableValue::from(json!("Alice Johnson")),
@@ -218,10 +212,7 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 0);
-        println!(
-            "Node Result - Add Company (should be Organization, no match): {:?}",
-            result
-        );
+        println!("Node Result - Add Company (should be Organization, no match): {result:?}");
     }
 
     // Delete the Person node
@@ -239,7 +230,7 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!("Node Result - Delete Person: {:?}", result);
+        println!("Node Result - Delete Person: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Removing {
             before: variablemap!(
                 "userName" => VariableValue::from(json!("John Doe")),
@@ -272,9 +263,6 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 0);
-        println!(
-            "Node Result - Add UnmappedLabel (no change, no match): {:?}",
-            result
-        );
+        println!("Node Result - Add UnmappedLabel (no change, no match): {result:?}");
     }
 }

--- a/shared-tests/src/use_cases/relabel/mod.rs
+++ b/shared-tests/src/use_cases/relabel/mod.rs
@@ -1,0 +1,280 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use drasi_middleware::relabel::RelabelMiddlewareFactory;
+use serde_json::json;
+
+use drasi_core::{
+    evaluation::{
+        context::QueryPartEvaluationContext, functions::FunctionRegistry,
+        variable_value::VariableValue,
+    },
+    middleware::MiddlewareTypeRegistry,
+    models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
+    query::QueryBuilder,
+};
+use drasi_functions_cypher::CypherFunctionSet;
+use drasi_query_cypher::CypherParser;
+
+use crate::QueryTestConfig;
+
+mod queries;
+
+macro_rules! variablemap {
+  ($( $key: expr => $val: expr ),*) => {{
+       let mut map = ::std::collections::BTreeMap::new();
+       $( map.insert($key.to_string().into(), $val); )*
+       map
+  }}
+}
+
+#[allow(clippy::print_stdout, clippy::unwrap_used)]
+pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
+    let mut middleware_registry = MiddlewareTypeRegistry::new();
+    middleware_registry.register(Arc::new(RelabelMiddlewareFactory::new()));
+    let middleware_registry = Arc::new(middleware_registry);
+
+    let rm_query = {
+        let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+        let parser = Arc::new(CypherParser::new(function_registry.clone()));
+        let mut builder = QueryBuilder::new(queries::relabel_query(), parser)
+            .with_function_registry(function_registry);
+        builder = config.config_query(builder).await;
+        builder = builder.with_middleware_registry(middleware_registry);
+        for mw in queries::middlewares() {
+            builder = builder.with_source_middleware(mw);
+        }
+        builder = builder.with_source_pipeline("test", &queries::source_pipeline());
+        builder.build().await
+    };
+
+    // Insert a Person node (should be relabeled to User)
+    {
+        let change = SourceChange::Insert {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "person1"),
+                    labels: vec!["Person".into()].into(),
+                    effective_from: 0,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "name": "John Doe",
+                    "email": "john.doe@example.com",
+                    "role": "Developer"
+                })),
+            },
+        };
+
+        let result = rm_query
+            .process_source_change(change.clone())
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        println!("Node Result - Add Person (should be User): {:?}", result);
+        assert!(result.contains(&QueryPartEvaluationContext::Adding {
+            after: variablemap!(
+                "userName" => VariableValue::from(json!("John Doe")),
+                "userEmail" => VariableValue::from(json!("john.doe@example.com")),
+                "userRole" => VariableValue::from(json!("Developer"))
+            )
+        }));
+    }
+
+    // Insert an Employee node (should be relabeled to Staff)
+    {
+        let change = SourceChange::Insert {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "employee1"),
+                    labels: vec!["Employee".into()].into(),
+                    effective_from: 0,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "name": "Jane Smith",
+                    "email": "jane.smith@example.com",
+                    "role": "Manager"
+                })),
+            },
+        };
+
+        // Employee gets relabeled to Staff, but our query looks for User, so no results
+        let result = rm_query
+            .process_source_change(change.clone())
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 0);
+        println!(
+            "Node Result - Add Employee (should be Staff, no match): {:?}",
+            result
+        );
+    }
+
+    // Update the Person node
+    {
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "person1"),
+                    labels: vec!["Person".into()].into(),
+                    effective_from: 1,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "name": "John Doe",
+                    "email": "john.doe@company.com",
+                    "role": "Senior Developer"
+                })),
+            },
+        };
+
+        let result = rm_query
+            .process_source_change(change.clone())
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        println!("Node Result - Update Person: {:?}", result);
+        assert!(result.contains(&QueryPartEvaluationContext::Updating {
+            before: variablemap!(
+                "userName" => VariableValue::from(json!("John Doe")),
+                "userEmail" => VariableValue::from(json!("john.doe@example.com")),
+                "userRole" => VariableValue::from(json!("Developer"))
+            ),
+            after: variablemap!(
+                "userName" => VariableValue::from(json!("John Doe")),
+                "userEmail" => VariableValue::from(json!("john.doe@company.com")),
+                "userRole" => VariableValue::from(json!("Senior Developer"))
+            )
+        }));
+    }
+
+    // Insert a node with multiple labels (Person and Employee)
+    {
+        let change = SourceChange::Insert {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "multi1"),
+                    labels: vec!["Person".into(), "Employee".into()].into(),
+                    effective_from: 0,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "name": "Alice Johnson",
+                    "email": "alice@example.com",
+                    "role": "Lead"
+                })),
+            },
+        };
+
+        // Both Person->User and Employee->Staff, but query looks for User, so it matches
+        let result = rm_query
+            .process_source_change(change.clone())
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        println!(
+            "Node Result - Add Person+Employee (becomes User+Staff): {:?}",
+            result
+        );
+        assert!(result.contains(&QueryPartEvaluationContext::Adding {
+            after: variablemap!(
+                "userName" => VariableValue::from(json!("Alice Johnson")),
+                "userEmail" => VariableValue::from(json!("alice@example.com")),
+                "userRole" => VariableValue::from(json!("Lead"))
+            )
+        }));
+    }
+
+    // Insert a Company node (should be relabeled to Organization)
+    {
+        let change = SourceChange::Insert {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "company1"),
+                    labels: vec!["Company".into()].into(),
+                    effective_from: 0,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "name": "Tech Corp",
+                    "email": "info@techcorp.com",
+                    "role": "Business"
+                })),
+            },
+        };
+
+        // Company gets relabeled to Organization, but our query looks for User, so no results
+        let result = rm_query
+            .process_source_change(change.clone())
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 0);
+        println!(
+            "Node Result - Add Company (should be Organization, no match): {:?}",
+            result
+        );
+    }
+
+    // Delete the Person node
+    {
+        let change = SourceChange::Delete {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("test", "person1"),
+                labels: vec!["Person".into()].into(),
+                effective_from: 2,
+            },
+        };
+
+        let result = rm_query
+            .process_source_change(change.clone())
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        println!("Node Result - Delete Person: {:?}", result);
+        assert!(result.contains(&QueryPartEvaluationContext::Removing {
+            before: variablemap!(
+                "userName" => VariableValue::from(json!("John Doe")),
+                "userEmail" => VariableValue::from(json!("john.doe@company.com")),
+                "userRole" => VariableValue::from(json!("Senior Developer"))
+            )
+        }));
+    }
+
+    // Insert a node with an unmapped label (should remain unchanged)
+    {
+        let change = SourceChange::Insert {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "unmapped1"),
+                    labels: vec!["UnmappedLabel".into()].into(),
+                    effective_from: 0,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "name": "Unmapped Node",
+                    "email": "unmapped@example.com",
+                    "role": "Unknown"
+                })),
+            },
+        };
+
+        // UnmappedLabel stays as UnmappedLabel, query looks for User, so no results
+        let result = rm_query
+            .process_source_change(change.clone())
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 0);
+        println!(
+            "Node Result - Add UnmappedLabel (no change, no match): {:?}",
+            result
+        );
+    }
+}

--- a/shared-tests/src/use_cases/relabel/queries.rs
+++ b/shared-tests/src/use_cases/relabel/queries.rs
@@ -1,0 +1,51 @@
+#![allow(clippy::unwrap_used)]
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use drasi_core::models::SourceMiddlewareConfig;
+use serde_json::json;
+
+pub fn relabel_query() -> &'static str {
+    "
+  MATCH 
+      (u:User)
+    RETURN
+      u.name as userName,
+      u.email as userEmail,
+      u.role as userRole
+    "
+}
+
+pub fn middlewares() -> Vec<Arc<SourceMiddlewareConfig>> {
+    let cfg: serde_json::Map<String, serde_json::Value> = json!({
+        "labelMappings": {
+            "Person": "User",
+            "Company": "Organization",
+            "Employee": "Staff"
+        }
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+
+    vec![Arc::new(SourceMiddlewareConfig::new(
+        "relabel", "relabel", cfg,
+    ))]
+}
+
+pub fn source_pipeline() -> Vec<String> {
+    vec!["relabel".to_string()]
+}

--- a/shared-tests/src/use_cases/remap/mod.rs
+++ b/shared-tests/src/use_cases/remap/mod.rs
@@ -99,7 +99,7 @@ pub async fn remap(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!("Node Result - Add t1: {:?}", result);
+        println!("Node Result - Add t1: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Adding {
             after: variablemap!(
                 "id" => VariableValue::from(json!("v1")),
@@ -146,7 +146,7 @@ pub async fn remap(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!("Node Result - Add t2: {:?}", result);
+        println!("Node Result - Add t2: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Updating {
             before: variablemap!(
                 "id" => VariableValue::from(json!("v1")),
@@ -197,7 +197,7 @@ pub async fn remap(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!("Node Result - Add t3: {:?}", result);
+        println!("Node Result - Add t3: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Adding {
             after: variablemap!(
                 "id" => VariableValue::from(json!("v2")),

--- a/shared-tests/src/use_cases/rolling_average_decrease_by_ten/mod.rs
+++ b/shared-tests/src/use_cases/rolling_average_decrease_by_ten/mod.rs
@@ -103,10 +103,7 @@ pub async fn rolling_average_decrease_by_ten(config: &(impl QueryTestConfig + Se
             .await
             .unwrap();
 
-        println!(
-            "Node Result - Update sensor value in loop ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Update sensor value in loop ({timestamp}): {result:?}");
 
         timestamp += 60 * 60;
     }
@@ -131,10 +128,7 @@ pub async fn rolling_average_decrease_by_ten(config: &(impl QueryTestConfig + Se
                 .process_source_change(node_change.clone())
                 .await
                 .unwrap();
-            println!(
-                "Node Result - Update sensor value in loop ({}): {:?}",
-                timestamp, node_result
-            );
+            println!("Node Result - Update sensor value in loop ({timestamp}): {node_result:?}");
             assert_eq!(node_result.len(), 0);
 
             timestamp += 60 * 60;
@@ -194,10 +188,7 @@ pub async fn rolling_average_decrease_by_ten(config: &(impl QueryTestConfig + Se
             .process_source_change(node_change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Update sensor value in loop ({}): {:?}",
-            timestamp, node_result
-        );
+        println!("Node Result - Update sensor value in loop ({timestamp}): {node_result:?}");
         assert_eq!(node_result.len(), 0);
     }
 }

--- a/shared-tests/src/use_cases/steps_happen_in_any_order/mod.rs
+++ b/shared-tests/src/use_cases/steps_happen_in_any_order/mod.rs
@@ -86,10 +86,7 @@ pub async fn steps_happen_in_any_order(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Add Completed Step X ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Add Completed Step X ({timestamp}): {result:?}");
         assert_eq!(result.len(), 0);
 
         // Add 10 days to timestamp
@@ -115,10 +112,7 @@ pub async fn steps_happen_in_any_order(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Add Completed Step Y ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Add Completed Step Y ({timestamp}): {result:?}");
         assert_eq!(result.len(), 0);
 
         // Add 50 days to timestamp
@@ -144,10 +138,7 @@ pub async fn steps_happen_in_any_order(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Add Completed Step Z ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Add Completed Step Z ({timestamp}): {result:?}");
         assert_eq!(result.len(), 0);
 
         // Add 10 days to timestamp
@@ -174,10 +165,7 @@ pub async fn steps_happen_in_any_order(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Add Completed Step ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Add Completed Step ({timestamp}): {result:?}");
         assert_eq!(result.len(), 0);
 
         // Add 5 days to timestamp
@@ -203,10 +191,7 @@ pub async fn steps_happen_in_any_order(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Add Completed Step ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Add Completed Step ({timestamp}): {result:?}");
         assert_eq!(result.len(), 0);
 
         // Add 5 days to timestamp
@@ -232,10 +217,7 @@ pub async fn steps_happen_in_any_order(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!(
-            "Node Result - Add Completed Step ({}): {:?}",
-            timestamp, result
-        );
+        println!("Node Result - Add Completed Step ({timestamp}): {result:?}");
         assert_eq!(result.len(), 1);
 
         assert!(result.contains(&QueryPartEvaluationContext::Adding {

--- a/shared-tests/src/use_cases/unwind/mod.rs
+++ b/shared-tests/src/use_cases/unwind/mod.rs
@@ -100,7 +100,7 @@ pub async fn unwind(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 2);
-        println!("Node Result - Add p1: {:?}", result);
+        println!("Node Result - Add p1: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Adding {
             after: variablemap!(
                 "pod" => VariableValue::from(json!("pod-1")),
@@ -160,7 +160,7 @@ pub async fn unwind(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        println!("Node Result - Update p1: {:?}", result);
+        println!("Node Result - Update p1: {result:?}");
         assert!(result.contains(&QueryPartEvaluationContext::Adding {
             after: variablemap!(
                 "pod" => VariableValue::from(json!("pod-1")),
@@ -208,7 +208,7 @@ pub async fn unwind(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!("Node Result - Update p1: {:?}", result);
+        println!("Node Result - Update p1: {result:?}");
         assert_eq!(result.len(), 2);
 
         assert!(result.contains(&QueryPartEvaluationContext::Removing {
@@ -247,7 +247,7 @@ pub async fn unwind(config: &(impl QueryTestConfig + Send)) {
             .process_source_change(change.clone())
             .await
             .unwrap();
-        println!("Node Result - Delete p1: {:?}", result);
+        println!("Node Result - Delete p1: {result:?}");
         assert_eq!(result.len(), 2);
 
         assert!(result.contains(&QueryPartEvaluationContext::Removing {


### PR DESCRIPTION
This pull request adds a new "Relabel" middleware to the codebase, which enables relabeling of node and relation labels in source data according to user-specified mappings. It also introduces comprehensive integration tests to verify the relabeling functionality and its interaction with Cypher queries. The changes are organized into middleware implementation, test coverage, and supporting infrastructure.

**New Middleware Implementation:**

* Introduced `relabel` middleware in `middleware/src/relabel/mod.rs`, which maps element labels based on a configurable mapping and integrates with the middleware factory system. The middleware processes all types of source changes (insert, update, delete) and applies label remapping accordingly.
* Registered the new middleware module in `middleware/src/lib.rs` to make it available for use.

**Test Coverage and Use Cases:**

* Added a new test module for relabeling in `shared-tests/src/in_memory/mod.rs`, ensuring the relabel middleware is exercised in the in-memory test suite.
* Implemented comprehensive integration tests for the relabel middleware in `shared-tests/src/use_cases/relabel/mod.rs`. These tests cover various scenarios: single and multiple label remapping, updates, deletions, unmapped labels, and their effect on Cypher query results.

**Supporting Infrastructure:**

* Added the relabel use case module to the use case registry in `shared-tests/src/use_cases/mod.rs`.
* Provided query definitions and middleware configuration for relabeling tests in `shared-tests/src/use_cases/relabel/queries.rs`. This includes the Cypher query and middleware configuration used in the tests.