### PR TITLE
Updated runner for generating code coverage

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   core_code_coverage:
     name: Generate Code Coverage for drasi-core
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     permissions:
       contents: read
     services:


### PR DESCRIPTION
# Description

This pull request makes a minor update to the GitHub Actions workflow by changing the runner for the `core_code_coverage` job to use a more specific machine type.

* Updated the `core_code_coverage` job in `.github/workflows/coverage.yaml` to run on `ubuntu-latest-4-cores` instead of `ubuntu-latest`, likely to improve performance or consistency.
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
