### PR TITLE
Add PR automation workflows for contributor management

### DIFF
--- a/.github/workflows/pr-assignment-check.yml
+++ b/.github/workflows/pr-assignment-check.yml
@@ -1,0 +1,141 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: PR Assignment Check
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  check-assignment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: read
+    steps:
+      - name: Check PR has linked issue and author is assigned
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const prAuthor = context.payload.pull_request.user.login;
+            const prBody = context.payload.pull_request.body || '';
+
+            console.log(`Checking PR #${prNumber} by @${prAuthor}`);
+
+            // Extract linked issue numbers from PR body
+            // Matches: "Fixes #123", "Closes #123", "Resolves #123", "#123", etc.
+            const issuePattern = /(?:(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*)?#(\d+)/gi;
+            const linkedIssues = [];
+            let match;
+            while ((match = issuePattern.exec(prBody)) !== null) {
+              linkedIssues.push(parseInt(match[1], 10));
+            }
+
+            // Remove duplicates
+            const uniqueIssues = [...new Set(linkedIssues)];
+            console.log(`Found linked issues: ${uniqueIssues.join(', ') || 'none'}`);
+
+            // Case 1: No linked issue found
+            if (uniqueIssues.length === 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: ['needs-issue']
+              });
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: `Hi @${prAuthor}, thanks for your contribution!
+
+            This PR doesn't appear to have a linked issue. Per our [contributing guidelines](https://github.com/drasi-project/drasi-core/blob/main/CONTRIBUTING.md#current-status), please:
+
+            1. Find an existing issue or [open a new one](https://github.com/drasi-project/drasi-core/issues/new/choose)
+            2. Wait to be assigned to the issue
+            3. Link the issue in your PR description using "Fixes #<issue-number>"
+
+            Please update the PR description to link to the relevant issue. If you need help finding an appropriate issue, check our [good first issues](https://github.com/drasi-project/drasi-core/issues?q=is:issue+is:open+label:%22good+first+issue%22).
+
+Join our [Discord server](https://aka.ms/drasidiscord) to engage with maintainers and the community!`
+              });
+
+              console.log('Added label and comment for missing linked issue');
+              return;
+            }
+
+            // Case 2: Check if PR author is assigned to any of the linked issues
+            let authorAssignedToAny = false;
+            let checkedIssues = [];
+
+            for (const issueNumber of uniqueIssues) {
+              try {
+                const issue = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                });
+
+                const assignees = issue.data.assignees.map(a => a.login);
+                checkedIssues.push({ number: issueNumber, assignees });
+
+                if (assignees.includes(prAuthor)) {
+                  authorAssignedToAny = true;
+                  console.log(`Author @${prAuthor} is assigned to issue #${issueNumber}`);
+                  break;
+                }
+              } catch (e) {
+                console.log(`Could not fetch issue #${issueNumber}: ${e.message}`);
+              }
+            }
+
+            if (!authorAssignedToAny) {
+              // Close the PR with explanation
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: `Hi @${prAuthor}, thanks for your interest in contributing to drasi-core!
+
+            However, I need to close this PR because you are not assigned to the linked issue(s). Per our [contributing guidelines](https://github.com/drasi-project/drasi-core/blob/main/CONTRIBUTING.md#current-status):
+
+            > Please start by choosing an existing issue, or opening an issue to work on. The maintainers will respond to your issue, please work with the maintainers to ensure that what you're doing is in scope for the project before writing any code.
+
+            **To contribute:**
+            1. Comment on the issue you'd like to work on to request assignment
+            2. Wait for a maintainer to assign you
+            3. Then open your PR
+
+            This process helps us coordinate work and avoid duplicate efforts. We appreciate your understanding!
+
+            If you believe this was closed in error (e.g., you were assigned but the automation didn't detect it), please let us know.
+
+Join our [Discord server](https://aka.ms/drasidiscord) to engage with maintainers and the community!`
+              });
+
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: prNumber,
+                state: 'closed'
+              });
+
+              console.log(`Closed PR #${prNumber} - author not assigned to linked issues`);
+            } else {
+              console.log(`PR #${prNumber} passed assignment check`);
+            }

--- a/.github/workflows/pr-first-approval-label.yml
+++ b/.github/workflows/pr-first-approval-label.yml
@@ -1,0 +1,81 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Label PR on First Approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  add-awaiting-review-label:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check approval count and add label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // Get all reviews for this PR
+            const reviews = await github.rest.pulls.listReviews({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            // Count unique approvals (latest review per user)
+            const latestReviewByUser = new Map();
+            for (const review of reviews.data) {
+              const existing = latestReviewByUser.get(review.user.login);
+              if (!existing || new Date(review.submitted_at) > new Date(existing.submitted_at)) {
+                latestReviewByUser.set(review.user.login, review);
+              }
+            }
+
+            const approvalCount = Array.from(latestReviewByUser.values())
+              .filter(r => r.state === 'APPROVED').length;
+
+            console.log(`PR #${prNumber} has ${approvalCount} approval(s)`);
+
+            // Add label if exactly 1 approval (first approval just happened)
+            if (approvalCount === 1) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: ['need-2nd-review']
+              });
+              console.log('Added "need-2nd-review" label');
+            }
+
+            // Remove label if 2+ approvals (PR is fully approved)
+            if (approvalCount >= 2) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: 'need-2nd-review'
+                });
+                console.log('Removed "need-2nd-review" label');
+              } catch (e) {
+                // Label might not exist, that's fine
+                if (e.status !== 404) throw e;
+              }
+            }


### PR DESCRIPTION
## Summary

- Add need-2nd-review label automation when a PR receives its first approval
- Add PR assignment validation that checks for linked issues and author assignment
- Auto-close PRs from contributors not assigned to the linked issue

## Context

With increased contributor activity from the LFX program, this reduces manual triage and enforces our
https://github.com/drasi-project/drasi-core/blob/main/CONTRIBUTING.md#current-status.

New Labels (already created)
- need-2nd-review - Has one approval, needs a second review
- needs-issue - PR must link to an assigned issue