### PR TITLE
temporary disabling --all-features flag for clippy

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -59,7 +59,7 @@ jobs:
           find ~/.cargo/registry/src -name "parser.c" -exec touch {} +
 
       - name: Run Cargo Clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets
 
   fmt_check:
     name: Format check


### PR DESCRIPTION
# Description

Currently, cargo clippy is failing due to the bundle feature flag for jq-rs. This PR disables the --all-features flag for `cargo clippy` so that other PRs can merge

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
