### PR TITLE
feat: add ln and log10 numeric functions

### DIFF
--- a/core/src/evaluation/functions/numeric/ln.rs
+++ b/core/src/evaluation/functions/numeric/ln.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+use drasi_query_ast::ast;
+
+use crate::evaluation::functions::ScalarFunction;
+use crate::evaluation::variable_value::float::Float;
+use crate::evaluation::variable_value::VariableValue;
+use crate::evaluation::{ExpressionEvaluationContext, FunctionError, FunctionEvaluationError};
+
+#[derive(Debug)]
+pub struct Ln {}
+
+#[async_trait]
+impl ScalarFunction for Ln {
+    async fn call(
+        &self,
+        _context: &ExpressionEvaluationContext,
+        expression: &ast::FunctionExpression,
+        args: Vec<VariableValue>,
+    ) -> Result<VariableValue, FunctionError> {
+        if args.len() != 1 {
+            return Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgumentCount,
+            });
+        }
+        match &args[0] {
+            VariableValue::Null => Ok(VariableValue::Null),
+            VariableValue::Integer(n) => {
+                let val = match n.as_i64() {
+                    Some(i) => i as f64,
+                    None => {
+                        return Err(FunctionError {
+                            function_name: expression.name.to_string(),
+                            error: FunctionEvaluationError::OverflowError,
+                        })
+                    }
+                };
+                if val <= 0.0 {
+                    return Ok(VariableValue::Null);
+                }
+                Ok(VariableValue::Float(
+                    match Float::from_f64(val.ln()) {
+                        Some(f) => f,
+                        None => {
+                            return Err(FunctionError {
+                                function_name: expression.name.to_string(),
+                                error: FunctionEvaluationError::OverflowError,
+                            })
+                        }
+                    },
+                ))
+            }
+            VariableValue::Float(n) => {
+                let val = match n.as_f64() {
+                    Some(f) => f,
+                    None => {
+                        return Err(FunctionError {
+                            function_name: expression.name.to_string(),
+                            error: FunctionEvaluationError::OverflowError,
+                        })
+                    }
+                };
+                if val <= 0.0 {
+                    return Ok(VariableValue::Null);
+                }
+                Ok(VariableValue::Float(
+                    match Float::from_f64(val.ln()) {
+                        Some(f) => f,
+                        None => {
+                            return Err(FunctionError {
+                                function_name: expression.name.to_string(),
+                                error: FunctionEvaluationError::OverflowError,
+                            })
+                        }
+                    },
+                ))
+            }
+            _ => Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgument(0),
+            }),
+        }
+    }
+}

--- a/core/src/evaluation/functions/numeric/log10.rs
+++ b/core/src/evaluation/functions/numeric/log10.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+use drasi_query_ast::ast;
+
+use crate::evaluation::functions::ScalarFunction;
+use crate::evaluation::variable_value::float::Float;
+use crate::evaluation::variable_value::VariableValue;
+use crate::evaluation::{ExpressionEvaluationContext, FunctionError, FunctionEvaluationError};
+
+#[derive(Debug)]
+pub struct Log10 {}
+
+#[async_trait]
+impl ScalarFunction for Log10 {
+    async fn call(
+        &self,
+        _context: &ExpressionEvaluationContext,
+        expression: &ast::FunctionExpression,
+        args: Vec<VariableValue>,
+    ) -> Result<VariableValue, FunctionError> {
+        if args.len() != 1 {
+            return Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgumentCount,
+            });
+        }
+        match &args[0] {
+            VariableValue::Null => Ok(VariableValue::Null),
+            VariableValue::Integer(n) => {
+                let val = match n.as_i64() {
+                    Some(i) => i as f64,
+                    None => {
+                        return Err(FunctionError {
+                            function_name: expression.name.to_string(),
+                            error: FunctionEvaluationError::OverflowError,
+                        })
+                    }
+                };
+                if val <= 0.0 {
+                    return Ok(VariableValue::Null);
+                }
+                Ok(VariableValue::Float(
+                    match Float::from_f64(val.log10()) {
+                        Some(f) => f,
+                        None => {
+                            return Err(FunctionError {
+                                function_name: expression.name.to_string(),
+                                error: FunctionEvaluationError::OverflowError,
+                            })
+                        }
+                    },
+                ))
+            }
+            VariableValue::Float(n) => {
+                let val = match n.as_f64() {
+                    Some(f) => f,
+                    None => {
+                        return Err(FunctionError {
+                            function_name: expression.name.to_string(),
+                            error: FunctionEvaluationError::OverflowError,
+                        })
+                    }
+                };
+                if val <= 0.0 {
+                    return Ok(VariableValue::Null);
+                }
+                Ok(VariableValue::Float(
+                    match Float::from_f64(val.log10()) {
+                        Some(f) => f,
+                        None => {
+                            return Err(FunctionError {
+                                function_name: expression.name.to_string(),
+                                error: FunctionEvaluationError::OverflowError,
+                            })
+                        }
+                    },
+                ))
+            }
+            _ => Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgument(0),
+            }),
+        }
+    }
+}

--- a/core/src/evaluation/functions/numeric/mod.rs
+++ b/core/src/evaluation/functions/numeric/mod.rs
@@ -15,6 +15,8 @@
 mod abs;
 mod ceil;
 mod floor;
+mod ln;
+mod log10;
 mod numeric_round;
 mod random;
 mod sign;
@@ -25,6 +27,8 @@ mod tests;
 pub use abs::Abs;
 pub use ceil::Ceil;
 pub use floor::Floor;
+pub use ln::Ln;
+pub use log10::Log10;
 pub use numeric_round::Round;
 pub use random::Rand;
 pub use sign::Sign;

--- a/core/src/evaluation/functions/numeric/tests.rs
+++ b/core/src/evaluation/functions/numeric/tests.rs
@@ -15,6 +15,7 @@
 mod abs_tests;
 mod ceil_tests;
 mod floor_tests;
+mod log_tests;
 mod random_tests;
 mod round_tests;
 mod sign_tests;

--- a/core/src/evaluation/functions/numeric/tests/log_tests.rs
+++ b/core/src/evaluation/functions/numeric/tests/log_tests.rs
@@ -1,0 +1,476 @@
+use std::sync::Arc;
+
+use drasi_query_ast::ast;
+
+use crate::evaluation::context::QueryVariables;
+use crate::evaluation::functions::numeric::{Ln, Log10};
+use crate::evaluation::functions::ScalarFunction;
+use crate::evaluation::variable_value::VariableValue;
+use crate::evaluation::{
+    ExpressionEvaluationContext, FunctionError, FunctionEvaluationError, InstantQueryClock,
+};
+
+// ============================================================================
+// Ln (natural logarithm) tests
+// ============================================================================
+
+#[tokio::test]
+async fn ln_too_few_args() {
+    let ln = Ln {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![];
+
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("ln"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = ln.call(&context, &func_expr, args.clone()).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+#[tokio::test]
+async fn ln_too_many_args() {
+    let ln = Ln {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Integer(1.into()),
+        VariableValue::Integer(2.into()),
+    ];
+
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("ln"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = ln.call(&context, &func_expr, args.clone()).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+#[tokio::test]
+async fn ln_null() {
+    let ln = Ln {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Null];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("ln"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = ln.call(&context, &func_expr, args.clone()).await.unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+#[tokio::test]
+async fn ln_positive_int() {
+    let ln = Ln {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // ln(1) = 0
+    let args = vec![VariableValue::Integer(1.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("ln"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = ln.call(&context, &func_expr, args.clone()).await.unwrap();
+    assert_eq!(result, 0_f64);
+}
+
+#[tokio::test]
+async fn ln_positive_float() {
+    let ln = Ln {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // ln(e) ≈ 1
+    let args = vec![VariableValue::Float(std::f64::consts::E.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("ln"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = ln.call(&context, &func_expr, args.clone()).await.unwrap();
+    // Check that result is approximately 1.0
+    if let VariableValue::Float(f) = result {
+        let val = f.as_f64().unwrap();
+        assert!((val - 1.0).abs() < 1e-10);
+    } else {
+        panic!("Expected Float result");
+    }
+}
+
+#[tokio::test]
+async fn ln_zero() {
+    let ln = Ln {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // ln(0) should return Null (domain error)
+    let args = vec![VariableValue::Integer(0.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("ln"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = ln.call(&context, &func_expr, args.clone()).await.unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+#[tokio::test]
+async fn ln_zero_float() {
+    let ln = Ln {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // ln(0.0) should return Null (domain error)
+    let args = vec![VariableValue::Float((0_f64).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("ln"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = ln.call(&context, &func_expr, args.clone()).await.unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+#[tokio::test]
+async fn ln_negative_int() {
+    let ln = Ln {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // ln(-1) should return Null (domain error)
+    let args = vec![VariableValue::Integer((-1).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("ln"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = ln.call(&context, &func_expr, args.clone()).await.unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+#[tokio::test]
+async fn ln_negative_float() {
+    let ln = Ln {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // ln(-1.5) should return Null (domain error)
+    let args = vec![VariableValue::Float((-1.5).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("ln"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = ln.call(&context, &func_expr, args.clone()).await.unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+// ============================================================================
+// Log10 (base-10 logarithm) tests
+// ============================================================================
+
+#[tokio::test]
+async fn log10_too_few_args() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![];
+
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10.call(&context, &func_expr, args.clone()).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+#[tokio::test]
+async fn log10_too_many_args() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Integer(1.into()),
+        VariableValue::Integer(2.into()),
+    ];
+
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10.call(&context, &func_expr, args.clone()).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+#[tokio::test]
+async fn log10_null() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Null];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10
+        .call(&context, &func_expr, args.clone())
+        .await
+        .unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+#[tokio::test]
+async fn log10_positive_int() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // log10(10) = 1
+    let args = vec![VariableValue::Integer(10.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10
+        .call(&context, &func_expr, args.clone())
+        .await
+        .unwrap();
+    assert_eq!(result, 1_f64);
+}
+
+#[tokio::test]
+async fn log10_positive_float() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // log10(100.0) = 2
+    let args = vec![VariableValue::Float((100_f64).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10
+        .call(&context, &func_expr, args.clone())
+        .await
+        .unwrap();
+    assert_eq!(result, 2_f64);
+}
+
+#[tokio::test]
+async fn log10_one() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // log10(1) = 0
+    let args = vec![VariableValue::Integer(1.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10
+        .call(&context, &func_expr, args.clone())
+        .await
+        .unwrap();
+    assert_eq!(result, 0_f64);
+}
+
+#[tokio::test]
+async fn log10_zero() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // log10(0) should return Null (domain error)
+    let args = vec![VariableValue::Integer(0.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10
+        .call(&context, &func_expr, args.clone())
+        .await
+        .unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+#[tokio::test]
+async fn log10_zero_float() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // log10(0.0) should return Null (domain error)
+    let args = vec![VariableValue::Float((0_f64).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10
+        .call(&context, &func_expr, args.clone())
+        .await
+        .unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+#[tokio::test]
+async fn log10_negative_int() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // log10(-1) should return Null (domain error)
+    let args = vec![VariableValue::Integer((-1).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10
+        .call(&context, &func_expr, args.clone())
+        .await
+        .unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+#[tokio::test]
+async fn log10_negative_float() {
+    let log10 = Log10 {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    // log10(-1.5) should return Null (domain error)
+    let args = vec![VariableValue::Float((-1.5).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("log10"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = log10
+        .call(&context, &func_expr, args.clone())
+        .await
+        .unwrap();
+    assert_eq!(result, VariableValue::Null);
+}

--- a/functions-cypher/src/lib.rs
+++ b/functions-cypher/src/lib.rs
@@ -69,6 +69,8 @@ fn register_numeric_functions(registry: &FunctionRegistry) {
     registry.register_function("abs", Function::Scalar(Arc::new(Abs {})));
     registry.register_function("ceil", Function::Scalar(Arc::new(Ceil {})));
     registry.register_function("floor", Function::Scalar(Arc::new(Floor {})));
+    registry.register_function("ln", Function::Scalar(Arc::new(Ln {})));
+    registry.register_function("log10", Function::Scalar(Arc::new(Log10 {})));
     registry.register_function("rand", Function::Scalar(Arc::new(Rand {})));
     registry.register_function("round", Function::Scalar(Arc::new(Round {})));
     registry.register_function("sign", Function::Scalar(Arc::new(Sign {})));

--- a/functions-gql/src/lib.rs
+++ b/functions-gql/src/lib.rs
@@ -66,6 +66,8 @@ fn register_numeric_functions(registry: &FunctionRegistry) {
     registry.register_function("abs", Function::Scalar(Arc::new(Abs {})));
     registry.register_function("ceil", Function::Scalar(Arc::new(Ceil {})));
     registry.register_function("floor", Function::Scalar(Arc::new(Floor {})));
+    registry.register_function("ln", Function::Scalar(Arc::new(Ln {})));
+    registry.register_function("log10", Function::Scalar(Arc::new(Log10 {})));
     registry.register_function("round", Function::Scalar(Arc::new(Round {})));
 }
 


### PR DESCRIPTION
# Description

Implements natural logarithm `ln` and base-10 logarithm `log10` scalar functions for Drasi's query evaluation system.

Added `ln` and `log10` struct with `ScalarFunction` trait
  - Accepts single numeric argument (Integer or Float)
  - Returns Float result for valid positive inputs
  - Returns Null for domain errors (inputs ≤ 0) and null inputs
  - Proper overflow and invalid argument error handling

Registered `ln` and `log10` for Cypher and GQL queries

Tested and all edge cases covered:
 - Null inputs → Null output
 - Positive numbers → Correct logarithm calculation
 - Zero and negative numbers → Null (domain error)
 - Invalid argument count → Error
 - Non-numeric inputs → Error
 - Both Integer and Float type support

## Type of change

- This pull request adds or changes features of Drasi and has an approved issue #211 

Fixes: #211 
