### PR TITLE
test: add comprehensive edge case tests for the range function in Drasi Core

### DIFF
--- a/core/src/evaluation/expressions/tests/list_functions.rs
+++ b/core/src/evaluation/expressions/tests/list_functions.rs
@@ -289,6 +289,280 @@ async fn test_list_range_invalid_arg_count() {
 }
 
 #[tokio::test]
+async fn test_list_range_invalid_arguments() {
+    let expr = "range(2,'18')";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    let result = evaluator
+        .evaluate_expression(&context, &expr)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        result,
+        EvaluationError::FunctionError(FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgument(1)
+        })
+    ));
+}
+
+#[tokio::test]
+async fn test_list_range_negative_numbers() {
+    let expr = "range(-5, 5)";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    assert_eq!(
+        evaluator
+            .evaluate_expression(&context, &expr)
+            .await
+            .unwrap(),
+        VariableValue::List(vec![
+            VariableValue::Integer(Integer::from(-5)),
+            VariableValue::Integer(Integer::from(-4)),
+            VariableValue::Integer(Integer::from(-3)),
+            VariableValue::Integer(Integer::from(-2)),
+            VariableValue::Integer(Integer::from(-1)),
+            VariableValue::Integer(Integer::from(0)),
+            VariableValue::Integer(Integer::from(1)),
+            VariableValue::Integer(Integer::from(2)),
+            VariableValue::Integer(Integer::from(3)),
+            VariableValue::Integer(Integer::from(4)),
+            VariableValue::Integer(Integer::from(5))
+        ])
+    );
+}
+
+#[tokio::test]
+async fn test_list_range_all_negative() {
+    let expr = "range(-10, -5)";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    assert_eq!(
+        evaluator
+            .evaluate_expression(&context, &expr)
+            .await
+            .unwrap(),
+        VariableValue::List(vec![
+            VariableValue::Integer(Integer::from(-10)),
+            VariableValue::Integer(Integer::from(-9)),
+            VariableValue::Integer(Integer::from(-8)),
+            VariableValue::Integer(Integer::from(-7)),
+            VariableValue::Integer(Integer::from(-6)),
+            VariableValue::Integer(Integer::from(-5))
+        ])
+    );
+}
+
+#[tokio::test]
+async fn test_list_range_start_greater_than_end() {
+    let expr = "range(10, 5)";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    // When start > end, the range is empty
+    assert_eq!(
+        evaluator
+            .evaluate_expression(&context, &expr)
+            .await
+            .unwrap(),
+        VariableValue::List(vec![])
+    );
+}
+
+#[tokio::test]
+async fn test_list_range_single_element() {
+    let expr = "range(5, 5)";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    assert_eq!(
+        evaluator
+            .evaluate_expression(&context, &expr)
+            .await
+            .unwrap(),
+        VariableValue::List(vec![VariableValue::Integer(Integer::from(5))])
+    );
+}
+
+#[tokio::test]
+async fn test_list_range_negative_with_step() {
+    let expr = "range(-10, 10, 5)";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    assert_eq!(
+        evaluator
+            .evaluate_expression(&context, &expr)
+            .await
+            .unwrap(),
+        VariableValue::List(vec![
+            VariableValue::Integer(Integer::from(-10)),
+            VariableValue::Integer(Integer::from(-5)),
+            VariableValue::Integer(Integer::from(0)),
+            VariableValue::Integer(Integer::from(5)),
+            VariableValue::Integer(Integer::from(10))
+        ])
+    );
+}
+
+#[tokio::test]
+async fn test_list_range_large_step() {
+    let expr = "range(0, 10, 100)";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    // Step is larger than range, should only include start
+    assert_eq!(
+        evaluator
+            .evaluate_expression(&context, &expr)
+            .await
+            .unwrap(),
+        VariableValue::List(vec![VariableValue::Integer(Integer::from(0))])
+    );
+}
+
+#[tokio::test]
+async fn test_list_range_invalid_step_argument() {
+    let expr = "range(0, 10, '2')";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    let result = evaluator
+        .evaluate_expression(&context, &expr)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        result,
+        EvaluationError::FunctionError(FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgument(2)
+        })
+    ));
+}
+
+#[tokio::test]
+async fn test_list_range_float_arguments() {
+    let expr = "range(0.5, 10.5)";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    let result = evaluator
+        .evaluate_expression(&context, &expr)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        result,
+        EvaluationError::FunctionError(FunctionError {
+            function_name: _,
+            error: FunctionEvaluationError::InvalidArgument(0)
+        })
+    ));
+}
+
+#[tokio::test]
+#[should_panic(expected = "assertion failed: step != 0")]
+async fn test_list_range_zero_step() {
+    // Note: This test documents that step_by(0) causes a panic
+    // This is a limitation of the current implementation using Rust's step_by
+    let expr = "range(0, 10, 0)";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    // This will panic with "assertion failed: step != 0" error
+    let _ = evaluator.evaluate_expression(&context, &expr).await;
+}
+
+#[tokio::test]
+async fn test_list_range_negative_step() {
+    let expr = "range(0, 10, -1)";
+    let expr = drasi_query_cypher::parse_expression(expr).unwrap();
+
+    let function_registry = create_list_expression_test_function_registry();
+    let ari = Arc::new(InMemoryResultIndex::new());
+    let evaluator = ExpressionEvaluator::new(function_registry.clone(), ari.clone());
+
+    let variables = QueryVariables::new();
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+    // Negative step is cast to usize, resulting in a very large step
+    // This should result in only the first element
+    let result = evaluator
+        .evaluate_expression(&context, &expr)
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        VariableValue::List(vec![VariableValue::Integer(Integer::from(0))])
+    );
+}
+
+#[tokio::test]
 async fn test_distinct() {
     let function_registry = create_list_expression_test_function_registry();
     let ari = Arc::new(InMemoryResultIndex::new());


### PR DESCRIPTION
# Description

This PR adds comprehensive unit test coverage for the `range` list function, focusing on edge cases, boundary conditions, and invalid argument handling.

The tests document and validate existing behavior for negative ranges, step handling, invalid inputs, and error semantics, improving confidence in correctness and preventing future regressions.

## New Tests Added (11 total)

- **test_list_range_invalid_arguments** – Tests `range(2, '18')` rejects string as second argument with `InvalidArgument(1)`
- **test_list_range_negative_numbers** – Tests range crossing zero from `-5` to `5`, returns 11 elements
- **test_list_range_all_negative** – Tests entirely negative range from `-10` to `-5`, returns 6 negative integers
- **test_list_range_start_greater_than_end** – Tests `range(10, 5)` returns empty list when start > end
- **test_list_range_single_element** – Tests `range(5, 5)` returns single-element list `[5]`
- **test_list_range_negative_with_step** – Tests `range(-10, 10, 5)` with negative start and step value
- **test_list_range_large_step** – Tests `range(0, 10, 100)` where step exceeds range, returns only the start element
- **test_list_range_invalid_step_argument** – Tests `range(0, 10, '2')` rejects string as step with `InvalidArgument(2)`
- **test_list_range_float_arguments** – Tests `range(0.5, 10.5)` rejects float arguments with `InvalidArgument(0)`
- **test_list_range_zero_step** – Tests `range(0, 10, 0)` panics with `assertion failed: step != 0` (`should_panic`)
- **test_list_range_negative_step** – Tests `range(0, 10, -1)` casts step to large `usize`, returns `[0]`

**Total range tests:** 14 (3 existing + 11 new)

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi.

## Related Issue

Related to: #245