### PR TITLE
Use pull-requests: write in approval label workflow

### DIFF
--- a/.github/workflows/pr-first-approval-label-run.yml
+++ b/.github/workflows/pr-first-approval-label-run.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
       issues: write
       actions: read
     steps:


### PR DESCRIPTION
The issues.addLabels API requires pull-requests: write (not just issues: write) when the target issue is a pull request. Update the Stage 2 workflow_run permissions accordingly.