### PR TITLE
Clippy fixed version

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -33,11 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install specific Rust version
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.83.0 # Pin to a specific Rust version
-          override: true
-          components: clippy, rustfmt
+        run: |
+          rustup update 1.83.0 && rustup default 1.83.0
+
+      - name: Install Clippy
+        run: rustup component add clippy
 
       - name: Run Cargo Clippy
         run: cargo clippy --all-targets --all-features
@@ -49,11 +49,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-            toolchain: nightly
-            override: true
+      - name: Install specific Rust version
+        run: |
+          rustup update nightly-1.83.0 && rustup default nightly-1.83.0
 
       - name: Run Cargo fmt
         run: |

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -37,9 +37,8 @@ jobs:
         with:
           toolchain: 1.83.0 # Pin to a specific Rust version
           override: true
+          components: clippy, rustfmt
 
-      - name: Install Clippy
-        run: rustup component add clippy rustfmt
       - name: Run Cargo Clippy
         run: cargo clippy --all-targets --all-features
 

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Install specific Rust version
         run: |
-          rustup update nightly-1.83.0 && rustup default nightly-1.83.0
+          rustup update nightly && rustup default nightly
 
       - name: Run Cargo fmt
         run: |

--- a/index-garnet/src/element_index.rs
+++ b/index-garnet/src/element_index.rs
@@ -533,7 +533,7 @@ impl ElementIndex for GarnetElementIndex {
 
         let mut pipeline = redis::pipe();
         pipeline.atomic();
-        println!("deleting element: {:?}", stored_element_ref);
+        log::debug!("Deleting element: {:?}", stored_element_ref);
         self.delete_element_internal(&mut pipeline, &stored_element_ref)
             .await?;
 


### PR DESCRIPTION
This pull request updates the way Rust toolchains are installed in the CI lint workflow, switching from the `actions-rs/toolchain` GitHub Action to direct `rustup` commands for both stable and nightly toolchains. It also removes the installation of `rustfmt` as a component during the Clippy step.

**CI Workflow Updates:**

* Replaced the use of `actions-rs/toolchain` for installing both stable (`1.83.0`) and nightly Rust toolchains with direct `rustup` commands in the `.github/workflows/ci-lint.yml` file. This simplifies the workflow and reduces dependency on third-party actions. [[1]](diffhunk://#diff-57157b14b324e35015a6c3e7dcacbca988efb53e3441e11e4ab4a07cbba16161L36-R41) [[2]](diffhunk://#diff-57157b14b324e35015a6c3e7dcacbca988efb53e3441e11e4ab4a07cbba16161L53-R54)
* Updated the Clippy installation step to only install `clippy`, removing `rustfmt` from the components added during this step.# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
