### PR TITLE
Fix pr-first-approval-label workflow for fork PRs

### DIFF
--- a/.github/workflows/pr-first-approval-label-run.yml
+++ b/.github/workflows/pr-first-approval-label-run.yml
@@ -1,0 +1,106 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stage 2 of the PR approval-labeling workflow. Runs in the base-repo context
+# (triggered by workflow_run) so it has a write GITHUB_TOKEN, even when the
+# original review was on a fork PR.
+#
+# The PR number is read from an artifact uploaded by Stage 1 and treated as
+# untrusted — review state is always re-queried from the GitHub API.
+
+name: Label PR on First Approval
+
+on:
+  workflow_run:
+    workflows: ["PR Review Trigger"]
+    types: [completed]
+
+jobs:
+  add-awaiting-review-label:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: write
+      actions: read
+    steps:
+      - name: Download PR number artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: review-info
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check approval count and manage label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+
+            // Read PR number from artifact (treat as untrusted input)
+            const raw = fs.readFileSync('pr_number.txt', 'utf8').trim();
+            const prNumber = parseInt(raw, 10);
+            if (isNaN(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number from artifact: ${raw}`);
+              return;
+            }
+
+            // Re-query reviews from the API (never trust artifact data for state)
+            const reviews = await github.rest.pulls.listReviews({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            // Count unique approvals (latest review per user)
+            const latestReviewByUser = new Map();
+            for (const review of reviews.data) {
+              const existing = latestReviewByUser.get(review.user.login);
+              if (!existing || new Date(review.submitted_at) > new Date(existing.submitted_at)) {
+                latestReviewByUser.set(review.user.login, review);
+              }
+            }
+
+            const approvalCount = Array.from(latestReviewByUser.values())
+              .filter(r => r.state === 'APPROVED').length;
+
+            console.log(`PR #${prNumber} has ${approvalCount} approval(s)`);
+
+            // Add label if exactly 1 approval (first approval just happened)
+            if (approvalCount === 1) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: ['need-2nd-review']
+              });
+              console.log('Added "need-2nd-review" label');
+            }
+
+            // Remove label if 2+ approvals (PR is fully approved)
+            if (approvalCount >= 2) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: 'need-2nd-review'
+                });
+                console.log('Removed "need-2nd-review" label');
+              } catch (e) {
+                // Label might not exist, that's fine
+                if (e.status !== 404) throw e;
+              }
+            }

--- a/.github/workflows/pr-first-approval-label.yml
+++ b/.github/workflows/pr-first-approval-label.yml
@@ -12,71 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Label PR on First Approval
+# Stage 1 of a two-stage workflow. The pull_request_review event runs with a
+# read-only GITHUB_TOKEN for fork PRs, so this workflow only saves the PR
+# number as an artifact. The privileged labeling logic lives in
+# pr-first-approval-label-run.yml, which triggers via workflow_run and
+# executes in the base-repo context with write permissions.
+
+name: PR Review Trigger
 
 on:
   pull_request_review:
     types: [submitted]
 
 jobs:
-  add-awaiting-review-label:
+  save-pr-number:
     if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-      issues: write
     steps:
-      - name: Check approval count and add label
-        uses: actions/github-script@v7
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const prNumber = context.payload.pull_request.number;
-
-            // Get all reviews for this PR
-            const reviews = await github.rest.pulls.listReviews({
-              owner,
-              repo,
-              pull_number: prNumber,
-            });
-
-            // Count unique approvals (latest review per user)
-            const latestReviewByUser = new Map();
-            for (const review of reviews.data) {
-              const existing = latestReviewByUser.get(review.user.login);
-              if (!existing || new Date(review.submitted_at) > new Date(existing.submitted_at)) {
-                latestReviewByUser.set(review.user.login, review);
-              }
-            }
-
-            const approvalCount = Array.from(latestReviewByUser.values())
-              .filter(r => r.state === 'APPROVED').length;
-
-            console.log(`PR #${prNumber} has ${approvalCount} approval(s)`);
-
-            // Add label if exactly 1 approval (first approval just happened)
-            if (approvalCount === 1) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: prNumber,
-                labels: ['need-2nd-review']
-              });
-              console.log('Added "need-2nd-review" label');
-            }
-
-            // Remove label if 2+ approvals (PR is fully approved)
-            if (approvalCount >= 2) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                  name: 'need-2nd-review'
-                });
-                console.log('Removed "need-2nd-review" label');
-              } catch (e) {
-                // Label might not exist, that's fine
-                if (e.status !== 404) throw e;
-              }
-            }
+          name: review-info
+          path: pr_number.txt

--- a/.github/workflows/readme.md
+++ b/.github/workflows/readme.md
@@ -67,6 +67,20 @@ To modify or create agentic workflows, you'll need to:
   - Pull requests targeting `main`.
   - Scheduled weekly (every Sunday at 00:30 UTC).
 
+### [pr-assignment-check.yml](pr-assignment-check.yml)
+- **Purpose**: Ensures external contributors have a linked issue and are assigned to it before submitting a PR. Maintainers (write/admin access) are exempt.
+- **Trigger**: `pull_request_target` on `opened`, `reopened`, or `edited`.
+- **Behavior**:
+  - If no linked issue is found, adds the `needs-issue` label and comments with instructions.
+  - If the author is not assigned to the linked issue, closes the PR with an explanation.
+
+### [pr-first-approval-label.yml](pr-first-approval-label.yml) + [pr-first-approval-label-run.yml](pr-first-approval-label-run.yml)
+- **Purpose**: Manages the `need-2nd-review` label based on PR approval count — adds it on the first approval and removes it once a second approval is received.
+- **Trigger**: `pull_request_review` on `submitted` (approval only).
+- **Design**: Uses a two-stage `workflow_run` pattern because the `pull_request_review` event provides only a read-only `GITHUB_TOKEN` for fork PRs:
+  1. **Stage 1** (`pr-first-approval-label.yml`): Saves the PR number as an artifact.
+  2. **Stage 2** (`pr-first-approval-label-run.yml`): Runs in the base-repo context with write permissions, re-queries reviews from the API, and manages the label.
+
 ### [release-plz.yml](release-plz.yml)
 - **Purpose**: Automates version bumps, changelog generation, and crate publishing using release-plz.
 - **Triggers**:


### PR DESCRIPTION
The pull_request_review event runs with a read-only GITHUB_TOKEN for fork PRs, causing a 403 on issues.addLabels regardless of the permissions block. Split into a two-stage workflow_run pattern:

- Stage 1 (pr-first-approval-label.yml): triggers on pull_request_review, saves the PR number as an artifact, and exits.
- Stage 2 (pr-first-approval-label-run.yml): triggers on workflow_run completion of Stage 1, runs in the base-repo context with write permissions, re-queries review state from the API, and manages the "need-2nd-review" label.