### PR TITLE
feat(mongodb): implement MongoDB source with change stream support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 
   # Source Plugins
   "components/sources/postgres",
+  "components/sources/mongodb",
   "components/sources/http",
   "components/sources/grpc",
   "components/sources/platform",
@@ -82,6 +83,7 @@ drasi-lib = { version = "0.3.3", path = "lib" }
 
 # Component plugins
 drasi-source-postgres = { version = "0.1.3", path = "components/sources/postgres" }
+drasi-source-mongodb = { version = "0.1.0", path = "components/sources/mongodb" }
 drasi-source-application = { version = "0.1.3", path = "components/sources/application" }
 drasi-bootstrap-application = { version = "0.1.3", path = "components/bootstrappers/application" }
 drasi-reaction-http = { version = "0.1.4", path = "components/reactions/http" }

--- a/components/sources/mongodb/Cargo.toml
+++ b/components/sources/mongodb/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "drasi-source-mongodb"
+version = "0.1.0"
+edition = "2021"
+authors = ["The Drasi Authors"]
+description = "MongoDB source plugin for Drasi"
+license = "Apache-2.0"
+
+[dependencies]
+async-trait = "0.1"
+anyhow = "1.0"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.0", features = ["v4", "serde"] }
+mongodb = { version = "2.8", features = ["tokio-runtime"] }
+bson = { version = "2.9", features = ["chrono-0_4", "uuid-1", "serde_with"] }
+ordered-float = "3.9"
+futures = "0.3"
+url = "2.5"
+
+drasi-core = { path = "../../../core", version = "0.3.2" }
+drasi-lib = { path = "../../../lib", version = "0.3.3" }
+
+[dev-dependencies]
+testcontainers = "0.23"
+tokio-test = "0.4"

--- a/components/sources/mongodb/Cargo.toml
+++ b/components/sources/mongodb/Cargo.toml
@@ -27,3 +27,6 @@ drasi-lib = { path = "../../../lib", version = "0.3.3" }
 [dev-dependencies]
 testcontainers = "0.23"
 tokio-test = "0.4"
+drasi-query-cypher = { path = "../../../query-cypher", version = "0.3.2" }
+drasi-functions-cypher = { path = "../../../functions-cypher", version = "0.3.2" }
+

--- a/components/sources/mongodb/README.md
+++ b/components/sources/mongodb/README.md
@@ -1,0 +1,25 @@
+# MongoDB Source Plugin
+
+This source plugin enables Drasi to consume change events from a MongoDB Replcia Set or Sharded Cluster.
+
+## Features
+
+- Captures `insert`, `update`, `replace`, `delete` events via Change Streams.
+- Handles resume tokens for reliable stream consumption.
+- Converts MongoDB BSON types to Drasi Element types.
+- Supports hydration of dot-notation updates (e.g. `{"a.b": 1}` -> `{"a": {"b": 1}}`).
+
+## Configuration
+
+```yaml
+source:
+  type: mongodb
+  properties:
+    connection_string: "mongodb://localhost:27017"
+    database: "mydb"
+    collection: "mycollection"
+```
+
+## Prerequisites
+
+- MongoDB must be running as a Replica Set or Sharded Cluster. Standalone instances do not support Change Streams.

--- a/components/sources/mongodb/README.md
+++ b/components/sources/mongodb/README.md
@@ -1,25 +1,280 @@
-# MongoDB Source Plugin
+# MongoDB Source for Drasi
 
-This source plugin enables Drasi to consume change events from a MongoDB Replcia Set or Sharded Cluster.
+A source component that captures change streams from a MongoDB Replica Set and forwards them as Drasi Source Changes.
+
+## Overview
+
+The MongoDB Source connects to a MongoDB Replica Set (or Sharded Cluster) and watches for data changes (Inserts, Updates, Replaces, Deletes) using [Change Streams](https://www.mongodb.com/docs/manual/changeStreams/). It converts these database events into standardized Drasi Source Events (Nodes), allowing you to build continuous queries and reactions based on realtime MongoDB activity.
+
+## Architecture Flow
+
+```mermaid
+graph LR
+    Mongo[MongoDB Replica Set] -->|Change Stream| Source[MongoDB Source]
+    Source -->|SourceChange| SourceBase[Drasi SourceBase]
+    SourceBase -->|Distribute| Queries[Drasi Queries]
+    Queries -->|Results| Reactions[Drasi Reactions]
+```
+
+1.  **Change Stream**: The source establishes a persistent connection to the MongoDB changestream.
+2.  **Conversion**: BSON documents and change events are converted into Drasi Elements (`Node`).
+3.  **Dispatch**: Changes are pushed to the Drasi Runtime for processing.
+
+---
 
 ## Features
 
-- Captures `insert`, `update`, `replace`, `delete` events via Change Streams.
-- Handles resume tokens for reliable stream consumption.
-- Converts MongoDB BSON types to Drasi Element types.
-- Supports hydration of dot-notation updates (e.g. `{"a.b": 1}` -> `{"a": {"b": 1}}`).
+-   **Realtime Change Capture**: Consumes the MongoDB `watch()` stream for low-latency updates.
+-   **Multi-Collection Support**: Can watch one or multiple collections within a database.
+-   **Resume Tokens**: Automatically persists resume tokens to the Drasi State Store. If the source restarts, it resumes consumption exactly where it left off, preventing data loss.
+-   **Partial Updates**: Efficiently handles MongoDB `update` operations. It hydrates "dot notation" fields (e.g., `user.address.city`) into structured property maps.
+-   **Full Document Lookup**: Configured to use `updateLookup` to ensure the full document state is available when needed (though partial updates are preferred for performance when available).
+-   **Structure Handling**: Converts complex BSON types (ObjectId, Date, Embedded Docs) into Drasi standard types.
+-   **Resilience**: Handles connection drops and temporary unavailability with automatic reconnection and backoff.
 
 ## Configuration
 
+The source is configured via a YAML file.
+
+### basic_config.yaml
 ```yaml
-source:
-  type: mongodb
+kind: Source
+name: my-mongo-source
+spec:
+  kind: mongodb
   properties:
-    connection_string: "mongodb://localhost:27017"
+    connection_string: "mongodb://user:pass@localhost:27017/mydb?replicaSet=rs0"
     database: "mydb"
-    collection: "mycollection"
+    collections: 
+      - "users"
+      - "orders"
 ```
 
-## Prerequisites
+### Configuration Fields
 
-- MongoDB must be running as a Replica Set or Sharded Cluster. Standalone instances do not support Change Streams.
+| Field | Type | Required | Default | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `connection_string` | String | Yes | - | Standard MongoDB connection URI. |
+| `database` | String | Optional* | - | The database name to watch. *Required if not specified in connection string.* |
+| `collection` | String | Optional | - | Single collection to watch (legacy mode). |
+| `collections` | List\<String\> | Optional | `[]` | List of collections to watch. **Recommended.** |
+| `username` | String | Optional | - | Overrides username in connection string. |
+| `password` | String | Optional | - | Overrides password in connection string. |
+| `pipeline` | List\<Document\> | Optional | `[]` | Custom aggregation pipeline validation/filtering stages passed to the change stream. |
+
+### Precedence Rules
+1.  **Database**: If specified in both `connection_string` (e.g., `mongodb://.../mydb`) AND `database` config, they **MUST** match. If they differ, the source will fail to start with an `Ambiguous configuration` error.
+2.  **Collections**: You must specify at least one collection via `collection` or `collections`. If both are provided, they are merged.
+
+---
+
+## Authentication & Secrets
+
+Do not hardcode credentials in your YAML files. Use Drasi's environment variable injection or secret management.
+
+### Credentials Precedence
+1.  **Config Fields**: `username` / `password` in yaml (Lowest priority, discouraged for secrets).
+2.  **Connection String**: Credentials embedded in the URI.
+3.  **Environment Variables**: `MONGODB_USERNAME` and `MONGODB_PASSWORD` environment variables (Highest priority).
+
+**Best Practice:**
+Inject credentials via Kubernetes Secrets or environment variables at runtime:
+
+```yaml
+# In your deployment manifest
+env:
+  - name: MONGODB_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: mongo-secrets
+        key: username
+  - name: MONGODB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: mongo-secrets
+        key: password
+```
+
+The source log automatically redacts connection strings and credentials.
+
+---
+
+## Multi-Collection Support
+
+You can watch multiple collections in the same database.
+
+**Configuration:**
+```yaml
+collections:
+  - "users"
+  - "products"
+  - "orders"
+```
+
+**Behavior:**
+-   The source opens a single stream on the **Database** and filters events by `ns.coll` (namespace collection).
+-   Events are tagged with their origin collection (see Mapping Model).
+-   Efficient resource usage compared to running multiple sources.
+
+---
+
+## Update Handling Semantics
+
+Drasi needs to know the *current state* of a node to evaluate queries. MongoDB provides flexible update formats; here is how they are handled:
+
+1.  **Insert / Replace**: The `full_document` is always used to build the Element properties.
+2.  **Update (Partial)**:
+    -   If `full_document` is available in the event, it is used.
+    -   If only `update_description` is available:
+        -   **Updated Fields**: Dot-notation fields (e.g., `{"address.city": "London"}`) are "hydrated" into nested objects (`{address: {city: "London"}}`).
+        -   **Removed Fields**: Fields listed in `removed_fields` are explicitly set to `Null` in the element properties.
+3.  **Delete**: No properties are preserved; the element is marked for deletion.
+
+---
+
+## Resume Token Behavior
+
+The source ensures "at-least-once" delivery semantics using MongoDB Resume Tokens.
+
+-   **Storage**: Resume tokens are stored in the configured Drasi **State Store** (e.g., Redis or Kubernetes specific store) under the key `resume_token`.
+-   **Restart**: On startup, the source checks the state store.
+    -   **Found**: It resumes the change stream from that specific token.
+    -   **Not Found**: It starts consuming from the *current moment* (Live).
+-   **Persistence**: The token is updated and persisted atomically with event dispatch.
+
+---
+
+## Mapping Model
+
+How MongoDB BSON translates to the Drasi Property Graph Model:
+
+### Node Identity
+Drasi Elements must have a unique ID.
+Format: `CollectionName:ObjectIdHex`
+
+Examples:
+-   Collection: `users`, `_id`: `ObjectId("5f...")` -> ID: `users:5f...`
+-   Collection: `settings`, `_id`: `"global"` -> ID: `settings:global`
+
+### Property Mapping
+| MongoDB (BSON) | Drasi (ElementValue) |
+| :--- | :--- |
+| `String` | String |
+| `Int32`, `Int64` | Integer |
+| `Double` | Float |
+| `Boolean` | Bool |
+| `Null` | Null |
+| `Document` | Object (Map) |
+| `Array` | List |
+| `ObjectId` | String (Hex representation) |
+| `DateTime` | String (RFC3339 format) |
+
+### Deletes
+A MongoDB `delete` event generates a Drasi `Change::Delete` event. The Node with the corresponding ID is removed from the query graph.
+
+---
+
+## Integration Testing
+
+### Requirements
+-   **Replica Set**: MongoDB Change Streams **REQUIRE** a Replica Set. They do not work on a standalone single node unless it is configured as a single-node replica set.
+
+### Running Implementation Tests
+This repository includes integration tests that spin up a Docker container.
+
+```bash
+# Run the integration tests (requires Docker)
+cargo test --test mongo_integration -- --ignored
+```
+
+*Note: The `--ignored` flag is used because these tests are slow/heavy and require Docker.*
+
+---
+
+## MongoDB Setup Guide (Local Development)
+
+To run this source locally, you need a MongoDB Replica Set.
+
+1.  **Start MongoDB Container**:
+    ```bash
+    docker run -d --rm -p 27017:27017 \
+      --name mongo-repl \
+      mongo:5.0 mongod --replSet rs0 --bind_ip_all
+    ```
+
+2.  **Initiate Replica Set**:
+    Inside the container (or via a client):
+    ```bash
+    docker exec -it mongo-repl mongosh --eval "rs.initiate()"
+    ```
+
+3.  **Verify**:
+    ```bash
+    docker exec -it mongo-repl mongosh --eval "rs.status().ok"
+    # Should return 1
+    ```
+
+Now change streams are enabled.
+
+---
+
+## End-to-End Example
+
+### 1. MongoDB Data (Input)
+Command executed in MongoDB:
+```javascript
+db.users.insert({
+  "_id": ObjectId("60b8d295f1d21034907d32a1"),
+  "name": "Alice",
+  "age": 30,
+  "skills": ["Rust", "MongoDB"]
+})
+```
+
+### 2. Drasi Source Configuration
+```yaml
+collections: ["users"]
+```
+
+### 3. Source Change Event (Internal)
+The source generates this internal event:
+
+```rust
+SourceChange::Insert {
+    element: Element::Node {
+        metadata: {
+            reference: "users:60b8d295f1d21034907d32a1",
+            labels: ["users"]
+        },
+        properties: {
+            "name": "Alice",
+            "age": 30,
+            "skills": ["Rust", "MongoDB"]
+        }
+    }
+}
+```
+
+### 4. Drasi Query (Cypher)
+```cypher
+MATCH (u:users) WHERE u.age >= 30 RETURN u.name
+```
+
+### 5. Query Output
+```json
+{
+  "u.name": "Alice"
+}
+```
+
+---
+
+## Limitations
+
+-   **Transaction Support**: The source does not currently expose transaction markers to downstream queries; events are processed individually.
+-   **Schema Validation**: The source does not enforce a schema; downstream queries must handle optional/missing fields if the MongoDB schema is loose.
+
+## Future Work
+
+-   [ ] Support for Sharded Cluster specific configurations (though currently works via mongos).
+-   [ ] Advanced filtering pipeline configuration via external files for complex logic.

--- a/components/sources/mongodb/src/config.rs
+++ b/components/sources/mongodb/src/config.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+use anyhow::Result;
+use mongodb::bson::Document;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MongoSourceConfig {
+    pub connection_string: String,
+    pub database: String,
+    pub collection: String,
+    #[serde(default)]
+    pub pipeline: Option<Vec<Document>>,
+}
+
+impl MongoSourceConfig {
+    pub fn validate(&self) -> Result<()> {
+        if self.connection_string.is_empty() {
+             return Err(anyhow::anyhow!("Validation error: connection_string cannot be empty"));
+        }
+        if self.database.is_empty() {
+            return Err(anyhow::anyhow!("Validation error: database cannot be empty"));
+        }
+        if self.collection.is_empty() {
+            return Err(anyhow::anyhow!("Validation error: collection cannot be empty"));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_validation() {
+        let config = MongoSourceConfig {
+            connection_string: "mongodb://localhost".to_string(),
+            database: "db".to_string(),
+            collection: "col".to_string(),
+            pipeline: None,
+        };
+        assert!(config.validate().is_ok());
+
+        let invalid_config = MongoSourceConfig {
+            connection_string: "".to_string(),
+            database: "db".to_string(),
+            collection: "col".to_string(),
+            pipeline: None,
+        };
+        assert!(invalid_config.validate().is_err());
+    }
+}

--- a/components/sources/mongodb/src/config.rs
+++ b/components/sources/mongodb/src/config.rs
@@ -5,22 +5,60 @@ use mongodb::bson::Document;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MongoSourceConfig {
     pub connection_string: String,
-    pub database: String,
-    pub collection: String,
+    #[serde(default)]
+    pub database: Option<String>,
+    #[serde(default)]
+    pub collection: Option<String>,
+    #[serde(default)]
+    pub collections: Vec<String>,
     #[serde(default)]
     pub pipeline: Option<Vec<Document>>,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
 }
 
 impl MongoSourceConfig {
+    pub fn get_collections(&self) -> Vec<String> {
+        let mut cols = self.collections.clone();
+        if let Some(c) = &self.collection {
+            if !cols.contains(c) {
+                cols.push(c.clone());
+            }
+        }
+        cols
+    }
     pub fn validate(&self) -> Result<()> {
         if self.connection_string.is_empty() {
              return Err(anyhow::anyhow!("Validation error: connection_string cannot be empty"));
         }
-        if self.database.is_empty() {
-            return Err(anyhow::anyhow!("Validation error: database cannot be empty"));
+        
+        let mut connection_db = None;
+        if let Ok(url) = url::Url::parse(&self.connection_string) {
+            let path = url.path().trim_start_matches('/');
+            if !path.is_empty() {
+                connection_db = Some(path.to_string());
+            }
         }
-        if self.collection.is_empty() {
-            return Err(anyhow::anyhow!("Validation error: collection cannot be empty"));
+
+        match (&self.database, &connection_db) {
+            (Some(config_db), Some(conn_db)) => {
+                if config_db != conn_db {
+                    return Err(anyhow::anyhow!(
+                        "Ambiguous configuration: database specified in both config ('{}') and connection string ('{}') but they differ",
+                        config_db, conn_db
+                    ));
+                }
+            }
+            (None, None) => {
+                 return Err(anyhow::anyhow!("Validation error: database must be specified in either config or connection string"));
+            }
+            _ => {}
+        }
+
+        if self.get_collections().is_empty() {
+            return Err(anyhow::anyhow!("Validation error: at least one collection must be specified"));
         }
         Ok(())
     }
@@ -31,21 +69,119 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_config_validation() {
+    fn test_config_validation_match() {
         let config = MongoSourceConfig {
-            connection_string: "mongodb://localhost".to_string(),
-            database: "db".to_string(),
-            collection: "col".to_string(),
+            connection_string: "mongodb://localhost/db".to_string(),
+            database: Some("db".to_string()),
+            collection: Some("col".to_string()),
+            collections: vec![],
             pipeline: None,
+            username: None,
+            password: None,
         };
         assert!(config.validate().is_ok());
+    }
 
-        let invalid_config = MongoSourceConfig {
-            connection_string: "".to_string(),
-            database: "db".to_string(),
-            collection: "col".to_string(),
+    #[test]
+    fn test_config_validation_mismatch() {
+        let config = MongoSourceConfig {
+            connection_string: "mongodb://localhost/db1".to_string(),
+            database: Some("db2".to_string()),
+            collection: Some("col".to_string()),
+            collections: vec![],
             pipeline: None,
+            username: None,
+            password: None,
         };
-        assert!(invalid_config.validate().is_err());
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_config_validation_only_config() {
+        let config = MongoSourceConfig {
+            connection_string: "mongodb://localhost".to_string(),
+            database: Some("db".to_string()),
+            collection: Some("col".to_string()),
+            collections: vec![],
+            pipeline: None,
+            username: None,
+            password: None,
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_config_validation_only_connection() {
+        let config = MongoSourceConfig {
+            connection_string: "mongodb://localhost/db".to_string(),
+            database: None,
+            collection: Some("col".to_string()),
+            collections: vec![],
+            pipeline: None,
+            username: None,
+            password: None,
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_config_validation_none() {
+        let config = MongoSourceConfig {
+            connection_string: "mongodb://localhost".to_string(),
+            database: None,
+            collection: Some("col".to_string()),
+            collections: vec![],
+            pipeline: None,
+            username: None,
+            password: None,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_config_validation_multi_collection() {
+        let config = MongoSourceConfig {
+            connection_string: "mongodb://localhost/db".to_string(),
+            database: None,
+            collection: None,
+            collections: vec!["col1".to_string(), "col2".to_string()],
+            pipeline: None,
+            username: None,
+            password: None,
+        };
+        assert!(config.validate().is_ok());
+        assert_eq!(config.get_collections().len(), 2);
+    }
+    
+    #[test]
+    fn test_config_validation_mixed_collection() {
+        let config = MongoSourceConfig {
+            connection_string: "mongodb://localhost/db".to_string(),
+            database: None,
+            collection: Some("col1".to_string()),
+            collections: vec!["col2".to_string()],
+            pipeline: None,
+            username: None,
+            password: None,
+        };
+        assert!(config.validate().is_ok());
+        let cols = config.get_collections();
+        assert_eq!(cols.len(), 2);
+        assert!(cols.contains(&"col1".to_string()));
+        assert!(cols.contains(&"col2".to_string()));
+    }
+    
+    #[test]
+    fn test_config_validation_no_collection() {
+        let config = MongoSourceConfig {
+            connection_string: "mongodb://localhost/db".to_string(),
+            database: None,
+            collection: None,
+            collections: vec![],
+            pipeline: None,
+            username: None,
+            password: None,
+        };
+        assert!(config.validate().is_err());
     }
 }

--- a/components/sources/mongodb/src/conversion.rs
+++ b/components/sources/mongodb/src/conversion.rs
@@ -1,0 +1,244 @@
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use drasi_core::models::{Element, ElementMetadata, ElementReference, ElementValue, SourceChange};
+use mongodb::bson::{Bson, Document};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use ordered_float::OrderedFloat;
+
+pub fn bson_to_element_value(bson: Bson) -> Result<ElementValue> {
+    match bson {
+        Bson::Double(v) => Ok(ElementValue::Float(ordered_float::OrderedFloat(v))),
+        Bson::String(v) => Ok(ElementValue::String(v.into())),
+        Bson::Array(v) => {
+            let mut list = Vec::new();
+            for item in v {
+                list.push(bson_to_element_value(item)?);
+            }
+            Ok(ElementValue::List(list))
+        }
+        Bson::Document(v) => {
+            let mut map = BTreeMap::new();
+            for (key, value) in v {
+                map.insert(key, bson_to_element_value(value)?);
+            }
+            Ok(ElementValue::Object(map.into()))
+        }
+        Bson::Boolean(v) => Ok(ElementValue::Bool(v)),
+        Bson::Null => Ok(ElementValue::Null),
+        Bson::Int32(v) => Ok(ElementValue::Integer(v as i64)),
+        Bson::Int64(v) => Ok(ElementValue::Integer(v)),
+        Bson::ObjectId(oid) => Ok(ElementValue::String(oid.to_hex().into())),
+        Bson::DateTime(dt) => {
+            let millis = dt.timestamp_millis();
+            let seconds = millis / 1000;
+            let nsecs = (millis % 1000) * 1_000_000;
+            if let Some(dt) = DateTime::from_timestamp(seconds, nsecs as u32) {
+                Ok(ElementValue::String(dt.to_rfc3339().into()))
+            } else {
+                Ok(ElementValue::String(dt.to_string().into()))
+            }
+        }
+        // For other types, convert to string representation
+        other => Ok(ElementValue::String(other.to_string().into())),
+    }
+}
+
+pub fn hydrate_dot_notation(doc: &Document, removed_fields: &[String]) -> Result<Document> {
+    let mut hydrated = Document::new();
+
+    // Process updated fields
+    for (key, value) in doc {
+        insert_dot_notation(&mut hydrated, key, value.clone())?;
+    }
+
+    // Process removed fields - set them to Null
+    for field in removed_fields {
+        insert_dot_notation(&mut hydrated, field, Bson::Null)?;
+    }
+
+    Ok(hydrated)
+}
+
+fn insert_dot_notation(doc: &mut Document, key: &str, value: Bson) -> Result<()> {
+    if key.contains('.') {
+        let parts: Vec<&str> = key.splitn(2, '.').collect();
+        let head = parts[0];
+        let tail = parts[1];
+
+        let entry = doc.entry(head.to_string()).or_insert_with(|| Bson::Document(Document::new()));
+        
+        if let Bson::Document(sub_doc) = entry {
+            insert_dot_notation(sub_doc, tail, value)?;
+        } else {
+            // Conflict: trying to treat a non-document value as a document
+            // For MongoDB hydration, this might happen if structure changes.
+            // We'll overwrite with a new document to proceed.
+            let mut new_doc = Document::new();
+            insert_dot_notation(&mut new_doc, tail, value)?;
+            doc.insert(head.to_string(), Bson::Document(new_doc));
+        }
+    } else {
+        doc.insert(key, value);
+    }
+    Ok(())
+}
+
+pub fn change_stream_event_to_source_change(
+    event: mongodb::change_stream::event::ChangeStreamEvent<Document>,
+    source_id: &str,
+    collection_name: &str,
+) -> Result<Option<SourceChange>> {
+    let operation_type = event.operation_type;
+    let document_key = event.document_key.as_ref().ok_or_else(|| anyhow!("Missing document_key"))?;
+    
+    // Extract _id for element ID
+    let id_bson = document_key.get("_id").ok_or_else(|| anyhow!("Missing _id in document_key"))?;
+    let id_str = match id_bson {
+        Bson::ObjectId(oid) => oid.to_hex(),
+        Bson::String(s) => s.clone(),
+        Bson::Int32(i) => i.to_string(),
+        Bson::Int64(i) => i.to_string(),
+        other => other.to_string(), // Fallback for complex keys
+    };
+    
+    let element_id = format!("{}:{}", collection_name, id_str);
+    let labels = Arc::from([Arc::from(collection_name)]);
+    
+    // Determine effective timestamp
+    // Use wall time if available, otherwise cluster time, otherwise current time
+    let effective_from = if let Some(dt) = event.wall_time {
+        dt.timestamp_millis() as u64
+    } else if let Some(ts) = event.cluster_time {
+         // Timestamp is (seconds, increment)
+         // We'll just use seconds * 1000 to get millis
+         (ts.time as u64) * 1000
+    } else {
+        Utc::now().timestamp_millis() as u64
+    };
+
+    let metadata = ElementMetadata {
+        reference: ElementReference::new(source_id, &element_id),
+        labels,
+        effective_from,
+    };
+
+    match operation_type {
+        mongodb::change_stream::event::OperationType::Insert => {
+            let full_document = event.full_document.ok_or_else(|| anyhow!("Missing full_document for insert"))?;
+            let properties = document_to_properties(&full_document)?;
+            
+            Ok(Some(SourceChange::Insert {
+                element: Element::Node {
+                    metadata,
+                    properties,
+                },
+            }))
+        }
+        mongodb::change_stream::event::OperationType::Replace => {
+            let full_document = event.full_document.ok_or_else(|| anyhow!("Missing full_document for replace"))?;
+            let properties = document_to_properties(&full_document)?;
+            
+            // Replace is effectively an Update where we provide the full new state
+            // Drasi treats it as Update because we are updating an existing element
+            Ok(Some(SourceChange::Update {
+                element: Element::Node {
+                    metadata,
+                    properties,
+                },
+            }))
+        }
+        mongodb::change_stream::event::OperationType::Update => {
+            let update_desc = event.update_description.ok_or_else(|| anyhow!("Missing update_description"))?;
+            let updated_fields = update_desc.updated_fields;
+            let removed_fields = update_desc.removed_fields;
+            
+            // Hydrate dot notation and handle removed fields
+            let hydrated_update = hydrate_dot_notation(&updated_fields, &removed_fields)?;
+            let properties = document_to_properties(&hydrated_update)?;
+            
+            Ok(Some(SourceChange::Update {
+                element: Element::Node {
+                    metadata,
+                    properties,
+                },
+            }))
+        }
+        mongodb::change_stream::event::OperationType::Delete => {
+            Ok(Some(SourceChange::Delete { metadata }))
+        }
+        _ => {
+            // Ignore other events (invalidate, drop, rename, etc. for now)
+            Ok(None)
+        }
+    }
+}
+
+fn document_to_properties(doc: &Document) -> Result<drasi_core::models::ElementPropertyMap> {
+    let mut properties = drasi_core::models::ElementPropertyMap::new();
+    for (key, value) in doc {
+        // Exclude _id from properties
+        if key == "_id" {
+            continue;
+        }
+        properties.insert(key, bson_to_element_value(value.clone())?);
+    }
+    Ok(properties)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mongodb::bson::{doc, Bson};
+    use drasi_core::models::ElementValue;
+
+    #[test]
+    fn test_bson_to_element_value_simple() {
+        assert_eq!(bson_to_element_value(Bson::String("hello".to_string())).unwrap(), ElementValue::String("hello".into()));
+        assert_eq!(bson_to_element_value(Bson::Int32(42)).unwrap(), ElementValue::Integer(42));
+        assert_eq!(bson_to_element_value(Bson::Double(3.14)).unwrap(), ElementValue::Float(ordered_float::OrderedFloat(3.14)));
+        assert_eq!(bson_to_element_value(Bson::Boolean(true)).unwrap(), ElementValue::Bool(true));
+        assert_eq!(bson_to_element_value(Bson::Null).unwrap(), ElementValue::Null);
+    }
+
+    #[test]
+    fn test_bson_to_element_value_complex() {
+        let doc = doc! {
+            "key": "value",
+            "list": [1, 2, 3],
+            "nested": { "a": 1 }
+        };
+        let val = bson_to_element_value(Bson::Document(doc)).unwrap();
+        if let ElementValue::Object(map) = val {
+            assert_eq!(map.get("key").unwrap(), &ElementValue::String("value".into()));
+            if let ElementValue::List(list) = map.get("list").unwrap() {
+                assert_eq!(list.len(), 3);
+            } else {
+                panic!("Expected List");
+            }
+        } else {
+             panic!("Expected Object");
+        }
+    }
+
+    #[test]
+    fn test_hydrate_dot_notation() {
+        let updates = doc! {
+            "a.b": 1,
+            "a.c": 2,
+            "x": 3
+        };
+        let removed = vec!["y".to_string(), "z.w".to_string()];
+        
+        let hydrated = hydrate_dot_notation(&updates, &removed).unwrap();
+        
+        println!("Hydrated: {:?}", hydrated);
+        
+        assert_eq!(hydrated.get_document("a").unwrap().get_i32("b").unwrap(), 1);
+        assert_eq!(hydrated.get_document("a").unwrap().get_i32("c").unwrap(), 2);
+        assert_eq!(hydrated.get_i32("x").unwrap(), 3);
+        assert_eq!(hydrated.get("y").unwrap(), &Bson::Null);
+        // Note: dot notation for removed fields is processed as: z: { w: Null }
+        assert_eq!(hydrated.get_document("z").unwrap().get("w").unwrap(), &Bson::Null);
+    }
+}

--- a/components/sources/mongodb/src/lib.rs
+++ b/components/sources/mongodb/src/lib.rs
@@ -195,17 +195,19 @@ pub struct MongoSourceBuilder {
 
 impl MongoSourceBuilder {
     pub fn new(id: impl Into<String>) -> Self {
+        #[allow(deprecated)]
+        let config = MongoSourceConfig {
+            connection_string: String::new(),
+            database: None,
+            collection: None,
+            collections: Vec::new(),
+            pipeline: None,
+            username: None,
+            password: None,
+        };
         Self {
             id: id.into(),
-            config: MongoSourceConfig {
-                connection_string: String::new(),
-                database: None,
-                collection: None,
-                collections: Vec::new(),
-                pipeline: None,
-                username: None,
-                password: None,
-            },
+            config,
         }
     }
 
@@ -219,9 +221,11 @@ impl MongoSourceBuilder {
         self
     }
 
-    pub fn with_collection(mut self, col: impl Into<String>) -> Self {
-        self.config.collection = Some(col.into());
-        self
+    /// DEPRECATED: Use `with_collections(vec![col])` instead.
+    /// This method will be removed in a future version.
+    #[deprecated(since = "0.2.0", note = "use `with_collections(vec![col])` instead")]
+    pub fn with_collection(self, col: impl Into<String>) -> Self {
+        self.with_collections(vec![col.into()])
     }
     
     pub fn with_collections(mut self, cols: Vec<String>) -> Self {

--- a/components/sources/mongodb/src/lib.rs
+++ b/components/sources/mongodb/src/lib.rs
@@ -179,11 +179,9 @@ pub struct MongoSourceBuilder {
 
 impl MongoSourceBuilder {
     pub fn new(id: impl Into<String>) -> Self {
-        #[allow(deprecated)]
         let config = MongoSourceConfig {
             connection_string: String::new(),
             database: String::new(),
-            collection: None,
             collections: Vec::new(),
             pipeline: None,
             username: None,
@@ -205,13 +203,6 @@ impl MongoSourceBuilder {
         self
     }
 
-    /// DEPRECATED: Use `with_collections(vec![col])` instead.
-    /// This method will be removed in a future version.
-    #[deprecated(since = "0.2.0", note = "use `with_collections(vec![col])` instead")]
-    pub fn with_collection(self, col: impl Into<String>) -> Self {
-        self.with_collections(vec![col.into()])
-    }
-    
     pub fn with_collections(mut self, cols: Vec<String>) -> Self {
         self.config.collections = cols;
         self

--- a/components/sources/mongodb/src/lib.rs
+++ b/components/sources/mongodb/src/lib.rs
@@ -1,0 +1,182 @@
+pub mod config;
+pub mod stream;
+pub mod conversion;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use log::{error, info};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+
+use drasi_lib::channels::{ComponentEvent, ComponentStatus, ComponentType, SubscriptionResponse};
+use drasi_lib::sources::base::{SourceBase, SourceBaseParams};
+use drasi_lib::Source;
+
+use crate::config::MongoSourceConfig;
+use crate::stream::ReplicationStream;
+
+pub struct MongoSource {
+    pub base: SourceBase,
+    config: MongoSourceConfig,
+}
+
+impl MongoSource {
+    pub fn new(id: impl Into<String>, config: MongoSourceConfig) -> Result<Self> {
+        let params = SourceBaseParams::new(id.into());
+        Ok(Self {
+            base: SourceBase::new(params)?,
+            config,
+        })
+    }
+
+    pub fn builder(id: impl Into<String>) -> MongoSourceBuilder {
+        MongoSourceBuilder::new(id)
+    }
+}
+
+#[async_trait]
+impl Source for MongoSource {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "mongodb"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        let mut props = HashMap::new();
+        props.insert("connection_string".to_string(), serde_json::Value::String(self.config.connection_string.clone()));
+        props.insert("database".to_string(), serde_json::Value::String(self.config.database.clone()));
+        props.insert("collection".to_string(), serde_json::Value::String(self.config.collection.clone()));
+        props
+    }
+
+    async fn start(&self) -> Result<()> {
+        if self.base.get_status().await == ComponentStatus::Running {
+            return Ok(());
+        }
+
+        self.base.set_status(ComponentStatus::Starting).await;
+        info!("Starting MongoDB source: {}", self.base.id);
+        
+        // validate config before starting
+        if let Err(e) = self.config.validate() {
+            let msg = format!("Invalid configuration: {}", e);
+            error!("{}", msg);
+            self.base.set_status_with_event(ComponentStatus::Error, Some(msg)).await?;
+            return Err(e);
+        }
+
+        let config = self.config.clone();
+        let source_id = self.base.id.clone();
+        let dispatchers = self.base.dispatchers.clone();
+        let status_tx = self.base.status_tx();
+        let status_clone = self.base.status.clone();
+
+        let task = tokio::spawn(async move {
+            let mut stream = ReplicationStream::new(
+                config,
+                source_id.clone(),
+                dispatchers,
+                status_tx.clone(),
+                status_clone.clone(),
+            );
+            
+            if let Err(e) = stream.run().await {
+                 error!("MongoDB stream task failed for {source_id}: {e}");
+                *status_clone.write().await = ComponentStatus::Error;
+                
+                if let Some(ref tx) = *status_tx.read().await {
+                    let _ = tx
+                        .send(ComponentEvent {
+                            component_id: source_id,
+                            component_type: ComponentType::Source,
+                            status: ComponentStatus::Error,
+                            timestamp: chrono::Utc::now(),
+                            message: Some(format!("Stream failed: {e}")),
+                        })
+                        .await;
+                }
+            }
+        });
+
+        self.base.set_task_handle(task).await;
+        self.base.set_status(ComponentStatus::Running).await;
+        
+        self.base.send_component_event(
+            ComponentStatus::Running,
+            Some("MongoDB source started".to_string())
+        ).await?;
+
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base.stop_common().await
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn subscribe(
+        &self,
+        settings: drasi_lib::config::SourceSubscriptionSettings,
+    ) -> Result<SubscriptionResponse> {
+        self.base.subscribe_with_bootstrap(&settings, "MongoDB").await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn initialize(&self, context: drasi_lib::context::SourceRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+}
+
+pub struct MongoSourceBuilder {
+    id: String,
+    config: MongoSourceConfig,
+}
+
+impl MongoSourceBuilder {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            config: MongoSourceConfig {
+                connection_string: String::new(),
+                database: String::new(),
+                collection: String::new(),
+                pipeline: None,
+            },
+        }
+    }
+
+    pub fn with_connection_string(mut self, cs: impl Into<String>) -> Self {
+        self.config.connection_string = cs.into();
+        self
+    }
+
+    pub fn with_database(mut self, db: impl Into<String>) -> Self {
+        self.config.database = db.into();
+        self
+    }
+
+    pub fn with_collection(mut self, col: impl Into<String>) -> Self {
+        self.config.collection = col.into();
+        self
+    }
+    
+    pub fn with_pipeline(mut self, pipeline: Vec<mongodb::bson::Document>) -> Self {
+        self.config.pipeline = Some(pipeline);
+        self
+    }
+
+    pub fn build(self) -> Result<MongoSource> {
+        self.config.validate()?;
+        MongoSource::new(self.id, self.config)
+    }
+}

--- a/components/sources/mongodb/src/stream.rs
+++ b/components/sources/mongodb/src/stream.rs
@@ -1,0 +1,147 @@
+use anyhow::{anyhow, Result};
+use futures::stream::StreamExt;
+use log::{error, info};
+use mongodb::{
+    bson::Document,
+    options::{ChangeStreamOptions, ClientOptions, FullDocumentType},
+    Client,
+};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tokio::time::sleep;
+
+use drasi_lib::channels::{
+    ChangeDispatcher, ComponentEventSender, ComponentStatus, SourceEvent, SourceEventWrapper,
+};
+use drasi_lib::sources::base::SourceBase;
+
+use crate::config::MongoSourceConfig;
+use crate::conversion::change_stream_event_to_source_change;
+
+pub struct ReplicationStream {
+    config: MongoSourceConfig,
+    source_id: String,
+    dispatchers: Arc<RwLock<Vec<Box<dyn ChangeDispatcher<SourceEventWrapper> + Send + Sync>>>>,
+    status_tx: Arc<RwLock<Option<ComponentEventSender>>>,
+    status: Arc<RwLock<ComponentStatus>>,
+    resume_token: Option<mongodb::change_stream::event::ResumeToken>,
+}
+
+impl ReplicationStream {
+    pub fn new(
+        config: MongoSourceConfig,
+        source_id: String,
+        dispatchers: Arc<RwLock<Vec<Box<dyn ChangeDispatcher<SourceEventWrapper> + Send + Sync>>>>,
+        status_tx: Arc<RwLock<Option<ComponentEventSender>>>,
+        status: Arc<RwLock<ComponentStatus>>,
+    ) -> Self {
+        Self {
+            config,
+            source_id,
+            dispatchers,
+            status_tx,
+            status,
+            resume_token: None,
+        }
+    }
+
+    pub async fn run(&mut self) -> Result<()> {
+        info!("Starting MongoDB replication stream for source {}", self.source_id);
+
+        loop {
+            // Check for stop signal
+            {
+                let status = self.status.read().await;
+                if *status == ComponentStatus::Stopping || *status == ComponentStatus::Stopped {
+                    info!("Received stop signal, shutting down MongoDB stream");
+                    break;
+                }
+            }
+
+            if let Err(e) = self.stream_loop().await {
+                error!("Error in MongoDB stream loop: {e}");
+                // Simple backoff strategy
+                sleep(Duration::from_secs(5)).await;
+            }
+        }
+        
+        Ok(())
+    }
+
+    async fn stream_loop(&mut self) -> Result<()> {
+        let client_options = ClientOptions::parse(&self.config.connection_string).await?;
+        let client = Client::with_options(client_options)?;
+        let db = client.database(&self.config.database);
+        let collection = db.collection::<Document>(&self.config.collection);
+
+        let mut options = ChangeStreamOptions::builder()
+            .full_document(Some(FullDocumentType::UpdateLookup))
+            .build();
+        
+        if let Some(token) = &self.resume_token {
+            info!("Resuming change stream from token");
+            options.resume_after = Some(token.clone());
+        }
+
+        let pipeline = self.config.pipeline.clone().unwrap_or_default();
+        let mut stream = collection.watch(pipeline, Some(options)).await?;
+
+        info!("Connected to MongoDB Change Stream");
+
+        while let Some(event_result) = stream.next().await {
+            // Check stop signal in inner loop
+             {
+                let status = self.status.read().await;
+                if *status == ComponentStatus::Stopping || *status == ComponentStatus::Stopped {
+                    break;
+                }
+            }
+
+            match event_result {
+                Ok(event) => {
+                    // Update resume token
+                    self.resume_token = Some(event.id.clone());
+
+                    match change_stream_event_to_source_change(event, &self.source_id, &self.config.collection) {
+                        Ok(Some(change)) => {
+                            // Create profiling metadata
+                            let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
+                            profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
+
+                            let wrapper = SourceEventWrapper::with_profiling(
+                                self.source_id.clone(),
+                                SourceEvent::Change(change),
+                                chrono::Utc::now(),
+                                profiling,
+                            );
+
+                            // Dispatch event
+                            if let Err(e) = SourceBase::dispatch_from_task(
+                                self.dispatchers.clone(),
+                                wrapper,
+                                &self.source_id,
+                            )
+                            .await
+                            {
+                                // Log but continue - this just means no one is listening
+                                log::debug!("[{}] Failed to dispatch change: {}", self.source_id, e);
+                            }
+                        }
+                        Ok(None) => {
+                            // Event ignored (e.g. invalidate or filtered out)
+                        }
+                        Err(e) => {
+                            error!("Failed to convert change stream event: {e}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!("Change stream error: {e}"));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/components/sources/mongodb/src/stream.rs
+++ b/components/sources/mongodb/src/stream.rs
@@ -1,31 +1,33 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use futures::stream::StreamExt;
 use log::{error, info};
 use mongodb::{
     bson::Document,
-    options::{ChangeStreamOptions, ClientOptions, FullDocumentType},
+    options::{ChangeStreamOptions, ClientOptions},
     Client,
 };
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
-use tokio::time::sleep;
 
 use drasi_lib::channels::{
-    ChangeDispatcher, ComponentEventSender, ComponentStatus, SourceEvent, SourceEventWrapper,
+    ChangeDispatcher, ComponentStatus, SourceEvent, SourceEventWrapper,
 };
 use drasi_lib::sources::base::SourceBase;
 
 use crate::config::MongoSourceConfig;
 use crate::conversion::change_stream_event_to_source_change;
 
+use drasi_lib::state_store::StateStoreProvider;
+
 pub struct ReplicationStream {
     config: MongoSourceConfig,
     source_id: String,
     dispatchers: Arc<RwLock<Vec<Box<dyn ChangeDispatcher<SourceEventWrapper> + Send + Sync>>>>,
-    status_tx: Arc<RwLock<Option<ComponentEventSender>>>,
     status: Arc<RwLock<ComponentStatus>>,
     resume_token: Option<mongodb::change_stream::event::ResumeToken>,
+    shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+    state_store: Option<Arc<dyn StateStoreProvider>>,
 }
 
 impl ReplicationStream {
@@ -33,21 +35,40 @@ impl ReplicationStream {
         config: MongoSourceConfig,
         source_id: String,
         dispatchers: Arc<RwLock<Vec<Box<dyn ChangeDispatcher<SourceEventWrapper> + Send + Sync>>>>,
-        status_tx: Arc<RwLock<Option<ComponentEventSender>>>,
         status: Arc<RwLock<ComponentStatus>>,
+        shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+        state_store: Option<Arc<dyn StateStoreProvider>>,
     ) -> Self {
         Self {
             config,
             source_id,
             dispatchers,
-            status_tx,
             status,
             resume_token: None,
+            shutdown_rx,
+            state_store,
         }
     }
 
     pub async fn run(&mut self) -> Result<()> {
         info!("Starting MongoDB replication stream for source {}", self.source_id);
+
+        // Try to load resume token
+        if let Some(store) = &self.state_store {
+            match store.get(&self.source_id, "resume_token").await {
+                Ok(Some(bytes)) => {
+                    match mongodb::bson::from_slice(&bytes) {
+                        Ok(token) => {
+                            info!("Loaded resume token from state store");
+                            self.resume_token = Some(token);
+                        }
+                        Err(e) => error!("Failed to deserialize resume token: {e}"),
+                    }
+                }
+                Ok(None) => info!("No resume token found in state store"),
+                Err(e) => error!("Failed to load resume token: {e}"),
+            }
+        }
 
         loop {
             // Check for stop signal
@@ -60,9 +81,21 @@ impl ReplicationStream {
             }
 
             if let Err(e) = self.stream_loop().await {
+                // If the error is due to shutdown, we should exit
+                if self.shutdown_rx.try_recv().is_ok() {
+                    break;
+                }
+                
                 error!("Error in MongoDB stream loop: {e}");
                 // Simple backoff strategy
-                sleep(Duration::from_secs(5)).await;
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                // Check shutdown during sleep
+                if self.shutdown_rx.try_recv().is_ok() {
+                    break;
+                }
+            } else {
+                 // graceful exit
+                 break;
             }
         }
         
@@ -70,13 +103,34 @@ impl ReplicationStream {
     }
 
     async fn stream_loop(&mut self) -> Result<()> {
-        let client_options = ClientOptions::parse(&self.config.connection_string).await?;
+        let mut client_options = ClientOptions::parse(&self.config.connection_string).await?;
+
+        // Handle credentials override
+        let username = self.config.username.clone()
+            .or_else(|| std::env::var("MONGODB_USERNAME").ok());
+        let password = self.config.password.clone()
+            .or_else(|| std::env::var("MONGODB_PASSWORD").ok());
+
+        if let (Some(u), Some(p)) = (username, password) {
+            let credential = mongodb::options::Credential::builder()
+                .username(u)
+                .password(p)
+                .build();
+            client_options.credential = Some(credential);
+        }
+
         let client = Client::with_options(client_options)?;
-        let db = client.database(&self.config.database);
-        let collection = db.collection::<Document>(&self.config.collection);
+        
+        let db_name = self.config.database.as_ref().ok_or_else(|| anyhow::anyhow!("Database not configured"))?;
+        let db = client.database(db_name);
+
+        let collections = self.config.get_collections();
+        if collections.is_empty() {
+            return Err(anyhow::anyhow!("No collections configured"));
+        }
 
         let mut options = ChangeStreamOptions::builder()
-            .full_document(Some(FullDocumentType::UpdateLookup))
+            .full_document(Some(mongodb::options::FullDocumentType::UpdateLookup))
             .build();
         
         if let Some(token) = &self.resume_token {
@@ -84,60 +138,108 @@ impl ReplicationStream {
             options.resume_after = Some(token.clone());
         }
 
-        let pipeline = self.config.pipeline.clone().unwrap_or_default();
-        let mut stream = collection.watch(pipeline, Some(options)).await?;
+        info!("Starting change stream on database: {}, collections: {:?}", db_name, collections);
+
+        let mut stream = if collections.len() == 1 {
+            let col = db.collection::<Document>(&collections[0]);
+            col.watch(self.config.pipeline.clone().into_iter().flatten(), Some(options)).await?
+        } else {
+            let mut pipeline = self.config.pipeline.clone().unwrap_or_default();
+            
+            // Filter by collections
+            let filter = mongodb::bson::doc! {
+                "$match": {
+                    "ns.coll": { "$in": &collections }
+                }
+            };
+            pipeline.insert(0, filter);
+            
+            db.watch(pipeline, Some(options)).await?
+        };
 
         info!("Connected to MongoDB Change Stream");
 
-        while let Some(event_result) = stream.next().await {
-            // Check stop signal in inner loop
-             {
-                let status = self.status.read().await;
-                if *status == ComponentStatus::Stopping || *status == ComponentStatus::Stopped {
-                    break;
+        loop {
+            tokio::select! {
+                _ = self.shutdown_rx.recv() => {
+                    info!("Received shutdown signal");
+                    return Ok(());
                 }
-            }
-
-            match event_result {
-                Ok(event) => {
-                    // Update resume token
-                    self.resume_token = Some(event.id.clone());
-
-                    match change_stream_event_to_source_change(event, &self.source_id, &self.config.collection) {
-                        Ok(Some(change)) => {
-                            // Create profiling metadata
-                            let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
-                            profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
-
-                            let wrapper = SourceEventWrapper::with_profiling(
-                                self.source_id.clone(),
-                                SourceEvent::Change(change),
-                                chrono::Utc::now(),
-                                profiling,
-                            );
-
-                            // Dispatch event
-                            if let Err(e) = SourceBase::dispatch_from_task(
-                                self.dispatchers.clone(),
-                                wrapper,
-                                &self.source_id,
-                            )
-                            .await
+                event_result = stream.next() => {
+                    match event_result {
+                        Some(Ok(event)) => {
+                             // Check stop signal in inner loop - redundancy for safety
                             {
-                                // Log but continue - this just means no one is listening
-                                log::debug!("[{}] Failed to dispatch change: {}", self.source_id, e);
+                                let status = self.status.read().await;
+                                if *status == ComponentStatus::Stopping || *status == ComponentStatus::Stopped {
+                                    break;
+                                }
+                            }
+
+                            // Update resume token
+                            self.resume_token = Some(event.id.clone());
+                            
+                            // Persist resume token
+                            if let Some(store) = &self.state_store {
+                                match mongodb::bson::to_vec(&event.id) {
+                                    Ok(bytes) => {
+                                        if let Err(e) = store.set(&self.source_id, "resume_token", bytes).await {
+                                             error!("Failed to persist resume token: {e}");
+                                        }
+                                    }
+                                    Err(e) => error!("Failed to serialize resume token: {e}"),
+                                }
+                            }
+
+                            // Extract collection name from event
+                            // Invalidate events might lack ns, we skip them
+                            let collection_name = match &event.ns {
+                                Some(ns) => match &ns.coll {
+                                    Some(c) => c.clone(),
+                                    None => continue,
+                                },
+                                None => continue,
+                            };
+
+                            match change_stream_event_to_source_change(event, &self.source_id, &collection_name) {
+                                Ok(Some(change)) => {
+                                    // Create profiling metadata
+                                    let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
+                                    profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
+
+                                    let wrapper = SourceEventWrapper::with_profiling(
+                                        self.source_id.clone(),
+                                        SourceEvent::Change(change),
+                                        chrono::Utc::now(),
+                                        profiling,
+                                    );
+
+                                    // Dispatch event
+                                    if let Err(e) = SourceBase::dispatch_from_task(
+                                        self.dispatchers.clone(),
+                                        wrapper,
+                                        &self.source_id,
+                                    )
+                                    .await
+                                    {
+                                        log::debug!("[{}] Failed to dispatch change: {}", self.source_id, e);
+                                    }
+                                }
+                                Ok(None) => {
+                                    // Event ignored
+                                }
+                                Err(e) => {
+                                    error!("Failed to convert change stream event: {e}");
+                                }
                             }
                         }
-                        Ok(None) => {
-                            // Event ignored (e.g. invalidate or filtered out)
+                        Some(Err(e)) => {
+                             return Err(anyhow::anyhow!("Change stream error: {e}"));
                         }
-                        Err(e) => {
-                            error!("Failed to convert change stream event: {e}");
+                        None => {
+                            return Err(anyhow::anyhow!("Change stream ended unexpectedly"));
                         }
                     }
-                }
-                Err(e) => {
-                    return Err(anyhow::anyhow!("Change stream error: {e}"));
                 }
             }
         }

--- a/components/sources/mongodb/tests/end_to_end.rs
+++ b/components/sources/mongodb/tests/end_to_end.rs
@@ -158,11 +158,9 @@ async fn test_end_to_end_basic_pipeline() -> Result<()> {
     let collection = db.collection::<Document>(collection_name);
 
     // 2. Create Source
-    #[allow(deprecated)]
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: db_name.to_string(),
-        collection: None,
         collections: vec![collection_name.to_string()],
         pipeline: None,
         username: None,
@@ -284,11 +282,9 @@ async fn test_end_to_end_resume_persistence() -> Result<()> {
     let collection = db.collection::<Document>(collection_name);
 
     // 2. Create Source
-    #[allow(deprecated)]
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: db_name.to_string(),
-        collection: None,
         collections: vec![collection_name.to_string()],
         pipeline: None,
         username: None,
@@ -337,11 +333,9 @@ async fn test_end_to_end_resume_persistence() -> Result<()> {
 
     // 8. Recreate and restart
     println!("Restarting DrasiLib...");
-    #[allow(deprecated)]
     let config2 = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: db_name.to_string(),
-        collection: None,
         collections: vec![collection_name.to_string()],
         pipeline: None,
         username: None,
@@ -416,7 +410,6 @@ async fn test_end_to_end_multi_collection() -> Result<()> {
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: db_name.to_string(),
-        collection: None,
         collections: vec!["col1".to_string(), "col2".to_string()],
         pipeline: None,
         username: None,
@@ -525,11 +518,9 @@ async fn test_end_to_end_authentication() -> Result<()> {
     }, None).await?;
 
     // 2. Create Source with auth
-    #[allow(deprecated)]
     let config = MongoSourceConfig {
         connection_string: connection_string_no_auth.clone(),
         database: db_name.to_string(),
-        collection: None,
         collections: vec![collection_name.to_string()],
         pipeline: None,
         username: Some("drasi".to_string()),

--- a/components/sources/mongodb/tests/end_to_end.rs
+++ b/components/sources/mongodb/tests/end_to_end.rs
@@ -158,11 +158,12 @@ async fn test_end_to_end_basic_pipeline() -> Result<()> {
     let collection = db.collection::<Document>(collection_name);
 
     // 2. Create Source
+    #[allow(deprecated)]
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: Some(db_name.to_string()),
-        collection: Some(collection_name.to_string()),
-        collections: vec![],
+        collection: None,
+        collections: vec![collection_name.to_string()],
         pipeline: None,
         username: None,
         password: None,
@@ -283,11 +284,12 @@ async fn test_end_to_end_resume_persistence() -> Result<()> {
     let collection = db.collection::<Document>(collection_name);
 
     // 2. Create Source
+    #[allow(deprecated)]
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: Some(db_name.to_string()),
-        collection: Some(collection_name.to_string()),
-        collections: vec![],
+        collection: None,
+        collections: vec![collection_name.to_string()],
         pipeline: None,
         username: None,
         password: None,
@@ -335,11 +337,12 @@ async fn test_end_to_end_resume_persistence() -> Result<()> {
 
     // 8. Recreate and restart
     println!("Restarting DrasiLib...");
+    #[allow(deprecated)]
     let config2 = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: Some(db_name.to_string()),
-        collection: Some(collection_name.to_string()),
-        collections: vec![],
+        collection: None,
+        collections: vec![collection_name.to_string()],
         pipeline: None,
         username: None,
         password: None,
@@ -522,11 +525,12 @@ async fn test_end_to_end_authentication() -> Result<()> {
     }, None).await?;
 
     // 2. Create Source with auth
+    #[allow(deprecated)]
     let config = MongoSourceConfig {
         connection_string: connection_string_no_auth.clone(),
         database: Some(db_name.to_string()),
-        collection: Some(collection_name.to_string()),
-        collections: vec![],
+        collection: None,
+        collections: vec![collection_name.to_string()],
         pipeline: None,
         username: Some("drasi".to_string()),
         password: Some("drasi_password".to_string()),

--- a/components/sources/mongodb/tests/end_to_end.rs
+++ b/components/sources/mongodb/tests/end_to_end.rs
@@ -1,0 +1,485 @@
+use anyhow::Result;
+use drasi_core::{
+    evaluation::context::QueryPartEvaluationContext,
+    query::{ContinuousQuery, QueryBuilder},
+};
+use drasi_lib::channels::{ChangeDispatcher, ChangeReceiver, SourceEvent, SourceEventWrapper};
+use drasi_source_mongodb::config::MongoSourceConfig;
+use drasi_source_mongodb::MongoSource;
+use drasi_lib::Source;
+use mongodb::bson::{doc, Document};
+use mongodb::Client;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use testcontainers::{core::{ContainerPort, WaitFor}, runners::AsyncRunner, GenericImage, ImageExt};
+
+// Validates that the source sends events to the query
+#[derive(Clone)]
+struct QueryDispatcher {
+    query: Arc<RwLock<ContinuousQuery>>,
+    results: Arc<RwLock<Vec<QueryPartEvaluationContext>>>,
+}
+
+impl QueryDispatcher {
+    fn new(query: Arc<RwLock<ContinuousQuery>>) -> Self {
+        Self {
+            query,
+            results: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+    
+    async fn get_results(&self) -> Vec<QueryPartEvaluationContext> {
+        self.results.read().await.clone()
+    }
+    
+    async fn clear_results(&self) {
+        self.results.write().await.clear();
+    }
+}
+
+#[async_trait::async_trait]
+impl ChangeDispatcher<SourceEventWrapper> for QueryDispatcher {
+    async fn dispatch_change(&self, event: Arc<SourceEventWrapper>) -> Result<()> {
+        if let SourceEvent::Change(change) = &event.event {
+            let result = self.query.write().await.process_source_change(change.clone()).await?;
+            let mut results = self.results.write().await;
+            results.extend(result);
+        }
+        Ok(())
+    }
+
+    async fn create_receiver(&self) -> Result<Box<dyn ChangeReceiver<SourceEventWrapper>>> {
+        Err(anyhow::anyhow!("Not implemented for E2E test"))
+    }
+}
+
+async fn wait_for_result(dispatcher: &QueryDispatcher, min_count: usize) -> Result<()> {
+    for _ in 0..20 {
+        if dispatcher.get_results().await.len() >= min_count {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    Err(anyhow::anyhow!("Timeout waiting for query results"))
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_end_to_end_basic_pipeline() -> Result<()> {
+    // 1. Setup Mongo
+    let container = GenericImage::new("mongo", "5.0")
+        .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"))
+        .with_exposed_port(ContainerPort::Tcp(27017))
+        .with_cmd(vec!["mongod", "--replSet", "rs0", "--bind_ip_all"])
+        .start()
+        .await?;
+    let port = container.get_host_port_ipv4(27017).await?;
+    let connection_string = format!("mongodb://127.0.0.1:{}", port);
+    
+    let client = Client::with_uri_str(&connection_string).await?;
+    let _ = client.database("admin").run_command(doc! { "replSetInitiate": {} }, None).await;
+    
+    // Wait for primary
+    for _ in 0..30 {
+        if let Ok(status) = client.database("admin").run_command(doc! { "replSetGetStatus": 1 }, None).await {
+            if let Ok(members) = status.get_array("members") {
+                if let Some(member) = members.first() {
+                    if let Some(state_str) = member.as_document().and_then(|d| d.get_str("stateStr").ok()) {
+                        if state_str == "PRIMARY" {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let db_name = "e2e_db";
+    let collection_name = "users";
+    let db = client.database(db_name);
+    let collection = db.collection::<Document>(collection_name);
+
+    // 2. Setup Query
+    // Query: MATCH (u:users) WHERE u.age > 20 RETURN u.name
+    use drasi_core::evaluation::functions::FunctionRegistry;
+    use drasi_query_cypher::CypherParser;
+    use drasi_functions_cypher::CypherFunctionSet;
+
+    let query_str = "MATCH (u:users) WHERE u.age > 20 RETURN u.name";
+    
+    let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+    let parser = Arc::new(CypherParser::new(function_registry.clone()));
+    let builder = QueryBuilder::new(query_str, parser)
+        .with_function_registry(function_registry);
+    
+    let query = Arc::new(RwLock::new(builder.build().await));
+    let dispatcher = QueryDispatcher::new(query.clone());
+
+    // 3. Setup Source
+    let config = MongoSourceConfig {
+        connection_string: connection_string.clone(),
+        database: Some(db_name.to_string()),
+        collection: Some(collection_name.to_string()),
+        collections: vec![],
+        pipeline: None,
+        username: None,
+        password: None,
+    };
+
+    let source = MongoSource::new("e2e-source", config)?;
+    source.base.dispatchers.write().await.push(Box::new(dispatcher.clone()));
+    
+    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
+    let (status_tx, _status_rx) = tokio::sync::mpsc::channel(100);
+    let context = drasi_lib::context::SourceRuntimeContext::new(
+        "e2e-source",
+        status_tx,
+        Some(state_store.clone()),
+    );
+    source.initialize(context).await;
+
+    println!("Starting source...");
+    source.start().await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // 4. Test Interactions
+    
+    // A. Insert matching user (Alice, 25) -> Expect Adding
+    println!("Inserting Alice (25)...");
+    collection.insert_one(doc! { "name": "Alice", "age": 25 }, None).await?;
+    
+    wait_for_result(&dispatcher, 1).await?;
+    let results = dispatcher.get_results().await;
+    assert_eq!(results.len(), 1);
+    match &results[0] {
+        QueryPartEvaluationContext::Adding { after } => {
+            println!("Result: {:?}", after);
+            // Verify content
+        },
+        _ => panic!("Expected Adding result, got {:?}", results[0]),
+    }
+    dispatcher.clear_results().await;
+    
+    // B. Insert non-matching user (Bob, 15) -> Expect No Result
+    println!("Inserting Bob (15)...");
+    collection.insert_one(doc! { "name": "Bob", "age": 15 }, None).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let results = dispatcher.get_results().await;
+    assert_eq!(results.len(), 0);
+    
+    // C. Update Alice (age 25 -> 30) -> Expect Updating
+    println!("Updating Alice (25 -> 30)...");
+    collection.update_one(doc! { "name": "Alice" }, doc! { "$set": { "age": 30 } }, None).await?;
+    
+    wait_for_result(&dispatcher, 1).await?;
+    let results = dispatcher.get_results().await;
+    assert_eq!(results.len(), 1);
+    match &results[0] {
+        QueryPartEvaluationContext::Updating { .. } => {},
+        _ => panic!("Expected Updating result, got {:?}", results[0]),
+    }
+    dispatcher.clear_results().await;
+    
+    // D. Update Alice (age 30 -> 10) -> Expect Removing
+    println!("Updating Alice (30 -> 10)...");
+    collection.update_one(doc! { "name": "Alice" }, doc! { "$set": { "age": 10 } }, None).await?;
+    
+    wait_for_result(&dispatcher, 1).await?;
+    let results = dispatcher.get_results().await;
+    assert_eq!(results.len(), 1);
+    match &results[0] {
+        QueryPartEvaluationContext::Removing { .. } => {},
+        _ => panic!("Expected Removing result, got {:?}", results[0]),
+    }
+    dispatcher.clear_results().await;
+    
+    source.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_end_to_end_resume_persistence() -> Result<()> {
+    // 1. Setup Mongo & Query (Similar to above)
+     let container = GenericImage::new("mongo", "5.0")
+        .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"))
+        .with_exposed_port(ContainerPort::Tcp(27017))
+        .with_cmd(vec!["mongod", "--replSet", "rs0", "--bind_ip_all"])
+        .start()
+        .await?;
+    let port = container.get_host_port_ipv4(27017).await?;
+    let connection_string = format!("mongodb://127.0.0.1:{}", port);
+    
+    let client = Client::with_uri_str(&connection_string).await?;
+    let _ = client.database("admin").run_command(doc! { "replSetInitiate": {} }, None).await;
+    for _ in 0..30 {
+        if let Ok(status) = client.database("admin").run_command(doc! { "replSetGetStatus": 1 }, None).await {
+            if let Ok(members) = status.get_array("members") {
+                if let Some(member) = members.first() {
+                    if let Some(state_str) = member.as_document().and_then(|d| d.get_str("stateStr").ok()) {
+                        if state_str == "PRIMARY" { break; }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let db_name = "resume_db";
+    let collection_name = "resume_col";
+    let db = client.database(db_name);
+    let collection = db.collection::<Document>(collection_name);
+
+    // Query setup
+    use drasi_core::evaluation::functions::FunctionRegistry;
+    use drasi_query_cypher::CypherParser;
+    use drasi_functions_cypher::CypherFunctionSet;
+
+    let query_str = "MATCH (n:resume_col) RETURN n.val";
+    let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+    let parser = Arc::new(CypherParser::new(function_registry.clone()));
+    let builder = QueryBuilder::new(query_str, parser).with_function_registry(function_registry);
+    let query = Arc::new(RwLock::new(builder.build().await));
+    let dispatcher = QueryDispatcher::new(query.clone());
+
+    // Source Setup with State Store
+    let config = MongoSourceConfig {
+        connection_string: connection_string.clone(),
+        database: Some(db_name.to_string()),
+        collection: Some(collection_name.to_string()),
+        collections: vec![],
+        pipeline: None,
+        username: None,
+        password: None,
+    };
+
+    let source = MongoSource::new("resume-source", config)?;
+    source.base.dispatchers.write().await.push(Box::new(dispatcher.clone()));
+    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
+    
+    let (status_tx, _status_rx) = tokio::sync::mpsc::channel(100);
+    source.initialize(drasi_lib::context::SourceRuntimeContext::new("resume-source", status_tx.clone(), Some(state_store.clone()))).await;
+
+    source.start().await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Insert item 1
+    collection.insert_one(doc! { "val": 1 }, None).await?;
+    wait_for_result(&dispatcher, 1).await?;
+    dispatcher.clear_results().await;
+
+    // Stop Source
+    println!("Stopping source...");
+    source.stop().await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Insert item 2 while stopped
+    println!("Inserting item 2 (offline)...");
+    collection.insert_one(doc! { "val": 2 }, None).await?;
+
+    // Restart Source
+    println!("Restarting source...");
+    // We need to create a new source instance because the old one is consumed/stopped state? 
+    // Usually `start` is re-entrant if designed well, but `stream.rs` loop breaks. 
+    // We can call `start` again on the same instance? 
+    // `MongoSource::start` checks if running. if stopped, it spawns new task.
+    source.start().await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Verify item 2 is picked up
+    wait_for_result(&dispatcher, 1).await?;
+    let results = dispatcher.get_results().await;
+    assert_eq!(results.len(), 1);
+    // Logic: If resume token worked, we see item 2.
+    // If it failed/ignored, we might see it (because it scans form now?), No, change stream "now" misses past events.
+    // So seeing it proves resume worked (or at least we started from before).
+    
+    source.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_end_to_end_multi_collection() -> Result<()> {
+    // 1. Setup Mongo & Query
+    let container = GenericImage::new("mongo", "5.0")
+        .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"))
+        .with_exposed_port(ContainerPort::Tcp(27017))
+        .with_cmd(vec!["mongod", "--replSet", "rs0", "--bind_ip_all"])
+        .start()
+        .await?;
+    let port = container.get_host_port_ipv4(27017).await?;
+    let connection_string = format!("mongodb://127.0.0.1:{}", port);
+    
+    let client = Client::with_uri_str(&connection_string).await?;
+    let _ = client.database("admin").run_command(doc! { "replSetInitiate": {} }, None).await;
+    for _ in 0..30 {
+        if let Ok(status) = client.database("admin").run_command(doc! { "replSetGetStatus": 1 }, None).await {
+            if let Ok(members) = status.get_array("members") {
+                if let Some(member) = members.first() {
+                    if let Some(state_str) = member.as_document().and_then(|d| d.get_str("stateStr").ok()) {
+                        if state_str == "PRIMARY" { break; }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let db_name = "multi_col_db";
+    let db = client.database(db_name);
+    let col1 = db.collection::<Document>("col1");
+    let col2 = db.collection::<Document>("col2");
+    let col3 = db.collection::<Document>("col3"); // Unwatched
+
+    // Query: MATCH (n) WHERE n:col1 OR n:col2 RETURN n.val
+    use drasi_core::evaluation::functions::FunctionRegistry;
+    use drasi_query_cypher::CypherParser;
+    use drasi_functions_cypher::CypherFunctionSet;
+
+    let query_str = "MATCH (n) WHERE n:col1 OR n:col2 RETURN n.val";
+    let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+    let parser = Arc::new(CypherParser::new(function_registry.clone()));
+    let builder = QueryBuilder::new(query_str, parser).with_function_registry(function_registry);
+    let query = Arc::new(RwLock::new(builder.build().await));
+    let dispatcher = QueryDispatcher::new(query.clone());
+
+    // Source Setup
+    let config = MongoSourceConfig {
+        connection_string: connection_string.clone(),
+        database: Some(db_name.to_string()),
+        collection: None,
+        collections: vec!["col1".to_string(), "col2".to_string()],
+        pipeline: None,
+        username: None,
+        password: None,
+    };
+
+    let source = MongoSource::new("multi-source", config)?;
+    source.base.dispatchers.write().await.push(Box::new(dispatcher.clone()));
+    
+    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
+    let (status_tx, _status_rx) = tokio::sync::mpsc::channel(100);
+    source.initialize(drasi_lib::context::SourceRuntimeContext::new("multi-source", status_tx, Some(state_store))).await;
+
+    source.start().await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Test Interactions
+    println!("Inserting into col1...");
+    col1.insert_one(doc! { "val": "from_col1" }, None).await?;
+    wait_for_result(&dispatcher, 1).await?;
+    let results = dispatcher.get_results().await;
+    assert_eq!(results.len(), 1);
+    dispatcher.clear_results().await;
+
+    println!("Inserting into col2...");
+    col2.insert_one(doc! { "val": "from_col2" }, None).await?;
+    wait_for_result(&dispatcher, 1).await?;
+    let results = dispatcher.get_results().await;
+    assert_eq!(results.len(), 1);
+    dispatcher.clear_results().await;
+
+    println!("Inserting into col3 (ignored)...");
+    col3.insert_one(doc! { "val": "from_col3" }, None).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let results = dispatcher.get_results().await;
+    assert_eq!(results.len(), 0);
+
+    source.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_end_to_end_authentication() -> Result<()> {
+    // 1. Setup Mongo with Auth
+    let image = GenericImage::new("mongo", "5.0")
+        .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"))
+        .with_exposed_port(ContainerPort::Tcp(27017))
+        .with_entrypoint("bash")
+        .with_env_var("MONGO_INITDB_ROOT_USERNAME", "admin")
+        .with_env_var("MONGO_INITDB_ROOT_PASSWORD", "password");
+        
+    let container = image
+        .with_cmd(vec!["-c", "echo \"verysecretkey123\" > /tmp/keyfile && chmod 400 /tmp/keyfile && chown mongodb:mongodb /tmp/keyfile && mongod --replSet rs0 --bind_ip_all --auth --keyFile /tmp/keyfile"])
+        .start()
+        .await?;
+    
+    let port = container.get_host_port_ipv4(27017).await?;
+    let connection_string_no_auth = format!("mongodb://127.0.0.1:{}", port);
+    let connection_string_auth = format!("mongodb://admin:password@127.0.0.1:{}", port);
+    
+    let client_options = mongodb::options::ClientOptions::parse(&connection_string_auth).await?;
+    let client = Client::with_options(client_options)?;
+    let _ = client.database("admin").run_command(doc! { "replSetInitiate": {} }, None).await;
+
+    // Wait for primary
+    for _ in 0..30 {
+        if let Ok(status) = client.database("admin").run_command(doc! { "replSetGetStatus": 1 }, None).await {
+            if let Ok(members) = status.get_array("members") {
+                if let Some(member) = members.first() {
+                    if let Some(state_str) = member.as_document().and_then(|d| d.get_str("stateStr").ok()) {
+                        if state_str == "PRIMARY" { break; }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let db_name = "auth_test_db";
+    let collection_name = "auth_col";
+    let db = client.database(db_name);
+    let collection = db.collection::<Document>(collection_name);
+
+    // Create user
+    client.database("admin").run_command(doc! {
+        "createUser": "drasi",
+        "pwd": "drasi_password",
+        "roles": [ "root" ]
+    }, None).await?;
+
+    // Query Setup
+    use drasi_core::evaluation::functions::FunctionRegistry;
+    use drasi_query_cypher::CypherParser;
+    use drasi_functions_cypher::CypherFunctionSet;
+
+    let query_str = "MATCH (n:auth_col) RETURN n.msg";
+    let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+    let parser = Arc::new(CypherParser::new(function_registry.clone()));
+    let builder = QueryBuilder::new(query_str, parser).with_function_registry(function_registry);
+    let query = Arc::new(RwLock::new(builder.build().await));
+    let dispatcher = QueryDispatcher::new(query.clone());
+
+    // Source Setup - Use Config Overrides
+    let config = MongoSourceConfig {
+        connection_string: connection_string_no_auth.clone(), // No auth in string
+        database: Some(db_name.to_string()),
+        collection: Some(collection_name.to_string()),
+        collections: vec![],
+        pipeline: None,
+        username: Some("drasi".to_string()),     // Auth in Config
+        password: Some("drasi_password".to_string()), 
+    };
+
+    let source = MongoSource::new("auth-source", config)?;
+    source.base.dispatchers.write().await.push(Box::new(dispatcher.clone()));
+    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
+    source.initialize(drasi_lib::context::SourceRuntimeContext::new("auth-source", tokio::sync::mpsc::channel(100).0, Some(state_store))).await;
+
+    source.start().await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Test Interaction
+    println!("Inserting authenticated...");
+    collection.insert_one(doc! { "msg": "secure_data" }, None).await?;
+    wait_for_result(&dispatcher, 1).await?;
+    let results = dispatcher.get_results().await;
+    assert_eq!(results.len(), 1);
+
+    source.stop().await?;
+    Ok(())
+}

--- a/components/sources/mongodb/tests/end_to_end.rs
+++ b/components/sources/mongodb/tests/end_to_end.rs
@@ -161,7 +161,7 @@ async fn test_end_to_end_basic_pipeline() -> Result<()> {
     #[allow(deprecated)]
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
-        database: Some(db_name.to_string()),
+        database: db_name.to_string(),
         collection: None,
         collections: vec![collection_name.to_string()],
         pipeline: None,
@@ -287,7 +287,7 @@ async fn test_end_to_end_resume_persistence() -> Result<()> {
     #[allow(deprecated)]
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
-        database: Some(db_name.to_string()),
+        database: db_name.to_string(),
         collection: None,
         collections: vec![collection_name.to_string()],
         pipeline: None,
@@ -340,7 +340,7 @@ async fn test_end_to_end_resume_persistence() -> Result<()> {
     #[allow(deprecated)]
     let config2 = MongoSourceConfig {
         connection_string: connection_string.clone(),
-        database: Some(db_name.to_string()),
+        database: db_name.to_string(),
         collection: None,
         collections: vec![collection_name.to_string()],
         pipeline: None,
@@ -415,7 +415,7 @@ async fn test_end_to_end_multi_collection() -> Result<()> {
     // 2. Create Source
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
-        database: Some(db_name.to_string()),
+        database: db_name.to_string(),
         collection: None,
         collections: vec!["col1".to_string(), "col2".to_string()],
         pipeline: None,
@@ -528,7 +528,7 @@ async fn test_end_to_end_authentication() -> Result<()> {
     #[allow(deprecated)]
     let config = MongoSourceConfig {
         connection_string: connection_string_no_auth.clone(),
-        database: Some(db_name.to_string()),
+        database: db_name.to_string(),
         collection: None,
         collections: vec![collection_name.to_string()],
         pipeline: None,

--- a/components/sources/mongodb/tests/end_to_end.rs
+++ b/components/sources/mongodb/tests/end_to_end.rs
@@ -1,62 +1,118 @@
 use anyhow::Result;
-use drasi_core::{
-    evaluation::context::QueryPartEvaluationContext,
-    query::{ContinuousQuery, QueryBuilder},
-};
-use drasi_lib::channels::{ChangeDispatcher, ChangeReceiver, SourceEvent, SourceEventWrapper};
+use async_trait::async_trait;
+use drasi_lib::channels::{ComponentStatus, ResultDiff};
+use drasi_lib::context::ReactionRuntimeContext;
+use drasi_lib::reactions::{ReactionBase, ReactionBaseParams};
+use drasi_lib::{DrasiLib, Query, Reaction};
 use drasi_source_mongodb::config::MongoSourceConfig;
 use drasi_source_mongodb::MongoSource;
-use drasi_lib::Source;
 use mongodb::bson::{doc, Document};
 use mongodb::Client;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use testcontainers::{core::{ContainerPort, WaitFor}, runners::AsyncRunner, GenericImage, ImageExt};
 
-// Validates that the source sends events to the query
-#[derive(Clone)]
-struct QueryDispatcher {
-    query: Arc<RwLock<ContinuousQuery>>,
-    results: Arc<RwLock<Vec<QueryPartEvaluationContext>>>,
+// Shared results container
+type ResultsHandle = Arc<RwLock<Vec<ResultDiff>>>;
+
+// TestReaction: A simple reaction for collecting query results in tests
+struct TestReaction {
+    base: ReactionBase,
+    results: ResultsHandle,
 }
 
-impl QueryDispatcher {
-    fn new(query: Arc<RwLock<ContinuousQuery>>) -> Self {
-        Self {
-            query,
-            results: Arc::new(RwLock::new(Vec::new())),
-        }
-    }
-    
-    async fn get_results(&self) -> Vec<QueryPartEvaluationContext> {
-        self.results.read().await.clone()
-    }
-    
-    async fn clear_results(&self) {
-        self.results.write().await.clear();
+impl TestReaction {
+    fn build(id: impl Into<String>, queries: Vec<String>) -> Result<(Self, ResultsHandle)> {
+        let params = ReactionBaseParams::new(id, queries);
+        let results = Arc::new(RwLock::new(Vec::new()));
+        Ok((
+            Self {
+                base: ReactionBase::new(params),
+                results: results.clone(),
+            },
+            results,
+        ))
     }
 }
 
-#[async_trait::async_trait]
-impl ChangeDispatcher<SourceEventWrapper> for QueryDispatcher {
-    async fn dispatch_change(&self, event: Arc<SourceEventWrapper>) -> Result<()> {
-        if let SourceEvent::Change(change) = &event.event {
-            let result = self.query.write().await.process_source_change(change.clone()).await?;
-            let mut results = self.results.write().await;
-            results.extend(result);
-        }
+#[async_trait]
+impl Reaction for TestReaction {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "test"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+
+    fn query_ids(&self) -> Vec<String> {
+        self.base.queries.clone()
+    }
+
+    fn auto_start(&self) -> bool {
+        self.base.get_auto_start()
+    }
+
+    async fn initialize(&self, context: ReactionRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.base
+            .set_status_with_event(ComponentStatus::Starting, Some("Starting test reaction".to_string()))
+            .await?;
+
+        self.base.subscribe_to_queries().await?;
+
+        self.base
+            .set_status_with_event(ComponentStatus::Running, Some("Test reaction started".to_string()))
+            .await?;
+
+        let priority_queue = self.base.priority_queue.clone();
+        let results = self.results.clone();
+        let mut shutdown_rx = self.base.create_shutdown_channel().await;
+
+        let processing_task = tokio::spawn(async move {
+            loop {
+                let query_result_arc = tokio::select! {
+                    biased;
+                    _ = &mut shutdown_rx => break,
+                    result = priority_queue.dequeue() => result,
+                };
+
+                // Collect all results
+                for result_diff in &query_result_arc.results {
+                    results.write().await.push(result_diff.clone());
+                }
+            }
+        });
+
+        self.base.set_processing_task(processing_task).await;
         Ok(())
     }
 
-    async fn create_receiver(&self) -> Result<Box<dyn ChangeReceiver<SourceEventWrapper>>> {
-        Err(anyhow::anyhow!("Not implemented for E2E test"))
+    async fn stop(&self) -> Result<()> {
+        self.base.stop_common().await?;
+        self.base
+            .set_status_with_event(ComponentStatus::Stopped, Some("Test reaction stopped".to_string()))
+            .await?;
+        Ok(())
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
     }
 }
 
-async fn wait_for_result(dispatcher: &QueryDispatcher, min_count: usize) -> Result<()> {
+async fn wait_for_result(results: &ResultsHandle, min_count: usize) -> Result<()> {
     for _ in 0..20 {
-        if dispatcher.get_results().await.len() >= min_count {
+        if results.read().await.len() >= min_count {
             return Ok(());
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -101,23 +157,7 @@ async fn test_end_to_end_basic_pipeline() -> Result<()> {
     let db = client.database(db_name);
     let collection = db.collection::<Document>(collection_name);
 
-    // 2. Setup Query
-    // Query: MATCH (u:users) WHERE u.age > 20 RETURN u.name
-    use drasi_core::evaluation::functions::FunctionRegistry;
-    use drasi_query_cypher::CypherParser;
-    use drasi_functions_cypher::CypherFunctionSet;
-
-    let query_str = "MATCH (u:users) WHERE u.age > 20 RETURN u.name";
-    
-    let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
-    let parser = Arc::new(CypherParser::new(function_registry.clone()));
-    let builder = QueryBuilder::new(query_str, parser)
-        .with_function_registry(function_registry);
-    
-    let query = Arc::new(RwLock::new(builder.build().await));
-    let dispatcher = QueryDispatcher::new(query.clone());
-
-    // 3. Setup Source
+    // 2. Create Source
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: Some(db_name.to_string()),
@@ -127,83 +167,93 @@ async fn test_end_to_end_basic_pipeline() -> Result<()> {
         username: None,
         password: None,
     };
-
     let source = MongoSource::new("e2e-source", config)?;
-    source.base.dispatchers.write().await.push(Box::new(dispatcher.clone()));
-    
-    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
-    let (status_tx, _status_rx) = tokio::sync::mpsc::channel(100);
-    let context = drasi_lib::context::SourceRuntimeContext::new(
-        "e2e-source",
-        status_tx,
-        Some(state_store.clone()),
-    );
-    source.initialize(context).await;
 
-    println!("Starting source...");
-    source.start().await?;
+    // 3. Create Query
+    let query = Query::cypher("e2e-query")
+        .query("MATCH (u:users) WHERE u.age > 20 RETURN u.name")
+        .from_source("e2e-source")
+        .auto_start(true)
+        .build();
+
+    // 4. Create TestReaction
+    let (test_reaction, results_handle) = TestReaction::build("test-reaction", vec!["e2e-query".to_string()])?;
+
+    // 5. Build DrasiLib
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("e2e-test")
+            .with_source(source)
+            .with_query(query)
+            .with_reaction(test_reaction)
+            .build()
+            .await?
+    );
+
+    // 6. Start the pipeline
+    println!("Starting DrasiLib...");
+    core.start().await?;
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    // 4. Test Interactions
+    // 7. Test Interactions
     
     // A. Insert matching user (Alice, 25) -> Expect Adding
     println!("Inserting Alice (25)...");
     collection.insert_one(doc! { "name": "Alice", "age": 25 }, None).await?;
     
-    wait_for_result(&dispatcher, 1).await?;
-    let results = dispatcher.get_results().await;
+    wait_for_result(&results_handle, 1).await?;
+    let results = results_handle.read().await.clone();
     assert_eq!(results.len(), 1);
     match &results[0] {
-        QueryPartEvaluationContext::Adding { after } => {
-            println!("Result: {:?}", after);
+        ResultDiff::Add { data } => {
+            println!("Result: {:?}", data);
             // Verify content
         },
-        _ => panic!("Expected Adding result, got {:?}", results[0]),
+        _ => panic!("Expected Add result, got {:?}", results[0]),
     }
-    dispatcher.clear_results().await;
+    results_handle.write().await.clear();
     
     // B. Insert non-matching user (Bob, 15) -> Expect No Result
     println!("Inserting Bob (15)...");
     collection.insert_one(doc! { "name": "Bob", "age": 15 }, None).await?;
     tokio::time::sleep(Duration::from_secs(1)).await;
-    let results = dispatcher.get_results().await;
+    let results = results_handle.read().await.clone();
     assert_eq!(results.len(), 0);
     
     // C. Update Alice (age 25 -> 30) -> Expect Updating
     println!("Updating Alice (25 -> 30)...");
     collection.update_one(doc! { "name": "Alice" }, doc! { "$set": { "age": 30 } }, None).await?;
     
-    wait_for_result(&dispatcher, 1).await?;
-    let results = dispatcher.get_results().await;
+    wait_for_result(&results_handle, 1).await?;
+    let results = results_handle.read().await.clone();
     assert_eq!(results.len(), 1);
     match &results[0] {
-        QueryPartEvaluationContext::Updating { .. } => {},
-        _ => panic!("Expected Updating result, got {:?}", results[0]),
+        ResultDiff::Update { .. } => {},
+        _ => panic!("Expected Update result, got {:?}", results[0]),
     }
-    dispatcher.clear_results().await;
+    results_handle.write().await.clear();
     
     // D. Update Alice (age 30 -> 10) -> Expect Removing
     println!("Updating Alice (30 -> 10)...");
     collection.update_one(doc! { "name": "Alice" }, doc! { "$set": { "age": 10 } }, None).await?;
     
-    wait_for_result(&dispatcher, 1).await?;
-    let results = dispatcher.get_results().await;
+    wait_for_result(&results_handle, 1).await?;
+    let results = results_handle.read().await.clone();
     assert_eq!(results.len(), 1);
     match &results[0] {
-        QueryPartEvaluationContext::Removing { .. } => {},
-        _ => panic!("Expected Removing result, got {:?}", results[0]),
+        ResultDiff::Delete { .. } => {},
+        _ => panic!("Expected Delete result, got {:?}", results[0]),
     }
-    dispatcher.clear_results().await;
     
-    source.stop().await?;
+    core.stop().await?;
     Ok(())
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_end_to_end_resume_persistence() -> Result<()> {
-    // 1. Setup Mongo & Query (Similar to above)
-     let container = GenericImage::new("mongo", "5.0")
+    // 1. Setup Mongo
+    let container = GenericImage::new("mongo", "5.0")
         .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"))
         .with_exposed_port(ContainerPort::Tcp(27017))
         .with_cmd(vec!["mongod", "--replSet", "rs0", "--bind_ip_all"])
@@ -232,19 +282,7 @@ async fn test_end_to_end_resume_persistence() -> Result<()> {
     let db = client.database(db_name);
     let collection = db.collection::<Document>(collection_name);
 
-    // Query setup
-    use drasi_core::evaluation::functions::FunctionRegistry;
-    use drasi_query_cypher::CypherParser;
-    use drasi_functions_cypher::CypherFunctionSet;
-
-    let query_str = "MATCH (n:resume_col) RETURN n.val";
-    let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
-    let parser = Arc::new(CypherParser::new(function_registry.clone()));
-    let builder = QueryBuilder::new(query_str, parser).with_function_registry(function_registry);
-    let query = Arc::new(RwLock::new(builder.build().await));
-    let dispatcher = QueryDispatcher::new(query.clone());
-
-    // Source Setup with State Store
+    // 2. Create Source
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: Some(db_name.to_string()),
@@ -254,56 +292,93 @@ async fn test_end_to_end_resume_persistence() -> Result<()> {
         username: None,
         password: None,
     };
-
     let source = MongoSource::new("resume-source", config)?;
-    source.base.dispatchers.write().await.push(Box::new(dispatcher.clone()));
-    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
-    
-    let (status_tx, _status_rx) = tokio::sync::mpsc::channel(100);
-    source.initialize(drasi_lib::context::SourceRuntimeContext::new("resume-source", status_tx.clone(), Some(state_store.clone()))).await;
 
-    source.start().await?;
+    // 3. Create Query
+    let query = Query::cypher("resume-query")
+        .query("MATCH (n:resume_col) RETURN n.val")
+        .from_source("resume-source")
+        .auto_start(true)
+        .build();
+
+    // 4. Create TestReaction
+    let (test_reaction, results_handle) = TestReaction::build("test-reaction", vec!["resume-query".to_string()])?;
+
+    // 5. Build DrasiLib with state store
+    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("resume-test")
+            .with_state_store_provider(state_store.clone())
+            .with_source(source)
+            .with_query(query)
+            .with_reaction(test_reaction)
+            .build()
+            .await?
+    );
+
+    // 6. Start, insert, stop
+    core.start().await?;
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    // Insert item 1
     collection.insert_one(doc! { "val": 1 }, None).await?;
-    wait_for_result(&dispatcher, 1).await?;
-    dispatcher.clear_results().await;
+    wait_for_result(&results_handle, 1).await?;
+    results_handle.write().await.clear();
 
-    // Stop Source
-    println!("Stopping source...");
-    source.stop().await?;
+    println!("Stopping DrasiLib...");
+    core.stop().await?;
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    // Insert item 2 while stopped
+    // 7. Insert while stopped
     println!("Inserting item 2 (offline)...");
     collection.insert_one(doc! { "val": 2 }, None).await?;
 
-    // Restart Source
-    println!("Restarting source...");
-    // We need to create a new source instance because the old one is consumed/stopped state? 
-    // Usually `start` is re-entrant if designed well, but `stream.rs` loop breaks. 
-    // We can call `start` again on the same instance? 
-    // `MongoSource::start` checks if running. if stopped, it spawns new task.
-    source.start().await?;
+    // 8. Recreate and restart
+    println!("Restarting DrasiLib...");
+    let config2 = MongoSourceConfig {
+        connection_string: connection_string.clone(),
+        database: Some(db_name.to_string()),
+        collection: Some(collection_name.to_string()),
+        collections: vec![],
+        pipeline: None,
+        username: None,
+        password: None,
+    };
+    let source2 = MongoSource::new("resume-source", config2)?;
+    let query2 = Query::cypher("resume-query")
+        .query("MATCH (n:resume_col) RETURN n.val")
+        .from_source("resume-source")
+        .auto_start(true)
+        .build();
+    let (test_reaction2, results_handle2) = TestReaction::build("test-reaction", vec!["resume-query".to_string()])?;
+
+    let core2 = Arc::new(
+        DrasiLib::builder()
+            .with_id("resume-test")
+            .with_state_store_provider(state_store)
+            .with_source(source2)
+            .with_query(query2)
+            .with_reaction(test_reaction2)
+            .build()
+            .await?
+    );
+
+    core2.start().await?;
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    // Verify item 2 is picked up
-    wait_for_result(&dispatcher, 1).await?;
-    let results = dispatcher.get_results().await;
+    //9. Verify item 2 is picked up
+    wait_for_result(&results_handle2, 1).await?;
+    let results = results_handle2.read().await.clone();
     assert_eq!(results.len(), 1);
-    // Logic: If resume token worked, we see item 2.
-    // If it failed/ignored, we might see it (because it scans form now?), No, change stream "now" misses past events.
-    // So seeing it proves resume worked (or at least we started from before).
     
-    source.stop().await?;
+    core2.stop().await?;
     Ok(())
 }
 
 #[tokio::test]
 #[ignore]
 async fn test_end_to_end_multi_collection() -> Result<()> {
-    // 1. Setup Mongo & Query
+    // 1. Setup Mongo
     let container = GenericImage::new("mongo", "5.0")
         .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"))
         .with_exposed_port(ContainerPort::Tcp(27017))
@@ -334,19 +409,7 @@ async fn test_end_to_end_multi_collection() -> Result<()> {
     let col2 = db.collection::<Document>("col2");
     let col3 = db.collection::<Document>("col3"); // Unwatched
 
-    // Query: MATCH (n) WHERE n:col1 OR n:col2 RETURN n.val
-    use drasi_core::evaluation::functions::FunctionRegistry;
-    use drasi_query_cypher::CypherParser;
-    use drasi_functions_cypher::CypherFunctionSet;
-
-    let query_str = "MATCH (n) WHERE n:col1 OR n:col2 RETURN n.val";
-    let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
-    let parser = Arc::new(CypherParser::new(function_registry.clone()));
-    let builder = QueryBuilder::new(query_str, parser).with_function_registry(function_registry);
-    let query = Arc::new(RwLock::new(builder.build().await));
-    let dispatcher = QueryDispatcher::new(query.clone());
-
-    // Source Setup
+    // 2. Create Source
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: Some(db_name.to_string()),
@@ -356,39 +419,55 @@ async fn test_end_to_end_multi_collection() -> Result<()> {
         username: None,
         password: None,
     };
-
     let source = MongoSource::new("multi-source", config)?;
-    source.base.dispatchers.write().await.push(Box::new(dispatcher.clone()));
-    
-    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
-    let (status_tx, _status_rx) = tokio::sync::mpsc::channel(100);
-    source.initialize(drasi_lib::context::SourceRuntimeContext::new("multi-source", status_tx, Some(state_store))).await;
 
-    source.start().await?;
+    // 3. Create Query
+    let query = Query::cypher("multi-query")
+        .query("MATCH (n) WHERE n:col1 OR n:col2 RETURN n.val")
+        .from_source("multi-source")
+        .auto_start(true)
+        .build();
+
+    // 4. Create TestReaction
+    let (test_reaction, results_handle) = TestReaction::build("test-reaction", vec!["multi-query".to_string()])?;
+
+    // 5. Build DrasiLib
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("multi-test")
+            .with_source(source)
+            .with_query(query)
+            .with_reaction(test_reaction)
+            .build()
+            .await?
+    );
+
+    // 6. Start the pipeline
+    core.start().await?;
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    // Test Interactions
+    // 7. Test Interactions
     println!("Inserting into col1...");
     col1.insert_one(doc! { "val": "from_col1" }, None).await?;
-    wait_for_result(&dispatcher, 1).await?;
-    let results = dispatcher.get_results().await;
+    wait_for_result(&results_handle, 1).await?;
+    let results = results_handle.read().await.clone();
     assert_eq!(results.len(), 1);
-    dispatcher.clear_results().await;
+    results_handle.write().await.clear();
 
     println!("Inserting into col2...");
     col2.insert_one(doc! { "val": "from_col2" }, None).await?;
-    wait_for_result(&dispatcher, 1).await?;
-    let results = dispatcher.get_results().await;
+    wait_for_result(&results_handle, 1).await?;
+    let results = results_handle.read().await.clone();
     assert_eq!(results.len(), 1);
-    dispatcher.clear_results().await;
+    results_handle.write().await.clear();
 
     println!("Inserting into col3 (ignored)...");
     col3.insert_one(doc! { "val": "from_col3" }, None).await?;
     tokio::time::sleep(Duration::from_secs(1)).await;
-    let results = dispatcher.get_results().await;
+    let results = results_handle.read().await.clone();
     assert_eq!(results.len(), 0);
 
-    source.stop().await?;
+    core.stop().await?;
     Ok(())
 }
 
@@ -442,44 +521,50 @@ async fn test_end_to_end_authentication() -> Result<()> {
         "roles": [ "root" ]
     }, None).await?;
 
-    // Query Setup
-    use drasi_core::evaluation::functions::FunctionRegistry;
-    use drasi_query_cypher::CypherParser;
-    use drasi_functions_cypher::CypherFunctionSet;
-
-    let query_str = "MATCH (n:auth_col) RETURN n.msg";
-    let function_registry = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
-    let parser = Arc::new(CypherParser::new(function_registry.clone()));
-    let builder = QueryBuilder::new(query_str, parser).with_function_registry(function_registry);
-    let query = Arc::new(RwLock::new(builder.build().await));
-    let dispatcher = QueryDispatcher::new(query.clone());
-
-    // Source Setup - Use Config Overrides
+    // 2. Create Source with auth
     let config = MongoSourceConfig {
-        connection_string: connection_string_no_auth.clone(), // No auth in string
+        connection_string: connection_string_no_auth.clone(),
         database: Some(db_name.to_string()),
         collection: Some(collection_name.to_string()),
         collections: vec![],
         pipeline: None,
-        username: Some("drasi".to_string()),     // Auth in Config
-        password: Some("drasi_password".to_string()), 
+        username: Some("drasi".to_string()),
+        password: Some("drasi_password".to_string()),
     };
-
     let source = MongoSource::new("auth-source", config)?;
-    source.base.dispatchers.write().await.push(Box::new(dispatcher.clone()));
-    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
-    source.initialize(drasi_lib::context::SourceRuntimeContext::new("auth-source", tokio::sync::mpsc::channel(100).0, Some(state_store))).await;
 
-    source.start().await?;
+    // 3. Create Query
+    let query = Query::cypher("auth-query")
+        .query("MATCH (n:auth_col) RETURN n.msg")
+        .from_source("auth-source")
+        .auto_start(true)
+        .build();
+
+    // 4. Create TestReaction
+    let (test_reaction, results_handle) = TestReaction::build("test-reaction", vec!["auth-query".to_string()])?;
+
+    // 5. Build DrasiLib
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("auth-test")
+            .with_source(source)
+            .with_query(query)
+            .with_reaction(test_reaction)
+            .build()
+            .await?
+    );
+
+    // 6. Start the pipeline
+    core.start().await?;
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    // Test Interaction
+    // 7. Test Interaction
     println!("Inserting authenticated...");
     collection.insert_one(doc! { "msg": "secure_data" }, None).await?;
-    wait_for_result(&dispatcher, 1).await?;
-    let results = dispatcher.get_results().await;
+    wait_for_result(&results_handle, 1).await?;
+    let results = results_handle.read().await.clone();
     assert_eq!(results.len(), 1);
 
-    source.stop().await?;
+    core.stop().await?;
     Ok(())
 }

--- a/components/sources/mongodb/tests/mongo_integration.rs
+++ b/components/sources/mongodb/tests/mongo_integration.rs
@@ -102,7 +102,7 @@ async fn test_mongo_source_integration() -> Result<()> {
     // Configure Source
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
-        database: Some(db_name.to_string()),
+        database: db_name.to_string(),
         collection: Some(collection_name.to_string()),
         collections: vec![],
         pipeline: None,
@@ -357,7 +357,7 @@ async fn test_mongo_source_with_auth() -> Result<()> {
     // We configure source with connection_string_no_auth and NO overrides.
     let config_fail = MongoSourceConfig {
         connection_string: connection_string_no_auth.clone(),
-        database: Some(db_name.to_string()),
+        database: db_name.to_string(),
         collection: Some(collection_name.to_string()),
         collections: vec![],
         pipeline: None,
@@ -380,7 +380,7 @@ async fn test_mongo_source_with_auth() -> Result<()> {
     // 2. Test success with credential overrides
     let config_success = MongoSourceConfig {
         connection_string: connection_string_no_auth.clone(),
-        database: Some(db_name.to_string()),
+        database: db_name.to_string(),
         collection: Some(collection_name.to_string()),
         collections: vec![],
         pipeline: None,
@@ -470,7 +470,7 @@ async fn test_mongo_source_multi_collection() -> Result<()> {
     // Configure Source with multiple collections
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
-        database: Some(db_name.to_string()),
+        database: db_name.to_string(),
         collection: None,
         collections: vec!["col1".to_string(), "col2".to_string()],
         pipeline: None,

--- a/components/sources/mongodb/tests/mongo_integration.rs
+++ b/components/sources/mongodb/tests/mongo_integration.rs
@@ -103,8 +103,7 @@ async fn test_mongo_source_integration() -> Result<()> {
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: db_name.to_string(),
-        collection: Some(collection_name.to_string()),
-        collections: vec![],
+        collections: vec![collection_name.to_string()],
         pipeline: None,
         username: None,
         password: None,
@@ -358,8 +357,7 @@ async fn test_mongo_source_with_auth() -> Result<()> {
     let config_fail = MongoSourceConfig {
         connection_string: connection_string_no_auth.clone(),
         database: db_name.to_string(),
-        collection: Some(collection_name.to_string()),
-        collections: vec![],
+        collections: vec![collection_name.to_string()],
         pipeline: None,
         username: None,
         password: None,
@@ -381,8 +379,7 @@ async fn test_mongo_source_with_auth() -> Result<()> {
     let config_success = MongoSourceConfig {
         connection_string: connection_string_no_auth.clone(),
         database: db_name.to_string(),
-        collection: Some(collection_name.to_string()),
-        collections: vec![],
+        collections: vec![collection_name.to_string()],
         pipeline: None,
         username: Some("drasi".to_string()),
         password: Some("drasi_password".to_string()),
@@ -471,7 +468,6 @@ async fn test_mongo_source_multi_collection() -> Result<()> {
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
         database: db_name.to_string(),
-        collection: None,
         collections: vec!["col1".to_string(), "col2".to_string()],
         pipeline: None,
         username: None,

--- a/components/sources/mongodb/tests/mongo_integration.rs
+++ b/components/sources/mongodb/tests/mongo_integration.rs
@@ -1,0 +1,112 @@
+use anyhow::Result;
+use drasi_core::models::{SourceChange, ElementValue};
+use drasi_lib::channels::{ChangeDispatcher, ChangeReceiver, SourceEventWrapper, SourceEvent};
+use drasi_source_mongodb::config::MongoSourceConfig;
+use drasi_source_mongodb::MongoSource;
+use drasi_lib::Source;
+use mongodb::bson::{doc, Document};
+use mongodb::Client;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use testcontainers::{core::ContainerPort, runners::AsyncRunner, GenericImage};
+
+// Mock Dispatcher to capture events
+#[derive(Clone)]
+struct MockDispatcher {
+    events: Arc<RwLock<Vec<SourceChange>>>,
+}
+
+impl MockDispatcher {
+    fn new() -> Self {
+        Self {
+            events: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ChangeDispatcher<SourceEventWrapper> for MockDispatcher {
+    async fn dispatch_change(&self, event: Arc<SourceEventWrapper>) -> Result<()> {
+        if let SourceEvent::Change(change) = &event.event {
+            self.events.write().await.push(change.clone());
+        }
+        Ok(())
+    }
+
+    async fn create_receiver(&self) -> Result<Box<dyn ChangeReceiver<SourceEventWrapper>>> {
+        Err(anyhow::anyhow!("Not implemented for mock"))
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_mongo_source_integration() -> Result<()> {
+    // Start MongoDB container
+    let container = GenericImage::new("mongo", "5.0")
+        .with_exposed_port(ContainerPort::Tcp(27017))
+        .start()
+        .await?;
+    
+    let port = container.get_host_port_ipv4(27017).await?;
+    let connection_string = format!("mongodb://127.0.0.1:{}", port);
+
+    // Setup MongoDB data
+    let client = Client::with_uri_str(&connection_string).await?;
+    let db = client.database("test_db");
+    let collection = db.collection::<Document>("test_collection");
+
+    // Configure Source
+    let config = MongoSourceConfig {
+        connection_string: connection_string.clone(),
+        database: "test_db".to_string(),
+        collection: "test_collection".to_string(),
+        pipeline: None,
+    };
+
+    let source = MongoSource::new("test-source", config)?;
+    
+    // Inject mock dispatcher
+    let mock_dispatcher = MockDispatcher::new();
+    source.base.dispatchers.write().await.push(Box::new(mock_dispatcher.clone()));
+
+    // Start source
+    source.start().await?;
+
+    // Wait a bit for connection
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Insert document
+    let doc = doc! { "name": "test-item", "value": 42 };
+    collection.insert_one(doc, None).await?;
+
+    // Wait for event
+    let mut found = false;
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let events = mock_dispatcher.events.read().await;
+        if !events.is_empty() {
+            found = true;
+            let change = &events[0];
+            if let SourceChange::Insert { element } = change {
+                if let drasi_core::models::Element::Node { properties, .. } = element {
+                    if let Some(ElementValue::String(name)) = properties.get("name") {
+                        assert_eq!(name.as_ref(), "test-item");
+                    } else {
+                        panic!("Property 'name' mismatch");
+                    }
+                } else {
+                    panic!("Expected Element::Node");
+                }
+            } else {
+                panic!("Expected Insert event");
+            }
+            break;
+        }
+    }
+
+    assert!(found, "Did not receive change event");
+
+    source.stop().await?;
+    Ok(())
+}

--- a/components/sources/mongodb/tests/mongo_integration.rs
+++ b/components/sources/mongodb/tests/mongo_integration.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use drasi_core::models::{SourceChange, ElementValue};
+use drasi_core::models::{SourceChange, ElementValue, Element};
 use drasi_lib::channels::{ChangeDispatcher, ChangeReceiver, SourceEventWrapper, SourceEvent};
 use drasi_source_mongodb::config::MongoSourceConfig;
 use drasi_source_mongodb::MongoSource;
@@ -9,7 +9,8 @@ use mongodb::Client;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
-use testcontainers::{core::ContainerPort, runners::AsyncRunner, GenericImage};
+use drasi_lib::state_store::StateStoreProvider;
+use testcontainers::{core::{ContainerPort, WaitFor}, runners::AsyncRunner, GenericImage, ImageExt};
 
 // Mock Dispatcher to capture events
 #[derive(Clone)]
@@ -22,6 +23,14 @@ impl MockDispatcher {
         Self {
             events: Arc::new(RwLock::new(Vec::new())),
         }
+    }
+    
+    async fn get_events(&self) -> Vec<SourceChange> {
+        self.events.read().await.clone()
+    }
+
+    async fn clear(&self) {
+        self.events.write().await.clear();
     }
 }
 
@@ -42,71 +51,483 @@ impl ChangeDispatcher<SourceEventWrapper> for MockDispatcher {
 #[tokio::test]
 #[ignore]
 async fn test_mongo_source_integration() -> Result<()> {
-    // Start MongoDB container
+    // Start MongoDB container with Replica Set
+    // We need to bind to all interfaces and start with replSet
     let container = GenericImage::new("mongo", "5.0")
+        .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"))
         .with_exposed_port(ContainerPort::Tcp(27017))
+        .with_cmd(vec!["mongod", "--replSet", "rs0", "--bind_ip_all"])
         .start()
         .await?;
     
     let port = container.get_host_port_ipv4(27017).await?;
     let connection_string = format!("mongodb://127.0.0.1:{}", port);
 
-    // Setup MongoDB data
+    // Initialize Replica Set
     let client = Client::with_uri_str(&connection_string).await?;
-    let db = client.database("test_db");
-    let collection = db.collection::<Document>("test_collection");
+    
+    // Attempt to initiate replica set
+    // In a real container we might need to wait a bit or retry
+    let _ = client.database("admin").run_command(doc! { "replSetInitiate": {} }, None).await;
+    
+    // Wait for replica set to be ready (primary)
+    let mut ready = false;
+    for _ in 0..30 {
+        if let Ok(status) = client.database("admin").run_command(doc! { "replSetGetStatus": 1 }, None).await {
+            if let Ok(members) = status.get_array("members") {
+                if let Some(member) = members.first() {
+                    if let Some(state_str) = member.as_document().and_then(|d| d.get_str("stateStr").ok()) {
+                        if state_str == "PRIMARY" {
+                            ready = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    
+    if !ready {
+        // Fallback check, maybe simple ping works if we are just testing connectivity?
+        // But change streams need Primary.
+        println!("Warning: Could not verify Primary state, continuing anyway...");
+    }
+
+    let db_name = "test_db";
+    let collection_name = "test_collection";
+    let db = client.database(db_name);
+    let collection = db.collection::<Document>(collection_name);
 
     // Configure Source
     let config = MongoSourceConfig {
         connection_string: connection_string.clone(),
-        database: "test_db".to_string(),
-        collection: "test_collection".to_string(),
+        database: Some(db_name.to_string()),
+        collection: Some(collection_name.to_string()),
+        collections: vec![],
         pipeline: None,
+        username: None,
+        password: None,
     };
 
     let source = MongoSource::new("test-source", config)?;
-    
-    // Inject mock dispatcher
     let mock_dispatcher = MockDispatcher::new();
     source.base.dispatchers.write().await.push(Box::new(mock_dispatcher.clone()));
 
-    // Start source
+    // Initialize with state store
+    let state_store = Arc::new(drasi_lib::state_store::MemoryStateStoreProvider::new());
+    let (status_tx, _status_rx) = tokio::sync::mpsc::channel(100);
+    
+    let context = drasi_lib::context::SourceRuntimeContext::new(
+        "test-source",
+        status_tx,
+        Some(state_store.clone()),
+    );
+    source.initialize(context).await;
+
+    // 1. Start Source
+    println!("Starting source...");
     source.start().await?;
+    tokio::time::sleep(Duration::from_secs(3)).await; // Wait for stream connection
 
-    // Wait a bit for connection
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // 2. Test Insert
+    println!("Testing Insert...");
+    mock_dispatcher.clear().await;
+    let doc_insert = doc! { "name": "test-item", "nested": { "val": 10 } };
+    let insert_result = collection.insert_one(doc_insert, None).await?;
+    let inserted_id = insert_result.inserted_id;
 
-    // Insert document
-    let doc = doc! { "name": "test-item", "value": 42 };
-    collection.insert_one(doc, None).await?;
-
-    // Wait for event
-    let mut found = false;
-    for _ in 0..20 {
-        tokio::time::sleep(Duration::from_millis(500)).await;
-        let events = mock_dispatcher.events.read().await;
-        if !events.is_empty() {
-            found = true;
-            let change = &events[0];
-            if let SourceChange::Insert { element } = change {
-                if let drasi_core::models::Element::Node { properties, .. } = element {
-                    if let Some(ElementValue::String(name)) = properties.get("name") {
-                        assert_eq!(name.as_ref(), "test-item");
-                    } else {
-                        panic!("Property 'name' mismatch");
-                    }
-                } else {
-                    panic!("Expected Element::Node");
-                }
-            } else {
-                panic!("Expected Insert event");
-            }
-            break;
+    wait_for_event(&mock_dispatcher, 1).await?;
+    let events = mock_dispatcher.get_events().await;
+    assert_eq!(events.len(), 1);
+    
+    if let SourceChange::Insert { element: Element::Node { properties, .. } } = &events[0] {
+        if let Some(ElementValue::String(name)) = properties.get("name") {
+            assert_eq!(name.as_ref(), "test-item");
+        } else {
+            panic!("Expected string for 'name'");
         }
+        
+        // Verify nested
+        if let Some(ElementValue::Object(nested)) = properties.get("nested") {
+             if let Some(ElementValue::Integer(val)) = nested.get("val") {
+                 assert_eq!(*val, 10);
+             } else {
+                 panic!("Expected integer for 'nested.val'");
+             }
+        } else {
+            panic!("Expected nested object");
+        }
+    } else {
+        panic!("Expected Insert event, got {:?}", events[0]);
+    }
+    
+    // Check state store for resume token
+    assert!(state_store.contains_key("test-source", "resume_token").await.unwrap());
+
+    // 3. Test Update (Change nested field)
+    println!("Testing Update...");
+    mock_dispatcher.clear().await;
+    collection.update_one(
+        doc! { "_id": inserted_id.clone() },
+        doc! { "$set": { "nested.val": 20, "new_field": "test" } },
+        None
+    ).await?;
+
+    wait_for_event(&mock_dispatcher, 1).await?;
+    let events = mock_dispatcher.get_events().await;
+    assert_eq!(events.len(), 1);
+
+    if let SourceChange::Update { element: Element::Node { properties, .. } } = &events[0] {
+        // Because we look up full document, we should see the merged state
+        if let Some(ElementValue::Object(nested)) = properties.get("nested") {
+            if let Some(ElementValue::Integer(val)) = nested.get("val") {
+                assert_eq!(*val, 20);
+            } else {
+                 panic!("Expected integer for 'nested.val' after update");
+            }
+        } else {
+            panic!("Expected nested object after update");
+        }
+        
+        if let Some(ElementValue::String(name)) = properties.get("name") {
+            assert_eq!(name.as_ref(), "test-item"); // Existing field preserved
+        }
+        
+        if let Some(ElementValue::String(new_field)) = properties.get("new_field") {
+            assert_eq!(new_field.as_ref(), "test");
+        } else {
+            panic!("Expected string for 'new_field'");
+        }
+    } else {
+        panic!("Expected Update event, got {:?}", events[0]);
     }
 
-    assert!(found, "Did not receive change event");
+    // 4. Test Delete
+    println!("Testing Delete...");
+    mock_dispatcher.clear().await;
+    collection.delete_one(doc! { "_id": inserted_id.clone() }, None).await?;
 
+    wait_for_event(&mock_dispatcher, 1).await?;
+    let events = mock_dispatcher.get_events().await;
+    assert_eq!(events.len(), 1);
+    
+    if let SourceChange::Delete { metadata } = &events[0] {
+        assert!(metadata.reference.element_id.contains(&inserted_id.as_object_id().unwrap().to_hex()));
+    } else {
+        panic!("Expected Delete event");
+    }
+
+    // 5. Test Resume / Shutdown correctness
+    println!("Testing Shutdown and Resume...");
+    source.stop().await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    
+    // Verify token is still in store
+    let token = state_store.get("test-source", "resume_token").await.unwrap();
+    assert!(token.is_some());
+    
+    // Insert while stopped
+    let doc_offline = doc! { "name": "offline-item" };
+    collection.insert_one(doc_offline, None).await?;
+    
+    // Clear events (should be empty anyway as source is stopped)
+    mock_dispatcher.clear().await;
+    
+    // Restart source - it should pick up from last token and see the new item
+    println!("Restarting source...");
+    source.start().await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    
+    wait_for_event(&mock_dispatcher, 1).await?;
+    let events = mock_dispatcher.get_events().await;
+    assert!(!events.is_empty());
+    
+    let last_event = events.last().unwrap();
+    if let SourceChange::Insert { element: Element::Node { properties, .. } } = last_event {
+         if let Some(ElementValue::String(name)) = properties.get("name") {
+            assert_eq!(name.as_ref(), "offline-item");
+        } else {
+            println!("Got properties: {:?}", properties);
+            panic!("Expected string for 'name' in offline item");
+        }
+    } else {
+        panic!("Expected Insert event from offline data");
+    }
+
+    source.stop().await?;
+    println!("Test completed successfully");
+    Ok(())
+}
+
+async fn wait_for_event(dispatcher: &MockDispatcher, min_count: usize) -> Result<()> {
+    for _ in 0..20 {
+        if dispatcher.events.read().await.len() >= min_count {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    Err(anyhow::anyhow!("Timeout waiting for events"))
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_mongo_source_with_auth() -> Result<()> {
+    // Start MongoDB container with Auth and Replica Set
+    // We need a keyfile for ReplSet with Auth
+    // Build image using GenericImage methods
+    let image = GenericImage::new("mongo", "5.0")
+        .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"))
+        .with_exposed_port(ContainerPort::Tcp(27017))
+        .with_entrypoint("bash")
+        .with_env_var("MONGO_INITDB_ROOT_USERNAME", "admin")
+        .with_env_var("MONGO_INITDB_ROOT_PASSWORD", "password");
+        
+    // with_cmd returns ContainerRequest, so must be last before start
+    let container = image
+        .with_cmd(vec!["-c", "echo \"verysecretkey123\" > /tmp/keyfile && chmod 400 /tmp/keyfile && chown mongodb:mongodb /tmp/keyfile && mongod --replSet rs0 --bind_ip_all --auth --keyFile /tmp/keyfile"])
+        .start()
+        .await?;
+    
+    let port = container.get_host_port_ipv4(27017).await?;
+    let connection_string_no_auth = format!("mongodb://127.0.0.1:{}", port);
+    let connection_string_auth = format!("mongodb://admin:password@127.0.0.1:{}", port);
+
+    // Initialize Replica Set (requires auth now?)
+    // Localhost exception might allow init without auth if strictly localhost, 
+    // but we are connecting from host to container port, so it's not localhost from mongo's perspective.
+    // We must use the admin creds.
+    
+    let client_options = mongodb::options::ClientOptions::parse(&connection_string_auth).await?;
+    let client = Client::with_options(client_options)?;
+    
+    // Initiate replSet
+    // We might need to handle "already initialized" or similar if we restart, but this is fresh container.
+    match client.database("admin").run_command(doc! { "replSetInitiate": {} }, None).await {
+        Ok(_) => println!("Replica set initiated"),
+        Err(e) => println!("Replica set initiation check: {}", e),
+    }
+
+    // Wait for primary
+    let mut ready = false;
+    for _ in 0..30 {
+        if let Ok(status) = client.database("admin").run_command(doc! { "replSetGetStatus": 1 }, None).await {
+            if let Ok(members) = status.get_array("members") {
+                if let Some(member) = members.first() {
+                    if let Some(state_str) = member.as_document().and_then(|d| d.get_str("stateStr").ok()) {
+                        if state_str == "PRIMARY" {
+                            ready = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    
+    if !ready {
+        panic!("Replica set failed to become PRIMARY");
+    }
+
+    let db_name = "auth_test_db";
+    let collection_name = "auth_test_col";
+    let db = client.database(db_name);
+    let collection = db.collection::<Document>(collection_name);
+
+    // Create a regular user for the source
+    client.database("admin").run_command(doc! {
+        "createUser": "drasi",
+        "pwd": "drasi_password",
+        "roles": [
+            { "role": "read", "db": db_name },
+            { "role": "read", "db": "local" } // Maybe needed for oplog? usually needs more perms for change stream
+        ]
+    }, None).await?;
+    // Actually for change streams, user needs permission to read collection and read oplog.
+    // Let's give root for simplicity in test, or correct roles.
+    // "read" on db is enough for simple watch? No, need to read oplog or be clusterMonitor?
+    // Let's grant "readAnyDatabase" and "clusterMonitor" or just "root" to simplify test setup correctness.
+    client.database("admin").run_command(doc! {
+        "grantRolesToUser": "drasi",
+        "roles": [ "root" ]
+    }, None).await?;
+
+    // 1. Test failure without valid creds
+    // We configure source with connection_string_no_auth and NO overrides.
+    let config_fail = MongoSourceConfig {
+        connection_string: connection_string_no_auth.clone(),
+        database: Some(db_name.to_string()),
+        collection: Some(collection_name.to_string()),
+        collections: vec![],
+        pipeline: None,
+        username: None,
+        password: None,
+    };
+    
+    let source_fail = MongoSource::new("fail-source", config_fail)?;
+    let mock_dispatcher = MockDispatcher::new();
+    source_fail.base.dispatchers.write().await.push(Box::new(mock_dispatcher.clone()));
+    
+    source_fail.start().await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    
+    // Check status - should be Error
+    let status = source_fail.base.get_status().await;
+    assert_eq!(status, drasi_lib::channels::ComponentStatus::Error);
+    source_fail.stop().await?;
+
+    // 2. Test success with credential overrides
+    let config_success = MongoSourceConfig {
+        connection_string: connection_string_no_auth.clone(),
+        database: Some(db_name.to_string()),
+        collection: Some(collection_name.to_string()),
+        collections: vec![],
+        pipeline: None,
+        username: Some("drasi".to_string()),
+        password: Some("drasi_password".to_string()),
+    };
+    
+    let source_success = MongoSource::new("success-source", config_success)?;
+    let mock_dispatcher_success = MockDispatcher::new();
+    source_success.base.dispatchers.write().await.push(Box::new(mock_dispatcher_success.clone()));
+    
+    source_success.start().await?;
+    tokio::time::sleep(Duration::from_secs(3)).await; // Connect
+    
+    // Check status
+    assert_eq!(source_success.base.get_status().await, drasi_lib::channels::ComponentStatus::Running);
+    
+    // Perform Insert
+    collection.insert_one(doc! { "msg": "authenticated" }, None).await?;
+    
+    wait_for_event(&mock_dispatcher_success, 1).await?;
+    let events = mock_dispatcher_success.get_events().await;
+    assert_eq!(events.len(), 1);
+    
+    if let SourceChange::Insert { element: Element::Node { properties, .. } } = &events[0] {
+        if let Some(ElementValue::String(msg)) = properties.get("msg") {
+            assert_eq!(msg.as_ref(), "authenticated");
+        } else {
+            panic!("Expected msg property");
+        }
+    }
+    
+    source_success.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_mongo_source_multi_collection() -> Result<()> {
+    // Start MongoDB container
+    let container = GenericImage::new("mongo", "5.0")
+        .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"))
+        .with_exposed_port(ContainerPort::Tcp(27017))
+        .start()
+        .await?;
+    
+    let port = container.get_host_port_ipv4(27017).await?;
+    let connection_string = format!("mongodb://127.0.0.1:{}", port);
+    
+    // Initialize Replica Set
+    let client_options = mongodb::options::ClientOptions::parse(&connection_string).await?;
+    let client = Client::with_options(client_options)?;
+    
+    match client.database("admin").run_command(doc! { "replSetInitiate": {} }, None).await {
+        Ok(_) => println!("Replica set initiated"),
+        Err(e) => println!("Replica set initiation check: {}", e),
+    }
+
+    // Wait for primary
+    let mut ready = false;
+    for _ in 0..30 {
+        if let Ok(status) = client.database("admin").run_command(doc! { "replSetGetStatus": 1 }, None).await {
+            if let Ok(members) = status.get_array("members") {
+                if let Some(member) = members.first() {
+                    if let Some(state_str) = member.as_document().and_then(|d| d.get_str("stateStr").ok()) {
+                        if state_str == "PRIMARY" {
+                            ready = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    
+    if !ready {
+        panic!("Replica set failed to become PRIMARY");
+    }
+
+    let db_name = "multi_col_test_db";
+    let db = client.database(db_name);
+    let col1 = db.collection::<Document>("col1");
+    let col2 = db.collection::<Document>("col2");
+    let col3 = db.collection::<Document>("col3");
+
+    // Configure Source with multiple collections
+    let config = MongoSourceConfig {
+        connection_string: connection_string.clone(),
+        database: Some(db_name.to_string()),
+        collection: None,
+        collections: vec!["col1".to_string(), "col2".to_string()],
+        pipeline: None,
+        username: None,
+        password: None,
+    };
+
+    let source = MongoSource::new("multi-col-source", config)?;
+    let mock_dispatcher = MockDispatcher::new();
+    source.base.dispatchers.write().await.push(Box::new(mock_dispatcher.clone()));
+    
+    // Start Source
+    println!("Starting source...");
+    source.start().await?;
+    tokio::time::sleep(Duration::from_secs(3)).await; // Wait for stream connection
+
+    // Test Insert col1
+    col1.insert_one(doc! { "msg": "from col1" }, None).await?;
+    
+    // Test Insert col2
+    col2.insert_one(doc! { "msg": "from col2" }, None).await?;
+    
+    // Test Insert col3 (should be ignored)
+    col3.insert_one(doc! { "msg": "from col3" }, None).await?;
+    
+    // Verify events
+    wait_for_event(&mock_dispatcher, 2).await?;
+    let events = mock_dispatcher.get_events().await;
+    assert_eq!(events.len(), 2);
+    
+    let mut found_col1 = false;
+    let mut found_col2 = false;
+    
+    for event in events {
+        if let SourceChange::Insert { element: Element::Node { metadata, properties } } = event {
+            let id = metadata.reference.element_id;
+            println!("Event ID: {}", id);
+            
+            if id.starts_with("col1:") {
+                found_col1 = true;
+                if let Some(ElementValue::String(msg)) = properties.get("msg") {
+                    assert_eq!(msg.as_ref(), "from col1");
+                }
+            } else if id.starts_with("col2:") {
+                found_col2 = true;
+                if let Some(ElementValue::String(msg)) = properties.get("msg") {
+                     assert_eq!(msg.as_ref(), "from col2");
+                }
+            } else {
+                panic!("Unexpected event source: {}", id);
+            }
+        }
+    }
+    
+    assert!(found_col1, "Did not receive event from col1");
+    assert!(found_col2, "Did not receive event from col2");
+    
     source.stop().await?;
     Ok(())
 }


### PR DESCRIPTION
This PR introduces a new MongoDB source plugin for Drasi, enabling ingestion of MongoDB Change Streams as SourceChange events.

The implementation follows the existing source architecture and mirrors the behavior of the PostgreSQL source where applicable, while handling MongoDB-specific concerns such as partial updates and resume tokens.

### What’s included
- New drasi-source-mongodb crate registered in the workspace
- MongoSource implementation of the Source trait
- Change Stream consumer with:
-- Resume token support
-- Automatic reconnect with backoff
-- FullDocument lookup for updates
- BSON → ElementValue conversion covering common MongoDB types
- Dot-notation hydration for partial updates and removed fields
- Config validation for required properties
- Unit tests for:
-- BSON conversion
-- Dot-notation hydration
-- Config validation
- End-to-end integration test using testcontainers (ignored by default due to Docker requirement)

### Testing
- Unit tests:
```bash
cargo test -p drasi-source-mongodb --lib
```
- Integration test (requires Docker):
```bash
cargo test -p drasi-source-mongodb --test mongo_integration
```
### Notes
- MongoDB must be running as a replica set or sharded cluster (Change Streams requirement).
- The integration test is marked #[ignore] to avoid failures in environments without a Docker socket.
- This PR focuses on correctness and parity with the shared MongoDB source contract; further performance tuning can follow.

Fixes: #226