### PR TITLE
Add e and exp numeric scalar functions

### DIFF
--- a/core/src/evaluation/functions/numeric/e.rs
+++ b/core/src/evaluation/functions/numeric/e.rs
@@ -1,0 +1,42 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use drasi_query_ast::ast;
+
+use crate::evaluation::functions::ScalarFunction;
+use crate::evaluation::variable_value::float::Float;
+use crate::evaluation::variable_value::VariableValue;
+use crate::evaluation::{ExpressionEvaluationContext, FunctionError, FunctionEvaluationError};
+
+#[derive(Debug)]
+pub struct E {}
+
+#[async_trait]
+impl ScalarFunction for E {
+    async fn call(
+        &self,
+        _context: &ExpressionEvaluationContext,
+        expression: &ast::FunctionExpression,
+        args: Vec<VariableValue>,
+    ) -> Result<VariableValue, FunctionError> {
+        if !args.is_empty() {
+            return Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgumentCount,
+            });
+        }
+        Ok(VariableValue::Float(Float::from(std::f64::consts::E)))
+    }
+}

--- a/core/src/evaluation/functions/numeric/exp.rs
+++ b/core/src/evaluation/functions/numeric/exp.rs
@@ -1,0 +1,88 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use drasi_query_ast::ast;
+
+use crate::evaluation::functions::ScalarFunction;
+use crate::evaluation::variable_value::float::Float;
+use crate::evaluation::variable_value::VariableValue;
+use crate::evaluation::{ExpressionEvaluationContext, FunctionError, FunctionEvaluationError};
+
+#[derive(Debug)]
+pub struct Exp {}
+
+#[async_trait]
+impl ScalarFunction for Exp {
+    async fn call(
+        &self,
+        _context: &ExpressionEvaluationContext,
+        expression: &ast::FunctionExpression,
+        args: Vec<VariableValue>,
+    ) -> Result<VariableValue, FunctionError> {
+        if args.len() != 1 {
+            return Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgumentCount,
+            });
+        }
+        match &args[0] {
+            VariableValue::Null => Ok(VariableValue::Null),
+            VariableValue::Integer(n) => {
+                let value = match n.as_i64() {
+                    Some(i) => (i as f64).exp(),
+                    None => {
+                        return Err(FunctionError {
+                            function_name: expression.name.to_string(),
+                            error: FunctionEvaluationError::OverflowError,
+                        })
+                    }
+                };
+                Ok(VariableValue::Float(match Float::from_f64(value) {
+                    Some(f) => f,
+                    None => {
+                        return Err(FunctionError {
+                            function_name: expression.name.to_string(),
+                            error: FunctionEvaluationError::OverflowError,
+                        })
+                    }
+                }))
+            }
+            VariableValue::Float(n) => {
+                let value = match n.as_f64() {
+                    Some(f) => f.exp(),
+                    None => {
+                        return Err(FunctionError {
+                            function_name: expression.name.to_string(),
+                            error: FunctionEvaluationError::OverflowError,
+                        })
+                    }
+                };
+                Ok(VariableValue::Float(match Float::from_f64(value) {
+                    Some(f) => f,
+                    None => {
+                        return Err(FunctionError {
+                            function_name: expression.name.to_string(),
+                            error: FunctionEvaluationError::OverflowError,
+                        })
+                    }
+                }))
+            }
+            _ => Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgument(0),
+            }),
+        }
+    }
+}

--- a/core/src/evaluation/functions/numeric/mod.rs
+++ b/core/src/evaluation/functions/numeric/mod.rs
@@ -14,6 +14,8 @@
 
 mod abs;
 mod ceil;
+mod e;
+mod exp;
 mod floor;
 mod numeric_round;
 mod random;
@@ -24,6 +26,8 @@ mod tests;
 
 pub use abs::Abs;
 pub use ceil::Ceil;
+pub use e::E;
+pub use exp::Exp;
 pub use floor::Floor;
 pub use numeric_round::Round;
 pub use random::Rand;

--- a/core/src/evaluation/functions/numeric/tests.rs
+++ b/core/src/evaluation/functions/numeric/tests.rs
@@ -14,6 +14,7 @@
 
 mod abs_tests;
 mod ceil_tests;
+mod exp_tests;
 mod floor_tests;
 mod random_tests;
 mod round_tests;

--- a/core/src/evaluation/functions/numeric/tests/exp_tests.rs
+++ b/core/src/evaluation/functions/numeric/tests/exp_tests.rs
@@ -1,0 +1,432 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use drasi_query_ast::ast;
+
+use crate::evaluation::context::QueryVariables;
+use crate::evaluation::functions::numeric::{E, Exp};
+use crate::evaluation::functions::ScalarFunction;
+use crate::evaluation::variable_value::VariableValue;
+use crate::evaluation::{
+    ExpressionEvaluationContext, FunctionError, FunctionEvaluationError, InstantQueryClock,
+};
+
+// ============================================================================
+// Tests for E (Euler's number constant)
+// ============================================================================
+
+#[tokio::test]
+async fn e_returns_eulers_number() {
+    let e = E {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("e"),
+        args: vec![],
+        position_in_query: 10,
+    };
+
+    let result = e.call(&context, &func_expr, args).await.unwrap();
+    match result {
+        VariableValue::Float(f) => {
+            let value = f.as_f64().unwrap();
+            // Euler's number is approximately 2.71828182845904523536...
+            assert!((value - std::f64::consts::E).abs() < 1e-10);
+        }
+        _ => panic!("Expected Float, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn e_with_args_fails() {
+    let e = E {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Integer(0.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("e"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = e.call(&context, &func_expr, args).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+#[tokio::test]
+async fn e_multiple_args_fails() {
+    let e = E {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Integer(1.into()),
+        VariableValue::Integer(2.into()),
+    ];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("e"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = e.call(&context, &func_expr, args).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+// ============================================================================
+// Tests for Exp (exponential function: e^x)
+// ============================================================================
+
+#[tokio::test]
+async fn exp_too_few_args() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+#[tokio::test]
+async fn exp_too_many_args() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![
+        VariableValue::Integer(1.into()),
+        VariableValue::Integer(2.into()),
+    ];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgumentCount
+        }
+    ));
+}
+
+#[tokio::test]
+async fn exp_null() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Null];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await.unwrap();
+    assert_eq!(result, VariableValue::Null);
+}
+
+#[tokio::test]
+async fn exp_zero_int() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Integer(0.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await.unwrap();
+    // exp(0) = 1
+    match result {
+        VariableValue::Float(f) => {
+            let value = f.as_f64().unwrap();
+            assert!((value - 1.0).abs() < 1e-10);
+        }
+        _ => panic!("Expected Float, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn exp_one_int() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Integer(1.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(1)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await.unwrap();
+    // exp(1) = e
+    match result {
+        VariableValue::Float(f) => {
+            let value = f.as_f64().unwrap();
+            assert!((value - std::f64::consts::E).abs() < 1e-10);
+        }
+        _ => panic!("Expected Float, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn exp_negative_int() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Integer((-1).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(-1)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await.unwrap();
+    // exp(-1) = 1/e ≈ 0.36787944117...
+    match result {
+        VariableValue::Float(f) => {
+            let value = f.as_f64().unwrap();
+            let expected = (-1_f64).exp();
+            assert!((value - expected).abs() < 1e-10);
+        }
+        _ => panic!("Expected Float, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn exp_positive_int() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Integer(2.into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(2)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await.unwrap();
+    // exp(2) = e^2 ≈ 7.3890560989...
+    match result {
+        VariableValue::Float(f) => {
+            let value = f.as_f64().unwrap();
+            let expected = (2_f64).exp();
+            assert!((value - expected).abs() < 1e-10);
+        }
+        _ => panic!("Expected Float, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn exp_zero_float() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Float((0.0).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await.unwrap();
+    // exp(0.0) = 1
+    match result {
+        VariableValue::Float(f) => {
+            let value = f.as_f64().unwrap();
+            assert!((value - 1.0).abs() < 1e-10);
+        }
+        _ => panic!("Expected Float, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn exp_one_float() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Float((1.0).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(1)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await.unwrap();
+    // exp(1.0) = e
+    match result {
+        VariableValue::Float(f) => {
+            let value = f.as_f64().unwrap();
+            assert!((value - std::f64::consts::E).abs() < 1e-10);
+        }
+        _ => panic!("Expected Float, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn exp_negative_float() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Float((-0.5).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await.unwrap();
+    // exp(-0.5) ≈ 0.60653665862...
+    match result {
+        VariableValue::Float(f) => {
+            let value = f.as_f64().unwrap();
+            let expected = (-0.5_f64).exp();
+            assert!((value - expected).abs() < 1e-10);
+        }
+        _ => panic!("Expected Float, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn exp_positive_float() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::Float((2.5).into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await.unwrap();
+    // exp(2.5) ≈ 12.1824939607...
+    match result {
+        VariableValue::Float(f) => {
+            let value = f.as_f64().unwrap();
+            let expected = (2.5_f64).exp();
+            assert!((value - expected).abs() < 1e-10);
+        }
+        _ => panic!("Expected Float, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn exp_invalid_argument_type() {
+    let exp = Exp {};
+    let binding = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&binding, Arc::new(InstantQueryClock::new(0, 0)));
+
+    let args = vec![VariableValue::String("invalid".into())];
+    let func_expr = ast::FunctionExpression {
+        name: Arc::from("exp"),
+        args: vec![ast::Expression::UnaryExpression(
+            ast::UnaryExpression::Literal(ast::Literal::Integer(0)),
+        )],
+        position_in_query: 10,
+    };
+
+    let result = exp.call(&context, &func_expr, args).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgument(0)
+        }
+    ));
+}

--- a/functions-cypher/src/lib.rs
+++ b/functions-cypher/src/lib.rs
@@ -68,6 +68,8 @@ fn register_text_functions(registry: &FunctionRegistry) {
 fn register_numeric_functions(registry: &FunctionRegistry) {
     registry.register_function("abs", Function::Scalar(Arc::new(Abs {})));
     registry.register_function("ceil", Function::Scalar(Arc::new(Ceil {})));
+    registry.register_function("e", Function::Scalar(Arc::new(E {})));
+    registry.register_function("exp", Function::Scalar(Arc::new(Exp {})));
     registry.register_function("floor", Function::Scalar(Arc::new(Floor {})));
     registry.register_function("rand", Function::Scalar(Arc::new(Rand {})));
     registry.register_function("round", Function::Scalar(Arc::new(Round {})));

--- a/functions-gql/src/lib.rs
+++ b/functions-gql/src/lib.rs
@@ -65,6 +65,8 @@ fn register_text_functions(registry: &FunctionRegistry) {
 fn register_numeric_functions(registry: &FunctionRegistry) {
     registry.register_function("abs", Function::Scalar(Arc::new(Abs {})));
     registry.register_function("ceil", Function::Scalar(Arc::new(Ceil {})));
+    registry.register_function("e", Function::Scalar(Arc::new(E {})));
+    registry.register_function("exp", Function::Scalar(Arc::new(Exp {})));
     registry.register_function("floor", Function::Scalar(Arc::new(Floor {})));
     registry.register_function("round", Function::Scalar(Arc::new(Round {})));
 }


### PR DESCRIPTION
# Description

This PR implements exponential scalar functions for Drasi by adding the Euler’s number constant (`e`) and the exponential function (`exp`), expanding the numeric function library as outlined in the feature request.

## Type of Change

<!--
Please select **one** of the following options that describes your change and delete the others.
Clearly identifying the type of change will help us review your PR faster and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link,
please create one now.
-->

- This pull request adds or changes features of Drasi and has an approved issue (#212 ).

<!--
Please update the following to link the associated issue. This is required for some kinds of changes (see above).
-->

## Implementation Details

### Core Logic Implementation

Created `E` and `Exp` structs in  
`core/src/evaluation/functions/numeric/numeric.rs` with the following behavior:

**`e()`**
- Takes **0 arguments**
- Returns Euler’s number (≈ 2.71828…) as a `Float`

**`exp(n)`**
- Takes **1 argument** (`Integer` or `Float`)
- Returns `e` raised to the power of `n`
- Returns `Null` when input is `Null`

**Error handling**
- `InvalidArgumentCount` for incorrect number of arguments
- `InvalidArgument` for non-numeric input types

### Function Registration

Registered the new functions in both query language modules:

**Cypher**
- Added `e` and `exp` in `functions-cypher/src/lib.rs`

**GQL**
- Added `e` and `exp` in `functions-gql/src/lib.rs`

## Testing

Added comprehensive unit tests covering:

- ✅ Constant value verification for `e()`
- ✅ `exp` with integer inputs (0, 1, negative values)
- ✅ `exp` with float inputs
- ✅ Null input handling (returns `Null`)
- ✅ Invalid argument counts
- ✅ Invalid argument types

## Testing Results
<img width="952" height="387" alt="Screenshot from 2026-01-29 17-55-58" src="https://github.com/user-attachments/assets/d689aec3-f0c3-4af9-88a4-cd23eba596c4" />

Fixes: #212 
