### PR TITLE
Add Qdrant vector database reaction for drasi-lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "components/reactions/storedproc-mssql",
   "components/reactions/storedproc-mysql",
   "components/reactions/storedproc-postgres",
+  "components/reactions/qdrant",
 
   # Index Plugins
   "components/indexes/rocksdb",

--- a/components/reactions/qdrant/Cargo.toml
+++ b/components/reactions/qdrant/Cargo.toml
@@ -1,0 +1,66 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-reaction-qdrant"
+version = "0.1.0"
+edition = "2021"
+authors = ["Drasi Project"]
+description = "Qdrant vector database reaction plugin for Drasi"
+license = "Apache-2.0"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi", "plugin", "reaction", "qdrant", "vector"]
+categories = ["database"]
+
+[lints]
+workspace = true
+
+[dependencies]
+drasi-lib = { version = "0.3.3", path = "../../../lib" }
+drasi-core = { version = "0.3.2", path = "../../../core" }
+
+# Async runtime
+tokio = { version = "1.0", features = ["full"] }
+async-trait = "0.1"
+futures = "0.3"
+tokio-stream = "0.1"
+
+# Qdrant client
+qdrant-client = "1.12"
+
+# HTTP client for Azure OpenAI
+reqwest = { version = "0.12", features = ["json"] }
+
+# Templating
+handlebars = "5.1"
+
+# Hashing/UUID
+sha2 = "0.10"
+uuid = { version = "1.0", features = ["v4", "v5"] }
+
+# Utilities
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+log = "0.4"
+anyhow = "1.0"
+chrono = "0.4"
+prost-types = "0.12"
+ordered-float = "3.0"
+rand = "0.8"
+
+[dev-dependencies]
+tokio-test = "0.4"
+env_logger = "0.11"
+serial_test = "3.0"
+testcontainers = "0.23"

--- a/components/reactions/qdrant/DESIGN.md
+++ b/components/reactions/qdrant/DESIGN.md
@@ -1,0 +1,142 @@
+# Qdrant Reaction - Architecture & Design
+
+This document describes the architecture of the Qdrant reaction. For usage documentation, see [README.md](./README.md).
+
+## Current Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           QdrantReaction                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  ┌────────────────┐    ┌────────────────┐    ┌────────────────┐         │
+│  │    Embedder    │    │   Handlebars   │    │   Document     │         │
+│  │     Trait      │    │   Templating   │    │    Builder     │         │
+│  └────────────────┘    └────────────────┘    └────────────────┘         │
+│         │                      │                      │                 │
+│  ┌──────┴───────┐              │               ┌──────┴───────┐         │
+│  │ MockEmbedder │              │               │  UUID Gen    │         │
+│  │ AzureOpenAI  │              │               │ (RFC 4122)   │         │
+│  └──────────────┘              │               └──────────────┘         │
+│                                │                                        │
+│  ┌──────────────────────────────────────────────────────────────────┐   │
+│  │                    Sync Protocol (start())                       │   │
+│  │   Subscribe → Snapshot → Batch Materialize → Process Loop        │   │
+│  └──────────────────────────────────────────────────────────────────┘   │
+│                                │                                        │
+│  ┌──────────────────────────────────────────────────────────────────┐   │
+│  │                      Batch Processing                            │   │
+│  │   ┌────────────────────┐      ┌────────────────────┐             │   │
+│  │   │ Embedding Batches  │      │  Upsert Batches    │             │   │
+│  │   │ (configurable size)│  →   │ (configurable size)│             │   │
+│  │   └────────────────────┘      └────────────────────┘             │   │
+│  └──────────────────────────────────────────────────────────────────┘   │
+│                                │                                        │
+│                                ▼                                        │
+│  ┌──────────────────────────────────────────────────────────────────┐   │
+│  │                       Qdrant Client                              │   │
+│  │                 (upsert / delete points)                         │   │
+│  └──────────────────────────────────────────────────────────────────┘   │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Implemented Features
+
+### Embedder Trait
+- **MockEmbedder**: SHA-256 based deterministic embeddings for testing
+- **AzureOpenAIEmbedder**: Production embeddings via Azure OpenAI API
+- Extensible trait allows custom embedder implementations
+
+### Batch Processing
+- **Embedding Batches**: Multiple documents embedded in single API call
+  - Configurable via `BatchConfig.embedding_batch_size` (default: 50)
+- **Upsert Batches**: Multiple points written in single Qdrant call
+  - Configurable via `BatchConfig.upsert_batch_size` (default: 100)
+
+### Materialized View Sync Protocol
+On startup, the reaction follows the drasi-lib synchronization protocol:
+1. **Subscribe** - Subscribes to queries, buffering incoming events
+2. **Snapshot** - Calls `get_current_results()` to load existing data
+3. **Materialize** - Batch upserts snapshot data to Qdrant
+4. **Process** - Processes incremental updates from event buffer
+
+This ensures consistent initial state before processing changes.
+
+### Deterministic UUIDs
+- RFC 4122 UUID v5 generation from `(collection_name, key_value)` namespace
+- Same key always produces same UUID across restarts
+- Enables idempotent upsert operations
+
+### Document Building
+- Handlebars templating for content generation
+- `json` helper for nested object serialization
+- Supports nested field paths (e.g., `product.category.name`)
+
+## Known Limitations
+
+### DrasiQuery Dependency for Snapshot Loading
+
+The snapshot loading phase depends on downcasting the query instance to `DrasiQuery`:
+
+```rust
+if let Some(drasi_query) = query.as_any().downcast_ref::<DrasiQuery>() {
+    let current_results = drasi_query.get_current_results().await;
+    // ...
+}
+```
+
+**Implications:**
+- If future versions of Drasi introduce other `Query` implementations (e.g., proxied queries, federated queries), this cast will fail
+- When the cast fails, the reaction logs a warning and skips snapshot loading for that query
+- The reaction will still function for incremental updates, but will start with an empty initial state
+
+**Mitigation:**
+- Consider adding `get_current_results()` to the `Query` trait in drasi-lib
+- Alternatively, use a trait object pattern with a `Snapshotable` trait
+
+## Future Improvements
+
+### Embedder Extraction to Shared Crate
+
+Extract the `Embedder` trait and implementations to a shared `drasi-embeddings` crate for reuse across multiple vector store reactions.
+
+**Proposed structure:**
+```
+components/shared/embeddings/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs           # Public exports
+│   ├── traits.rs        # Embedder trait
+│   ├── azure_openai.rs  # AzureOpenAIEmbedder
+│   ├── openai.rs        # OpenAI (non-Azure)
+│   ├── mock.rs          # MockEmbedder
+│   └── cache.rs         # Optional caching layer
+```
+
+**Benefits:**
+- Reuse across Qdrant, Redis, pgvector reactions
+- Centralized embedder configuration
+- Shared caching and rate limiting
+- Consistent API across vector stores
+
+### Additional Embedder Providers
+- OpenAI (non-Azure)
+- Ollama (local models)
+- Hugging Face Inference API
+- Cohere embeddings
+
+### Embedding Cache
+- Optional caching layer to avoid re-embedding identical content
+- LRU cache with configurable size
+- Content hash as cache key
+
+### Metadata Filtering
+- Selective field storage in Qdrant payload
+- Filter expressions for payload fields
+- Index configuration for filtered search
+
+### Multi-Collection Support
+- Route different queries to different collections
+- Per-query collection configuration
+- Cross-collection search coordination

--- a/components/reactions/qdrant/README.md
+++ b/components/reactions/qdrant/README.md
@@ -1,0 +1,620 @@
+# Qdrant Reaction
+
+A vector database reaction that synchronizes Drasi query results to Qdrant for semantic search and retrieval-augmented generation (RAG) applications.
+
+## Overview
+
+The Qdrant Reaction generates embeddings from query result data and stores them as searchable vector points in a Qdrant collection. It enables semantic search over your continuous query results, making it ideal for building AI-powered search, recommendation systems, and RAG pipelines.
+
+**Output Method**: Uses gRPC to communicate with Qdrant, supporting both local instances and Qdrant Cloud.
+
+### Key Capabilities
+
+- **Automatic Embedding Generation**: Generates embeddings using Azure OpenAI or mock embedders
+- **Template-Based Content**: Uses Handlebars templates to construct document content from query results
+- **Deterministic Point IDs**: RFC 4122 UUID v5 ensures consistent point IDs for upsert/delete operations
+- **Collection Management**: Optionally creates collections with correct vector dimensions
+- **Full Lifecycle Support**: Handles ADD, UPDATE, and DELETE operations from continuous queries
+
+### Use Cases
+
+- **Semantic Search**: Enable natural language search over structured data
+- **RAG Applications**: Build retrieval-augmented generation pipelines
+- **Recommendation Systems**: Find similar items based on content
+- **Knowledge Bases**: Create searchable document repositories from query results
+- **Content Discovery**: Surface related content based on semantic similarity
+
+**Best for**: Applications requiring semantic search over continuously updated data.
+
+**Not recommended for**: Scenarios where exact keyword matching is sufficient.
+
+### Synchronization Protocol
+
+The reaction follows the drasi-lib materialized view protocol:
+
+1. **Subscribe** - Subscribes to configured queries, buffering incoming events
+2. **Snapshot** - Loads existing query results via `get_current_results()`
+3. **Materialize** - Batch upserts snapshot data to Qdrant collection
+4. **Process** - Processes incremental updates from the event buffer
+
+This ensures the reaction starts with a consistent view of all existing data before processing incremental changes. Progress is logged for large datasets (> 1000 items).
+
+## Configuration
+
+### Builder Pattern (Recommended)
+
+The builder pattern provides a fluent, type-safe API for creating QdrantReaction instances.
+
+#### With MockEmbedder (Testing)
+
+```rust
+use drasi_reaction_qdrant::{
+    QdrantReaction, QdrantReactionConfig, QdrantConfig,
+    EmbeddingConfig, DocumentConfig, BatchConfig, RetryConfig, MockEmbedder,
+};
+use std::sync::Arc;
+
+let config = QdrantReactionConfig {
+    qdrant: QdrantConfig {
+        endpoint: "http://localhost:6334".to_string(),
+        api_key: None,
+        collection_name: "my_documents".to_string(),
+        create_collection: true,
+    },
+    embedding: EmbeddingConfig::Mock { dimensions: 1536 },
+    document: DocumentConfig {
+        document_template: "{{name}}: {{description}}".to_string(),
+        key_field: "id".to_string(),
+        ..Default::default()
+    },
+    batch: BatchConfig::default(),
+    retry: RetryConfig::default(),
+};
+
+let embedder = Arc::new(MockEmbedder::new(1536));
+let reaction = QdrantReaction::with_embedder(
+    "my-qdrant-reaction",
+    vec!["product-query".to_string()],
+    config,
+    embedder,
+)?;
+
+drasi.add_reaction(Arc::new(reaction)).await?;
+```
+
+#### With AzureOpenAIEmbedder (Production)
+
+```rust
+use drasi_reaction_qdrant::{
+    QdrantReaction, QdrantReactionConfig, QdrantConfig,
+    EmbeddingConfig, DocumentConfig, BatchConfig, RetryConfig, AzureOpenAIEmbedder,
+};
+use std::sync::Arc;
+
+let config = QdrantReactionConfig {
+    qdrant: QdrantConfig {
+        endpoint: "http://localhost:6334".to_string(),
+        api_key: None,
+        collection_name: "products".to_string(),
+        create_collection: true,
+    },
+    embedding: EmbeddingConfig::AzureOpenai {
+        endpoint: "https://myresource.openai.azure.com".to_string(),
+        model: "text-embedding-3-large".to_string(),
+        api_key: "your-api-key".to_string(),
+        dimensions: 3072,
+        api_version: "2024-02-01".to_string(),
+    },
+    document: DocumentConfig {
+        document_template: "Product: {{name}}. Description: {{description}}. Category: {{category}}".to_string(),
+        title_template: Some("{{name}}".to_string()),
+        key_field: "product_id".to_string(),
+        metadata_fields: None,
+    },
+    batch: BatchConfig::default(),
+    retry: RetryConfig::default(),
+};
+
+let embedder = Arc::new(AzureOpenAIEmbedder::new(
+    "https://myresource.openai.azure.com".to_string(),
+    "text-embedding-3-large".to_string(),
+    "your-api-key".to_string(),
+    3072,
+    "2024-02-01".to_string(),
+));
+
+let reaction = QdrantReaction::with_embedder(
+    "product-search",
+    vec!["product-updates".to_string()],
+    config,
+    embedder,
+)?;
+
+drasi.add_reaction(Arc::new(reaction)).await?;
+```
+
+### Config Struct Approach
+
+For programmatic configuration or deserialization scenarios:
+
+```rust
+use drasi_reaction_qdrant::{
+    QdrantReaction, QdrantReactionConfig, QdrantConfig,
+    EmbeddingConfig, DocumentConfig, BatchConfig, RetryConfig, MockEmbedder,
+};
+use std::sync::Arc;
+
+let config = QdrantReactionConfig {
+    qdrant: QdrantConfig {
+        endpoint: "http://localhost:6334".to_string(),
+        api_key: None,
+        collection_name: "test_collection".to_string(),
+        create_collection: true,
+    },
+    embedding: EmbeddingConfig::Mock { dimensions: 768 },
+    document: DocumentConfig {
+        document_template: "{{content}}".to_string(),
+        title_template: None,
+        key_field: "id".to_string(),
+        metadata_fields: None,
+    },
+    batch: BatchConfig::default(),
+    retry: RetryConfig::default(),
+};
+
+let embedder = Arc::new(MockEmbedder::new(768));
+let reaction = QdrantReaction::with_embedder(
+    "test-reaction",
+    vec!["test-query".to_string()],
+    config,
+    embedder,
+)?;
+```
+
+## Configuration Options
+
+### Core Options
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `id` | Unique identifier for the reaction | `String` | **(Required)** |
+| `queries` | Query IDs to subscribe to | `Vec<String>` | **(Required)** |
+| `auto_start` | Start automatically when added | `bool` | `true` |
+| `priority_queue_capacity` | Maximum events in queue | `usize` | `10000` |
+
+### Qdrant Options (`QdrantConfig`)
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `endpoint` | Qdrant gRPC endpoint URL | `String` | **(Required)** |
+| `api_key` | API key for Qdrant Cloud | `Option<String>` | `None` |
+| `collection_name` | Target collection name | `String` | **(Required)** |
+| `create_collection` | Create collection if missing | `bool` | `true` |
+
+### Embedding Options (`EmbeddingConfig`)
+
+`EmbeddingConfig` is a tagged enum with variants for each embedding provider. Each variant contains only the fields relevant to that provider, providing compile-time enforcement of required fields.
+
+#### Mock Variant
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `dimensions` | Embedding vector dimensions | `usize` | `3072` |
+
+#### AzureOpenai Variant
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `endpoint` | Azure OpenAI endpoint | `String` | **(Required)** |
+| `model` | Model deployment name | `String` | **(Required)** |
+| `api_key` | Azure OpenAI API key | `String` | **(Required)** |
+| `dimensions` | Embedding vector dimensions | `usize` | `3072` |
+| `api_version` | Azure OpenAI API version | `String` | `"2024-02-01"` |
+
+### Document Options (`DocumentConfig`)
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `document_template` | Handlebars template for content | `String` | **(Required)** |
+| `title_template` | Optional title template | `Option<String>` | `None` |
+| `key_field` | Field path for point ID generation | `String` | **(Required)** |
+| `metadata_fields` | Fields to include in payload | `Option<Vec<String>>` | `None` (all fields) |
+
+### Batch Options (`BatchConfig`)
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `embedding_batch_size` | Max documents per embedding API call | `usize` | `50` |
+| `upsert_batch_size` | Max points per Qdrant upsert call | `usize` | `100` |
+
+### Retry Options (`RetryConfig`)
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `max_retries` | Maximum retry attempts before failure | `u32` | `3` |
+| `initial_delay_ms` | Initial delay between retries (ms) | `u64` | `100` |
+| `max_delay_ms` | Maximum delay between retries (ms) | `u64` | `5000` |
+
+Retry uses exponential backoff with jitter. On persistent failure:
+- **Snapshot loading**: Fails startup (prevents inconsistent state)
+- **Stream processing**: Panics (forces pod restart for zero data loss)
+
+## Template Variables
+
+Document templates have access to all fields from the query result data.
+
+### Available Variables
+
+For ADD and UPDATE events:
+- All fields from `after` data (e.g., `{{name}}`, `{{description}}`, `{{price}}`)
+- Nested fields using dot notation (e.g., `{{product.category.name}}`)
+
+For DELETE events:
+- All fields from `before` data
+
+### Template Helpers
+
+The `json` helper converts values to JSON strings:
+
+```handlebars
+Full object: {{json this}}
+Nested field: {{json metadata}}
+```
+
+### Example Templates
+
+**Simple product:**
+```handlebars
+{{name}}: {{description}}
+```
+
+**Rich product with metadata:**
+```handlebars
+Product: {{name}}
+Category: {{category}}
+Description: {{description}}
+Price: ${{price}}
+Tags: {{json tags}}
+```
+
+**Article with structured content:**
+```handlebars
+Title: {{title}}
+Author: {{author.name}}
+Summary: {{summary}}
+Full Content: {{body}}
+```
+
+## Usage Examples
+
+### Example 1: Basic Testing Setup
+
+Simple setup with mock embeddings for development:
+
+```rust
+use drasi_reaction_qdrant::{QdrantReaction, QdrantReactionConfig, QdrantConfig, EmbeddingConfig, DocumentConfig, BatchConfig, RetryConfig, MockEmbedder};
+use std::sync::Arc;
+
+let config = QdrantReactionConfig {
+    qdrant: QdrantConfig {
+        endpoint: "http://localhost:6334".to_string(),
+        api_key: None,
+        collection_name: "dev_collection".to_string(),
+        create_collection: true,
+    },
+    embedding: EmbeddingConfig::Mock { dimensions: 384 },
+    document: DocumentConfig {
+        document_template: "{{title}}: {{content}}".to_string(),
+        key_field: "id".to_string(),
+        ..Default::default()
+    },
+    batch: BatchConfig::default(),
+    retry: RetryConfig::default(),
+};
+
+let embedder = Arc::new(MockEmbedder::new(384));
+let reaction = QdrantReaction::with_embedder(
+    "dev-search",
+    vec!["articles".to_string()],
+    config,
+    embedder,
+)?;
+
+drasi.add_reaction(Arc::new(reaction)).await?;
+```
+
+### Example 2: Production Azure OpenAI
+
+Full production setup with Azure OpenAI embeddings:
+
+```rust
+use drasi_reaction_qdrant::{QdrantReaction, QdrantReactionConfig, QdrantConfig, EmbeddingConfig, DocumentConfig, BatchConfig, RetryConfig, AzureOpenAIEmbedder};
+use std::sync::Arc;
+
+let config = QdrantReactionConfig {
+    qdrant: QdrantConfig {
+        endpoint: "https://my-qdrant.cloud:6333".to_string(),
+        api_key: Some("qdrant-api-key".to_string()),
+        collection_name: "production_docs".to_string(),
+        create_collection: true,
+    },
+    embedding: EmbeddingConfig::AzureOpenai {
+        endpoint: "https://myresource.openai.azure.com".to_string(),
+        model: "text-embedding-3-large".to_string(),
+        api_key: "azure-api-key".to_string(),
+        dimensions: 3072,
+        api_version: "2024-02-01".to_string(),
+    },
+    document: DocumentConfig {
+        document_template: "{{title}}\n\n{{summary}}\n\n{{body}}".to_string(),
+        title_template: Some("{{title}}".to_string()),
+        key_field: "document_id".to_string(),
+        metadata_fields: None,
+    },
+    batch: BatchConfig::default(),
+    retry: RetryConfig::default(),
+};
+
+let embedder = Arc::new(AzureOpenAIEmbedder::new(
+    "https://myresource.openai.azure.com".to_string(),
+    "text-embedding-3-large".to_string(),
+    "azure-api-key".to_string(),
+    3072,
+    "2024-02-01".to_string(),
+));
+
+let reaction = QdrantReaction::with_embedder(
+    "doc-search",
+    vec!["document-updates".to_string()],
+    config,
+    embedder,
+)?;
+
+drasi.add_reaction(Arc::new(reaction)).await?;
+```
+
+### Example 3: E-commerce Product Search
+
+Optimized for product catalog search:
+
+```rust
+let config = QdrantReactionConfig {
+    qdrant: QdrantConfig {
+        endpoint: "http://localhost:6334".to_string(),
+        api_key: None,
+        collection_name: "products".to_string(),
+        create_collection: true,
+    },
+    embedding: EmbeddingConfig::AzureOpenai {
+        endpoint: "https://myresource.openai.azure.com".to_string(),
+        model: "text-embedding-ada-002".to_string(),
+        api_key: "your-key".to_string(),
+        dimensions: 1536,
+        api_version: "2024-02-01".to_string(),
+    },
+    document: DocumentConfig {
+        // Rich product description for semantic search
+        document_template: r#"
+Product: {{name}}
+Brand: {{brand}}
+Category: {{category}} > {{subcategory}}
+Description: {{description}}
+Features: {{json features}}
+Price: ${{price}}
+        "#.trim().to_string(),
+        title_template: Some("{{name}} by {{brand}}".to_string()),
+        key_field: "sku".to_string(),
+        metadata_fields: None,
+    },
+    batch: BatchConfig::default(),
+    retry: RetryConfig::default(),
+};
+```
+
+### Example 4: Multi-Query Monitoring
+
+Subscribe to multiple queries:
+
+```rust
+let reaction = QdrantReaction::with_embedder(
+    "unified-search",
+    vec![
+        "product-updates".to_string(),
+        "article-updates".to_string(),
+        "faq-updates".to_string(),
+    ],
+    config,
+    embedder,
+)?;
+
+drasi.add_reaction(Arc::new(reaction)).await?;
+```
+
+### Example 5: Custom Embedder Implementation
+
+Implement the `Embedder` trait for custom providers:
+
+```rust
+use drasi_reaction_qdrant::Embedder;
+use anyhow::Result;
+use async_trait::async_trait;
+
+pub struct MyCustomEmbedder {
+    dimensions: usize,
+    // ... your configuration
+}
+
+#[async_trait]
+impl Embedder for MyCustomEmbedder {
+    async fn generate(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        // Call your embedding service here
+        let embeddings = texts.iter()
+            .map(|text| {
+                // Generate embedding for text
+                vec![0.0f32; self.dimensions] // placeholder
+            })
+            .collect();
+        Ok(embeddings)
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    fn name(&self) -> &str {
+        "my_custom_embedder"
+    }
+}
+
+// Use with QdrantReaction
+let embedder = Arc::new(MyCustomEmbedder { dimensions: 768 });
+let reaction = QdrantReaction::with_embedder(
+    "custom-search",
+    vec!["my-query".to_string()],
+    config,
+    embedder,
+)?;
+```
+
+## Embedder Implementations
+
+### MockEmbedder
+
+Deterministic SHA-256 based embeddings for testing. Produces consistent embeddings without external API calls.
+
+```rust
+use drasi_reaction_qdrant::MockEmbedder;
+
+let embedder = MockEmbedder::new(1536); // 1536 dimensions
+
+// Same text always produces same embedding
+let emb1 = embedder.generate(&["hello".to_string()]).await?;
+let emb2 = embedder.generate(&["hello".to_string()]).await?;
+assert_eq!(emb1, emb2);
+```
+
+**Use for**: Unit tests, integration tests, development, demos.
+
+### AzureOpenAIEmbedder
+
+Production embeddings via Azure OpenAI API.
+
+```rust
+use drasi_reaction_qdrant::AzureOpenAIEmbedder;
+
+let embedder = AzureOpenAIEmbedder::new(
+    "https://myresource.openai.azure.com".to_string(),
+    "text-embedding-3-large".to_string(),  // deployment name
+    "your-api-key".to_string(),
+    3072,  // dimensions for text-embedding-3-large
+    "2024-02-01".to_string(),  // API version
+);
+```
+
+**Supported models**:
+- `text-embedding-3-large` (3072 dimensions)
+- `text-embedding-3-small` (1536 dimensions)
+- `text-embedding-ada-002` (1536 dimensions)
+
+**Use for**: Production deployments with Azure OpenAI.
+
+## Performance Considerations
+
+### Embedding Latency
+
+| Embedder | Latency | Notes |
+|----------|---------|-------|
+| MockEmbedder | < 1ms | In-process, no network |
+| AzureOpenAIEmbedder | 50-200ms | Network dependent |
+
+### Throughput Guidelines
+
+| Scenario | Events/Sec | Recommendation |
+|----------|-----------|----------------|
+| Low Volume | < 10 | Default configuration |
+| Medium Volume | 10-50 | Increase queue capacity |
+| High Volume | > 50 | Consider batching, use dedicated embedder instances |
+
+### Memory Usage
+
+- **Priority Queue**: Buffers up to `priority_queue_capacity` events
+- **Embedding Cache**: No caching (each document generates new embedding)
+- **Qdrant Client**: Maintains persistent gRPC connection
+
+### Tuning Tips
+
+1. **Queue Capacity**: Increase `priority_queue_capacity` for bursty workloads
+2. **Embedding Dimensions**: Use smaller models (ada-002) for lower latency
+3. **Document Templates**: Keep templates concise to reduce embedding costs
+4. **Collection Indexing**: Let Qdrant optimize with `create_collection: true`
+
+## Troubleshooting
+
+### No Points Appearing in Qdrant
+
+**Symptoms**: Reaction runs but collection remains empty
+
+**Solutions**:
+1. Verify query is producing results
+2. Check reaction is subscribed to correct query IDs
+3. Verify Qdrant endpoint is reachable
+4. Check collection exists or `create_collection: true`
+5. Enable debug logging: `RUST_LOG=debug`
+
+### Template Rendering Errors
+
+**Symptoms**: Points have empty content or errors in logs
+
+**Solutions**:
+1. Verify template syntax (Handlebars format)
+2. Check field names match query result structure
+3. Use `{{json this}}` to inspect available fields
+4. Test templates with simple expressions first
+
+### Azure OpenAI Connection Issues
+
+**Symptoms**: "Azure OpenAI API error" in logs
+
+**Solutions**:
+1. Verify endpoint URL format: `https://{resource}.openai.azure.com`
+2. Check API key is valid and not expired
+3. Verify deployment name matches Azure configuration
+4. Check API version is supported (try `2024-02-01`)
+5. Ensure network allows outbound HTTPS
+
+### Qdrant Connection Failures
+
+**Symptoms**: "Failed to connect to Qdrant" errors
+
+**Solutions**:
+1. Verify Qdrant is running: `curl http://localhost:6333/health`
+2. Check endpoint URL includes correct port (6334 for gRPC)
+3. For Qdrant Cloud, verify API key is set
+4. Check firewall/network allows gRPC traffic
+
+## Limitations
+
+1. **Single Embedder**: One embedder per reaction (no per-query embedders)
+2. **Cosine Distance Only**: Collections created with cosine similarity
+3. **No Metadata Filtering**: All fields stored, no selective filtering yet
+
+For very high-throughput scenarios, consider:
+- Multiple reaction instances with different query subscriptions
+- Adjusting batch sizes via `BatchConfig` for your workload
+- Pre-computed embeddings stored in source data
+
+## License
+
+Copyright 2026 The Drasi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/components/reactions/qdrant/src/config.rs
+++ b/components/reactions/qdrant/src/config.rs
@@ -1,0 +1,508 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Configuration types for the Qdrant reaction.
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level configuration for the Qdrant reaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QdrantReactionConfig {
+    /// Qdrant connection configuration
+    pub qdrant: QdrantConfig,
+
+    /// Embedding service configuration
+    pub embedding: EmbeddingConfig,
+
+    /// Document generation configuration
+    pub document: DocumentConfig,
+
+    /// Batch processing configuration
+    #[serde(default)]
+    pub batch: BatchConfig,
+
+    /// Retry configuration for transient failures
+    #[serde(default)]
+    pub retry: RetryConfig,
+}
+
+/// Configuration for connecting to Qdrant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QdrantConfig {
+    /// Qdrant gRPC endpoint (e.g., "http://localhost:6334")
+    pub endpoint: String,
+
+    /// Optional API key for authenticated access
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// Name of the collection to store vectors in
+    pub collection_name: String,
+
+    /// Whether to create the collection if it doesn't exist (default: true)
+    #[serde(default = "default_create_collection")]
+    pub create_collection: bool,
+}
+
+fn default_create_collection() -> bool {
+    true
+}
+
+/// Configuration for the embedding service.
+///
+/// This is a tagged enum where each variant contains only the fields relevant
+/// to that embedding provider. This provides compile-time enforcement of
+/// required fields per provider.
+///
+/// # JSON Format
+///
+/// ```json
+/// // Mock embedder
+/// {
+///   "service_type": "mock",
+///   "dimensions": 1536
+/// }
+///
+/// // Azure OpenAI embedder
+/// {
+///   "service_type": "azure_openai",
+///   "endpoint": "https://myresource.openai.azure.com",
+///   "model": "text-embedding-3-large",
+///   "api_key": "your-key",
+///   "dimensions": 3072,
+///   "api_version": "2024-02-01"
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "service_type", rename_all = "snake_case")]
+pub enum EmbeddingConfig {
+    /// Mock embedding service using SHA-256 (for testing)
+    Mock {
+        /// Embedding dimensions
+        #[serde(default = "default_dimensions")]
+        dimensions: usize,
+    },
+
+    /// Azure OpenAI embedding service
+    AzureOpenai {
+        /// Azure OpenAI endpoint
+        /// e.g., "https://myresource.openai.azure.com"
+        endpoint: String,
+
+        /// Model/deployment name
+        model: String,
+
+        /// API key
+        api_key: String,
+
+        /// Embedding dimensions (default: 3072 for text-embedding-3-large)
+        #[serde(default = "default_dimensions")]
+        dimensions: usize,
+
+        /// API version for Azure OpenAI (default: "2024-02-01")
+        #[serde(default = "default_api_version")]
+        api_version: String,
+    },
+}
+
+fn default_dimensions() -> usize {
+    3072
+}
+
+fn default_api_version() -> String {
+    "2024-02-01".to_string()
+}
+
+impl EmbeddingConfig {
+    /// Returns the embedding dimensions for this configuration.
+    pub fn dimensions(&self) -> usize {
+        match self {
+            EmbeddingConfig::Mock { dimensions } => *dimensions,
+            EmbeddingConfig::AzureOpenai { dimensions, .. } => *dimensions,
+        }
+    }
+}
+
+impl Default for EmbeddingConfig {
+    fn default() -> Self {
+        EmbeddingConfig::Mock {
+            dimensions: default_dimensions(),
+        }
+    }
+}
+
+/// Configuration for document generation from query results.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentConfig {
+    /// Handlebars template for generating document content to embed.
+    /// Available variables: all fields from the query result data.
+    /// Example: "Product: {{name}}. Description: {{description}}"
+    pub document_template: String,
+
+    /// Optional Handlebars template for generating document title.
+    /// Example: "{{name}}"
+    #[serde(default)]
+    pub title_template: Option<String>,
+
+    /// Field path to extract the unique key from query result data.
+    /// Supports nested paths using dots (e.g., "after.id").
+    /// This key is used to generate deterministic point IDs.
+    pub key_field: String,
+
+    /// Optional metadata fields to include in the Qdrant point payload.
+    /// If not specified, all fields from the query result are included.
+    #[serde(default)]
+    pub metadata_fields: Option<Vec<String>>,
+}
+
+impl Default for DocumentConfig {
+    fn default() -> Self {
+        Self {
+            document_template: "{{content}}".to_string(),
+            title_template: None,
+            key_field: "id".to_string(),
+            metadata_fields: None,
+        }
+    }
+}
+
+/// Configuration for batch processing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchConfig {
+    /// Maximum number of documents per embedding API call.
+    /// Smaller values reduce memory usage but increase API calls.
+    /// Default: 50
+    #[serde(default = "default_embedding_batch_size")]
+    pub embedding_batch_size: usize,
+
+    /// Maximum number of points per Qdrant upsert call.
+    /// Larger values improve throughput but increase memory usage.
+    /// Default: 100
+    #[serde(default = "default_upsert_batch_size")]
+    pub upsert_batch_size: usize,
+}
+
+fn default_embedding_batch_size() -> usize {
+    50
+}
+
+fn default_upsert_batch_size() -> usize {
+    100
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        Self {
+            embedding_batch_size: default_embedding_batch_size(),
+            upsert_batch_size: default_upsert_batch_size(),
+        }
+    }
+}
+
+/// Configuration for retry behavior on transient failures.
+///
+/// Uses exponential backoff with jitter to handle transient errors
+/// from Qdrant and embedding services.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    /// Maximum number of retry attempts before failing.
+    /// Default: 3
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
+
+    /// Initial delay between retries in milliseconds.
+    /// Default: 100
+    #[serde(default = "default_initial_delay_ms")]
+    pub initial_delay_ms: u64,
+
+    /// Maximum delay between retries in milliseconds.
+    /// Exponential backoff is capped at this value.
+    /// Default: 5000
+    #[serde(default = "default_max_delay_ms")]
+    pub max_delay_ms: u64,
+}
+
+fn default_max_retries() -> u32 {
+    3
+}
+
+fn default_initial_delay_ms() -> u64 {
+    100
+}
+
+fn default_max_delay_ms() -> u64 {
+    5000
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: default_max_retries(),
+            initial_delay_ms: default_initial_delay_ms(),
+            max_delay_ms: default_max_delay_ms(),
+        }
+    }
+}
+
+impl QdrantReactionConfig {
+    /// Validates the configuration, returning an error if any required fields are missing.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        // Validate Qdrant config
+        if self.qdrant.endpoint.is_empty() {
+            anyhow::bail!("Qdrant endpoint is required");
+        }
+        if self.qdrant.collection_name.is_empty() {
+            anyhow::bail!("Qdrant collection name is required");
+        }
+
+        // Validate embedding config
+        if self.embedding.dimensions() == 0 {
+            anyhow::bail!("Embedding dimensions must be greater than 0");
+        }
+
+        // Validate document config
+        if self.document.document_template.is_empty() {
+            anyhow::bail!("Document template is required");
+        }
+        if self.document.key_field.is_empty() {
+            anyhow::bail!("Key field is required");
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_mock_config() {
+        let config = QdrantReactionConfig {
+            qdrant: QdrantConfig {
+                endpoint: "http://localhost:6334".to_string(),
+                api_key: None,
+                collection_name: "test_collection".to_string(),
+                create_collection: true,
+            },
+            embedding: EmbeddingConfig::Mock { dimensions: 1536 },
+            document: DocumentConfig {
+                document_template: "{{content}}".to_string(),
+                key_field: "id".to_string(),
+                ..Default::default()
+            },
+            batch: BatchConfig::default(),
+            retry: RetryConfig::default(),
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_valid_azure_openai_config() {
+        let config = QdrantReactionConfig {
+            qdrant: QdrantConfig {
+                endpoint: "http://localhost:6334".to_string(),
+                api_key: None,
+                collection_name: "test_collection".to_string(),
+                create_collection: true,
+            },
+            embedding: EmbeddingConfig::AzureOpenai {
+                endpoint: "https://myresource.openai.azure.com".to_string(),
+                model: "text-embedding-3-large".to_string(),
+                api_key: "secret-key".to_string(),
+                dimensions: 3072,
+                api_version: "2024-02-01".to_string(),
+            },
+            document: DocumentConfig {
+                document_template: "{{content}}".to_string(),
+                key_field: "id".to_string(),
+                ..Default::default()
+            },
+            batch: BatchConfig::default(),
+            retry: RetryConfig::default(),
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_missing_qdrant_endpoint() {
+        let config = QdrantReactionConfig {
+            qdrant: QdrantConfig {
+                endpoint: "".to_string(),
+                api_key: None,
+                collection_name: "test_collection".to_string(),
+                create_collection: true,
+            },
+            embedding: EmbeddingConfig::default(),
+            document: DocumentConfig::default(),
+            batch: BatchConfig::default(),
+            retry: RetryConfig::default(),
+        };
+
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("endpoint is required"));
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let config = QdrantReactionConfig {
+            qdrant: QdrantConfig {
+                endpoint: "http://localhost:6334".to_string(),
+                api_key: Some("qdrant-key".to_string()),
+                collection_name: "my_vectors".to_string(),
+                create_collection: false,
+            },
+            embedding: EmbeddingConfig::AzureOpenai {
+                endpoint: "https://test.openai.azure.com".to_string(),
+                model: "embedding-model".to_string(),
+                api_key: "openai-key".to_string(),
+                dimensions: 1536,
+                api_version: "2024-02-01".to_string(),
+            },
+            document: DocumentConfig {
+                document_template: "Name: {{name}}, Description: {{description}}".to_string(),
+                title_template: Some("{{name}}".to_string()),
+                key_field: "product_id".to_string(),
+                metadata_fields: Some(vec!["name".to_string(), "category".to_string()]),
+            },
+            batch: BatchConfig {
+                embedding_batch_size: 25,
+                upsert_batch_size: 50,
+            },
+            retry: RetryConfig {
+                max_retries: 5,
+                initial_delay_ms: 200,
+                max_delay_ms: 10000,
+            },
+        };
+
+        let json = serde_json::to_string(&config).expect("Serialization failed");
+        let deserialized: QdrantReactionConfig =
+            serde_json::from_str(&json).expect("Deserialization failed");
+
+        assert_eq!(config.qdrant.endpoint, deserialized.qdrant.endpoint);
+        assert_eq!(
+            config.qdrant.collection_name,
+            deserialized.qdrant.collection_name
+        );
+        assert_eq!(
+            config.embedding.dimensions(),
+            deserialized.embedding.dimensions()
+        );
+        assert_eq!(
+            config.document.document_template,
+            deserialized.document.document_template
+        );
+        assert_eq!(
+            config.batch.embedding_batch_size,
+            deserialized.batch.embedding_batch_size
+        );
+        assert_eq!(
+            config.batch.upsert_batch_size,
+            deserialized.batch.upsert_batch_size
+        );
+    }
+
+    #[test]
+    fn test_batch_config_defaults() {
+        let config = BatchConfig::default();
+        assert_eq!(config.embedding_batch_size, 50);
+        assert_eq!(config.upsert_batch_size, 100);
+    }
+
+    #[test]
+    fn test_batch_config_serde_default() {
+        // Test that batch config defaults are applied when not specified in JSON
+        let json = r#"{
+            "qdrant": {
+                "endpoint": "http://localhost:6334",
+                "collection_name": "test"
+            },
+            "embedding": {
+                "service_type": "mock",
+                "dimensions": 1536
+            },
+            "document": {
+                "document_template": "{{content}}",
+                "key_field": "id"
+            }
+        }"#;
+
+        let config: QdrantReactionConfig = serde_json::from_str(json).expect("Should deserialize");
+        assert_eq!(config.batch.embedding_batch_size, 50);
+        assert_eq!(config.batch.upsert_batch_size, 100);
+    }
+
+    #[test]
+    fn test_retry_config_defaults() {
+        let config = RetryConfig::default();
+        assert_eq!(config.max_retries, 3);
+        assert_eq!(config.initial_delay_ms, 100);
+        assert_eq!(config.max_delay_ms, 5000);
+    }
+
+    #[test]
+    fn test_retry_config_serde_default() {
+        // Test that retry config defaults are applied when not specified in JSON
+        let json = r#"{
+            "qdrant": {
+                "endpoint": "http://localhost:6334",
+                "collection_name": "test"
+            },
+            "embedding": {
+                "service_type": "mock",
+                "dimensions": 1536
+            },
+            "document": {
+                "document_template": "{{content}}",
+                "key_field": "id"
+            }
+        }"#;
+
+        let config: QdrantReactionConfig = serde_json::from_str(json).expect("Should deserialize");
+        assert_eq!(config.retry.max_retries, 3);
+        assert_eq!(config.retry.initial_delay_ms, 100);
+        assert_eq!(config.retry.max_delay_ms, 5000);
+    }
+
+    #[test]
+    fn test_retry_config_custom_values() {
+        let json = r#"{
+            "qdrant": {
+                "endpoint": "http://localhost:6334",
+                "collection_name": "test"
+            },
+            "embedding": {
+                "service_type": "mock",
+                "dimensions": 1536
+            },
+            "document": {
+                "document_template": "{{content}}",
+                "key_field": "id"
+            },
+            "retry": {
+                "max_retries": 5,
+                "initial_delay_ms": 200,
+                "max_delay_ms": 10000
+            }
+        }"#;
+
+        let config: QdrantReactionConfig = serde_json::from_str(json).expect("Should deserialize");
+        assert_eq!(config.retry.max_retries, 5);
+        assert_eq!(config.retry.initial_delay_ms, 200);
+        assert_eq!(config.retry.max_delay_ms, 10000);
+    }
+}

--- a/components/reactions/qdrant/src/document.rs
+++ b/components/reactions/qdrant/src/document.rs
@@ -1,0 +1,388 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Document processing utilities for the Qdrant reaction.
+//!
+//! This module provides:
+//! - Deterministic UUID generation using RFC 4122 UUID v5
+//! - Document building from query results using Handlebars templates
+//! - Key extraction from nested JSON structures
+
+use anyhow::{Context, Result};
+use handlebars::Handlebars;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Namespace UUID for Drasi Qdrant point ID generation.
+/// This is a fixed UUID used with UUID v5 to ensure deterministic generation.
+const DRASI_QDRANT_NAMESPACE: Uuid = Uuid::from_bytes([
+    0x64, 0x72, 0x61, 0x73, 0x69, 0x2d, 0x71, 0x64, // "drasi-qd"
+    0x72, 0x61, 0x6e, 0x74, 0x2d, 0x6e, 0x73, 0x00, // "rant-ns\0"
+]);
+
+/// A document prepared for vector storage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Document {
+    /// Deterministic point ID generated from the key
+    pub point_id: Uuid,
+
+    /// Content text for embedding generation
+    pub content: String,
+
+    /// Optional document title
+    pub title: Option<String>,
+
+    /// Full metadata payload for the Qdrant point
+    pub metadata: serde_json::Value,
+
+    /// The original key used to generate the point ID
+    pub key: String,
+}
+
+/// Builder for creating documents from query results.
+pub struct DocumentBuilder<'a> {
+    handlebars: &'a Handlebars<'static>,
+    document_template_name: &'a str,
+    title_template_name: Option<&'a str>,
+    key_field: &'a str,
+}
+
+impl<'a> DocumentBuilder<'a> {
+    /// Create a new document builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `handlebars` - Handlebars instance with registered templates
+    /// * `document_template_name` - Name of the registered document template
+    /// * `title_template_name` - Optional name of the registered title template
+    /// * `key_field` - Field path to extract the unique key (e.g., "id", "after.id")
+    pub fn new(
+        handlebars: &'a Handlebars<'static>,
+        document_template_name: &'a str,
+        title_template_name: Option<&'a str>,
+        key_field: &'a str,
+    ) -> Self {
+        Self {
+            handlebars,
+            document_template_name,
+            title_template_name,
+            key_field,
+        }
+    }
+
+    /// Build a document from query result data.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - JSON data from the query result
+    ///
+    /// # Returns
+    ///
+    /// A Document with generated content, title, point ID, and metadata.
+    pub fn build(&self, data: &serde_json::Value) -> Result<Document> {
+        // Extract key
+        let key = extract_field(data, self.key_field)
+            .with_context(|| format!("Failed to extract key field '{}'", self.key_field))?;
+
+        // Generate deterministic UUID
+        let point_id = generate_deterministic_uuid(&key);
+
+        // Render document content
+        let content = self
+            .handlebars
+            .render(self.document_template_name, data)
+            .with_context(|| "Failed to render document template")?;
+
+        // Render title if template is provided
+        let title = if let Some(title_template) = self.title_template_name {
+            Some(
+                self.handlebars
+                    .render(title_template, data)
+                    .with_context(|| "Failed to render title template")?,
+            )
+        } else {
+            None
+        };
+
+        Ok(Document {
+            point_id,
+            content,
+            title,
+            metadata: data.clone(),
+            key,
+        })
+    }
+}
+
+/// Generate a deterministic UUID from a key string.
+///
+/// Uses UUID v5 (RFC 4122) with a Drasi-specific namespace. The same key
+/// always produces the same UUID, enabling consistent point IDs for
+/// upsert and delete operations.
+///
+/// # Example
+///
+/// ```
+/// use drasi_reaction_qdrant::generate_deterministic_uuid;
+///
+/// let uuid1 = generate_deterministic_uuid("product-123");
+/// let uuid2 = generate_deterministic_uuid("product-123");
+/// assert_eq!(uuid1, uuid2);
+///
+/// let uuid3 = generate_deterministic_uuid("product-456");
+/// assert_ne!(uuid1, uuid3);
+/// ```
+pub fn generate_deterministic_uuid(key: &str) -> Uuid {
+    Uuid::new_v5(&DRASI_QDRANT_NAMESPACE, key.as_bytes())
+}
+
+/// Extract a field value from JSON data using a dot-separated path.
+///
+/// # Arguments
+///
+/// * `data` - JSON value to extract from
+/// * `field_path` - Dot-separated path (e.g., "id", "after.product_id", "nested.deep.value")
+///
+/// # Returns
+///
+/// The string representation of the extracted value, or an error if not found.
+pub fn extract_field(data: &serde_json::Value, field_path: &str) -> Result<String> {
+    let parts: Vec<&str> = field_path.split('.').collect();
+    let mut current = data;
+
+    for part in &parts {
+        current = current
+            .get(*part)
+            .with_context(|| format!("Field '{part}' not found in path '{field_path}'"))?;
+    }
+
+    match current {
+        serde_json::Value::String(s) => Ok(s.clone()),
+        serde_json::Value::Number(n) => Ok(n.to_string()),
+        serde_json::Value::Bool(b) => Ok(b.to_string()),
+        serde_json::Value::Null => Ok("null".to_string()),
+        _ => Ok(current.to_string()),
+    }
+}
+
+/// Setup Handlebars with document and title templates.
+///
+/// # Arguments
+///
+/// * `document_template` - Handlebars template for document content
+/// * `title_template` - Optional Handlebars template for document title
+///
+/// # Returns
+///
+/// Configured Handlebars instance with templates registered.
+pub fn setup_handlebars(
+    document_template: &str,
+    title_template: Option<&str>,
+) -> Result<Handlebars<'static>> {
+    let mut handlebars = Handlebars::new();
+
+    // Disable HTML escaping for plain text content
+    handlebars.register_escape_fn(handlebars::no_escape);
+
+    handlebars
+        .register_template_string("document", document_template)
+        .with_context(|| "Failed to register document template")?;
+
+    if let Some(title_tmpl) = title_template {
+        handlebars
+            .register_template_string("title", title_tmpl)
+            .with_context(|| "Failed to register title template")?;
+    }
+
+    Ok(handlebars)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_deterministic_uuid_consistency() {
+        let key = "product-123";
+        let uuid1 = generate_deterministic_uuid(key);
+        let uuid2 = generate_deterministic_uuid(key);
+        assert_eq!(uuid1, uuid2, "Same key should produce same UUID");
+    }
+
+    #[test]
+    fn test_deterministic_uuid_different_keys() {
+        let uuid1 = generate_deterministic_uuid("product-123");
+        let uuid2 = generate_deterministic_uuid("product-456");
+        assert_ne!(
+            uuid1, uuid2,
+            "Different keys should produce different UUIDs"
+        );
+    }
+
+    #[test]
+    fn test_deterministic_uuid_format() {
+        let uuid = generate_deterministic_uuid("test-key");
+        // Should be a valid UUID
+        let uuid_str = uuid.to_string();
+        assert_eq!(uuid_str.len(), 36); // UUID format: 8-4-4-4-12
+        assert!(uuid_str.chars().filter(|c| *c == '-').count() == 4);
+    }
+
+    #[test]
+    fn test_extract_field_simple() {
+        let data = json!({
+            "id": "123",
+            "name": "Test Product"
+        });
+
+        let id = extract_field(&data, "id").expect("Failed to extract field");
+        assert_eq!(id, "123");
+
+        let name = extract_field(&data, "name").expect("Failed to extract field");
+        assert_eq!(name, "Test Product");
+    }
+
+    #[test]
+    fn test_extract_field_nested() {
+        let data = json!({
+            "after": {
+                "product_id": "456",
+                "details": {
+                    "sku": "SKU-001"
+                }
+            }
+        });
+
+        let id = extract_field(&data, "after.product_id").expect("Failed to extract field");
+        assert_eq!(id, "456");
+
+        let sku = extract_field(&data, "after.details.sku").expect("Failed to extract field");
+        assert_eq!(sku, "SKU-001");
+    }
+
+    #[test]
+    fn test_extract_field_numeric() {
+        let data = json!({
+            "count": 42,
+            "price": 19.99
+        });
+
+        let count = extract_field(&data, "count").expect("Failed to extract field");
+        assert_eq!(count, "42");
+
+        let price = extract_field(&data, "price").expect("Failed to extract field");
+        assert_eq!(price, "19.99");
+    }
+
+    #[test]
+    fn test_extract_field_boolean() {
+        let data = json!({
+            "active": true
+        });
+
+        let active = extract_field(&data, "active").expect("Failed to extract field");
+        assert_eq!(active, "true");
+    }
+
+    #[test]
+    fn test_extract_field_not_found() {
+        let data = json!({
+            "id": "123"
+        });
+
+        let result = extract_field(&data, "nonexistent");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_document_builder() {
+        let handlebars = setup_handlebars(
+            "Product: {{name}}. Description: {{description}}",
+            Some("{{name}}"),
+        )
+        .expect("Failed to setup handlebars");
+
+        let builder = DocumentBuilder::new(&handlebars, "document", Some("title"), "id");
+
+        let data = json!({
+            "id": "prod-001",
+            "name": "Widget",
+            "description": "A useful widget"
+        });
+
+        let doc = builder.build(&data).expect("Failed to build document");
+
+        assert_eq!(doc.key, "prod-001");
+        assert_eq!(doc.content, "Product: Widget. Description: A useful widget");
+        assert_eq!(doc.title, Some("Widget".to_string()));
+        assert_eq!(doc.point_id, generate_deterministic_uuid("prod-001"));
+    }
+
+    #[test]
+    fn test_document_builder_no_title() {
+        let handlebars =
+            setup_handlebars("Content: {{content}}", None).expect("Failed to setup handlebars");
+
+        let builder = DocumentBuilder::new(&handlebars, "document", None, "id");
+
+        let data = json!({
+            "id": "item-001",
+            "content": "Some content here"
+        });
+
+        let doc = builder.build(&data).expect("Failed to build document");
+
+        assert_eq!(doc.key, "item-001");
+        assert_eq!(doc.content, "Content: Some content here");
+        assert!(doc.title.is_none());
+    }
+
+    #[test]
+    fn test_document_builder_nested_key() {
+        let handlebars =
+            setup_handlebars("{{after.name}}", None).expect("Failed to setup handlebars");
+
+        let builder = DocumentBuilder::new(&handlebars, "document", None, "after.id");
+
+        let data = json!({
+            "after": {
+                "id": "nested-123",
+                "name": "Nested Item"
+            }
+        });
+
+        let doc = builder.build(&data).expect("Failed to build document");
+
+        assert_eq!(doc.key, "nested-123");
+        assert_eq!(doc.content, "Nested Item");
+    }
+
+    #[test]
+    fn test_handlebars_no_escape() {
+        let handlebars = setup_handlebars("{{content}}", None).expect("Failed to setup handlebars");
+
+        let builder = DocumentBuilder::new(&handlebars, "document", None, "id");
+
+        let data = json!({
+            "id": "html-001",
+            "content": "<p>HTML & special \"chars\"</p>"
+        });
+
+        let doc = builder.build(&data).expect("Failed to build document");
+
+        // Should not escape HTML
+        assert_eq!(doc.content, "<p>HTML & special \"chars\"</p>");
+    }
+}

--- a/components/reactions/qdrant/src/embedder/azure_openai.rs
+++ b/components/reactions/qdrant/src/embedder/azure_openai.rs
@@ -1,0 +1,301 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Azure OpenAI embedder implementation.
+//!
+//! This module provides an embedder that uses Azure OpenAI's embedding API
+//! to generate vector embeddings for text content.
+
+use super::Embedder;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use log::debug;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+/// Azure OpenAI embedder that generates embeddings using the Azure OpenAI API.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use drasi_reaction_qdrant::{AzureOpenAIEmbedder, Embedder};
+///
+/// #[tokio::main]
+/// async fn main() -> anyhow::Result<()> {
+///     let embedder = AzureOpenAIEmbedder::new(
+///         "https://myresource.openai.azure.com".to_string(),
+///         "text-embedding-3-large".to_string(),
+///         "your-api-key".to_string(),
+///         3072,
+///         "2024-02-01".to_string(),
+///     );
+///
+///     let embeddings = embedder.generate(&["Hello, world!".to_string()]).await?;
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone)]
+pub struct AzureOpenAIEmbedder {
+    client: Client,
+    endpoint: String,
+    model: String,
+    api_key: String,
+    dimensions: usize,
+    api_version: String,
+}
+
+impl AzureOpenAIEmbedder {
+    /// Create a new Azure OpenAI embedder.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Azure OpenAI endpoint (e.g., "https://myresource.openai.azure.com")
+    /// * `model` - Deployment name for the embedding model
+    /// * `api_key` - Azure OpenAI API key
+    /// * `dimensions` - Expected embedding dimensions
+    /// * `api_version` - Azure OpenAI API version (e.g., "2024-02-01")
+    pub fn new(
+        endpoint: String,
+        model: String,
+        api_key: String,
+        dimensions: usize,
+        api_version: String,
+    ) -> Self {
+        Self {
+            client: Client::new(),
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            model,
+            api_key,
+            dimensions,
+            api_version,
+        }
+    }
+
+    /// Build the API URL for the embeddings endpoint.
+    fn build_url(&self) -> String {
+        format!(
+            "{}/openai/deployments/{}/embeddings?api-version={}",
+            self.endpoint, self.model, self.api_version
+        )
+    }
+}
+
+/// Request body for the Azure OpenAI embeddings API.
+#[derive(Debug, Serialize)]
+struct EmbeddingRequest {
+    input: Vec<String>,
+}
+
+/// Response from the Azure OpenAI embeddings API.
+#[derive(Debug, Deserialize)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+    // model: String,
+    // usage: EmbeddingUsage,
+}
+
+/// Individual embedding data from the API response.
+#[derive(Debug, Deserialize)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+    index: usize,
+}
+
+/// Error response from the Azure OpenAI API.
+#[derive(Debug, Deserialize)]
+struct ApiError {
+    error: ApiErrorDetails,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorDetails {
+    message: String,
+    // code: Option<String>,
+}
+
+#[async_trait]
+impl Embedder for AzureOpenAIEmbedder {
+    async fn generate(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let url = self.build_url();
+        let request_body = EmbeddingRequest {
+            input: texts.to_vec(),
+        };
+
+        debug!(
+            "Requesting embeddings from Azure OpenAI for {} texts",
+            texts.len()
+        );
+
+        let response = self
+            .client
+            .post(&url)
+            .header("api-key", &self.api_key)
+            .header("Content-Type", "application/json")
+            .json(&request_body)
+            .send()
+            .await
+            .context("Failed to send request to Azure OpenAI")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+
+            // Try to parse as API error
+            if let Ok(api_error) = serde_json::from_str::<ApiError>(&error_text) {
+                anyhow::bail!(
+                    "Azure OpenAI API error ({}): {}",
+                    status,
+                    api_error.error.message
+                );
+            }
+
+            anyhow::bail!("Azure OpenAI API error ({status}): {error_text}");
+        }
+
+        let response_body: EmbeddingResponse = response
+            .json()
+            .await
+            .context("Failed to parse Azure OpenAI response")?;
+
+        // Sort by index to ensure correct order
+        let mut embeddings = response_body.data;
+        embeddings.sort_by_key(|e| e.index);
+
+        let result: Vec<Vec<f32>> = embeddings.into_iter().map(|e| e.embedding).collect();
+
+        debug!("Received {} embeddings from Azure OpenAI", result.len());
+
+        Ok(result)
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    fn name(&self) -> &str {
+        "azure_openai"
+    }
+}
+
+impl std::fmt::Debug for AzureOpenAIEmbedder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzureOpenAIEmbedder")
+            .field("endpoint", &self.endpoint)
+            .field("model", &self.model)
+            .field("dimensions", &self.dimensions)
+            .field("api_version", &self.api_version)
+            .field("api_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_url() {
+        let embedder = AzureOpenAIEmbedder::new(
+            "https://myresource.openai.azure.com".to_string(),
+            "text-embedding-3-large".to_string(),
+            "test-key".to_string(),
+            3072,
+            "2024-02-01".to_string(),
+        );
+
+        let url = embedder.build_url();
+        assert_eq!(
+            url,
+            "https://myresource.openai.azure.com/openai/deployments/text-embedding-3-large/embeddings?api-version=2024-02-01"
+        );
+    }
+
+    #[test]
+    fn test_build_url_trailing_slash() {
+        let embedder = AzureOpenAIEmbedder::new(
+            "https://myresource.openai.azure.com/".to_string(),
+            "model".to_string(),
+            "key".to_string(),
+            1536,
+            "2024-02-01".to_string(),
+        );
+
+        let url = embedder.build_url();
+        assert!(url.starts_with("https://myresource.openai.azure.com/openai/"));
+        assert!(!url.contains("//openai"));
+    }
+
+    #[test]
+    fn test_debug_redacts_api_key() {
+        let embedder = AzureOpenAIEmbedder::new(
+            "https://test.openai.azure.com".to_string(),
+            "model".to_string(),
+            "super-secret-key".to_string(),
+            1536,
+            "2024-02-01".to_string(),
+        );
+
+        let debug_str = format!("{embedder:?}");
+        assert!(!debug_str.contains("super-secret-key"));
+        assert!(debug_str.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_dimensions() {
+        let embedder = AzureOpenAIEmbedder::new(
+            "https://test.openai.azure.com".to_string(),
+            "model".to_string(),
+            "key".to_string(),
+            3072,
+            "2024-02-01".to_string(),
+        );
+
+        assert_eq!(embedder.dimensions(), 3072);
+    }
+
+    #[test]
+    fn test_name() {
+        let embedder = AzureOpenAIEmbedder::new(
+            "https://test.openai.azure.com".to_string(),
+            "model".to_string(),
+            "key".to_string(),
+            1536,
+            "2024-02-01".to_string(),
+        );
+
+        assert_eq!(embedder.name(), "azure_openai");
+    }
+
+    #[tokio::test]
+    async fn test_empty_input() {
+        let embedder = AzureOpenAIEmbedder::new(
+            "https://test.openai.azure.com".to_string(),
+            "model".to_string(),
+            "key".to_string(),
+            1536,
+            "2024-02-01".to_string(),
+        );
+
+        let result = embedder.generate(&[]).await;
+        assert!(result.is_ok());
+        assert!(result.expect("Should succeed").is_empty());
+    }
+}

--- a/components/reactions/qdrant/src/embedder/mock.rs
+++ b/components/reactions/qdrant/src/embedder/mock.rs
@@ -1,0 +1,257 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Mock embedder implementation using SHA-256 for deterministic testing.
+//!
+//! This embedder generates deterministic embeddings based on the SHA-256 hash
+//! of the input text, enabling reproducible tests without external API dependencies.
+//!
+//! # Algorithm
+//!
+//! 1. Compute SHA-256 hash of the input text (32 bytes)
+//! 2. For each dimension `i`:
+//!    - `byte_index = (i * 4) % 32`
+//!    - Construct a 32-bit seed from 4 consecutive hash bytes (wrapping)
+//!    - Convert seed to a float in range [-1, 1]
+//! 3. Normalize the resulting vector to unit length (L2 norm)
+//!
+//! This produces consistent embeddings that are:
+//! - Deterministic: Same input always produces the same embedding
+//! - Normalized: Unit vectors suitable for cosine similarity
+
+use super::Embedder;
+use anyhow::Result;
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+/// Mock embedder that generates deterministic embeddings using SHA-256.
+///
+/// # Example
+///
+/// ```
+/// use drasi_reaction_qdrant::MockEmbedder;
+/// use drasi_reaction_qdrant::Embedder;
+///
+/// #[tokio::main]
+/// async fn main() -> anyhow::Result<()> {
+///     let embedder = MockEmbedder::new(1536);
+///
+///     let embeddings = embedder.generate(&["Hello, world!".to_string()]).await?;
+///     assert_eq!(embeddings.len(), 1);
+///     assert_eq!(embeddings[0].len(), 1536);
+///
+///     // Embeddings are deterministic
+///     let embeddings2 = embedder.generate(&["Hello, world!".to_string()]).await?;
+///     assert_eq!(embeddings[0], embeddings2[0]);
+///
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct MockEmbedder {
+    dimensions: usize,
+}
+
+impl MockEmbedder {
+    /// Create a new mock embedder with the specified dimensions.
+    ///
+    /// # Arguments
+    ///
+    /// * `dimensions` - The number of dimensions for generated embeddings.
+    ///   Common values: 1536 (ada-002), 3072 (text-embedding-3-large)
+    pub fn new(dimensions: usize) -> Self {
+        Self { dimensions }
+    }
+
+    /// Generate a single embedding for the given text.
+    fn generate_single(&self, text: &str) -> Vec<f32> {
+        // Step 1: Compute SHA-256 hash
+        let mut hasher = Sha256::new();
+        hasher.update(text.as_bytes());
+        let hash = hasher.finalize();
+
+        // Step 2: Generate raw embedding values from hash
+        let mut embedding = Vec::with_capacity(self.dimensions);
+        for i in 0..self.dimensions {
+            let byte_index = (i * 4) % 32;
+
+            // Construct 32-bit seed from 4 consecutive hash bytes (with wrapping)
+            let seed = ((hash[byte_index] as u32) << 24)
+                | ((hash[(byte_index + 1) % 32] as u32) << 16)
+                | ((hash[(byte_index + 2) % 32] as u32) << 8)
+                | (hash[(byte_index + 3) % 32] as u32);
+
+            // Convert to float in range [-1, 1]
+            // Match JavaScript: (unsignedSeed / 0xFFFFFFFF) * 2 - 1
+            let value = (seed as f64 / u32::MAX as f64) * 2.0 - 1.0;
+            embedding.push(value as f32);
+        }
+
+        // Step 3: Normalize to unit vector (L2 norm)
+        let magnitude: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if magnitude > 0.0 {
+            for value in &mut embedding {
+                *value /= magnitude;
+            }
+        }
+
+        embedding
+    }
+}
+
+#[async_trait]
+impl Embedder for MockEmbedder {
+    async fn generate(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|t| self.generate_single(t)).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    fn name(&self) -> &str {
+        "mock"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_deterministic_embeddings() {
+        let embedder = MockEmbedder::new(1536);
+        let text = "Hello, world!".to_string();
+
+        let embedding1 = embedder
+            .generate(&[text.clone()])
+            .await
+            .expect("Failed to generate embedding");
+        let embedding2 = embedder
+            .generate(&[text])
+            .await
+            .expect("Failed to generate embedding");
+
+        assert_eq!(
+            embedding1, embedding2,
+            "Same text should produce same embedding"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_different_texts_different_embeddings() {
+        let embedder = MockEmbedder::new(1536);
+
+        let embedding1 = embedder
+            .generate(&["Hello".to_string()])
+            .await
+            .expect("Failed to generate embedding");
+        let embedding2 = embedder
+            .generate(&["World".to_string()])
+            .await
+            .expect("Failed to generate embedding");
+
+        assert_ne!(
+            embedding1, embedding2,
+            "Different texts should produce different embeddings"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_correct_dimensions() {
+        let dimensions = 3072;
+        let embedder = MockEmbedder::new(dimensions);
+
+        let embeddings = embedder
+            .generate(&["test".to_string()])
+            .await
+            .expect("Failed to generate embedding");
+
+        assert_eq!(embeddings.len(), 1);
+        assert_eq!(embeddings[0].len(), dimensions);
+        assert_eq!(embedder.dimensions(), dimensions);
+    }
+
+    #[tokio::test]
+    async fn test_batch_embedding() {
+        let embedder = MockEmbedder::new(1536);
+        let texts = vec![
+            "First text".to_string(),
+            "Second text".to_string(),
+            "Third text".to_string(),
+        ];
+
+        let embeddings = embedder
+            .generate(&texts)
+            .await
+            .expect("Failed to generate embeddings");
+
+        assert_eq!(embeddings.len(), 3);
+        for embedding in &embeddings {
+            assert_eq!(embedding.len(), 1536);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_normalized_embeddings() {
+        let embedder = MockEmbedder::new(1536);
+        let embeddings = embedder
+            .generate(&["test normalization".to_string()])
+            .await
+            .expect("Failed to generate embedding");
+
+        // Calculate L2 norm
+        let norm: f32 = embeddings[0].iter().map(|x| x * x).sum::<f32>().sqrt();
+
+        // Should be approximately 1.0 (unit vector)
+        assert!(
+            (norm - 1.0).abs() < 0.0001,
+            "Embedding should be normalized to unit length, got norm = {norm}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_empty_text() {
+        let embedder = MockEmbedder::new(1536);
+        let embeddings = embedder
+            .generate(&["".to_string()])
+            .await
+            .expect("Failed to generate embedding");
+
+        assert_eq!(embeddings.len(), 1);
+        assert_eq!(embeddings[0].len(), 1536);
+    }
+
+    #[tokio::test]
+    async fn test_embedder_name() {
+        let embedder = MockEmbedder::new(1536);
+        assert_eq!(embedder.name(), "mock");
+    }
+
+    #[tokio::test]
+    async fn test_unicode_text() {
+        let embedder = MockEmbedder::new(1536);
+        let embeddings = embedder
+            .generate(&["こんにちは世界 🌍".to_string()])
+            .await
+            .expect("Failed to generate embedding");
+
+        assert_eq!(embeddings.len(), 1);
+        assert_eq!(embeddings[0].len(), 1536);
+
+        // Verify normalization
+        let norm: f32 = embeddings[0].iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 0.0001);
+    }
+}

--- a/components/reactions/qdrant/src/embedder/mod.rs
+++ b/components/reactions/qdrant/src/embedder/mod.rs
@@ -1,0 +1,75 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Embedder trait and implementations for generating text embeddings.
+//!
+//! This module provides:
+//! - `Embedder` trait for abstracting embedding generation
+//! - `MockEmbedder` for deterministic testing (SHA-256 based)
+//! - `AzureOpenAIEmbedder` for production use
+//!
+//! The trait is designed for potential future extraction to a shared crate.
+
+pub mod azure_openai;
+pub mod mock;
+
+pub use azure_openai::AzureOpenAIEmbedder;
+pub use mock::MockEmbedder;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// Trait for generating text embeddings.
+///
+/// This trait abstracts the embedding generation process, allowing different
+/// implementations (mock, Azure OpenAI, etc.) to be used interchangeably.
+///
+/// # Design Notes
+///
+/// This trait is designed to be:
+/// - **Send + Sync**: Safe for concurrent use across async tasks
+/// - **Batch-oriented**: Generates embeddings for multiple texts at once for efficiency
+/// - **Provider-agnostic**: Can be implemented for any embedding service
+///
+/// # Future Considerations
+///
+/// This trait is a candidate for extraction to a shared `drasi-embeddings` crate
+/// to enable reuse across multiple reactions (e.g., Qdrant, Redis, pgvector).
+#[async_trait]
+pub trait Embedder: Send + Sync {
+    /// Generate embeddings for a batch of texts.
+    ///
+    /// # Arguments
+    ///
+    /// * `texts` - Slice of text strings to generate embeddings for
+    ///
+    /// # Returns
+    ///
+    /// A vector of embedding vectors, one for each input text.
+    /// Each embedding is a vector of f32 values with length equal to `dimensions()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if embedding generation fails (e.g., API error, network issue).
+    async fn generate(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>;
+
+    /// Get the dimensionality of the embeddings produced by this embedder.
+    ///
+    /// This is used when creating Qdrant collections to ensure the vector
+    /// index is configured with the correct dimensions.
+    fn dimensions(&self) -> usize;
+
+    /// Get the name/type of this embedder for logging purposes.
+    fn name(&self) -> &str;
+}

--- a/components/reactions/qdrant/src/lib.rs
+++ b/components/reactions/qdrant/src/lib.rs
@@ -1,0 +1,77 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Drasi Qdrant Reaction
+//!
+//! This crate provides a reaction plugin that synchronizes Drasi query results
+//! to a Qdrant vector database. It generates embeddings for document content
+//! and stores them as searchable vector points in Qdrant.
+//!
+//! # Features
+//!
+//! - **Azure OpenAI Embeddings**: Production-ready embedding generation using Azure OpenAI
+//! - **Mock Embeddings**: Deterministic SHA-256 based embeddings for testing
+//! - **Handlebars Templates**: Flexible document content generation from query results
+//! - **Deterministic UUIDs**: RFC 4122 UUID v5 generation for consistent point IDs
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use drasi_reaction_qdrant::{
+//!     QdrantReaction, QdrantReactionConfig, QdrantConfig,
+//!     EmbeddingConfig, DocumentConfig, BatchConfig, RetryConfig, MockEmbedder,
+//! };
+//! use std::sync::Arc;
+//!
+//! fn main() -> anyhow::Result<()> {
+//!     let config = QdrantReactionConfig {
+//!         qdrant: QdrantConfig {
+//!             endpoint: "http://localhost:6334".to_string(),
+//!             api_key: None,
+//!             collection_name: "my_collection".to_string(),
+//!             create_collection: true,
+//!         },
+//!         embedding: EmbeddingConfig::Mock { dimensions: 1536 },
+//!         document: DocumentConfig {
+//!             document_template: "{{content}}".to_string(),
+//!             key_field: "id".to_string(),
+//!             ..Default::default()
+//!         },
+//!         batch: BatchConfig::default(),
+//!         retry: RetryConfig::default(),
+//!     };
+//!
+//!     let embedder = Arc::new(MockEmbedder::new(1536));
+//!     let reaction = QdrantReaction::with_embedder(
+//!         "my-qdrant-reaction",
+//!         vec!["query1".to_string()],
+//!         config,
+//!         embedder,
+//!     )?;
+//!     Ok(())
+//! }
+//! ```
+
+pub mod config;
+pub mod document;
+pub mod embedder;
+pub mod qdrant;
+
+// Re-export main types for convenience
+pub use config::{
+    BatchConfig, DocumentConfig, EmbeddingConfig, QdrantConfig, QdrantReactionConfig, RetryConfig,
+};
+pub use document::{generate_deterministic_uuid, Document, DocumentBuilder};
+pub use embedder::{AzureOpenAIEmbedder, Embedder, MockEmbedder};
+pub use qdrant::{ErrorHandler, QdrantReaction};

--- a/components/reactions/qdrant/src/qdrant.rs
+++ b/components/reactions/qdrant/src/qdrant.rs
@@ -1,0 +1,1163 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Qdrant vector database reaction implementation.
+//!
+//! This module provides the main `QdrantReaction` that synchronizes Drasi query
+//! results to a Qdrant vector database by generating embeddings and storing them
+//! as searchable vector points.
+
+use crate::config::{EmbeddingConfig, QdrantReactionConfig, RetryConfig};
+use crate::document::{
+    extract_field, generate_deterministic_uuid, setup_handlebars, Document, DocumentBuilder,
+};
+use crate::embedder::{AzureOpenAIEmbedder, Embedder, MockEmbedder};
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use handlebars::Handlebars;
+use log::{debug, error, info, warn};
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, DeletePointsBuilder, Distance, PointStruct, PointsIdsList,
+    UpsertPointsBuilder, VectorParamsBuilder,
+};
+use qdrant_client::Qdrant;
+use rand::Rng;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+use drasi_lib::channels::{ComponentStatus, ResultDiff};
+use drasi_lib::managers::log_component_start;
+use drasi_lib::queries::manager::DrasiQuery;
+use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
+use drasi_lib::Reaction;
+
+/// Error handler callback type for handling failures after retry exhaustion.
+///
+/// The handler receives an `anyhow::Error` describing the failure.
+/// By default (if no handler is set), errors are logged and processing continues.
+pub type ErrorHandler = Arc<dyn Fn(anyhow::Error) + Send + Sync>;
+
+/// Qdrant vector database reaction.
+///
+/// Synchronizes Drasi query results to Qdrant by:
+/// 1. Generating document content from query results using Handlebars templates
+/// 2. Creating embeddings for the document content
+/// 3. Storing the embeddings as vector points in Qdrant
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use drasi_reaction_qdrant::{
+///     QdrantReaction, QdrantReactionConfig, QdrantConfig,
+///     EmbeddingConfig, DocumentConfig, BatchConfig, RetryConfig, MockEmbedder,
+/// };
+/// use std::sync::Arc;
+///
+/// fn main() -> anyhow::Result<()> {
+///     let config = QdrantReactionConfig {
+///         qdrant: QdrantConfig {
+///             endpoint: "http://localhost:6334".to_string(),
+///             api_key: None,
+///             collection_name: "my_collection".to_string(),
+///             create_collection: true,
+///         },
+///         embedding: EmbeddingConfig::Mock { dimensions: 1536 },
+///         document: DocumentConfig::default(),
+///         batch: BatchConfig::default(),
+///         retry: RetryConfig::default(),
+///     };
+///     let embedder = Arc::new(MockEmbedder::new(1536));
+///
+///     let reaction = QdrantReaction::with_embedder(
+///         "my-reaction",
+///         vec!["my-query".to_string()],
+///         config,
+///         embedder,
+///     )?;
+///     Ok(())
+/// }
+/// ```
+pub struct QdrantReaction {
+    base: ReactionBase,
+    config: QdrantReactionConfig,
+    embedder: Arc<dyn Embedder>,
+    qdrant_client: Arc<Mutex<Option<Qdrant>>>,
+    handlebars: Handlebars<'static>,
+    error_handler: Option<ErrorHandler>,
+}
+
+impl QdrantReaction {
+    /// Create a new Qdrant reaction with the default embedder based on configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique identifier for the reaction
+    /// * `queries` - Query IDs to subscribe to
+    /// * `config` - Configuration for Qdrant, embedding, and document generation
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Configuration validation fails
+    /// - Template compilation fails
+    /// - Azure OpenAI is configured but credentials are missing
+    pub fn new(
+        id: impl Into<String>,
+        queries: Vec<String>,
+        config: QdrantReactionConfig,
+    ) -> Result<Self> {
+        config.validate()?;
+
+        // Create embedder based on configuration
+        let embedder: Arc<dyn Embedder> = match &config.embedding {
+            EmbeddingConfig::Mock { dimensions } => Arc::new(MockEmbedder::new(*dimensions)),
+            EmbeddingConfig::AzureOpenai {
+                endpoint,
+                model,
+                api_key,
+                dimensions,
+                api_version,
+            } => Arc::new(AzureOpenAIEmbedder::new(
+                endpoint.clone(),
+                model.clone(),
+                api_key.clone(),
+                *dimensions,
+                api_version.clone(),
+            )),
+        };
+
+        Self::with_embedder(id, queries, config, embedder)
+    }
+
+    /// Create a new Qdrant reaction with a custom embedder.
+    ///
+    /// This is useful for testing with mock embedders or using custom embedding
+    /// implementations.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique identifier for the reaction
+    /// * `queries` - Query IDs to subscribe to
+    /// * `config` - Configuration for Qdrant and document generation
+    /// * `embedder` - Custom embedder implementation
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Configuration validation fails
+    /// - Template compilation fails
+    pub fn with_embedder(
+        id: impl Into<String>,
+        queries: Vec<String>,
+        config: QdrantReactionConfig,
+        embedder: Arc<dyn Embedder>,
+    ) -> Result<Self> {
+        let id = id.into();
+
+        // Validate configuration
+        config.validate()?;
+
+        // Setup Handlebars
+        let handlebars = setup_handlebars(
+            &config.document.document_template,
+            config.document.title_template.as_deref(),
+        )?;
+
+        let params = ReactionBaseParams::new(id, queries);
+
+        Ok(Self {
+            base: ReactionBase::new(params),
+            config,
+            embedder,
+            qdrant_client: Arc::new(Mutex::new(None)),
+            handlebars,
+            error_handler: None,
+        })
+    }
+
+    /// Create a builder for constructing a QdrantReaction.
+    pub fn builder(id: impl Into<String>) -> QdrantReactionBuilder {
+        QdrantReactionBuilder::new(id)
+    }
+
+    /// Initialize the Qdrant client connection.
+    async fn initialize_qdrant_client(&self) -> Result<Qdrant> {
+        let mut builder = Qdrant::from_url(&self.config.qdrant.endpoint);
+
+        if let Some(ref api_key) = self.config.qdrant.api_key {
+            builder = builder.api_key(api_key.clone());
+        }
+
+        let client = builder.build().context("Failed to create Qdrant client")?;
+
+        info!(
+            "[{}] Connected to Qdrant at {}",
+            self.base.id, self.config.qdrant.endpoint
+        );
+
+        Ok(client)
+    }
+
+    /// Ensure the collection exists, creating it if necessary.
+    async fn ensure_collection(&self, client: &Qdrant) -> Result<()> {
+        let collection_name = &self.config.qdrant.collection_name;
+
+        // Check if collection exists
+        let exists = client
+            .collection_exists(collection_name)
+            .await
+            .context("Failed to check collection existence")?;
+
+        if exists {
+            info!(
+                "[{}] Collection '{}' already exists",
+                self.base.id, collection_name
+            );
+            return Ok(());
+        }
+
+        if !self.config.qdrant.create_collection {
+            anyhow::bail!(
+                "Collection '{collection_name}' does not exist and create_collection is false"
+            );
+        }
+
+        // Create collection with the correct dimensions
+        let dimensions = self.embedder.dimensions() as u64;
+
+        client
+            .create_collection(
+                CreateCollectionBuilder::new(collection_name)
+                    .vectors_config(VectorParamsBuilder::new(dimensions, Distance::Cosine)),
+            )
+            .await
+            .context("Failed to create collection")?;
+
+        info!(
+            "[{}] Created collection '{}' with {} dimensions",
+            self.base.id, collection_name, dimensions
+        );
+
+        Ok(())
+    }
+
+    /// Upsert a point to Qdrant.
+    async fn upsert_point(
+        &self,
+        client: &Qdrant,
+        point_id: uuid::Uuid,
+        embedding: Vec<f32>,
+        payload: serde_json::Value,
+    ) -> Result<()> {
+        let collection_name = &self.config.qdrant.collection_name;
+
+        // Convert payload to Qdrant format
+        let qdrant_payload: HashMap<String, qdrant_client::qdrant::Value> =
+            convert_json_to_qdrant_payload(&payload);
+
+        let point = PointStruct::new(point_id.to_string(), embedding, qdrant_payload);
+
+        client
+            .upsert_points(UpsertPointsBuilder::new(collection_name, vec![point]).wait(true))
+            .await
+            .context("Failed to upsert point to Qdrant")?;
+
+        debug!(
+            "[{}] Upserted point {} to collection '{}'",
+            self.base.id, point_id, collection_name
+        );
+
+        Ok(())
+    }
+
+    /// Delete a point from Qdrant.
+    async fn delete_point(&self, client: &Qdrant, point_id: uuid::Uuid) -> Result<()> {
+        let collection_name = &self.config.qdrant.collection_name;
+
+        client
+            .delete_points(
+                DeletePointsBuilder::new(collection_name)
+                    .points(PointsIdsList {
+                        ids: vec![point_id.to_string().into()],
+                    })
+                    .wait(true),
+            )
+            .await
+            .context("Failed to delete point from Qdrant")?;
+
+        debug!(
+            "[{}] Deleted point {} from collection '{}'",
+            self.base.id, point_id, collection_name
+        );
+
+        Ok(())
+    }
+}
+
+/// Retry an async operation with exponential backoff and jitter.
+///
+/// # Arguments
+///
+/// * `operation_name` - Name of the operation for logging
+/// * `config` - Retry configuration
+/// * `reaction_id` - Reaction ID for logging
+/// * `operation` - Async closure to retry
+///
+/// # Returns
+///
+/// Returns the result of the operation if successful within max_retries attempts,
+/// otherwise returns the last error encountered.
+async fn retry_with_backoff<T, F, Fut>(
+    operation_name: &str,
+    config: &RetryConfig,
+    reaction_id: &str,
+    mut operation: F,
+) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut attempt = 0;
+    let mut delay_ms = config.initial_delay_ms;
+
+    loop {
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(e) if attempt < config.max_retries => {
+                attempt += 1;
+                warn!(
+                    "[{reaction_id}] {operation_name} failed (attempt {}/{}): {e}. Retrying in {delay_ms}ms...",
+                    attempt,
+                    config.max_retries + 1
+                );
+
+                // Add jitter (±25% randomization to prevent thundering herd)
+                let jitter_factor = rand::thread_rng().gen_range(0.75..1.25);
+                let actual_delay = (delay_ms as f64 * jitter_factor) as u64;
+
+                tokio::time::sleep(Duration::from_millis(actual_delay)).await;
+
+                // Exponential backoff capped at max_delay_ms
+                delay_ms = (delay_ms * 2).min(config.max_delay_ms);
+            }
+            Err(e) => {
+                error!(
+                    "[{reaction_id}] {operation_name} failed after {} attempts. Final error: {e:#}",
+                    attempt + 1
+                );
+                return Err(e);
+            }
+        }
+    }
+}
+
+/// Process a batch of documents: build docs, generate embeddings, upsert to Qdrant.
+///
+/// This function handles the complete pipeline for a batch of data items:
+/// 1. Builds Document structs from data using templates
+/// 2. Generates embeddings in sub-batches (respecting API limits)
+/// 3. Creates Qdrant PointStructs with embeddings and metadata
+/// 4. Performs batch upsert to Qdrant
+///
+/// Returns the number of successfully upserted points.
+async fn process_upsert_batch(
+    data_items: &[serde_json::Value],
+    document_builder: &DocumentBuilder<'_>,
+    embedder: &Arc<dyn Embedder>,
+    client: &Qdrant,
+    collection_name: &str,
+    embedding_batch_size: usize,
+    reaction_id: &str,
+) -> Result<usize> {
+    // 1. Build all documents (filter failures, log errors)
+    let docs: Vec<Document> = data_items
+        .iter()
+        .filter_map(|data| match document_builder.build(data) {
+            Ok(d) => Some(d),
+            Err(e) => {
+                error!("[{reaction_id}] Failed to build document: {e}");
+                None
+            }
+        })
+        .collect();
+
+    if docs.is_empty() {
+        return Ok(0);
+    }
+
+    // 2. Extract content strings for embedding
+    let contents: Vec<String> = docs.iter().map(|d| d.content.clone()).collect();
+
+    // 3. Generate embeddings in sub-batches (respect API limits)
+    let mut all_embeddings: Vec<Vec<f32>> = Vec::with_capacity(contents.len());
+    for chunk in contents.chunks(embedding_batch_size) {
+        let chunk_vec: Vec<String> = chunk.to_vec();
+        let embeddings = embedder
+            .generate(&chunk_vec)
+            .await
+            .context("Failed to generate embeddings for batch")?;
+        all_embeddings.extend(embeddings);
+    }
+
+    // Verify we got the right number of embeddings
+    if all_embeddings.len() != docs.len() {
+        anyhow::bail!(
+            "Embedding count mismatch: expected {}, got {}",
+            docs.len(),
+            all_embeddings.len()
+        );
+    }
+
+    // 4. Build PointStructs
+    let points: Vec<PointStruct> = docs
+        .iter()
+        .zip(all_embeddings.iter())
+        .map(|(doc, embedding)| {
+            let payload = convert_json_to_qdrant_payload(&doc.metadata);
+            PointStruct::new(doc.point_id.to_string(), embedding.clone(), payload)
+        })
+        .collect();
+
+    // 5. Batch upsert to Qdrant
+    let count = points.len();
+    client
+        .upsert_points(UpsertPointsBuilder::new(collection_name, points).wait(true))
+        .await
+        .context("Failed to batch upsert points to Qdrant")?;
+
+    debug!("[{reaction_id}] Batch upserted {count} points to '{collection_name}'");
+    Ok(count)
+}
+
+/// Builder for QdrantReaction
+pub struct QdrantReactionBuilder {
+    id: String,
+    queries: Vec<String>,
+    config: Option<QdrantReactionConfig>,
+    embedder: Option<Arc<dyn Embedder>>,
+    priority_queue_capacity: Option<usize>,
+    auto_start: bool,
+    error_handler: Option<ErrorHandler>,
+}
+
+impl QdrantReactionBuilder {
+    /// Create a new builder with the given reaction ID.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            queries: Vec::new(),
+            config: None,
+            embedder: None,
+            priority_queue_capacity: None,
+            auto_start: true,
+            error_handler: None,
+        }
+    }
+
+    /// Set the query IDs to subscribe to.
+    pub fn with_queries(mut self, queries: Vec<String>) -> Self {
+        self.queries = queries;
+        self
+    }
+
+    /// Add a query ID to subscribe to.
+    pub fn with_query(mut self, query_id: impl Into<String>) -> Self {
+        self.queries.push(query_id.into());
+        self
+    }
+
+    /// Connect this reaction to receive results from a query.
+    pub fn from_query(mut self, query_id: impl Into<String>) -> Self {
+        self.queries.push(query_id.into());
+        self
+    }
+
+    /// Set the configuration.
+    pub fn with_config(mut self, config: QdrantReactionConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    /// Set a custom embedder (overrides config-based embedder).
+    pub fn with_embedder(mut self, embedder: Arc<dyn Embedder>) -> Self {
+        self.embedder = Some(embedder);
+        self
+    }
+
+    /// Set custom priority queue capacity.
+    pub fn with_priority_queue_capacity(mut self, capacity: usize) -> Self {
+        self.priority_queue_capacity = Some(capacity);
+        self
+    }
+
+    /// Set whether the reaction should auto-start.
+    pub fn with_auto_start(mut self, auto_start: bool) -> Self {
+        self.auto_start = auto_start;
+        self
+    }
+
+    /// Set an error handler for failures after retry exhaustion.
+    ///
+    /// If not set, errors are logged and processing continues.
+    pub fn with_error_handler<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(anyhow::Error) + Send + Sync + 'static,
+    {
+        self.error_handler = Some(Arc::new(handler));
+        self
+    }
+
+    /// Build the QdrantReaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Configuration is not set
+    /// - Configuration validation fails
+    /// - Template compilation fails
+    pub fn build(self) -> Result<QdrantReaction> {
+        let config = self.config.context("Configuration is required")?;
+        config.validate()?;
+
+        // Use provided embedder or create from config
+        let embedder: Arc<dyn Embedder> = if let Some(e) = self.embedder {
+            e
+        } else {
+            match &config.embedding {
+                EmbeddingConfig::Mock { dimensions } => Arc::new(MockEmbedder::new(*dimensions)),
+                EmbeddingConfig::AzureOpenai {
+                    endpoint,
+                    model,
+                    api_key,
+                    dimensions,
+                    api_version,
+                } => Arc::new(AzureOpenAIEmbedder::new(
+                    endpoint.clone(),
+                    model.clone(),
+                    api_key.clone(),
+                    *dimensions,
+                    api_version.clone(),
+                )),
+            }
+        };
+
+        let handlebars = setup_handlebars(
+            &config.document.document_template,
+            config.document.title_template.as_deref(),
+        )?;
+
+        let mut params =
+            ReactionBaseParams::new(self.id, self.queries).with_auto_start(self.auto_start);
+        if let Some(capacity) = self.priority_queue_capacity {
+            params = params.with_priority_queue_capacity(capacity);
+        }
+
+        Ok(QdrantReaction {
+            base: ReactionBase::new(params),
+            config,
+            embedder,
+            qdrant_client: Arc::new(Mutex::new(None)),
+            handlebars,
+            error_handler: self.error_handler,
+        })
+    }
+}
+
+#[async_trait]
+impl Reaction for QdrantReaction {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "qdrant"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        let mut props = HashMap::new();
+        props.insert(
+            "qdrant_endpoint".to_string(),
+            serde_json::Value::String(self.config.qdrant.endpoint.clone()),
+        );
+        props.insert(
+            "collection_name".to_string(),
+            serde_json::Value::String(self.config.qdrant.collection_name.clone()),
+        );
+        props.insert(
+            "embedding_service".to_string(),
+            serde_json::Value::String(self.embedder.name().to_string()),
+        );
+        props.insert(
+            "embedding_dimensions".to_string(),
+            serde_json::Value::Number(self.embedder.dimensions().into()),
+        );
+        props
+    }
+
+    fn query_ids(&self) -> Vec<String> {
+        self.base.queries.clone()
+    }
+
+    fn auto_start(&self) -> bool {
+        self.base.get_auto_start()
+    }
+
+    async fn initialize(&self, context: drasi_lib::context::ReactionRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn start(&self) -> Result<()> {
+        log_component_start("Reaction", &self.base.id);
+
+        // Transition to Starting
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Starting,
+                Some("Starting Qdrant reaction".to_string()),
+            )
+            .await?;
+
+        // Initialize Qdrant client
+        let client = self.initialize_qdrant_client().await?;
+
+        // Ensure collection exists
+        self.ensure_collection(&client).await?;
+
+        // Store client
+        {
+            let mut client_guard = self.qdrant_client.lock().await;
+            *client_guard = Some(client.clone());
+        }
+
+        // ============================================================
+        // SYNC PROTOCOL: Subscribe -> Snapshot -> Materialize -> Process
+        // ============================================================
+
+        // 1. SUBSCRIBE - Subscribe first so events start buffering
+        self.base.subscribe_to_queries().await?;
+
+        // 2. SNAPSHOT & MATERIALIZE - Load existing query results into Qdrant
+        // Access QueryProvider via context
+        let context = self.base.context().await.ok_or_else(|| {
+            anyhow::anyhow!("Context not initialized - was reaction added to DrasiLib?")
+        })?;
+        let query_provider = context.query_provider;
+
+        // Setup document builder for snapshot processing
+        let document_builder = DocumentBuilder::new(
+            &self.handlebars,
+            "document",
+            if self.config.document.title_template.is_some() {
+                Some("title")
+            } else {
+                None
+            },
+            &self.config.document.key_field,
+        );
+
+        for query_id in &self.base.queries {
+            let query = query_provider.get_query_instance(query_id).await?;
+
+            // Cast to DrasiQuery to access get_current_results()
+            // NOTE: UpsertPointsBuilder uses upsert (overwrite) semantics,
+            // so idempotency is guaranteed by UUID generation
+            if let Some(drasi_query) = query.as_any().downcast_ref::<DrasiQuery>() {
+                let current_results = drasi_query.get_current_results().await;
+
+                if !current_results.is_empty() {
+                    let total = current_results.len();
+                    info!(
+                        "[{}] Loading {} existing results from query '{}'",
+                        self.base.id, total, query_id
+                    );
+
+                    // Process snapshot in batches with retry and progress logging
+                    let mut processed = 0;
+                    for chunk in current_results.chunks(self.config.batch.upsert_batch_size) {
+                        // Clone data for the retry closure
+                        let chunk_vec: Vec<serde_json::Value> = chunk.to_vec();
+
+                        // Retry with exponential backoff - fail startup on persistent error
+                        let count = retry_with_backoff(
+                            "Snapshot batch upsert",
+                            &self.config.retry,
+                            &self.base.id,
+                            || {
+                                let chunk_ref = &chunk_vec;
+                                let doc_builder = &document_builder;
+                                let emb = &self.embedder;
+                                let cli = &client;
+                                let coll = &self.config.qdrant.collection_name;
+                                let emb_batch = self.config.batch.embedding_batch_size;
+                                let rid = &self.base.id;
+                                async move {
+                                    process_upsert_batch(
+                                        chunk_ref,
+                                        doc_builder,
+                                        emb,
+                                        cli,
+                                        coll,
+                                        emb_batch,
+                                        rid,
+                                    )
+                                    .await
+                                }
+                            },
+                        )
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "Snapshot loading failed for query '{}' after {} retries. \
+                                 Cannot start in inconsistent state.",
+                                query_id, self.config.retry.max_retries
+                            )
+                        })?;
+
+                        processed += count;
+
+                        // Progress logging for large datasets
+                        if total > 1000 && processed % 1000 < self.config.batch.upsert_batch_size {
+                            info!(
+                                "[{}] Snapshot progress: {}/{} ({:.1}%)",
+                                self.base.id,
+                                processed,
+                                total,
+                                (processed as f64 / total as f64) * 100.0
+                            );
+                        }
+                    }
+
+                    info!(
+                        "[{}] Snapshot loading complete for query '{}' ({} items)",
+                        self.base.id, query_id, processed
+                    );
+                }
+            } else {
+                warn!(
+                    "[{}] Query '{}' is not a DrasiQuery, skipping snapshot",
+                    self.base.id, query_id
+                );
+            }
+        }
+
+        // Transition to Running
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Running,
+                Some("Qdrant reaction started".to_string()),
+            )
+            .await?;
+
+        info!(
+            "[{}] Started - syncing to Qdrant collection '{}' from queries: {:?}",
+            self.base.id, self.config.qdrant.collection_name, self.base.queries
+        );
+
+        // 3. PROCESS - Spawn processing task for incremental updates
+        let priority_queue = self.base.priority_queue.clone();
+        let reaction_id = self.base.id.clone();
+        let qdrant_client = self.qdrant_client.clone();
+        let embedder = self.embedder.clone();
+        let handlebars = self.handlebars.clone();
+        let config = self.config.clone();
+        let error_handler = self.error_handler.clone();
+
+        let mut shutdown_rx = self.base.create_shutdown_channel().await;
+
+        let processing_task = tokio::spawn(async move {
+            let document_builder = DocumentBuilder::new(
+                &handlebars,
+                "document",
+                if config.document.title_template.is_some() {
+                    Some("title")
+                } else {
+                    None
+                },
+                &config.document.key_field,
+            );
+
+            loop {
+                let query_result_arc = tokio::select! {
+                    biased;
+
+                    _ = &mut shutdown_rx => {
+                        debug!("[{reaction_id}] Received shutdown signal, exiting processing loop");
+                        break;
+                    }
+
+                    result = priority_queue.dequeue() => result,
+                };
+
+                let query_result = (*query_result_arc).clone();
+
+                if query_result.results.is_empty() {
+                    debug!("[{reaction_id}] Received empty result set from query");
+                    continue;
+                }
+
+                debug!(
+                    "[{reaction_id}] Processing {} results from query '{}'",
+                    query_result.results.len(),
+                    query_result.query_id
+                );
+
+                // Get Qdrant client
+                let client = {
+                    let guard = qdrant_client.lock().await;
+                    match guard.as_ref() {
+                        Some(c) => c.clone(),
+                        None => {
+                            error!("[{reaction_id}] Qdrant client not initialized");
+                            continue;
+                        }
+                    }
+                };
+
+                // Separate adds/updates from deletes for batch processing
+                let mut upsert_data: Vec<serde_json::Value> = Vec::new();
+                let mut delete_ids: Vec<uuid::Uuid> = Vec::new();
+
+                for result in &query_result.results {
+                    match result {
+                        ResultDiff::Add { data } | ResultDiff::Update { after: data, .. } => {
+                            upsert_data.push(data.clone());
+                        }
+                        ResultDiff::Delete { data } => {
+                            match extract_field(data, &config.document.key_field) {
+                                Ok(key) => {
+                                    delete_ids.push(generate_deterministic_uuid(&key));
+                                }
+                                Err(e) => {
+                                    error!("[{reaction_id}] Failed to extract key for delete: {e}");
+                                }
+                            }
+                        }
+                        ResultDiff::Aggregation { .. } => {
+                            warn!(
+                                "[{reaction_id}] Aggregation results not supported for vector storage"
+                            );
+                        }
+                        ResultDiff::Noop => {
+                            // Nothing to do
+                        }
+                    }
+                }
+
+                // Batch process upserts with retry
+                if !upsert_data.is_empty() {
+                    for chunk in upsert_data.chunks(config.batch.upsert_batch_size) {
+                        let chunk_vec: Vec<serde_json::Value> = chunk.to_vec();
+                        let chunk_len = chunk_vec.len();
+
+                        // Retry with exponential backoff - invoke error handler on persistent failure
+                        if let Err(e) =
+                            retry_with_backoff("Batch upsert", &config.retry, &reaction_id, || {
+                                let chunk_ref = &chunk_vec;
+                                let doc_builder = &document_builder;
+                                let emb = &embedder;
+                                let cli = &client;
+                                let coll = &config.qdrant.collection_name;
+                                let emb_batch = config.batch.embedding_batch_size;
+                                let rid = &reaction_id;
+                                async move {
+                                    process_upsert_batch(
+                                        chunk_ref,
+                                        doc_builder,
+                                        emb,
+                                        cli,
+                                        coll,
+                                        emb_batch,
+                                        rid,
+                                    )
+                                    .await
+                                }
+                            })
+                            .await
+                        {
+                            let err = anyhow::anyhow!(
+                                "Batch upsert failed after {} retries. {} items dropped. Error: {e:#}",
+                                config.retry.max_retries,
+                                chunk_len
+                            );
+                            error!("[{reaction_id}] {err}");
+                            if let Some(ref handler) = error_handler {
+                                handler(err);
+                            }
+                        }
+                    }
+                }
+
+                // Batch process deletes with retry
+                if !delete_ids.is_empty() {
+                    let collection_name = config.qdrant.collection_name.clone();
+                    let delete_count = delete_ids.len();
+                    let ids: Vec<qdrant_client::qdrant::PointId> =
+                        delete_ids.iter().map(|id| id.to_string().into()).collect();
+
+                    // Retry with exponential backoff - invoke error handler on persistent failure
+                    if let Err(e) =
+                        retry_with_backoff("Batch delete", &config.retry, &reaction_id, || {
+                            let cli = &client;
+                            let coll = &collection_name;
+                            let ids_clone = ids.clone();
+                            async move {
+                                cli.delete_points(
+                                    DeletePointsBuilder::new(coll)
+                                        .points(PointsIdsList { ids: ids_clone })
+                                        .wait(true),
+                                )
+                                .await
+                                .context("Failed to delete points from Qdrant")?;
+                                Ok(())
+                            }
+                        })
+                        .await
+                    {
+                        let err = anyhow::anyhow!(
+                            "Batch delete failed after {} retries. {} deletes dropped. Error: {e:#}",
+                            config.retry.max_retries,
+                            delete_count
+                        );
+                        error!("[{reaction_id}] {err}");
+                        if let Some(ref handler) = error_handler {
+                            handler(err);
+                        }
+                    }
+
+                    debug!(
+                        "[{reaction_id}] Deleted {delete_count} points from '{collection_name}'"
+                    );
+                }
+            }
+        });
+
+        self.base.set_processing_task(processing_task).await;
+
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        // Stop processing
+        self.base.stop_common().await?;
+
+        // Clear Qdrant client
+        {
+            let mut client_guard = self.qdrant_client.lock().await;
+            *client_guard = None;
+        }
+
+        // Transition to Stopped
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Stopped,
+                Some("Qdrant reaction stopped".to_string()),
+            )
+            .await?;
+
+        info!("[{}] Stopped Qdrant reaction", self.base.id);
+
+        Ok(())
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+}
+
+/// Convert JSON value to Qdrant payload format.
+fn convert_json_to_qdrant_payload(
+    value: &serde_json::Value,
+) -> HashMap<String, qdrant_client::qdrant::Value> {
+    let mut payload = HashMap::new();
+
+    if let serde_json::Value::Object(map) = value {
+        for (key, val) in map {
+            payload.insert(key.clone(), json_to_qdrant_value(val));
+        }
+    }
+
+    payload
+}
+
+/// Convert a single JSON value to Qdrant value.
+fn json_to_qdrant_value(value: &serde_json::Value) -> qdrant_client::qdrant::Value {
+    use qdrant_client::qdrant::value::Kind;
+    use qdrant_client::qdrant::Value as QdrantValue;
+
+    match value {
+        serde_json::Value::Null => QdrantValue {
+            kind: Some(Kind::NullValue(0)),
+        },
+        serde_json::Value::Bool(b) => QdrantValue {
+            kind: Some(Kind::BoolValue(*b)),
+        },
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                QdrantValue {
+                    kind: Some(Kind::IntegerValue(i)),
+                }
+            } else if let Some(f) = n.as_f64() {
+                QdrantValue {
+                    kind: Some(Kind::DoubleValue(f)),
+                }
+            } else {
+                QdrantValue {
+                    kind: Some(Kind::StringValue(n.to_string())),
+                }
+            }
+        }
+        serde_json::Value::String(s) => QdrantValue {
+            kind: Some(Kind::StringValue(s.clone())),
+        },
+        serde_json::Value::Array(arr) => {
+            use qdrant_client::qdrant::ListValue;
+            let list = ListValue {
+                values: arr.iter().map(json_to_qdrant_value).collect(),
+            };
+            QdrantValue {
+                kind: Some(Kind::ListValue(list)),
+            }
+        }
+        serde_json::Value::Object(obj) => {
+            use qdrant_client::qdrant::Struct;
+            let fields: HashMap<String, QdrantValue> = obj
+                .iter()
+                .map(|(k, v)| (k.clone(), json_to_qdrant_value(v)))
+                .collect();
+            QdrantValue {
+                kind: Some(Kind::StructValue(Struct { fields })),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{BatchConfig, DocumentConfig, QdrantConfig, RetryConfig};
+
+    fn create_test_config() -> QdrantReactionConfig {
+        QdrantReactionConfig {
+            qdrant: QdrantConfig {
+                endpoint: "http://localhost:6334".to_string(),
+                api_key: None,
+                collection_name: "test_collection".to_string(),
+                create_collection: true,
+            },
+            embedding: EmbeddingConfig::Mock { dimensions: 1536 },
+            document: DocumentConfig {
+                document_template: "{{name}}: {{description}}".to_string(),
+                title_template: Some("{{name}}".to_string()),
+                key_field: "id".to_string(),
+                metadata_fields: None,
+            },
+            batch: BatchConfig::default(),
+            retry: RetryConfig::default(),
+        }
+    }
+
+    #[test]
+    fn test_create_reaction_with_mock_embedder() {
+        let config = create_test_config();
+        let embedder = Arc::new(MockEmbedder::new(1536));
+
+        let reaction = QdrantReaction::with_embedder(
+            "test-reaction",
+            vec!["query1".to_string()],
+            config,
+            embedder,
+        );
+
+        assert!(reaction.is_ok());
+        let reaction = reaction.expect("Reaction should be created");
+        assert_eq!(reaction.id(), "test-reaction");
+        assert_eq!(reaction.type_name(), "qdrant");
+    }
+
+    #[test]
+    fn test_reaction_properties() {
+        let config = create_test_config();
+        let embedder = Arc::new(MockEmbedder::new(1536));
+
+        let reaction = QdrantReaction::with_embedder(
+            "test-reaction",
+            vec!["query1".to_string()],
+            config,
+            embedder,
+        )
+        .expect("Reaction should be created");
+
+        let props = reaction.properties();
+        assert_eq!(
+            props.get("qdrant_endpoint"),
+            Some(&serde_json::Value::String(
+                "http://localhost:6334".to_string()
+            ))
+        );
+        assert_eq!(
+            props.get("collection_name"),
+            Some(&serde_json::Value::String("test_collection".to_string()))
+        );
+        assert_eq!(
+            props.get("embedding_service"),
+            Some(&serde_json::Value::String("mock".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_builder_pattern() {
+        let config = create_test_config();
+        let embedder = Arc::new(MockEmbedder::new(1536));
+
+        let reaction = QdrantReaction::builder("builder-test")
+            .with_query("query1")
+            .with_query("query2")
+            .with_config(config)
+            .with_embedder(embedder)
+            .with_auto_start(false)
+            .build();
+
+        assert!(reaction.is_ok());
+        let reaction = reaction.expect("Reaction should be created");
+        assert_eq!(reaction.query_ids().len(), 2);
+        assert!(!reaction.auto_start());
+    }
+
+    #[test]
+    fn test_json_to_qdrant_payload() {
+        let json = serde_json::json!({
+            "string": "hello",
+            "number": 42,
+            "float": 3.15,
+            "bool": true,
+            "null": null,
+            "array": [1, 2, 3],
+            "nested": {
+                "key": "value"
+            }
+        });
+
+        let payload = convert_json_to_qdrant_payload(&json);
+
+        assert!(payload.contains_key("string"));
+        assert!(payload.contains_key("number"));
+        assert!(payload.contains_key("float"));
+        assert!(payload.contains_key("bool"));
+        assert!(payload.contains_key("null"));
+        assert!(payload.contains_key("array"));
+        assert!(payload.contains_key("nested"));
+    }
+}

--- a/components/reactions/qdrant/tests/integration_test.rs
+++ b/components/reactions/qdrant/tests/integration_test.rs
@@ -1,0 +1,610 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the Qdrant reaction using testcontainers.
+
+mod qdrant_helpers;
+
+use drasi_reaction_qdrant::{
+    generate_deterministic_uuid, BatchConfig, DocumentConfig, EmbeddingConfig, MockEmbedder,
+    QdrantConfig, QdrantReactionConfig, RetryConfig,
+};
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, Distance, PointStruct, UpsertPointsBuilder, VectorParamsBuilder,
+};
+use qdrant_helpers::{get_points_count, search_points, setup_qdrant};
+use serial_test::serial;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Test that the mock embedder produces deterministic embeddings
+#[tokio::test]
+async fn test_mock_embedder_deterministic() {
+    use drasi_reaction_qdrant::Embedder;
+
+    let embedder = MockEmbedder::new(1536);
+
+    let text = "This is a test document for embedding".to_string();
+    let embedding1 = embedder
+        .generate(&[text.clone()])
+        .await
+        .expect("Should generate embedding");
+    let embedding2 = embedder
+        .generate(&[text])
+        .await
+        .expect("Should generate embedding");
+
+    assert_eq!(
+        embedding1, embedding2,
+        "Same text should produce same embedding"
+    );
+    assert_eq!(embedding1[0].len(), 1536, "Should have correct dimensions");
+
+    // Verify normalization
+    let norm: f32 = embedding1[0].iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!(
+        (norm - 1.0).abs() < 0.0001,
+        "Embedding should be normalized to unit length"
+    );
+}
+
+/// Test that different texts produce different embeddings
+#[tokio::test]
+async fn test_mock_embedder_different_texts() {
+    use drasi_reaction_qdrant::Embedder;
+
+    let embedder = MockEmbedder::new(1536);
+
+    let embedding1 = embedder
+        .generate(&["Hello world".to_string()])
+        .await
+        .expect("Should generate embedding");
+    let embedding2 = embedder
+        .generate(&["Goodbye world".to_string()])
+        .await
+        .expect("Should generate embedding");
+
+    assert_ne!(
+        embedding1, embedding2,
+        "Different texts should produce different embeddings"
+    );
+}
+
+/// Test deterministic UUID generation
+#[test]
+fn test_deterministic_uuid_generation() {
+    let key = "product-123";
+    let uuid1 = generate_deterministic_uuid(key);
+    let uuid2 = generate_deterministic_uuid(key);
+
+    assert_eq!(uuid1, uuid2, "Same key should produce same UUID");
+
+    let uuid3 = generate_deterministic_uuid("product-456");
+    assert_ne!(
+        uuid1, uuid3,
+        "Different keys should produce different UUIDs"
+    );
+}
+
+/// Test UUID format
+#[test]
+fn test_uuid_format() {
+    let uuid = generate_deterministic_uuid("test-key-12345");
+    let uuid_str = uuid.to_string();
+
+    // UUID format: 8-4-4-4-12
+    assert_eq!(uuid_str.len(), 36);
+    assert_eq!(uuid_str.chars().filter(|c| *c == '-').count(), 4);
+}
+
+/// Test configuration validation
+#[test]
+fn test_config_validation_success() {
+    let config = QdrantReactionConfig {
+        qdrant: QdrantConfig {
+            endpoint: "http://localhost:6334".to_string(),
+            api_key: None,
+            collection_name: "test".to_string(),
+            create_collection: true,
+        },
+        embedding: EmbeddingConfig::Mock { dimensions: 1536 },
+        document: DocumentConfig {
+            document_template: "{{content}}".to_string(),
+            key_field: "id".to_string(),
+            ..Default::default()
+        },
+        batch: BatchConfig::default(),
+        retry: RetryConfig::default(),
+    };
+
+    assert!(config.validate().is_ok());
+}
+
+/// Test configuration validation failure for missing endpoint
+#[test]
+fn test_config_validation_missing_endpoint() {
+    let config = QdrantReactionConfig {
+        qdrant: QdrantConfig {
+            endpoint: "".to_string(),
+            api_key: None,
+            collection_name: "test".to_string(),
+            create_collection: true,
+        },
+        embedding: EmbeddingConfig::default(),
+        document: DocumentConfig::default(),
+        batch: BatchConfig::default(),
+        retry: RetryConfig::default(),
+    };
+
+    let result = config.validate();
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("endpoint"));
+}
+
+/// Test Qdrant connection and collection creation
+#[tokio::test]
+#[serial]
+async fn test_qdrant_connection() {
+    let qdrant = setup_qdrant().await;
+    let client = qdrant.get_client().expect("Should create client");
+
+    // Verify connection by listing collections
+    let collections = client
+        .list_collections()
+        .await
+        .expect("Should list collections");
+    assert!(collections.collections.is_empty() || !collections.collections.is_empty());
+
+    qdrant.cleanup().await;
+}
+
+/// Test creating a collection and upserting points
+#[tokio::test]
+#[serial]
+async fn test_upsert_and_search() {
+    use drasi_reaction_qdrant::Embedder;
+
+    let qdrant = setup_qdrant().await;
+    let client = qdrant.get_client().expect("Should create client");
+    let embedder = MockEmbedder::new(128);
+
+    let collection_name = "test_upsert_search";
+
+    // Create collection
+    client
+        .create_collection(
+            CreateCollectionBuilder::new(collection_name)
+                .vectors_config(VectorParamsBuilder::new(128, Distance::Cosine)),
+        )
+        .await
+        .expect("Should create collection");
+
+    // Generate embedding and upsert point
+    let text = "This is a test document about machine learning".to_string();
+    let embeddings = embedder
+        .generate(&[text])
+        .await
+        .expect("Should generate embedding");
+
+    let point_id = generate_deterministic_uuid("doc-001");
+    let mut payload: HashMap<String, qdrant_client::qdrant::Value> = HashMap::new();
+    payload.insert(
+        "title".to_string(),
+        qdrant_client::qdrant::Value {
+            kind: Some(qdrant_client::qdrant::value::Kind::StringValue(
+                "Test Document".to_string(),
+            )),
+        },
+    );
+
+    let point = PointStruct::new(point_id.to_string(), embeddings[0].clone(), payload);
+
+    client
+        .upsert_points(UpsertPointsBuilder::new(collection_name, vec![point]).wait(true))
+        .await
+        .expect("Should upsert point");
+
+    // Verify point count
+    let count = get_points_count(&client, collection_name)
+        .await
+        .expect("Should get points count");
+    assert_eq!(count, 1);
+
+    // Search for the point
+    let search_result = search_points(&client, collection_name, embeddings[0].clone(), 10)
+        .await
+        .expect("Should search points");
+
+    assert_eq!(search_result.result.len(), 1);
+    assert_eq!(
+        search_result.result[0]
+            .id
+            .clone()
+            .unwrap()
+            .point_id_options
+            .unwrap(),
+        qdrant_client::qdrant::point_id::PointIdOptions::Uuid(point_id.to_string())
+    );
+
+    qdrant.cleanup().await;
+}
+
+/// Test updating an existing point (upsert with same ID)
+#[tokio::test]
+#[serial]
+async fn test_update_point() {
+    use drasi_reaction_qdrant::Embedder;
+
+    let qdrant = setup_qdrant().await;
+    let client = qdrant.get_client().expect("Should create client");
+    let embedder = MockEmbedder::new(128);
+
+    let collection_name = "test_update";
+
+    // Create collection
+    client
+        .create_collection(
+            CreateCollectionBuilder::new(collection_name)
+                .vectors_config(VectorParamsBuilder::new(128, Distance::Cosine)),
+        )
+        .await
+        .expect("Should create collection");
+
+    let point_id = generate_deterministic_uuid("doc-update-001");
+
+    // Insert initial point
+    let text1 = "Initial document content".to_string();
+    let embeddings1 = embedder
+        .generate(&[text1])
+        .await
+        .expect("Should generate embedding");
+
+    let mut payload1: HashMap<String, qdrant_client::qdrant::Value> = HashMap::new();
+    payload1.insert(
+        "version".to_string(),
+        qdrant_client::qdrant::Value {
+            kind: Some(qdrant_client::qdrant::value::Kind::IntegerValue(1)),
+        },
+    );
+
+    let point1 = PointStruct::new(point_id.to_string(), embeddings1[0].clone(), payload1);
+
+    client
+        .upsert_points(UpsertPointsBuilder::new(collection_name, vec![point1]).wait(true))
+        .await
+        .expect("Should upsert point");
+
+    // Update with new content
+    let text2 = "Updated document content".to_string();
+    let embeddings2 = embedder
+        .generate(&[text2])
+        .await
+        .expect("Should generate embedding");
+
+    let mut payload2: HashMap<String, qdrant_client::qdrant::Value> = HashMap::new();
+    payload2.insert(
+        "version".to_string(),
+        qdrant_client::qdrant::Value {
+            kind: Some(qdrant_client::qdrant::value::Kind::IntegerValue(2)),
+        },
+    );
+
+    let point2 = PointStruct::new(point_id.to_string(), embeddings2[0].clone(), payload2);
+
+    client
+        .upsert_points(UpsertPointsBuilder::new(collection_name, vec![point2]).wait(true))
+        .await
+        .expect("Should upsert updated point");
+
+    // Verify still only one point
+    let count = get_points_count(&client, collection_name)
+        .await
+        .expect("Should get points count");
+    assert_eq!(count, 1);
+
+    // Verify the embedding was updated (search with new embedding should return it)
+    let search_result = search_points(&client, collection_name, embeddings2[0].clone(), 1)
+        .await
+        .expect("Should search points");
+
+    assert_eq!(search_result.result.len(), 1);
+    // Score should be very high (close to 1.0) for exact match
+    assert!(search_result.result[0].score > 0.99);
+
+    qdrant.cleanup().await;
+}
+
+/// Test deleting a point
+#[tokio::test]
+#[serial]
+async fn test_delete_point() {
+    use drasi_reaction_qdrant::Embedder;
+    use qdrant_client::qdrant::{DeletePointsBuilder, PointsIdsList};
+
+    let qdrant = setup_qdrant().await;
+    let client = qdrant.get_client().expect("Should create client");
+    let embedder = MockEmbedder::new(128);
+
+    let collection_name = "test_delete";
+
+    // Create collection
+    client
+        .create_collection(
+            CreateCollectionBuilder::new(collection_name)
+                .vectors_config(VectorParamsBuilder::new(128, Distance::Cosine)),
+        )
+        .await
+        .expect("Should create collection");
+
+    let point_id = generate_deterministic_uuid("doc-delete-001");
+
+    // Insert point
+    let text = "Document to be deleted".to_string();
+    let embeddings = embedder
+        .generate(&[text])
+        .await
+        .expect("Should generate embedding");
+
+    let payload: HashMap<String, qdrant_client::qdrant::Value> = HashMap::new();
+    let point = PointStruct::new(point_id.to_string(), embeddings[0].clone(), payload);
+
+    client
+        .upsert_points(UpsertPointsBuilder::new(collection_name, vec![point]).wait(true))
+        .await
+        .expect("Should upsert point");
+
+    // Verify point exists
+    let count = get_points_count(&client, collection_name)
+        .await
+        .expect("Should get points count");
+    assert_eq!(count, 1);
+
+    // Delete point
+    client
+        .delete_points(
+            DeletePointsBuilder::new(collection_name)
+                .points(PointsIdsList {
+                    ids: vec![point_id.to_string().into()],
+                })
+                .wait(true),
+        )
+        .await
+        .expect("Should delete point");
+
+    // Verify point was deleted
+    let count = get_points_count(&client, collection_name)
+        .await
+        .expect("Should get points count");
+    assert_eq!(count, 0);
+
+    qdrant.cleanup().await;
+}
+
+/// Test batch processing of multiple points
+#[tokio::test]
+#[serial]
+async fn test_batch_processing() {
+    use drasi_reaction_qdrant::Embedder;
+
+    let qdrant = setup_qdrant().await;
+    let client = qdrant.get_client().expect("Should create client");
+    let embedder = MockEmbedder::new(128);
+
+    let collection_name = "test_batch";
+
+    // Create collection
+    client
+        .create_collection(
+            CreateCollectionBuilder::new(collection_name)
+                .vectors_config(VectorParamsBuilder::new(128, Distance::Cosine)),
+        )
+        .await
+        .expect("Should create collection");
+
+    // Create multiple points
+    let texts = vec![
+        "First document about artificial intelligence".to_string(),
+        "Second document about machine learning".to_string(),
+        "Third document about deep learning".to_string(),
+    ];
+
+    let embeddings = embedder
+        .generate(&texts)
+        .await
+        .expect("Should generate embeddings");
+    assert_eq!(embeddings.len(), 3);
+
+    let points: Vec<PointStruct> = texts
+        .iter()
+        .enumerate()
+        .zip(embeddings.iter())
+        .map(|((i, text), embedding)| {
+            let point_id = generate_deterministic_uuid(&format!("batch-doc-{i}"));
+            let mut payload: HashMap<String, qdrant_client::qdrant::Value> = HashMap::new();
+            payload.insert(
+                "content".to_string(),
+                qdrant_client::qdrant::Value {
+                    kind: Some(qdrant_client::qdrant::value::Kind::StringValue(
+                        text.clone(),
+                    )),
+                },
+            );
+            PointStruct::new(point_id.to_string(), embedding.clone(), payload)
+        })
+        .collect();
+
+    // Batch upsert
+    client
+        .upsert_points(UpsertPointsBuilder::new(collection_name, points).wait(true))
+        .await
+        .expect("Should upsert points");
+
+    // Verify all points were created
+    let count = get_points_count(&client, collection_name)
+        .await
+        .expect("Should get points count");
+    assert_eq!(count, 3);
+
+    qdrant.cleanup().await;
+}
+
+/// Test that similar texts produce similar embeddings (semantic search)
+#[tokio::test]
+#[serial]
+async fn test_semantic_similarity() {
+    use drasi_reaction_qdrant::Embedder;
+
+    let qdrant = setup_qdrant().await;
+    let client = qdrant.get_client().expect("Should create client");
+    let embedder = MockEmbedder::new(128);
+
+    let collection_name = "test_similarity";
+
+    // Create collection
+    client
+        .create_collection(
+            CreateCollectionBuilder::new(collection_name)
+                .vectors_config(VectorParamsBuilder::new(128, Distance::Cosine)),
+        )
+        .await
+        .expect("Should create collection");
+
+    // Create documents
+    let docs = vec![
+        ("doc1", "The quick brown fox jumps over the lazy dog"),
+        ("doc2", "A fast brown fox leaps over a sleepy dog"),
+        (
+            "doc3",
+            "Machine learning is a subset of artificial intelligence",
+        ),
+    ];
+
+    for (id, content) in &docs {
+        let embeddings = embedder
+            .generate(&[content.to_string()])
+            .await
+            .expect("Should generate embedding");
+        let point_id = generate_deterministic_uuid(id);
+        let mut payload: HashMap<String, qdrant_client::qdrant::Value> = HashMap::new();
+        payload.insert(
+            "id".to_string(),
+            qdrant_client::qdrant::Value {
+                kind: Some(qdrant_client::qdrant::value::Kind::StringValue(
+                    id.to_string(),
+                )),
+            },
+        );
+        let point = PointStruct::new(point_id.to_string(), embeddings[0].clone(), payload);
+        client
+            .upsert_points(UpsertPointsBuilder::new(collection_name, vec![point]).wait(true))
+            .await
+            .expect("Should upsert point");
+    }
+
+    // Search with a query similar to the first two documents
+    let query = "A brown fox and a dog".to_string();
+    let query_embedding = embedder
+        .generate(&[query])
+        .await
+        .expect("Should generate embedding");
+
+    let search_result = search_points(&client, collection_name, query_embedding[0].clone(), 3)
+        .await
+        .expect("Should search points");
+
+    assert_eq!(search_result.result.len(), 3);
+
+    // All results should be returned with scores
+    // Note: With mock embedder, similarity is based on SHA-256 hash, not semantic meaning
+    // Cosine similarity ranges from -1 to 1, so we just verify search returns results
+    // and that each result has a score (can be negative with dissimilar vectors)
+    for result in &search_result.result {
+        // Score exists and is within valid cosine similarity range
+        assert!(result.score >= -1.0 && result.score <= 1.0);
+    }
+
+    qdrant.cleanup().await;
+}
+
+/// Test QdrantReaction can be created with config
+#[test]
+fn test_reaction_creation() {
+    use drasi_reaction_qdrant::QdrantReaction;
+
+    let config = QdrantReactionConfig {
+        qdrant: QdrantConfig {
+            endpoint: "http://localhost:6334".to_string(),
+            api_key: None,
+            collection_name: "test_collection".to_string(),
+            create_collection: true,
+        },
+        embedding: EmbeddingConfig::Mock { dimensions: 1536 },
+        document: DocumentConfig {
+            document_template: "{{name}}: {{description}}".to_string(),
+            title_template: Some("{{name}}".to_string()),
+            key_field: "id".to_string(),
+            metadata_fields: None,
+        },
+        batch: BatchConfig::default(),
+        retry: RetryConfig::default(),
+    };
+
+    let embedder = Arc::new(MockEmbedder::new(1536));
+    let reaction = QdrantReaction::with_embedder(
+        "test-reaction",
+        vec!["query1".to_string()],
+        config,
+        embedder,
+    );
+
+    assert!(reaction.is_ok());
+}
+
+/// Test QdrantReaction builder pattern
+#[test]
+fn test_reaction_builder() {
+    use drasi_reaction_qdrant::QdrantReaction;
+
+    let config = QdrantReactionConfig {
+        qdrant: QdrantConfig {
+            endpoint: "http://localhost:6334".to_string(),
+            api_key: None,
+            collection_name: "test_collection".to_string(),
+            create_collection: true,
+        },
+        embedding: EmbeddingConfig::Mock { dimensions: 1536 },
+        document: DocumentConfig::default(),
+        batch: BatchConfig::default(),
+        retry: RetryConfig::default(),
+    };
+
+    let embedder = Arc::new(MockEmbedder::new(1536));
+
+    let reaction = QdrantReaction::builder("builder-test")
+        .with_query("query1")
+        .with_query("query2")
+        .with_config(config)
+        .with_embedder(embedder)
+        .with_auto_start(false)
+        .with_priority_queue_capacity(5000)
+        .build();
+
+    assert!(reaction.is_ok());
+    let reaction = reaction.expect("Reaction should be created");
+
+    use drasi_lib::Reaction;
+    assert_eq!(reaction.id(), "builder-test");
+    assert_eq!(reaction.query_ids().len(), 2);
+    assert!(!reaction.auto_start());
+}

--- a/components/reactions/qdrant/tests/live_azure_test.rs
+++ b/components/reactions/qdrant/tests/live_azure_test.rs
@@ -1,0 +1,157 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Live integration test for AzureOpenAIEmbedder against real Azure OpenAI API.
+//!
+//! This test is ignored by default and only runs when explicitly requested.
+//!
+//! # Running the test
+//!
+//! ```bash
+//! export TEST_AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
+//! export TEST_AZURE_OPENAI_KEY="your-api-key"
+//! export TEST_AZURE_OPENAI_MODEL="text-embedding-3-large"
+//! cargo test -p drasi-reaction-qdrant --test live_azure_test -- --ignored
+//! ```
+
+mod qdrant_helpers;
+
+use drasi_reaction_qdrant::{generate_deterministic_uuid, AzureOpenAIEmbedder, Embedder};
+use qdrant_client::qdrant::{
+    CreateCollectionBuilder, Distance, PointStruct, UpsertPointsBuilder, Value, VectorParamsBuilder,
+};
+use qdrant_helpers::{search_points, setup_qdrant};
+use std::collections::HashMap;
+use std::env;
+
+/// Helper to get required environment variable or panic with clear message
+fn require_env(name: &str) -> String {
+    env::var(name).unwrap_or_else(|_| {
+        panic!(
+            "Environment variable {name} is required for live Azure test. \
+             Set it before running: export {name}=\"your-value\""
+        )
+    })
+}
+
+/// Live integration test for AzureOpenAIEmbedder against real Azure OpenAI API.
+///
+/// This test verifies the full pipeline:
+/// 1. Create AzureOpenAIEmbedder with real credentials
+/// 2. Setup Qdrant testcontainer
+/// 3. Generate embedding for test text
+/// 4. Upsert embedding to Qdrant
+/// 5. Search to confirm the pipeline works end-to-end
+#[tokio::test]
+#[ignore] // Only run when explicitly requested with: cargo test -- --ignored
+async fn test_azure_openai_embedder_live() {
+    env_logger::try_init().ok();
+
+    // 1. Read credentials from environment
+    let endpoint = require_env("TEST_AZURE_OPENAI_ENDPOINT");
+    let api_key = require_env("TEST_AZURE_OPENAI_KEY");
+    let model = require_env("TEST_AZURE_OPENAI_MODEL");
+
+    // 2. Create AzureOpenAIEmbedder
+    let dimensions = 3072; // text-embedding-3-large default
+    let embedder = AzureOpenAIEmbedder::new(
+        endpoint,
+        model,
+        api_key,
+        dimensions,
+        "2024-02-01".to_string(),
+    );
+
+    assert_eq!(embedder.dimensions(), dimensions);
+    assert_eq!(embedder.name(), "azure_openai");
+
+    // 3. Setup Qdrant testcontainer
+    let qdrant = setup_qdrant().await;
+    let client = qdrant.get_client().expect("Should create Qdrant client");
+
+    // 4. Create collection with correct dimensions
+    let collection_name = "live_azure_test";
+    client
+        .create_collection(
+            CreateCollectionBuilder::new(collection_name).vectors_config(VectorParamsBuilder::new(
+                dimensions as u64,
+                Distance::Cosine,
+            )),
+        )
+        .await
+        .expect("Should create collection");
+
+    // 5. Generate embedding for test text
+    let test_text = "Drasi is a continuous query engine for streaming data".to_string();
+    let embeddings = embedder
+        .generate(&[test_text.clone()])
+        .await
+        .expect("Should generate embedding from Azure OpenAI");
+
+    // 6. Verify embedding dimensions
+    assert_eq!(embeddings.len(), 1, "Should return one embedding");
+    assert!(
+        !embeddings[0].is_empty(),
+        "Embedding vector should not be empty"
+    );
+    assert_eq!(
+        embeddings[0].len(),
+        dimensions,
+        "Embedding should have {dimensions} dimensions"
+    );
+
+    // Verify embedding values are reasonable (normalized for cosine similarity)
+    let magnitude: f32 = embeddings[0].iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!(
+        (magnitude - 1.0).abs() < 0.1,
+        "Embedding should be roughly normalized, got magnitude: {magnitude}"
+    );
+
+    // 7. Upsert to Qdrant
+    let point_id = generate_deterministic_uuid("drasi-live-test");
+    let mut payload: HashMap<String, Value> = HashMap::new();
+    payload.insert("text".to_string(), Value::from(test_text.clone()));
+
+    let point = PointStruct::new(point_id.to_string(), embeddings[0].clone(), payload);
+    client
+        .upsert_points(UpsertPointsBuilder::new(collection_name, vec![point]).wait(true))
+        .await
+        .expect("Should upsert point to Qdrant");
+
+    // 8. Search to confirm full pipeline works
+    let search_result = search_points(&client, collection_name, embeddings[0].clone(), 1)
+        .await
+        .expect("Should search points");
+
+    assert_eq!(
+        search_result.result.len(),
+        1,
+        "Should find one matching point"
+    );
+    assert!(
+        search_result.result[0].score > 0.99,
+        "Self-search should have very high score (got {})",
+        search_result.result[0].score
+    );
+
+    log::info!(
+        "Live Azure OpenAI test passed! Generated {} dimension embedding, \
+         upserted to Qdrant, and verified with search (score: {:.4})",
+        embeddings[0].len(),
+        search_result.result[0].score
+    );
+
+    // 9. Cleanup
+    qdrant.cleanup().await;
+}

--- a/components/reactions/qdrant/tests/qdrant_helpers.rs
+++ b/components/reactions/qdrant/tests/qdrant_helpers.rs
@@ -1,0 +1,305 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test utilities for Qdrant-based testing using testcontainers
+//!
+//! This module provides helper functions for testing components that require
+//! a Qdrant vector database, using testcontainers to provide a real Qdrant
+//! server environment.
+
+use anyhow::Result;
+use qdrant_client::qdrant::{SearchPointsBuilder, SearchResponse};
+use qdrant_client::Qdrant;
+use std::sync::Arc;
+use std::time::Duration;
+use testcontainers::core::{ContainerPort, WaitFor};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+
+/// Qdrant container configuration
+#[derive(Debug, Clone)]
+pub struct QdrantConfig {
+    pub host: String,
+    pub grpc_port: u16,
+    pub http_port: u16,
+}
+
+impl QdrantConfig {
+    /// Get the gRPC endpoint URL
+    pub fn grpc_endpoint(&self) -> String {
+        format!("http://{}:{}", self.host, self.grpc_port)
+    }
+
+    /// Get the HTTP endpoint URL
+    pub fn http_endpoint(&self) -> String {
+        format!("http://{}:{}", self.host, self.http_port)
+    }
+}
+
+/// Setup a Qdrant testcontainer and return a guard that manages cleanup
+///
+/// Returns a `QdrantGuard` that manages the container lifecycle. The container
+/// will be stopped and removed via blocking cleanup when the guard is dropped.
+///
+/// **RECOMMENDED**: Call `.cleanup().await` explicitly before the test ends for
+/// the most reliable cleanup.
+///
+/// # Example
+/// ```ignore
+/// let qdrant = setup_qdrant().await;
+/// // Use qdrant.config() to get connection details
+/// // ... test code ...
+/// qdrant.cleanup().await; // Explicit cleanup (recommended)
+/// Ok(())
+/// ```
+pub async fn setup_qdrant() -> QdrantGuard {
+    QdrantGuard::new().await
+}
+
+/// Low-level setup function that returns raw container and config
+#[allow(clippy::unwrap_used)]
+async fn setup_qdrant_raw() -> (ContainerAsync<GenericImage>, QdrantConfig) {
+    // Qdrant ports
+    let grpc_port = 6334;
+    let http_port = 6333;
+
+    // Create Qdrant container using generic image
+    let container = GenericImage::new("qdrant/qdrant", "latest")
+        .with_exposed_port(ContainerPort::Tcp(grpc_port))
+        .with_exposed_port(ContainerPort::Tcp(http_port))
+        .with_wait_for(WaitFor::message_on_stdout("gRPC listening"))
+        .start()
+        .await
+        .unwrap();
+
+    let mapped_grpc_port = container.get_host_port_ipv4(grpc_port).await.unwrap();
+    let mapped_http_port = container.get_host_port_ipv4(http_port).await.unwrap();
+
+    let config = QdrantConfig {
+        host: "localhost".to_string(), // DevSkim: ignore DS137138
+        grpc_port: mapped_grpc_port,
+        http_port: mapped_http_port,
+    };
+
+    // Give Qdrant a moment to fully initialize
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    (container, config)
+}
+
+/// Guard wrapper for Qdrant container that ensures proper cleanup
+///
+/// This struct wraps the Qdrant container and uses blocking cleanup in Drop.
+#[derive(Clone)]
+pub struct QdrantGuard {
+    inner: Arc<QdrantGuardInner>,
+}
+
+struct QdrantGuardInner {
+    container: std::sync::Mutex<Option<ContainerAsync<GenericImage>>>,
+    config: QdrantConfig,
+}
+
+impl QdrantGuard {
+    /// Create a new Qdrant container with guaranteed cleanup
+    pub async fn new() -> Self {
+        let (container, config) = setup_qdrant_raw().await;
+        Self {
+            inner: Arc::new(QdrantGuardInner {
+                container: std::sync::Mutex::new(Some(container)),
+                config,
+            }),
+        }
+    }
+
+    /// Get the Qdrant configuration
+    pub fn config(&self) -> &QdrantConfig {
+        &self.inner.config
+    }
+
+    /// Get a Qdrant client connection
+    pub fn get_client(&self) -> Result<Qdrant> {
+        let client = Qdrant::from_url(&self.config().grpc_endpoint()).build()?;
+        Ok(client)
+    }
+
+    /// Explicitly stop and remove the container
+    ///
+    /// Call this at the end of your test to ensure the container is cleaned up.
+    pub async fn cleanup(self) {
+        let container_to_stop = {
+            if let Ok(mut container_guard) = self.inner.container.lock() {
+                container_guard.take()
+            } else {
+                None
+            }
+        };
+
+        if let Some(container) = container_to_stop {
+            let container_id = container.id().to_string();
+
+            match container.stop().await {
+                Ok(_) => {
+                    log::debug!("Successfully stopped Qdrant container: {container_id}");
+                }
+                Err(e) => {
+                    log::warn!("Error stopping container {container_id}: {e}");
+                }
+            }
+
+            drop(container);
+        }
+    }
+}
+
+impl Drop for QdrantGuardInner {
+    fn drop(&mut self) {
+        if let Ok(mut container_guard) = self.container.lock() {
+            if let Some(container) = container_guard.take() {
+                let container_id = container.id().to_string();
+
+                let cleanup_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                        handle.block_on(async move {
+                            let _ = container.stop().await;
+                            drop(container);
+                        });
+                    } else {
+                        drop(container);
+                    }
+                }));
+
+                if cleanup_result.is_ok() {
+                    log::debug!("Qdrant container {container_id} cleaned up in Drop");
+                } else {
+                    log::warn!("Failed to cleanup Qdrant container {container_id} in Drop");
+                }
+            }
+        }
+    }
+}
+
+/// Search for points in a Qdrant collection
+///
+/// # Arguments
+/// * `client` - Qdrant client
+/// * `collection_name` - Name of the collection to search
+/// * `vector` - Query vector
+/// * `limit` - Maximum number of results
+///
+/// # Returns
+/// Search response with matching points
+pub async fn search_points(
+    client: &Qdrant,
+    collection_name: &str,
+    vector: Vec<f32>,
+    limit: u64,
+) -> Result<SearchResponse> {
+    let response = client
+        .search_points(SearchPointsBuilder::new(collection_name, vector, limit).with_payload(true))
+        .await?;
+
+    Ok(response)
+}
+
+/// Get collection info from Qdrant
+///
+/// # Arguments
+/// * `client` - Qdrant client
+/// * `collection_name` - Name of the collection
+///
+/// # Returns
+/// Collection info response
+pub async fn get_collection_info(
+    client: &Qdrant,
+    collection_name: &str,
+) -> Result<qdrant_client::qdrant::GetCollectionInfoResponse> {
+    let info = client.collection_info(collection_name).await?;
+    Ok(info)
+}
+
+/// Get the count of points in a collection
+///
+/// # Arguments
+/// * `client` - Qdrant client
+/// * `collection_name` - Name of the collection
+///
+/// # Returns
+/// Number of points in the collection
+pub async fn get_points_count(client: &Qdrant, collection_name: &str) -> Result<u64> {
+    let info = client.collection_info(collection_name).await?;
+    Ok(info
+        .result
+        .map(|r| r.points_count.unwrap_or(0))
+        .unwrap_or(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qdrant_client::qdrant::{CreateCollectionBuilder, Distance, VectorParamsBuilder};
+
+    #[tokio::test]
+    async fn test_setup_qdrant() {
+        let qdrant = setup_qdrant().await;
+        let config = qdrant.config();
+
+        assert_eq!(config.host, "localhost"); // DevSkim: ignore DS137138
+        assert!(config.grpc_port > 0);
+        assert!(config.http_port > 0);
+
+        // Verify we can connect
+        let client = qdrant.get_client().expect("Should create client");
+
+        // List collections (should be empty)
+        let collections = client
+            .list_collections()
+            .await
+            .expect("Should list collections");
+        assert!(collections.collections.is_empty());
+
+        qdrant.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn test_create_collection() {
+        let qdrant = setup_qdrant().await;
+        let client = qdrant.get_client().expect("Should create client");
+
+        // Create a test collection
+        let collection_name = "test_collection";
+        client
+            .create_collection(
+                CreateCollectionBuilder::new(collection_name)
+                    .vectors_config(VectorParamsBuilder::new(128, Distance::Cosine)),
+            )
+            .await
+            .expect("Should create collection");
+
+        // Verify collection exists
+        let exists = client
+            .collection_exists(collection_name)
+            .await
+            .expect("Should check existence");
+        assert!(exists);
+
+        // Verify collection info
+        let info = get_collection_info(&client, collection_name)
+            .await
+            .expect("Should get collection info");
+        assert!(info.result.is_some());
+
+        qdrant.cleanup().await;
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a new reaction plugin (`drasi-reaction-qdrant`) that materializes Drasi query results as embeddings in a Qdrant vector database. It generates documents using handlebar-templates for the query results, and then generates embeddings for those documents using models, and finally stores them as searchable vector points in Qdrant.

Fixes - #149 

## Features

- **Embedder Trait**: Abstraction for embedding generation with two implementations:
  - `MockEmbedder`: SHA-256 based deterministic embeddings for testing
  - `AzureOpenAIEmbedder`: Real embeddings via Azure OpenAI API
  
- **Batch Optimization**: Configurable batch sizes for embedding API calls and Qdrant upserts
  - `embedding_batch_size` (default: 50): Max documents per embedding API call
  - `upsert_batch_size` (default: 100): Max points per Qdrant upsert call
  
- **Retry Logic**: Configurable retry with exponential backoff and jitter
  - `max_retries` (default: 3): Max retry attempts
  - `initial_delay_ms` (default: 100): Initial delay between retries
  - `max_delay_ms` (default: 5000): Maximum delay cap
  - Snapshot phase: fails startup on persistent error (prevents inconsistent state)
  - Stream phase: panics on persistent failure (zero data loss guarantee)

- **Materialized View Sync Protocol**: Loads existing query results on startup via `get_current_results()` before processing incremental updates

- **Deterministic UUID Generation**: RFC 4122 UUID v5 for consistent point IDs across upsert/delete operations (enables idempotent operations)

- **Handlebars Templating**: Flexible document content generation from query results

## Changes

| File | Description |
|------|-------------|
| `Cargo.toml` | Added `components/reactions/qdrant` to workspace |
| `components/reactions/qdrant/Cargo.toml` | Crate manifest with dependencies |
| `components/reactions/qdrant/README.md` | User guide and configuration reference |
| `components/reactions/qdrant/DESIGN.md` | Future architecture roadmap |
| `components/reactions/qdrant/src/lib.rs` | Public API re-exports |
| `components/reactions/qdrant/src/config.rs` | Configuration types |
| `components/reactions/qdrant/src/document.rs` | Document building and UUID generation |
| `components/reactions/qdrant/src/embedder/mod.rs` | Embedder trait definition |
| `components/reactions/qdrant/src/embedder/mock.rs` | MockEmbedder implementation |
| `components/reactions/qdrant/src/embedder/azure_openai.rs` | AzureOpenAIEmbedder implementation |
| `components/reactions/qdrant/src/qdrant.rs` | Main QdrantReaction implementation |
| `components/reactions/qdrant/tests/qdrant_helpers.rs` | Testcontainers utilities |
| `components/reactions/qdrant/tests/integration_test.rs` | Integration tests |
| `components/reactions/qdrant/tests/live_azure_test.rs` | Live Azure OpenAI integration test (ignored by default) |

## Test Plan

- Unit tests pass (40 tests)
- Integration tests pass with testcontainers (17 tests)
- Doc tests compile-checked (5 tests with `no_run`)
- Live Azure OpenAI test verified (1 ignored test)
- `cargo clippy` passes
- `cargo fmt` applied

### Running Tests

```bash
# Unit tests only
cargo test -p drasi-reaction-qdrant --lib

# Integration tests (requires Docker)
cargo test -p drasi-reaction-qdrant --test integration_test

# All tests
cargo test -p drasi-reaction-qdrant

# Live Azure OpenAI test (requires Azure credentials)
export TEST_AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
export TEST_AZURE_OPENAI_KEY="your-api-key"
export TEST_AZURE_OPENAI_MODEL="text-embedding-3-large"
cargo test -p drasi-reaction-qdrant --test live_azure_test -- --ignored
```

## Dependencies Added

| Crate | Version | Purpose |
|-------|---------|---------|
| `qdrant-client` | 1.12 | Qdrant gRPC client |
| `reqwest` | 0.12 | HTTP client for Azure OpenAI |
| `handlebars` | 5.1 | Template rendering |
| `sha2` | 0.10 | SHA-256 hashing for mock embeddings |
| `rand` | 0.8 | Retry jitter randomization |
| `testcontainers` | 0.23 | Integration testing (dev) |