### PR TITLE
Update building prereqs to include libjq

### DIFF
--- a/docs/contributing/contributing-code/contributing-code-prerequisites/README.md
+++ b/docs/contributing/contributing-code/contributing-code-prerequisites/README.md
@@ -23,13 +23,13 @@ This is the list of core dependencies to install for the most common tasks. In g
 
 Building the `middleware` crate will require `libjq` to be installed in your system. This can be done by [installing JQ](https://jqlang.org/download/) using your system package manager, such as Homebrew on MacOS, vcpkg on Windows or apt on Linux. Depending on your installation, you may also need to manually set the `JQ_LIB_DIR` environment variable if the build cannot automatically find it. Some common places where you might find this are:
 
-| | |
+| Package Manager | Path |
 |-|-|
-| `/opt/homebrew/lib` | Homebrew |
-| `/usr/lib/x86_64-linux-gnu` | apt |
-| `/usr/lib64` | tdnf |
-| `C:\vcpkg\installed\x64-windows\lib` | vcpkg |
-| `C:\ProgramData\chocolatey\lib` | Chocolatey |
+| Homebrew | `/opt/homebrew/lib` |
+| apt | `/usr/lib/x86_64-linux-gnu` |
+| tdnf | `/usr/lib64` |
+| vcpkg | `C:\vcpkg\installed\x64-windows\lib` |
+| Chocolatey | `C:\ProgramData\chocolatey\lib` |
 
 ### Enable Git Hooks
 


### PR DESCRIPTION
This pull request adds documentation for a shared library dependency required for building the `middleware` crate. The most significant change is the inclusion of installation instructions and troubleshooting guidance for `libjq`.

Dependency documentation updates:

* Added a new section under prerequisites detailing the need for the `libjq` shared library when building the `middleware` crate, including installation instructions and common library paths for various package managers.