### PR TITLE
Gate event processor behind bootstrap completion

### DIFF
--- a/components/sources/README.md
+++ b/components/sources/README.md
@@ -339,8 +339,6 @@ The unified event envelope:
 pub enum SourceEvent {
     Change(SourceChange),              // Data change
     Control(SourceControl),            // Query coordination
-    BootstrapStart { query_id: String },
-    BootstrapEnd { query_id: String },
 }
 ```
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -93,5 +93,4 @@ pretty_assertions = "1.4"
 test-case = "3.3"
 
 # Additional testing dependencies
-futures = "0.3"
 rstest = "0.18"

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -201,10 +201,6 @@ pub enum SourceEvent {
     Change(SourceChange),
     /// Control event for query coordination
     Control(SourceControl),
-    /// Bootstrap start marker for a specific query
-    BootstrapStart { query_id: String },
-    /// Bootstrap end marker for a specific query
-    BootstrapEnd { query_id: String },
 }
 
 /// Wrapper for source events with metadata

--- a/lib/src/lifecycle.rs
+++ b/lib/src/lifecycle.rs
@@ -186,7 +186,10 @@ impl LifecycleManager {
 
         for id in reaction_ids {
             let status = self.reaction_manager.get_reaction_status(id.clone()).await;
-            if matches!(status, Ok(ComponentStatus::Running)) {
+            if matches!(
+                status,
+                Ok(ComponentStatus::Running | ComponentStatus::Starting)
+            ) {
                 if let Err(e) = self.reaction_manager.stop_reaction(id.clone()).await {
                     error!("Error stopping reaction {id}: {e}");
                 }
@@ -206,7 +209,10 @@ impl LifecycleManager {
 
         for id in query_ids {
             let status = self.query_manager.get_query_status(id.clone()).await;
-            if matches!(status, Ok(ComponentStatus::Running)) {
+            if matches!(
+                status,
+                Ok(ComponentStatus::Running | ComponentStatus::Starting)
+            ) {
                 if let Err(e) = self.query_manager.stop_query(id.clone()).await {
                     error!("Error stopping query {id}: {e}");
                 }
@@ -226,7 +232,10 @@ impl LifecycleManager {
 
         for id in source_ids {
             let status = self.source_manager.get_source_status(id.clone()).await;
-            if matches!(status, Ok(ComponentStatus::Running)) {
+            if matches!(
+                status,
+                Ok(ComponentStatus::Running | ComponentStatus::Starting)
+            ) {
                 if let Err(e) = self.source_manager.stop_source(id.clone()).await {
                     error!("Error stopping source {id}: {e}");
                 }

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -18,7 +18,7 @@ use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 
 // Import drasi-core components
 use drasi_core::{
@@ -139,6 +139,8 @@ pub struct DrasiQuery {
     source_manager: Arc<SourceManager>,
     // Track subscription tasks for cleanup
     subscription_tasks: Arc<RwLock<Vec<tokio::task::JoinHandle<()>>>>,
+    // Abort handles for bootstrap + supervisor tasks (for cleanup on stop)
+    bootstrap_abort_handles: Arc<RwLock<Vec<tokio::task::AbortHandle>>>,
     // Track bootstrap state per source
     bootstrap_state: Arc<RwLock<HashMap<String, BootstrapPhase>>>,
     // IndexFactory for creating storage backend indexes
@@ -173,6 +175,7 @@ impl DrasiQuery {
             priority_queue,
             source_manager,
             subscription_tasks: Arc::new(RwLock::new(Vec::new())),
+            bootstrap_abort_handles: Arc::new(RwLock::new(Vec::new())),
             bootstrap_state: Arc::new(RwLock::new(HashMap::new())),
             index_factory,
             middleware_registry,
@@ -199,6 +202,7 @@ impl Query for DrasiQuery {
         log_component_start("Query", &self.base.config.id);
 
         *self.base.status.write().await = ComponentStatus::Starting;
+        self.bootstrap_state.write().await.clear();
 
         let event = ComponentEvent {
             component_id: self.base.config.id.clone(),
@@ -571,6 +575,10 @@ impl Query for DrasiQuery {
         // Wrap continuous_query in Arc for sharing across tasks
         let continuous_query = Arc::new(continuous_query);
 
+        // Gate that blocks the streaming event processor until bootstrap completes.
+        // Events buffer safely in the priority queue during bootstrap.
+        let bootstrap_gate = Arc::new(Notify::new());
+
         // NEW: Handle bootstrap channels
         if !bootstrap_channels.is_empty() {
             info!(
@@ -612,6 +620,9 @@ impl Query for DrasiQuery {
             let instance_id = self.instance_id.clone();
             let bootstrap_current_results = self.current_results.clone();
 
+            let mut bootstrap_handles = Vec::new();
+            let mut abort_handles = Vec::new();
+
             for (source_id, mut bootstrap_rx) in bootstrap_channels {
                 // Mark source bootstrap as in progress
                 bootstrap_state
@@ -630,6 +641,7 @@ impl Query for DrasiQuery {
                 let base_dispatchers_clone = base_dispatchers.clone();
                 let instance_id_clone = instance_id.clone();
                 let current_results_clone = bootstrap_current_results.clone();
+                let bootstrap_gate_clone = bootstrap_gate.clone();
 
                 let span = tracing::info_span!(
                     "query_bootstrap",
@@ -637,7 +649,7 @@ impl Query for DrasiQuery {
                     component_id = %query_id,
                     component_type = "query"
                 );
-                tokio::spawn(
+                let handle = tokio::spawn(
                     async move {
                         let mut count = 0u64;
 
@@ -697,15 +709,11 @@ impl Query for DrasiQuery {
                             "[BOOTSTRAP] Query '{query_id_clone}' completed bootstrap from source '{source_id_clone}' ({count} events)"
                         );
 
-                        // Mark source bootstrap as completed
-                        bootstrap_state_clone
-                            .write()
-                            .await
-                            .insert(source_id_clone.to_string(), BootstrapPhase::Completed);
-
-                        // Check if all sources have completed bootstrap
+                        // Mark source bootstrap as completed and check if all sources are done
+                        // under a single write lock to prevent duplicate completion signals
                         let all_completed = {
-                            let state = bootstrap_state_clone.read().await;
+                            let mut state = bootstrap_state_clone.write().await;
+                            state.insert(source_id_clone.to_string(), BootstrapPhase::Completed);
                             state
                                 .values()
                                 .all(|phase| *phase == BootstrapPhase::Completed)
@@ -750,31 +758,76 @@ impl Query for DrasiQuery {
                                     "[BOOTSTRAP] Emitted bootstrapCompleted signal for query '{query_id_clone}'"
                                 );
                             }
+
+                            // Open the bootstrap gate so the event processor can start
+                            bootstrap_gate_clone.notify_one();
+                            info!("[BOOTSTRAP] Query '{query_id_clone}' bootstrap gate opened");
                         }
                     }
                     .instrument(span),
                 );
+                abort_handles.push(handle.abort_handle());
+                bootstrap_handles.push(handle);
             }
+
+            // Supervisor task: monitors all bootstrap tasks and opens the gate
+            // with an Error status if any task panics. Without this, a panicked
+            // bootstrap task would leave the gate closed forever.
+            {
+                let bootstrap_gate_clone = bootstrap_gate.clone();
+                let status_clone = self.base.status.clone();
+                let event_tx_clone = self.base.event_tx.clone();
+                let query_id_clone = self.base.config.id.clone();
+                let instance_id_clone = self.instance_id.clone();
+
+                let span = tracing::info_span!(
+                    "bootstrap_supervisor",
+                    instance_id = %instance_id_clone,
+                    component_id = %query_id_clone,
+                    component_type = "query"
+                );
+                let supervisor_handle = tokio::spawn(
+                    async move {
+                        let results = futures::future::join_all(bootstrap_handles).await;
+                        let panic_count = results.iter().filter(|r| matches!(r, Err(e) if e.is_panic())).count();
+
+                        if panic_count > 0 {
+                            error!(
+                                "[BOOTSTRAP] Query '{query_id_clone}' {panic_count} bootstrap task(s) panicked, \
+                                 transitioning to Error and opening gate"
+                            );
+
+                            *status_clone.write().await = ComponentStatus::Error;
+
+                            let error_event = ComponentEvent {
+                                component_id: query_id_clone.clone(),
+                                component_type: ComponentType::Query,
+                                status: ComponentStatus::Error,
+                                timestamp: chrono::Utc::now(),
+                                message: Some(format!(
+                                    "Bootstrap failed: {panic_count} task(s) panicked"
+                                )),
+                            };
+                            let _ = event_tx_clone.send(error_event).await;
+
+                            bootstrap_gate_clone.notify_one();
+                        }
+                        // If all tasks succeeded, the last one already opened the gate.
+                    }
+                    .instrument(span),
+                );
+                abort_handles.push(supervisor_handle.abort_handle());
+            }
+
+            // Store abort handles for cleanup on stop()
+            *self.bootstrap_abort_handles.write().await = abort_handles;
         } else {
             info!(
                 "Query '{}' no bootstrap channels, skipping bootstrap",
                 self.base.config.id
             );
-        }
-
-        // Set status to Running before starting event processor
-        *self.base.status.write().await = ComponentStatus::Running;
-
-        let event = ComponentEvent {
-            component_id: self.base.config.id.clone(),
-            component_type: ComponentType::Query,
-            status: ComponentStatus::Running,
-            timestamp: chrono::Utc::now(),
-            message: Some("Query started successfully".to_string()),
-        };
-
-        if let Err(e) = self.base.event_tx.send(event).await {
-            error!("Failed to send component event: {e}");
+            // No bootstrap needed — open the gate immediately
+            bootstrap_gate.notify_one();
         }
 
         // NEW: Spawn event processor task that reads from priority queue
@@ -786,6 +839,8 @@ impl Query for DrasiQuery {
         let priority_queue = self.priority_queue.clone();
         let status = self.base.status.clone();
         let instance_id = self.instance_id.clone();
+        let event_tx_for_processor = self.base.event_tx.clone();
+        let config_id_for_processor = self.base.config.id.clone();
 
         // Create shutdown channel for graceful termination
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -799,6 +854,57 @@ impl Query for DrasiQuery {
         );
         let handle = tokio::spawn(
             async move {
+                info!("Query '{query_id}' waiting for bootstrap gate before processing events");
+
+                // Wait for bootstrap to complete (or immediate signal if no bootstrap).
+                // If shutdown arrives while waiting, exit cleanly.
+                tokio::select! {
+                    biased;
+
+                    _ = &mut shutdown_rx => {
+                        info!(
+                            "Query '{query_id}' received shutdown during bootstrap wait, exiting"
+                        );
+                        return;
+                    }
+
+                    _ = bootstrap_gate.notified() => {
+                        info!("Query '{query_id}' bootstrap gate opened, starting event processing");
+                    }
+                }
+
+                // Bootstrap complete — transition to Running only if still Starting.
+                // If stop() was called during bootstrap, status may already be
+                // Stopping and we must not overwrite it.
+                let should_run = {
+                    let mut guard = status.write().await;
+                    if matches!(*guard, ComponentStatus::Starting) {
+                        *guard = ComponentStatus::Running;
+                        true
+                    } else {
+                        warn!(
+                            "Query '{query_id}' bootstrap completed but status is {:?}, \
+                             skipping transition to Running",
+                            *guard
+                        );
+                        false
+                    }
+                };
+
+                if should_run {
+                    let running_event = ComponentEvent {
+                        component_id: config_id_for_processor,
+                        component_type: ComponentType::Query,
+                        status: ComponentStatus::Running,
+                        timestamp: chrono::Utc::now(),
+                        message: Some("Query started successfully".to_string()),
+                    };
+
+                    if let Err(e) = event_tx_for_processor.send(running_event).await {
+                        error!("Failed to send component event: {e}");
+                    }
+                }
+
                 info!("Query '{query_id}' starting priority queue event processor");
 
                 loop {
@@ -852,10 +958,6 @@ impl Query for DrasiQuery {
                             debug!(
                                 "Query '{query_id}' ignoring control event from source '{source_id}'"
                             );
-                            continue;
-                        }
-                        SourceEvent::BootstrapStart { .. } | SourceEvent::BootstrapEnd { .. } => {
-                            debug!("Query '{query_id}' ignoring bootstrap marker event (deprecated)");
                             continue;
                         }
                     };
@@ -1025,6 +1127,15 @@ impl Query for DrasiQuery {
                     self.base.config.id, e
                 );
             }
+        }
+
+        // Abort bootstrap tasks and supervisor
+        let bootstrap_aborts: Vec<_> = {
+            let mut handles = self.bootstrap_abort_handles.write().await;
+            handles.drain(..).collect()
+        };
+        for handle in bootstrap_aborts {
+            handle.abort();
         }
 
         // Drain and abort source subscription forwarders so they don't leak across restarts
@@ -1305,20 +1416,25 @@ impl QueryManager {
         if let Some(query) = query {
             let status = query.status().await;
 
-            // If the query is running, stop it first
-            if matches!(status, ComponentStatus::Running) {
+            // If the query is running or starting, stop it first
+            if matches!(status, ComponentStatus::Running | ComponentStatus::Starting) {
                 info!("Stopping query '{id}' before deletion");
-                query.stop().await?;
+                if let Err(e) = query.stop().await {
+                    warn!(
+                        "Failed to stop query '{id}' during deletion (may already be stopped): {e}"
+                    );
+                }
 
                 // Wait a bit to ensure the query has fully stopped
                 tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-                // Verify it's stopped
+                // Verify it's stopped - accept Stopped or Error
                 let new_status = query.status().await;
-                if !matches!(new_status, ComponentStatus::Stopped) {
-                    return Err(anyhow::anyhow!(
-                        "Failed to stop query '{id}' before deletion"
-                    ));
+                if !matches!(
+                    new_status,
+                    ComponentStatus::Stopped | ComponentStatus::Error
+                ) {
+                    warn!("Query '{id}' in unexpected state {new_status:?} after stop, proceeding with deletion");
                 }
             } else {
                 // Still validate the operation for non-running states


### PR DESCRIPTION
## Description

Gate the streaming event processor behind bootstrap completion to fix a race condition where streaming events could be processed before bootstrap finishes, corrupting query state.

When a query subscribes to a source with bootstrap enabled, `DrasiQuery::start()` spawns bootstrap processor tasks and the streaming event processor concurrently. Both call `process_source_change()` on the same `ContinuousQuery` with no synchronization. This means a streaming UPDATE can be processed before the bootstrap INSERT that establishes the element, leading to incorrect results.

The fix uses a `tokio::sync::Notify` gate:
- The event processor awaits the gate before entering its processing loop
- Bootstrap completion signals the gate after emitting `bootstrapCompleted`
- When no bootstrap channels exist, the gate signals immediately (zero delay)
- Streaming events buffer safely in the priority queue during bootstrap (both Channel and Broadcast dispatch modes handle this correctly via `enqueue_wait` / `enqueue`)
- Shutdown during bootstrap wait is handled cleanly via `tokio::select!` on `shutdown_rx`
- `stop()` cancels in-flight bootstrap tasks and the supervisor via stored `AbortHandle`s, preventing orphaned tasks
- The supervisor distinguishes cancellation (from `stop()`) from actual panics via `is_panic()`, so clean shutdown doesn't trigger the Error path
- A supervisor task monitors all bootstrap tasks via `join_all` and opens the gate with an `Error` status if any task panics, preventing the event processor from blocking indefinitely

Additionally, `ComponentStatus::Running` is now set *after* bootstrap completes rather than before, which is semantically correct -- external consumers can rely on `Running` meaning "bootstrap complete, actively processing streaming events." Since queries can now remain in `Starting` for the duration of bootstrap, `delete_query/source/reaction` and `stop_all_components()` also handle the `Starting` state so that components can be cleanly deleted or shut down mid-bootstrap.

Also removes the deprecated `BootstrapStart`/`BootstrapEnd` variants from `SourceEvent` which were only matched-and-ignored.

## Test coverage
Adds `TestBootstrapMockSource`, which is a test source that provides a controlled bootstrap channel.
Also added a test (`test_bootstrap_gate_delays_running_status`) that verifies the gate blocks the query in `Starting` state until bootstrap completes, then transitions to `Running`.

## Type of change

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).

Fixes: #257 