### PR TITLE
Add validation for SourceUpdate upsert semantics

### DIFF
--- a/index-garnet/tests/scenario_tests.rs
+++ b/index-garnet/tests/scenario_tests.rs
@@ -406,3 +406,50 @@ mod collect_aggregation {
         collect_aggregation::multiple_collects_test(&test_config).await;
     }
 }
+
+mod source_update_upsert {
+    use super::GarnetQueryConfig;
+    use shared_tests::use_cases::*;
+
+    #[tokio::test]
+    async fn test_upsert_semantics() {
+        let test_config = GarnetQueryConfig::new(false);
+        source_update_upsert::test_upsert_semantics(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_partial_updates() {
+        let test_config = GarnetQueryConfig::new(false);
+        source_update_upsert::test_partial_updates(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_stateless_processing() {
+        let test_config = GarnetQueryConfig::new(false);
+        source_update_upsert::test_stateless_processing(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_query_matching() {
+        let test_config = GarnetQueryConfig::new(false);
+        source_update_upsert::test_query_matching(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_multiple_entities() {
+        let test_config = GarnetQueryConfig::new(false);
+        source_update_upsert::test_multiple_entities(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_relationship_upsert() {
+        let test_config = GarnetQueryConfig::new(false);
+        source_update_upsert::test_relationship_upsert(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_aggregation_with_upserts() {
+        let test_config = GarnetQueryConfig::new(false);
+        source_update_upsert::test_aggregation_with_upserts(&test_config).await;
+    }
+}

--- a/index-rocksdb/tests/scenario_tests.rs
+++ b/index-rocksdb/tests/scenario_tests.rs
@@ -326,3 +326,50 @@ mod collect_aggregation {
         collect_aggregation::multiple_collects_test(&test_config).await;
     }
 }
+
+mod source_update_upsert {
+    use super::RocksDbQueryConfig;
+    use shared_tests::use_cases::*;
+
+    #[tokio::test]
+    async fn test_upsert_semantics() {
+        let test_config = RocksDbQueryConfig::new();
+        source_update_upsert::test_upsert_semantics(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_partial_updates() {
+        let test_config = RocksDbQueryConfig::new();
+        source_update_upsert::test_partial_updates(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_stateless_processing() {
+        let test_config = RocksDbQueryConfig::new();
+        source_update_upsert::test_stateless_processing(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_query_matching() {
+        let test_config = RocksDbQueryConfig::new();
+        source_update_upsert::test_query_matching(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_multiple_entities() {
+        let test_config = RocksDbQueryConfig::new();
+        source_update_upsert::test_multiple_entities(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_relationship_upsert() {
+        let test_config = RocksDbQueryConfig::new();
+        source_update_upsert::test_relationship_upsert(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_aggregation_with_upserts() {
+        let test_config = RocksDbQueryConfig::new();
+        source_update_upsert::test_aggregation_with_upserts(&test_config).await;
+    }
+}

--- a/shared-tests/src/in_memory/mod.rs
+++ b/shared-tests/src/in_memory/mod.rs
@@ -582,3 +582,50 @@ mod collect_aggregation {
         collect_aggregation::multiple_collects_test(&test_config).await;
     }
 }
+
+mod source_update_upsert {
+    use super::InMemoryQueryConfig;
+    use crate::use_cases::*;
+
+    #[tokio::test]
+    async fn test_upsert_semantics() {
+        let test_config = InMemoryQueryConfig::new();
+        source_update_upsert::test_upsert_semantics(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_partial_updates() {
+        let test_config = InMemoryQueryConfig::new();
+        source_update_upsert::test_partial_updates(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_stateless_processing() {
+        let test_config = InMemoryQueryConfig::new();
+        source_update_upsert::test_stateless_processing(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_query_matching() {
+        let test_config = InMemoryQueryConfig::new();
+        source_update_upsert::test_query_matching(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_multiple_entities() {
+        let test_config = InMemoryQueryConfig::new();
+        source_update_upsert::test_multiple_entities(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_relationship_upsert() {
+        let test_config = InMemoryQueryConfig::new();
+        source_update_upsert::test_relationship_upsert(&test_config).await;
+    }
+
+    #[tokio::test]
+    async fn test_aggregation_with_upserts() {
+        let test_config = InMemoryQueryConfig::new();
+        source_update_upsert::test_aggregation_with_upserts(&test_config).await;
+    }
+}

--- a/shared-tests/src/use_cases/mod.rs
+++ b/shared-tests/src/use_cases/mod.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use drasi_core::query::QueryBuilder;
-use drasi_query_ast::ast::Query;
 
 pub mod building_comfort;
 pub mod collect_aggregation;
@@ -33,6 +30,7 @@ pub mod promote;
 pub mod relabel;
 pub mod remap;
 pub mod sensor_heartbeat;
+pub mod source_update_upsert;
 pub mod unwind;
 
 pub mod before;
@@ -52,5 +50,5 @@ pub mod windows;
 
 #[async_trait]
 pub trait QueryTestConfig {
-    async fn config_query(&self, builder: QueryBuilder, query: Arc<Query>) -> QueryBuilder;
+    async fn config_query(&self, builder: QueryBuilder) -> QueryBuilder;
 }

--- a/shared-tests/src/use_cases/source_update_upsert/README.md
+++ b/shared-tests/src/use_cases/source_update_upsert/README.md
@@ -1,0 +1,13 @@
+# SourceUpdate Upsert Semantics Tests
+
+## Purpose
+
+Continuous Queries in Drasi process `SourceChange` events. These tests validate that `SourceChange::Update` implements correct **upsert semantics**: the first update to a non-existent element creates it, and subsequent updates modify the existing element. This is a fundamental contract of the continuous query engine.
+
+## Why This Matters
+
+**Stateless Source Adapters**
+Many real-world data sources cannot track whether entities exist in the engine. IoT sensors send periodic snapshots, polling-based adapters fetch current state and analytics platforms like Azure Data Explorer (Kusto) can continuously export events where events describe the state of entities at a specific timestamp. These sources need a simple contract: send updates, and the engine handles creation vs. modification.
+
+**Behavioral Consistency**
+These tests guarantee that all storage backend implementations (in-memory, RocksDB, Garnet, future backends) handle upserts for `SourceChange::Update` events sent by any such sources identically.

--- a/shared-tests/src/use_cases/source_update_upsert/mod.rs
+++ b/shared-tests/src/use_cases/source_update_upsert/mod.rs
@@ -1,0 +1,774 @@
+#![allow(clippy::unwrap_used)]
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use serde_json::json;
+
+use drasi_core::{
+    evaluation::{
+        context::QueryPartEvaluationContext, functions::FunctionRegistry,
+        variable_value::VariableValue,
+    },
+    models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
+    query::{ContinuousQuery, QueryBuilder},
+};
+use drasi_functions_cypher::CypherFunctionSet;
+use drasi_query_cypher::CypherParser;
+
+use crate::QueryTestConfig;
+
+mod queries;
+
+macro_rules! variablemap {
+  ($( $key: expr => $val: expr ),*) => {{
+       let mut map = ::std::collections::BTreeMap::new();
+       $( map.insert($key.to_string().into(), $val); )*
+       map
+  }}
+}
+
+/// Validates that first SourceUpdate creates a new entity, and subsequent SourceUpdate operations modify the existing entity.
+/// This confirms the fundamental upsert contract: Update creates if absent, otherwise updates.
+pub async fn test_upsert_semantics(config: &(impl QueryTestConfig + Send)) {
+    //println!("\n=== Test 1: Basic Upsert Semantics ===");
+
+    let all_entities_query = build_query(queries::all_entities_query(), config).await;
+
+    // First SourceUpdate for a new entity - should create it
+    {
+        //println!("Sending first SourceUpdate for entity1 (should create)...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "entity1"),
+                    labels: Arc::new([Arc::from("Entity")]),
+                    effective_from: 1000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "entity1",
+                    "name": "Entity One",
+                    "status": "active",
+                    "value": 100
+                })),
+            },
+        };
+
+        let result = all_entities_query
+            .process_source_change(change)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1, "Should have exactly one result");
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("entity1")),
+                    "name" => VariableValue::from(json!("Entity One")),
+                    "status" => VariableValue::from(json!("active")),
+                    "value" => VariableValue::from(json!(100))
+                ),
+            }),
+            "First SourceUpdate should ADD the entity"
+        );
+        //println!("✓ First SourceUpdate created new entity");
+    }
+
+    // Second SourceUpdate for the same entity - should update it
+    {
+        //println!("Sending second SourceUpdate for entity1 (should update)...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "entity1"),
+                    labels: Arc::new([Arc::from("Entity")]),
+                    effective_from: 2000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "entity1",
+                    "name": "Entity One Updated",
+                    "status": "inactive",
+                    "value": 200
+                })),
+            },
+        };
+
+        let result = all_entities_query
+            .process_source_change(change)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1, "Should have exactly one result");
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "id" => VariableValue::from(json!("entity1")),
+                    "name" => VariableValue::from(json!("Entity One")),
+                    "status" => VariableValue::from(json!("active")),
+                    "value" => VariableValue::from(json!(100))
+                ),
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("entity1")),
+                    "name" => VariableValue::from(json!("Entity One Updated")),
+                    "status" => VariableValue::from(json!("inactive")),
+                    "value" => VariableValue::from(json!(200))
+                ),
+            }),
+            "Second SourceUpdate should UPDATE the existing entity"
+        );
+        //println!("✓ Second SourceUpdate updated existing entity");
+    }
+
+    //println!("✓ Test 1 PASSED: SourceUpdate implements upsert semantics");
+}
+
+/// Ensures that partial property updates correctly merge with existing entity state, preserving properties not included in the update.
+/// Critical for incremental updates where only changed fields are sent.
+pub async fn test_partial_updates(config: &(impl QueryTestConfig + Send)) {
+    //println!("\n=== Test 2: Partial Property Updates ===");
+
+    let all_entities_query = build_query(queries::all_entities_query(), config).await;
+
+    // Create entity with multiple properties
+    {
+        //println!("Creating entity with full properties...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "entity2"),
+                    labels: Arc::new([Arc::from("Entity")]),
+                    effective_from: 1000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "entity2",
+                    "name": "Full Entity",
+                    "status": "online",
+                    "value": 42
+                })),
+            },
+        };
+
+        let result = all_entities_query
+            .process_source_change(change)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(matches!(
+            result[0],
+            QueryPartEvaluationContext::Adding { .. }
+        ));
+        //println!("✓ Entity created with all properties");
+    }
+
+    // Partial update - only update value
+    {
+        //println!("Sending partial update (only value property)...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "entity2"),
+                    labels: Arc::new([Arc::from("Entity")]),
+                    effective_from: 2000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "value": 84
+                })),
+            },
+        };
+
+        let result = all_entities_query
+            .process_source_change(change)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "id" => VariableValue::from(json!("entity2")),
+                    "name" => VariableValue::from(json!("Full Entity")),
+                    "status" => VariableValue::from(json!("online")),
+                    "value" => VariableValue::from(json!(42))
+                ),
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("entity2")),
+                    "name" => VariableValue::from(json!("Full Entity")),  // Preserved
+                    "status" => VariableValue::from(json!("online")),     // Preserved
+                    "value" => VariableValue::from(json!(84))              // Updated
+                ),
+            }),
+            "Partial update should preserve unspecified properties"
+        );
+        //println!("✓ Partial update preserved unspecified properties");
+    }
+
+    //println!("✓ Test 2 PASSED: Partial updates preserve existing properties");
+}
+
+/// Simulates stateless event sources that send complete entity snapshots with each event, without tracking whether entities exist.
+/// Validates that the engine correctly handles repeated full-state updates from sources like IoT sensors or polling-based adapters.
+pub async fn test_stateless_processing(config: &(impl QueryTestConfig + Send)) {
+    //println!("\n=== Test 3: Stateless Event Processing ===");
+    //println!("Simulating a stateless process sending complete state each time...");
+
+    let sensor_query = build_query(queries::sensor_readings_query(), config).await;
+
+    // Event 1: First event from stateless process
+    {
+        //println!("Event 1: Initial sensor reading...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("iot", "sensor1"),
+                    labels: Arc::new([Arc::from("Sensor")]),
+                    effective_from: 1000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "sensor1",
+                    "temp": 20,
+                    "humidity": 60,
+                    "battery": 100
+                })),
+            },
+        };
+
+        let result = sensor_query.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("sensor1")),
+                    "temp" => VariableValue::from(json!(20)),
+                    "humidity" => VariableValue::from(json!(60)),
+                    "battery" => VariableValue::from(json!(100))
+                ),
+            }),
+            "First event should create the sensor"
+        );
+        //println!("✓ Event 1: Created new sensor node");
+    }
+
+    // Event 2: Second complete state update
+    {
+        //println!("Event 2: Updated sensor reading...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("iot", "sensor1"),
+                    labels: Arc::new([Arc::from("Sensor")]),
+                    effective_from: 2000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "sensor1",
+                    "temp": 21,
+                    "humidity": 61,
+                    "battery": 99
+                })),
+            },
+        };
+
+        let result = sensor_query.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "id" => VariableValue::from(json!("sensor1")),
+                    "temp" => VariableValue::from(json!(20)),
+                    "humidity" => VariableValue::from(json!(60)),
+                    "battery" => VariableValue::from(json!(100))
+                ),
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("sensor1")),
+                    "temp" => VariableValue::from(json!(21)),
+                    "humidity" => VariableValue::from(json!(61)),
+                    "battery" => VariableValue::from(json!(99))
+                ),
+            }),
+            "Second event should update existing sensor"
+        );
+        //println!("✓ Event 2: Updated existing sensor node");
+    }
+
+    // Event 3: Third complete state update
+    {
+        //println!("Event 3: Another sensor reading...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("iot", "sensor1"),
+                    labels: Arc::new([Arc::from("Sensor")]),
+                    effective_from: 3000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "sensor1",
+                    "temp": 22,
+                    "humidity": 62,
+                    "battery": 98
+                })),
+            },
+        };
+
+        let result = sensor_query.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "id" => VariableValue::from(json!("sensor1")),
+                    "temp" => VariableValue::from(json!(21)),
+                    "humidity" => VariableValue::from(json!(61)),
+                    "battery" => VariableValue::from(json!(99))
+                ),
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("sensor1")),
+                    "temp" => VariableValue::from(json!(22)),
+                    "humidity" => VariableValue::from(json!(62)),
+                    "battery" => VariableValue::from(json!(98))
+                ),
+            }),
+            "Third event should update existing sensor"
+        );
+        //println!("✓ Event 3: Updated existing sensor node");
+    }
+
+    //println!("✓ Test 3 PASSED: Stateless processing works correctly with SourceUpdate");
+}
+
+/// Verifies that entities correctly enter and exit query result sets when property changes affect filter condition matching.
+/// Tests the engine's ability to track entities transitioning between matching and non-matching states.
+pub async fn test_query_matching(config: &(impl QueryTestConfig + Send)) {
+    //println!("\n=== Test 4: Query Matching Verification ===");
+
+    let online_devices = build_query(queries::online_devices_query(), config).await;
+
+    // Create device with status=online (should match query)
+    {
+        //println!("Creating device with status='online'...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "device1"),
+                    labels: Arc::new([Arc::from("Device")]),
+                    effective_from: 1000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "device1",
+                    "name": "Test Device",
+                    "status": "online",
+                    "temp": 25,
+                    "humidity": 50
+                })),
+            },
+        };
+
+        let result = online_devices.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("device1")),
+                    "name" => VariableValue::from(json!("Test Device")),
+                    "temp" => VariableValue::from(json!(25)),
+                    "humidity" => VariableValue::from(json!(50))
+                ),
+            }),
+            "Device with status='online' should match query"
+        );
+        //println!("✓ Device created and matched query");
+    }
+
+    // Update device to status=offline (should unmatch query)
+    {
+        //println!("Updating device to status='offline'...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "device1"),
+                    labels: Arc::new([Arc::from("Device")]),
+                    effective_from: 2000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "device1",
+                    "name": "Test Device",
+                    "status": "offline",
+                    "temp": 25,
+                    "humidity": 50
+                })),
+            },
+        };
+
+        let result = online_devices.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                    "id" => VariableValue::from(json!("device1")),
+                    "name" => VariableValue::from(json!("Test Device")),
+                    "temp" => VariableValue::from(json!(25)),
+                    "humidity" => VariableValue::from(json!(50))
+                ),
+            }),
+            "Device with status='offline' should be removed from results"
+        );
+        //println!("✓ Device updated and removed from query results");
+    }
+
+    // Update device back to status=online (should match again)
+    {
+        //println!("Updating device back to status='online'...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "device1"),
+                    labels: Arc::new([Arc::from("Device")]),
+                    effective_from: 3000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "device1",
+                    "name": "Test Device",
+                    "status": "online",
+                    "temp": 26,
+                    "humidity": 51
+                })),
+            },
+        };
+
+        let result = online_devices.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("device1")),
+                    "name" => VariableValue::from(json!("Test Device")),
+                    "temp" => VariableValue::from(json!(26)),
+                    "humidity" => VariableValue::from(json!(51))
+                ),
+            }),
+            "Device with status='online' should match query again"
+        );
+        //println!("✓ Device re-added to query results");
+    }
+
+    //println!("✓ Test 4 PASSED: Query matching works correctly with SourceUpdate");
+}
+
+/// Confirms that updates to one entity are properly isolated and do not affect other entities in the query.
+/// Ensures the engine correctly manages concurrent entity state without cross-contamination.
+pub async fn test_multiple_entities(config: &(impl QueryTestConfig + Send)) {
+    //println!("\n=== Test 5: Multiple Entities Isolation ===");
+
+    let all_entities = build_query(queries::all_entities_query(), config).await;
+
+    // Create three entities
+    //println!("Creating three entities...");
+    for i in 1..=3 {
+        let id = format!("entity{}", i);
+        let name = format!("Entity {}", i);
+
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", &id),
+                    labels: Arc::new([Arc::from("Entity")]),
+                    effective_from: (i * 1000) as u64,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": &id,
+                    "name": &name,
+                    "status": "active",
+                    "value": i * 10
+                })),
+            },
+        };
+
+        let result = all_entities.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(matches!(
+            result[0],
+            QueryPartEvaluationContext::Adding { .. }
+        ));
+        //println!("✓ Created {}", id);
+    }
+
+    // Update only entity2
+    {
+        //println!("Updating only entity2...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "entity2"),
+                    labels: Arc::new([Arc::from("Entity")]),
+                    effective_from: 4000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "entity2",
+                    "name": "Entity 2 Updated",
+                    "status": "inactive",
+                    "value": 99
+                })),
+            },
+        };
+
+        let result = all_entities.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1, "Should only affect entity2");
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "id" => VariableValue::from(json!("entity2")),
+                    "name" => VariableValue::from(json!("Entity 2")),
+                    "status" => VariableValue::from(json!("active")),
+                    "value" => VariableValue::from(json!(20))
+                ),
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("entity2")),
+                    "name" => VariableValue::from(json!("Entity 2 Updated")),
+                    "status" => VariableValue::from(json!("inactive")),
+                    "value" => VariableValue::from(json!(99))
+                ),
+            }),
+            "Should update only entity2"
+        );
+        //println!("✓ Updated only entity2, others unaffected");
+    }
+
+    //println!("✓ Test 5 PASSED: Multiple entities are properly isolated");
+}
+
+/// Validates that upsert semantics work correctly for relationships (edges), not just nodes.
+/// Tests creation and modification of graph edges using SourceUpdate operations.
+pub async fn test_relationship_upsert(config: &(impl QueryTestConfig + Send)) {
+    //println!("\n=== Test 6: Relationship Upsert ===");
+
+    let connected_query = build_query(queries::connected_devices_query(), config).await;
+
+    // First create the nodes
+    for id in ["device1", "device2"] {
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", id),
+                    labels: Arc::new([Arc::from("Device")]),
+                    effective_from: 1000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": id
+                })),
+            },
+        };
+        let _ = connected_query.process_source_change(change).await;
+    }
+
+    // First SourceUpdate for relationship - should create it
+    {
+        //println!("Creating relationship with SourceUpdate...");
+        let change = SourceChange::Update {
+            element: Element::Relation {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "conn1"),
+                    labels: Arc::new([Arc::from("CONNECTED_TO")]),
+                    effective_from: 2000,
+                },
+                in_node: ElementReference::new("test", "device1"),
+                out_node: ElementReference::new("test", "device2"),
+                properties: ElementPropertyMap::from(json!({
+                    "strength": 50
+                })),
+            },
+        };
+
+        let result = connected_query.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "from_id" => VariableValue::from(json!("device1")),
+                    "to_id" => VariableValue::from(json!("device2")),
+                    "strength" => VariableValue::from(json!(50))
+                ),
+            }),
+            "First relationship SourceUpdate should create it"
+        );
+        //println!("✓ Relationship created");
+    }
+
+    // Second SourceUpdate for same relationship - should update it
+    {
+        //println!("Updating relationship with SourceUpdate...");
+        let change = SourceChange::Update {
+            element: Element::Relation {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "conn1"),
+                    labels: Arc::new([Arc::from("CONNECTED_TO")]),
+                    effective_from: 3000,
+                },
+                in_node: ElementReference::new("test", "device1"),
+                out_node: ElementReference::new("test", "device2"),
+                properties: ElementPropertyMap::from(json!({
+                    "strength": 75
+                })),
+            },
+        };
+
+        let result = connected_query.process_source_change(change).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result.contains(&QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "from_id" => VariableValue::from(json!("device1")),
+                    "to_id" => VariableValue::from(json!("device2")),
+                    "strength" => VariableValue::from(json!(50))
+                ),
+                after: variablemap!(
+                    "from_id" => VariableValue::from(json!("device1")),
+                    "to_id" => VariableValue::from(json!("device2")),
+                    "strength" => VariableValue::from(json!(75))
+                ),
+            }),
+            "Second relationship SourceUpdate should update it"
+        );
+        //println!("✓ Relationship updated");
+    }
+
+    //println!("✓ Test 6 PASSED: Relationship upsert works correctly");
+}
+
+/// Tests that aggregation queries correctly update aggregate values when entities are created or modified via SourceUpdate.
+/// Validates incremental aggregation maintenance across entity lifecycle transitions.
+pub async fn test_aggregation_with_upserts(config: &(impl QueryTestConfig + Send)) {
+    //println!("\n=== Test 7: Aggregation with Upserts ===");
+
+    let count_query = build_query(queries::entity_count_by_status_query(), config).await;
+
+    // Create first entity with status=active
+    {
+        //println!("Creating first entity with status='active'...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "e1"),
+                    labels: Arc::new([Arc::from("Entity")]),
+                    effective_from: 1000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "e1",
+                    "status": "active"
+                })),
+            },
+        };
+
+        let result = count_query.process_source_change(change).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
+            grouping_keys: vec!["status".to_string()],
+            default_before: true,
+            default_after: false,
+            before: Some(variablemap!(
+                "status" => VariableValue::from(json!("active")),
+                "count" => VariableValue::from(json!(0))
+            )),
+            after: variablemap!(
+                "status" => VariableValue::from(json!("active")),
+                "count" => VariableValue::from(json!(1))
+            ),
+        }));
+        //println!("✓ Count for 'active' = 1");
+    }
+
+    // Create second entity with status=active
+    {
+        //println!("Creating second entity with status='active'...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "e2"),
+                    labels: Arc::new([Arc::from("Entity")]),
+                    effective_from: 2000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "e2",
+                    "status": "active"
+                })),
+            },
+        };
+
+        let result = count_query.process_source_change(change).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(matches!(&result[0],
+            QueryPartEvaluationContext::Aggregation { after, .. }
+            if after.get("count") == Some(&VariableValue::from(json!(2)))
+        ));
+        //println!("✓ Count for 'active' = 2");
+    }
+
+    // Update first entity to status=inactive
+    {
+        //println!("Updating first entity to status='inactive'...");
+        let change = SourceChange::Update {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("test", "e1"),
+                    labels: Arc::new([Arc::from("Entity")]),
+                    effective_from: 3000,
+                },
+                properties: ElementPropertyMap::from(json!({
+                    "id": "e1",
+                    "status": "inactive"
+                })),
+            },
+        };
+
+        let result = count_query.process_source_change(change).await.unwrap();
+        assert_eq!(result.len(), 2); // Two aggregation changes
+
+        // Check active count decreased to 1
+        assert!(result.iter().any(|ctx| matches!(ctx,
+            QueryPartEvaluationContext::Aggregation { after, .. }
+            if after.get("status") == Some(&VariableValue::from(json!("active")))
+            && after.get("count") == Some(&VariableValue::from(json!(1)))
+        )));
+
+        // Check inactive count increased to 1
+        assert!(result.iter().any(|ctx| matches!(ctx,
+            QueryPartEvaluationContext::Aggregation { after, before, .. }
+            if after.get("status") == Some(&VariableValue::from(json!("inactive")))
+            && after.get("count") == Some(&VariableValue::from(json!(1)))
+            && before.as_ref().and_then(|b| b.get("count")) == Some(&VariableValue::from(json!(0)))
+        )));
+
+        //println!("✓ Count for 'active' = 1, 'inactive' = 1");
+    }
+
+    //println!("✓ Test 7 PASSED: Aggregations work correctly with upserts");
+}
+
+// Helper function to build a query
+async fn build_query(query_str: &str, config: &(impl QueryTestConfig + Send)) -> ContinuousQuery {
+    let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+    let parser = Arc::new(CypherParser::new(function_registry.clone()));
+    let mut builder =
+        QueryBuilder::new(query_str, parser).with_function_registry(function_registry);
+    builder = config.config_query(builder).await;
+    builder.build().await
+}

--- a/shared-tests/src/use_cases/source_update_upsert/queries.rs
+++ b/shared-tests/src/use_cases/source_update_upsert/queries.rs
@@ -1,0 +1,55 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Simple query to track all entities
+pub fn all_entities_query() -> &'static str {
+    "
+    MATCH (e:Entity)
+    RETURN e.id as id, e.name as name, e.status as status, e.value as value
+    "
+}
+
+/// Query to track online devices
+pub fn online_devices_query() -> &'static str {
+    "
+    MATCH (d:Device)
+    WHERE d.status = 'online'
+    RETURN d.id as id, d.name as name, d.temp as temp, d.humidity as humidity
+    "
+}
+
+/// Query to track sensors with temperature
+pub fn sensor_readings_query() -> &'static str {
+    "
+    MATCH (s:Sensor)
+    WHERE s.temp IS NOT NULL
+    RETURN s.id as id, s.temp as temp, s.humidity as humidity, s.battery as battery
+    "
+}
+
+/// Query to track relationships
+pub fn connected_devices_query() -> &'static str {
+    "
+    MATCH (d1:Device)-[c:CONNECTED_TO]->(d2:Device)
+    RETURN d1.id as from_id, d2.id as to_id, c.strength as strength
+    "
+}
+
+/// Aggregation query to count entities by status
+pub fn entity_count_by_status_query() -> &'static str {
+    "
+    MATCH (e:Entity)
+    RETURN e.status as status, count(e) as count
+    "
+}


### PR DESCRIPTION
# Description

Validates that SourceChange::Update implements correct upsert semantics (create-then-update) with 7 tests covering partial updates, stateless processing, query matching, relationships, and aggregations.

All tests pass on in-memory, RocksDB, and Garnet.

1. **`test_upsert_semantics`** - Validates first update creates, subsequent updates modify
2. **`test_partial_updates`** - Ensures partial property updates preserve unspecified properties
3. **`test_stateless_processing`** - Simulates stateless sources sending complete snapshots
4. **`test_query_matching`** - Verifies entities correctly enter/exit result sets on property
changes
5. **`test_multiple_entities`** - Confirms entity updates are properly isolated
6. **`test_relationship_upsert`** - Validates upsert works for relationships (edges), not just
nodes
7. **`test_aggregation_with_upserts`** - Tests aggregation queries handle entity lifecycle 
transitions

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).