### PR TITLE
Surface ResultRowId on QueryPartEvaluationContext

### DIFF
--- a/components/reactions/platform/src/types.rs
+++ b/components/reactions/platform/src/types.rs
@@ -179,17 +179,17 @@ impl ResultEvent {
 
         for ctx in data {
             match ctx {
-                QueryPartEvaluationContext::Adding { after } => {
+                QueryPartEvaluationContext::Adding { after, .. } => {
                     added_results.push(variables_to_json(after));
                 }
-                QueryPartEvaluationContext::Updating { before, after } => {
+                QueryPartEvaluationContext::Updating { before, after, .. } => {
                     updated_results.push(UpdatePayload {
                         before: Some(variables_to_json(before)),
                         after: Some(variables_to_json(after)),
                         grouping_keys: None,
                     });
                 }
-                QueryPartEvaluationContext::Removing { before } => {
+                QueryPartEvaluationContext::Removing { before, .. } => {
                     deleted_results.push(variables_to_json(before));
                 }
                 QueryPartEvaluationContext::Aggregation {

--- a/core/src/evaluation/parts/mod.rs
+++ b/core/src/evaluation/parts/mod.rs
@@ -69,7 +69,7 @@ impl QueryPartEvaluator {
         );
 
         match context {
-            QueryPartEvaluationContext::Adding { after } => {
+            QueryPartEvaluationContext::Adding { after, .. } => {
                 let agg_snapshot = match &part.return_clause {
                     ProjectionClause::GroupBy {
                         grouping: _,
@@ -123,11 +123,15 @@ impl QueryPartEvaluator {
                         grouping_keys,
                         default_before: true,
                         default_after: false,
+                        row_signature: 0,
                     }]),
-                    _ => Ok(vec![QueryPartEvaluationContext::Adding { after: data }]),
+                    _ => Ok(vec![QueryPartEvaluationContext::Adding {
+                        after: data,
+                        row_signature: 0,
+                    }]),
                 }
             }
-            QueryPartEvaluationContext::Updating { before, after } => {
+            QueryPartEvaluationContext::Updating { before, after, .. } => {
                 if before == after && !change_context.is_future_reprocess {
                     return Ok(vec![QueryPartEvaluationContext::Noop]);
                 };
@@ -231,6 +235,7 @@ impl QueryPartEvaluator {
                             Some(before_out) => {
                                 return Ok(vec![QueryPartEvaluationContext::Removing {
                                     before: before_out,
+                                    row_signature: 0,
                                 }])
                             }
                             None => return Ok(vec![QueryPartEvaluationContext::Noop]),
@@ -263,14 +268,16 @@ impl QueryPartEvaluator {
                         Some(before_out) => Ok(vec![QueryPartEvaluationContext::Updating {
                             before: before_out,
                             after: after_out,
+                            row_signature: 0,
                         }]),
                         None => Ok(vec![QueryPartEvaluationContext::Adding {
                             after: after_out,
+                            row_signature: 0,
                         }]),
                     },
                 }
             }
-            QueryPartEvaluationContext::Removing { before } => {
+            QueryPartEvaluationContext::Removing { before, .. } => {
                 let agg_before = match &part.return_clause {
                     ProjectionClause::GroupBy {
                         grouping: _,
@@ -323,8 +330,12 @@ impl QueryPartEvaluator {
                         grouping_keys,
                         default_before: false,
                         default_after: true,
+                        row_signature: 0,
                     }]),
-                    _ => Ok(vec![QueryPartEvaluationContext::Removing { before: data }]),
+                    _ => Ok(vec![QueryPartEvaluationContext::Removing {
+                        before: data,
+                        row_signature: 0,
+                    }]),
                 }
             }
             QueryPartEvaluationContext::Aggregation {
@@ -333,6 +344,7 @@ impl QueryPartEvaluator {
                 grouping_keys,
                 default_before,
                 default_after,
+                ..
             } => {
                 if let Some(before) = &before {
                     if before == &after && !change_context.is_future_reprocess && !default_before {
@@ -531,6 +543,7 @@ impl QueryPartEvaluator {
                         if before.is_some() && !before_filtered {
                             return Ok(vec![QueryPartEvaluationContext::Removing {
                                 before: next_before.unwrap_or_default(),
+                                row_signature: 0,
                             }]);
                         } else {
                             return Ok(vec![QueryPartEvaluationContext::Noop]);
@@ -566,11 +579,13 @@ impl QueryPartEvaluator {
                         if before_filtered || !should_revert {
                             Ok(vec![QueryPartEvaluationContext::Adding {
                                 after: next_after,
+                                row_signature: 0,
                             }])
                         } else {
                             Ok(vec![QueryPartEvaluationContext::Updating {
                                 before: next_before.unwrap_or_default(),
                                 after: next_after,
+                                row_signature: 0,
                             }])
                         }
                     }
@@ -652,6 +667,7 @@ impl QueryPartEvaluator {
                 grouping_keys,
                 default_before: false,
                 default_after: false,
+                row_signature: 0,
             }]);
         }
         let before_in = before_in.unwrap();
@@ -672,6 +688,7 @@ impl QueryPartEvaluator {
                 grouping_keys,
                 default_before: false,
                 default_after: false,
+                row_signature: 0,
             }]);
         }
 
@@ -682,6 +699,7 @@ impl QueryPartEvaluator {
                 grouping_keys: grouping_keys.clone(),
                 default_before: false,
                 default_after: false,
+                row_signature: 0,
             },
             QueryPartEvaluationContext::Aggregation {
                 before: Some(before_out),
@@ -698,6 +716,7 @@ impl QueryPartEvaluator {
                 grouping_keys: grouping_keys.clone(),
                 default_before: false,
                 default_after: false,
+                row_signature: 0,
             },
         ])
     }

--- a/core/src/evaluation/parts/tests.rs
+++ b/core/src/evaluation/parts/tests.rs
@@ -20,6 +20,9 @@ use crate::evaluation::{functions::FunctionRegistry, InstantQueryClock};
 
 use super::*;
 
+/// Placeholder for `row_signature` in test assertions — ignored during comparison.
+const IGNORED_ROW_SIGNATURE: u64 = 0;
+
 macro_rules! variablemap {
   ($( $key: expr => $val: expr ),*) => {{
        let mut map = ::std::collections::BTreeMap::new();

--- a/core/src/evaluation/parts/tests/multi_part.rs
+++ b/core/src/evaluation/parts/tests/multi_part.rs
@@ -14,7 +14,7 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use super::process_solution;
+use super::{process_solution, IGNORED_ROW_SIGNATURE};
 
 use crate::{
     evaluation::{
@@ -80,6 +80,7 @@ async fn aggregating_part_to_scalar_part_add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -90,6 +91,7 @@ async fn aggregating_part_to_scalar_part_add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -99,7 +101,8 @@ async fn aggregating_part_to_scalar_part_add_solution() {
             after: variablemap![
               "key" => json!("foo"),
               "my_sum" => json!(3.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -108,6 +111,7 @@ async fn aggregating_part_to_scalar_part_add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -117,7 +121,8 @@ async fn aggregating_part_to_scalar_part_add_solution() {
             after: variablemap![
               "key" => json!("bar"),
               "my_sum" => json!(5.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -195,6 +200,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -204,6 +210,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -213,6 +220,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -223,6 +231,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1.clone()],
             after: variablemap!["a" => node1a.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -236,7 +245,8 @@ async fn aggregating_part_to_scalar_part_update_solution() {
             after: variablemap![
               "key" => json!("foo"),
               "my_sum" => json!(4.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -246,6 +256,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1a.clone()],
             after: variablemap!["a" => node1b.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -259,7 +270,8 @@ async fn aggregating_part_to_scalar_part_update_solution() {
             after: variablemap![
               "key" => json!("foo"),
               "my_sum" => json!(3.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -269,6 +281,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1b.clone()],
             after: variablemap!["a" => node1c.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -279,6 +292,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(3.0)
             ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -288,6 +302,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1c.clone()],
             after: variablemap!["a" => node1d.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -298,6 +313,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(7.0)
             ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -307,6 +323,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node2.clone()],
             after: variablemap!["a" => node2a.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -321,6 +338,7 @@ async fn aggregating_part_to_scalar_part_update_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(5.0)
             ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -368,6 +386,7 @@ async fn aggregating_part_to_scalar_part_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -377,6 +396,7 @@ async fn aggregating_part_to_scalar_part_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -386,6 +406,7 @@ async fn aggregating_part_to_scalar_part_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -395,6 +416,7 @@ async fn aggregating_part_to_scalar_part_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -408,7 +430,8 @@ async fn aggregating_part_to_scalar_part_remove_solution() {
             after: variablemap![
               "key" => json!("foo"),
               "my_sum" => json!(1.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -417,6 +440,7 @@ async fn aggregating_part_to_scalar_part_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -427,6 +451,7 @@ async fn aggregating_part_to_scalar_part_remove_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(1.0)
             ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -476,6 +501,7 @@ async fn aggregating_part_to_aggregating_part_add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -493,6 +519,7 @@ async fn aggregating_part_to_aggregating_part_add_solution() {
             grouping_keys: vec!["Category".to_string()],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -501,6 +528,7 @@ async fn aggregating_part_to_aggregating_part_add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -518,6 +546,7 @@ async fn aggregating_part_to_aggregating_part_add_solution() {
             grouping_keys: vec!["Category".to_string()],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -526,6 +555,7 @@ async fn aggregating_part_to_aggregating_part_add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -543,6 +573,7 @@ async fn aggregating_part_to_aggregating_part_add_solution() {
             grouping_keys: vec!["Category".to_string()],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -598,6 +629,7 @@ async fn aggregating_part_to_aggregating_part_update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -607,6 +639,7 @@ async fn aggregating_part_to_aggregating_part_update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -616,6 +649,7 @@ async fn aggregating_part_to_aggregating_part_update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -626,6 +660,7 @@ async fn aggregating_part_to_aggregating_part_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1.clone()],
             after: variablemap!["a" => node1a.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -643,6 +678,7 @@ async fn aggregating_part_to_aggregating_part_update_solution() {
             grouping_keys: vec!["Category".to_string()],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -706,6 +742,7 @@ async fn aggregating_part_to_aggregating_part_group_switch() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -715,6 +752,7 @@ async fn aggregating_part_to_aggregating_part_group_switch() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -724,6 +762,7 @@ async fn aggregating_part_to_aggregating_part_group_switch() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -734,6 +773,7 @@ async fn aggregating_part_to_aggregating_part_group_switch() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1.clone()],
             after: variablemap!["a" => node1a.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -751,6 +791,7 @@ async fn aggregating_part_to_aggregating_part_group_switch() {
             grouping_keys: vec!["Category".to_string()],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -760,6 +801,7 @@ async fn aggregating_part_to_aggregating_part_group_switch() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1a.clone()],
             after: variablemap!["a" => node1b.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -778,6 +820,7 @@ async fn aggregating_part_to_aggregating_part_group_switch() {
                 grouping_keys: vec!["Category".to_string()],
                 default_before: false,
                 default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
             },
             QueryPartEvaluationContext::Aggregation {
                 before: Some(variablemap![
@@ -791,6 +834,7 @@ async fn aggregating_part_to_aggregating_part_group_switch() {
                 grouping_keys: vec!["Category".to_string()],
                 default_before: false,
                 default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
             },
         ]
     );
@@ -817,6 +861,7 @@ async fn test_list_indexing_with_clause() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: BTreeMap::new(),
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -825,7 +870,8 @@ async fn test_list_indexing_with_clause() {
         vec![QueryPartEvaluationContext::Adding {
             after: variablemap![
               "expression" => json!(7)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -891,6 +937,7 @@ async fn aggregating_part_to_aggregating_part_group_switch_with_comments() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -900,6 +947,7 @@ async fn aggregating_part_to_aggregating_part_group_switch_with_comments() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -909,6 +957,7 @@ async fn aggregating_part_to_aggregating_part_group_switch_with_comments() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -919,6 +968,7 @@ async fn aggregating_part_to_aggregating_part_group_switch_with_comments() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1.clone()],
             after: variablemap!["a" => node1a.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -936,6 +986,7 @@ async fn aggregating_part_to_aggregating_part_group_switch_with_comments() {
             grouping_keys: vec!["Category".to_string()],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -945,6 +996,7 @@ async fn aggregating_part_to_aggregating_part_group_switch_with_comments() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1a.clone()],
             after: variablemap!["a" => node1b.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -963,6 +1015,7 @@ async fn aggregating_part_to_aggregating_part_group_switch_with_comments() {
                 grouping_keys: vec!["Category".to_string()],
                 default_before: false,
                 default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
             },
             QueryPartEvaluationContext::Aggregation {
                 before: Some(variablemap![
@@ -976,6 +1029,7 @@ async fn aggregating_part_to_aggregating_part_group_switch_with_comments() {
                 grouping_keys: vec!["Category".to_string()],
                 default_before: false,
                 default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
             },
         ]
     );
@@ -1027,6 +1081,7 @@ async fn sequential_aggregations1() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1042,6 +1097,7 @@ async fn sequential_aggregations1() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1050,6 +1106,7 @@ async fn sequential_aggregations1() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1065,6 +1122,7 @@ async fn sequential_aggregations1() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1073,6 +1131,7 @@ async fn sequential_aggregations1() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1088,6 +1147,7 @@ async fn sequential_aggregations1() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1096,6 +1156,7 @@ async fn sequential_aggregations1() {
         &evaluator,
         QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1111,6 +1172,7 @@ async fn sequential_aggregations1() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1119,6 +1181,7 @@ async fn sequential_aggregations1() {
         &evaluator,
         QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1134,6 +1197,7 @@ async fn sequential_aggregations1() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -1183,6 +1247,7 @@ async fn sequential_aggregations2() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1198,6 +1263,7 @@ async fn sequential_aggregations2() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1206,6 +1272,7 @@ async fn sequential_aggregations2() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1221,6 +1288,7 @@ async fn sequential_aggregations2() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1229,6 +1297,7 @@ async fn sequential_aggregations2() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1244,6 +1313,7 @@ async fn sequential_aggregations2() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1252,6 +1322,7 @@ async fn sequential_aggregations2() {
         &evaluator,
         QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1267,6 +1338,7 @@ async fn sequential_aggregations2() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1275,6 +1347,7 @@ async fn sequential_aggregations2() {
         &evaluator,
         QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1290,6 +1363,7 @@ async fn sequential_aggregations2() {
             grouping_keys: vec![],
             default_before: false,
             default_after: false,
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -1342,6 +1416,7 @@ async fn aggregating_part_to_scalar_part_add_solution_emit_remove() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1351,7 +1426,8 @@ async fn aggregating_part_to_scalar_part_add_solution_emit_remove() {
             after: variablemap![
               "key" => json!("foo"),
               "my_sum" => json!(1.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1360,6 +1436,7 @@ async fn aggregating_part_to_scalar_part_add_solution_emit_remove() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1373,7 +1450,8 @@ async fn aggregating_part_to_scalar_part_add_solution_emit_remove() {
             after: variablemap![
               "key" => json!("foo"),
               "my_sum" => json!(3.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1382,6 +1460,7 @@ async fn aggregating_part_to_scalar_part_add_solution_emit_remove() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -1391,7 +1470,8 @@ async fn aggregating_part_to_scalar_part_add_solution_emit_remove() {
             after: variablemap![
               "key" => json!("bar"),
               "my_sum" => json!(5.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1400,6 +1480,7 @@ async fn aggregating_part_to_scalar_part_add_solution_emit_remove() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node4.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1412,7 +1493,8 @@ async fn aggregating_part_to_scalar_part_add_solution_emit_remove() {
             before: variablemap![
               "key" => json!("foo"),
               "my_sum" => json!(3.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }

--- a/core/src/evaluation/parts/tests/single_part_aggregating.rs
+++ b/core/src/evaluation/parts/tests/single_part_aggregating.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use super::process_solution;
+use super::{process_solution, IGNORED_ROW_SIGNATURE};
 
 use crate::{
     evaluation::{
@@ -77,6 +77,7 @@ async fn aggregating_query_add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -95,7 +96,8 @@ async fn aggregating_query_add_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(1.0),
               "my_min" => json!(1.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -104,6 +106,7 @@ async fn aggregating_query_add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -122,7 +125,8 @@ async fn aggregating_query_add_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(3.0),
               "my_min" => json!(1.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -131,6 +135,7 @@ async fn aggregating_query_add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -149,7 +154,8 @@ async fn aggregating_query_add_solution() {
               "key" => json!("bar"),
               "my_sum" => json!(5.0),
               "my_min" => json!(5.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -213,6 +219,7 @@ async fn aggregating_query_update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -222,6 +229,7 @@ async fn aggregating_query_update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -231,6 +239,7 @@ async fn aggregating_query_update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -241,6 +250,7 @@ async fn aggregating_query_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1.clone()],
             after: variablemap!["a" => node1a.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -259,7 +269,8 @@ async fn aggregating_query_update_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(4.0),
               "my_min" => json!(2.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -269,6 +280,7 @@ async fn aggregating_query_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1a.clone()],
             after: variablemap!["a" => node1b.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -287,7 +299,8 @@ async fn aggregating_query_update_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(9.0),
               "my_min" => json!(2.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -297,6 +310,7 @@ async fn aggregating_query_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1b.clone()],
             after: variablemap!["a" => node1c.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -315,7 +329,8 @@ async fn aggregating_query_update_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(2.0),
               "my_min" => json!(2.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -325,6 +340,7 @@ async fn aggregating_query_update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1c.clone()],
             after: variablemap!["a" => node1d.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -339,7 +355,8 @@ async fn aggregating_query_update_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(5.0),
               "my_min" => json!(2.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -379,6 +396,7 @@ async fn aggregating_query_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -388,6 +406,7 @@ async fn aggregating_query_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -397,6 +416,7 @@ async fn aggregating_query_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -406,6 +426,7 @@ async fn aggregating_query_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -424,7 +445,8 @@ async fn aggregating_query_remove_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(1.0),
               "my_min" => json!(1.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -433,6 +455,7 @@ async fn aggregating_query_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -451,7 +474,8 @@ async fn aggregating_query_remove_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(3.0),
               "my_min" => json!(1.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -460,6 +484,7 @@ async fn aggregating_query_remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -478,7 +503,8 @@ async fn aggregating_query_remove_solution() {
               "key" => json!("foo"),
               "my_sum" => json!(2.0),
               "my_min" => json!(2.0)
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -524,6 +550,7 @@ async fn group_switch() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -533,6 +560,7 @@ async fn group_switch() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -542,6 +570,7 @@ async fn group_switch() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -552,6 +581,7 @@ async fn group_switch() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1.clone()],
             after: variablemap!["a" => node1a.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -569,7 +599,8 @@ async fn group_switch() {
                 after: variablemap![
                   "key" => json!("bar"),
                   "my_sum" => json!(6.0)
-                ]
+                ],
+                row_signature: IGNORED_ROW_SIGNATURE,
             },
             QueryPartEvaluationContext::Aggregation {
                 grouping_keys: vec!["key".to_string()],
@@ -582,7 +613,8 @@ async fn group_switch() {
                 after: variablemap![
                   "key" => json!("foo"),
                   "my_sum" => json!(2.0)
-                ]
+                ],
+                row_signature: IGNORED_ROW_SIGNATURE,
             }
         ]
     );
@@ -658,6 +690,7 @@ async fn group_switch_complex_accumulator() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -667,6 +700,7 @@ async fn group_switch_complex_accumulator() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -676,6 +710,7 @@ async fn group_switch_complex_accumulator() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -686,6 +721,7 @@ async fn group_switch_complex_accumulator() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1.clone()],
             after: variablemap!["a" => node1a.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -703,7 +739,8 @@ async fn group_switch_complex_accumulator() {
                 after: variablemap![
                   "key" => json!("bar"),
                   "my_avg" => json!(3.0)
-                ]
+                ],
+                row_signature: IGNORED_ROW_SIGNATURE,
             },
             QueryPartEvaluationContext::Aggregation {
                 grouping_keys: vec!["key".to_string()],
@@ -716,7 +753,8 @@ async fn group_switch_complex_accumulator() {
                 after: variablemap![
                   "key" => json!("foo"),
                   "my_avg" => json!(2.0)
-                ]
+                ],
+                row_signature: IGNORED_ROW_SIGNATURE,
             }
         ]
     );
@@ -792,6 +830,7 @@ async fn test_aggregating_function_sum_duration() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -806,7 +845,8 @@ async fn test_aggregating_function_sum_duration() {
             ]),
             after: variablemap![
               "my_sum" => VariableValue::Duration(Duration::new(ChronoDuration::seconds(1),0,0))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -815,6 +855,7 @@ async fn test_aggregating_function_sum_duration() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -829,7 +870,8 @@ async fn test_aggregating_function_sum_duration() {
             ]),
             after: variablemap![
               "my_sum" => VariableValue::Duration(Duration::new(ChronoDuration::hours(2) + ChronoDuration::minutes(1)+ ChronoDuration::seconds(1) + ChronoDuration::milliseconds(2),0,0))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -888,6 +930,7 @@ async fn test_aggregating_function_max_duration() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -903,7 +946,8 @@ async fn test_aggregating_function_max_duration() {
             ]),
             after: variablemap![
               "max_result" => VariableValue::Duration(Duration::new(ChronoDuration::seconds(1),0,0))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -912,6 +956,7 @@ async fn test_aggregating_function_max_duration() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -927,7 +972,8 @@ async fn test_aggregating_function_max_duration() {
             ]),
             after: variablemap![
               "max_result" => VariableValue::Duration(Duration::new(ChronoDuration::hours(2) + ChronoDuration::minutes(1)+ ChronoDuration::milliseconds(2),0,0))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -936,6 +982,7 @@ async fn test_aggregating_function_max_duration() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -951,7 +998,8 @@ async fn test_aggregating_function_max_duration() {
             ]),
             after: variablemap![
               "max_result" => VariableValue::Duration(Duration::new(ChronoDuration::hours(2) + ChronoDuration::minutes(1)+ ChronoDuration::milliseconds(2),0,0))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -1025,6 +1073,7 @@ async fn test_aggregating_function_max_temporal_instant() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1042,7 +1091,8 @@ async fn test_aggregating_function_max_temporal_instant() {
             after: variablemap![
                 "max_date" => VariableValue::Date(chrono::NaiveDate::from_ymd_opt(2021, 1, 1).unwrap()),
                 "max_localdatetime" => VariableValue::LocalDateTime(chrono::NaiveDateTime::new(chrono::NaiveDate::from_ymd_opt(2019, 6, 6).unwrap(), chrono::NaiveTime::from_hms_opt(1, 1, 1).unwrap()))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1051,6 +1101,7 @@ async fn test_aggregating_function_max_temporal_instant() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1068,7 +1119,8 @@ async fn test_aggregating_function_max_temporal_instant() {
             after: variablemap![
                 "max_date" => VariableValue::Date(chrono::NaiveDate::from_ymd_opt(2021, 1, 2).unwrap()),
                 "max_localdatetime" => VariableValue::LocalDateTime(chrono::NaiveDateTime::new(chrono::NaiveDate::from_ymd_opt(2019, 6, 7).unwrap(), chrono::NaiveTime::from_hms_opt(2, 2, 2).unwrap()))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1077,6 +1129,7 @@ async fn test_aggregating_function_max_temporal_instant() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1094,7 +1147,8 @@ async fn test_aggregating_function_max_temporal_instant() {
             after: variablemap![
                 "max_date" => VariableValue::Date(chrono::NaiveDate::from_ymd_opt(2021, 1, 2).unwrap()),
                 "max_localdatetime" => VariableValue::LocalDateTime(chrono::NaiveDateTime::new(chrono::NaiveDate::from_ymd_opt(2019, 6, 7).unwrap(), chrono::NaiveTime::from_hms_opt(2, 2, 2).unwrap()))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -1153,6 +1207,7 @@ async fn test_aggregating_function_min_temporal_duration() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1168,7 +1223,8 @@ async fn test_aggregating_function_min_temporal_duration() {
             ]),
             after: variablemap![
               "min_result" => VariableValue::Duration(Duration::new(ChronoDuration::seconds(1),0,0))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1177,6 +1233,7 @@ async fn test_aggregating_function_min_temporal_duration() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1192,7 +1249,8 @@ async fn test_aggregating_function_min_temporal_duration() {
             ]),
             after: variablemap![
               "min_result" => VariableValue::Duration(Duration::new(ChronoDuration::seconds(1),0,0))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1201,6 +1259,7 @@ async fn test_aggregating_function_min_temporal_duration() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1216,7 +1275,8 @@ async fn test_aggregating_function_min_temporal_duration() {
             ]),
             after: variablemap![
               "min_result" => VariableValue::Duration(Duration::new(ChronoDuration::seconds(1),0,0))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -1289,6 +1349,7 @@ async fn test_aggregating_function_min_temporal_instant() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1306,7 +1367,8 @@ async fn test_aggregating_function_min_temporal_instant() {
             after: variablemap![
                 "min_time" => VariableValue::LocalTime(NaiveTime::from_hms_opt(21, 1, 1).unwrap()),
                 "min_localdatetime" => VariableValue::LocalDateTime(NaiveDateTime::new(chrono::NaiveDate::from_ymd_opt(2019, 6, 6).unwrap(), chrono::NaiveTime::from_hms_opt(1, 1, 1).unwrap()))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1317,6 +1379,7 @@ async fn test_aggregating_function_min_temporal_instant() {
             after: variablemap![
                 "a" => node2.clone()
             ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1334,7 +1397,8 @@ async fn test_aggregating_function_min_temporal_instant() {
             after: variablemap![
                 "min_time" => VariableValue::LocalTime(NaiveTime::from_hms_milli_opt(11,32,23,123).unwrap()),
                 "min_localdatetime" => VariableValue::LocalDateTime(NaiveDateTime::new(chrono::NaiveDate::from_ymd_opt(2019, 6, 1).unwrap(), chrono::NaiveTime::from_hms_opt(1, 1, 1).unwrap()))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -1345,6 +1409,7 @@ async fn test_aggregating_function_min_temporal_instant() {
             after: variablemap![
                 "a" => node1.clone()
             ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -1362,7 +1427,8 @@ async fn test_aggregating_function_min_temporal_instant() {
             after: variablemap![
                 "min_time" => VariableValue::LocalTime(NaiveTime::from_hms_milli_opt(11,32,23,123).unwrap()),
                 "min_localdatetime" => VariableValue::LocalDateTime(NaiveDateTime::new(chrono::NaiveDate::from_ymd_opt(2019, 6, 1).unwrap(), chrono::NaiveTime::from_hms_opt(1, 1, 1).unwrap()))
-            ]
+            ],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }

--- a/core/src/evaluation/parts/tests/single_part_non_aggregating.rs
+++ b/core/src/evaluation/parts/tests/single_part_non_aggregating.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use super::process_solution;
+use super::{process_solution, IGNORED_ROW_SIGNATURE};
 
 use crate::{
     evaluation::{
@@ -50,13 +50,15 @@ async fn add_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
     assert_eq!(
         result.await,
         vec![QueryPartEvaluationContext::Adding {
-            after: variablemap!["a" => node1.clone()]
+            after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -96,6 +98,7 @@ async fn update_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -106,6 +109,7 @@ async fn update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1.clone()],
             after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -113,7 +117,8 @@ async fn update_solution() {
         result.await,
         vec![QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node1.clone()],
-            after: variablemap!["a" => node2.clone()]
+            after: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 
@@ -123,6 +128,7 @@ async fn update_solution() {
         QueryPartEvaluationContext::Updating {
             before: variablemap!["a" => node2.clone()],
             after: variablemap!["a" => node3.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
@@ -130,6 +136,7 @@ async fn update_solution() {
         result.await,
         vec![QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node2.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }
@@ -157,6 +164,7 @@ async fn remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Adding {
             after: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     )
     .await;
@@ -166,13 +174,15 @@ async fn remove_solution() {
         &evaluator,
         QueryPartEvaluationContext::Removing {
             before: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         },
     );
 
     assert_eq!(
         result.await,
         vec![QueryPartEvaluationContext::Removing {
-            before: variablemap!["a" => node1.clone()]
+            before: variablemap!["a" => node1.clone()],
+            row_signature: IGNORED_ROW_SIGNATURE,
         }]
     );
 }

--- a/core/src/query/tests/mod.rs
+++ b/core/src/query/tests/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod row_signature_tests;
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/core/src/query/tests/row_signature_tests.rs
+++ b/core/src/query/tests/row_signature_tests.rs
@@ -1,0 +1,292 @@
+// Copyright 2024 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use drasi_query_cypher::CypherParser;
+use serde_json::json;
+
+use crate::{
+    evaluation::{
+        context::QueryPartEvaluationContext,
+        functions::{Function, FunctionRegistry, Sum},
+    },
+    in_memory_index::{
+        in_memory_element_index::InMemoryElementIndex, in_memory_future_queue::InMemoryFutureQueue,
+        in_memory_result_index::InMemoryResultIndex,
+    },
+    models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
+    query::QueryBuilder,
+};
+
+fn create_registry_with_sum() -> Arc<FunctionRegistry> {
+    let registry = Arc::new(FunctionRegistry::new());
+    registry.register_function("sum", Function::Aggregating(Arc::new(Sum {})));
+    registry
+}
+
+async fn build_simple_query(query_str: &str) -> crate::query::ContinuousQuery {
+    let function_registry = Arc::new(FunctionRegistry::new());
+    let parser = Arc::new(CypherParser::new(function_registry.clone()));
+    let builder = QueryBuilder::new(query_str, parser);
+    builder.build().await
+}
+
+async fn build_aggregating_query(query_str: &str) -> crate::query::ContinuousQuery {
+    let function_registry = create_registry_with_sum();
+    let parser = Arc::new(CypherParser::new(function_registry.clone()));
+    let builder =
+        QueryBuilder::new(query_str, parser).with_function_registry(function_registry.clone());
+    builder.build().await
+}
+
+async fn build_query_with_indexes(query_str: &str) -> crate::query::ContinuousQuery {
+    let function_registry = Arc::new(FunctionRegistry::new());
+    let parser = Arc::new(CypherParser::new(function_registry.clone()));
+    let element_index = Arc::new(InMemoryElementIndex::new());
+    let result_index = Arc::new(InMemoryResultIndex::new());
+    let future_queue = Arc::new(InMemoryFutureQueue::new());
+    let builder = QueryBuilder::new(query_str, parser)
+        .with_element_index(element_index.clone())
+        .with_archive_index(element_index)
+        .with_result_index(result_index)
+        .with_future_queue(future_queue);
+    builder.build().await
+}
+
+async fn build_aggregating_query_with_indexes(query_str: &str) -> crate::query::ContinuousQuery {
+    let function_registry = create_registry_with_sum();
+    let parser = Arc::new(CypherParser::new(function_registry.clone()));
+    let element_index = Arc::new(InMemoryElementIndex::new());
+    let result_index = Arc::new(InMemoryResultIndex::new());
+    let future_queue = Arc::new(InMemoryFutureQueue::new());
+    let builder = QueryBuilder::new(query_str, parser)
+        .with_function_registry(function_registry.clone())
+        .with_element_index(element_index.clone())
+        .with_archive_index(element_index)
+        .with_result_index(result_index)
+        .with_future_queue(future_queue);
+    builder.build().await
+}
+
+fn make_node(source: &str, id: &str, label: &str, props: serde_json::Value) -> SourceChange {
+    SourceChange::Insert {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(source, id),
+                labels: Arc::new([Arc::from(label)]),
+                effective_from: 1000,
+            },
+            properties: ElementPropertyMap::from(props),
+        },
+    }
+}
+
+fn make_update(source: &str, id: &str, label: &str, props: serde_json::Value) -> SourceChange {
+    SourceChange::Update {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(source, id),
+                labels: Arc::new([Arc::from(label)]),
+                effective_from: 2000,
+            },
+            properties: ElementPropertyMap::from(props),
+        },
+    }
+}
+
+fn make_delete(source: &str, id: &str) -> SourceChange {
+    SourceChange::Delete {
+        metadata: ElementMetadata {
+            reference: ElementReference::new(source, id),
+            labels: Arc::new([]),
+            effective_from: 3000,
+        },
+    }
+}
+
+#[tokio::test]
+async fn non_aggregating_insert_has_nonzero_row_signature() {
+    let query = build_simple_query("MATCH (n:Sensor) RETURN n.name").await;
+
+    let change = make_node("test", "s1", "Sensor", json!({"name": "temp_1"}));
+    let result = query.process_source_change(change).await.unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(matches!(
+        &result[0],
+        QueryPartEvaluationContext::Adding { .. }
+    ));
+    assert_ne!(
+        result[0].row_signature(),
+        0,
+        "Adding result should have a non-zero row_signature"
+    );
+}
+
+#[tokio::test]
+async fn non_aggregating_update_preserves_row_signature() {
+    let query = build_query_with_indexes("MATCH (n:Sensor) RETURN n.name").await;
+
+    let insert = make_node("test", "s1", "Sensor", json!({"name": "temp_1"}));
+    let insert_result = query.process_source_change(insert).await.unwrap();
+    assert_eq!(insert_result.len(), 1);
+    let insert_row_signature = insert_result[0].row_signature();
+
+    let update = make_update("test", "s1", "Sensor", json!({"name": "temp_1_updated"}));
+    let update_result = query.process_source_change(update).await.unwrap();
+    assert_eq!(update_result.len(), 1);
+    assert!(matches!(
+        &update_result[0],
+        QueryPartEvaluationContext::Updating { .. }
+    ));
+    assert_eq!(
+        update_result[0].row_signature(),
+        insert_row_signature,
+        "Update of same node should preserve row_signature"
+    );
+}
+
+#[tokio::test]
+async fn non_aggregating_delete_preserves_row_signature() {
+    let query = build_query_with_indexes("MATCH (n:Sensor) RETURN n.name").await;
+
+    let insert = make_node("test", "s1", "Sensor", json!({"name": "temp_1"}));
+    let insert_result = query.process_source_change(insert).await.unwrap();
+    assert_eq!(insert_result.len(), 1);
+    let insert_row_signature = insert_result[0].row_signature();
+
+    let delete = make_delete("test", "s1");
+    let delete_result = query.process_source_change(delete).await.unwrap();
+    assert_eq!(delete_result.len(), 1);
+    assert!(matches!(
+        &delete_result[0],
+        QueryPartEvaluationContext::Removing { .. }
+    ));
+    assert_eq!(
+        delete_result[0].row_signature(),
+        insert_row_signature,
+        "Delete of same node should preserve row_signature"
+    );
+}
+
+#[tokio::test]
+async fn different_solutions_get_different_row_signatures() {
+    let query = build_simple_query("MATCH (n:Sensor) RETURN n.name").await;
+
+    let change1 = make_node("test", "s1", "Sensor", json!({"name": "temp_1"}));
+    let result1 = query.process_source_change(change1).await.unwrap();
+    assert_eq!(result1.len(), 1);
+
+    let change2 = make_node("test", "s2", "Sensor", json!({"name": "temp_1"}));
+    let result2 = query.process_source_change(change2).await.unwrap();
+    assert_eq!(result2.len(), 1);
+
+    assert_ne!(
+        result1[0].row_signature(),
+        result2[0].row_signature(),
+        "Different graph solutions should produce different row_signatures even with identical projected values"
+    );
+}
+
+#[tokio::test]
+async fn aggregating_query_has_nonzero_row_signature() {
+    let query = build_aggregating_query(
+        "MATCH (n:Sensor) RETURN n.region AS region, sum(n.value) AS total",
+    )
+    .await;
+
+    let change = make_node(
+        "test",
+        "s1",
+        "Sensor",
+        json!({"region": "west", "value": 10}),
+    );
+    let result = query.process_source_change(change).await.unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(matches!(
+        &result[0],
+        QueryPartEvaluationContext::Aggregation { .. }
+    ));
+    assert_ne!(
+        result[0].row_signature(),
+        0,
+        "Aggregation result should have a non-zero row_signature"
+    );
+}
+
+#[tokio::test]
+async fn aggregating_same_group_preserves_row_signature() {
+    let query = build_aggregating_query_with_indexes(
+        "MATCH (n:Sensor) RETURN n.region AS region, sum(n.value) AS total",
+    )
+    .await;
+
+    let change1 = make_node(
+        "test",
+        "s1",
+        "Sensor",
+        json!({"region": "west", "value": 10}),
+    );
+    let result1 = query.process_source_change(change1).await.unwrap();
+    assert_eq!(result1.len(), 1);
+    let first_row_signature = result1[0].row_signature();
+
+    let change2 = make_node(
+        "test",
+        "s2",
+        "Sensor",
+        json!({"region": "west", "value": 20}),
+    );
+    let result2 = query.process_source_change(change2).await.unwrap();
+    assert_eq!(result2.len(), 1);
+    assert_eq!(
+        result2[0].row_signature(),
+        first_row_signature,
+        "Adding to same aggregation group should preserve row_signature"
+    );
+}
+
+#[tokio::test]
+async fn aggregating_different_groups_get_different_row_signatures() {
+    let query = build_aggregating_query(
+        "MATCH (n:Sensor) RETURN n.region AS region, sum(n.value) AS total",
+    )
+    .await;
+
+    let change1 = make_node(
+        "test",
+        "s1",
+        "Sensor",
+        json!({"region": "west", "value": 10}),
+    );
+    let result1 = query.process_source_change(change1).await.unwrap();
+    assert_eq!(result1.len(), 1);
+
+    let change2 = make_node(
+        "test",
+        "s2",
+        "Sensor",
+        json!({"region": "east", "value": 20}),
+    );
+    let result2 = query.process_source_change(change2).await.unwrap();
+    assert_eq!(result2.len(), 1);
+
+    assert_ne!(
+        result1[0].row_signature(),
+        result2[0].row_signature(),
+        "Different GROUP BY values should produce different row_signatures"
+    );
+}

--- a/examples/query/process_monitor.rs
+++ b/examples/query/process_monitor.rs
@@ -65,13 +65,13 @@ async fn process_change(query: &ContinuousQuery, change: SourceChange) {
     let result = query.process_source_change(change).await.unwrap();
     for context in result {
         match context {
-            QueryPartEvaluationContext::Adding { after } => {
+            QueryPartEvaluationContext::Adding { after, .. } => {
                 println!("Adding: {after:?}");
             }
-            QueryPartEvaluationContext::Removing { before } => {
+            QueryPartEvaluationContext::Removing { before, .. } => {
                 println!("Removing: {before:?}");
             }
-            QueryPartEvaluationContext::Updating { before, after } => {
+            QueryPartEvaluationContext::Updating { before, after, .. } => {
                 println!("Updating: {before:?} -> {after:?}");
             }
             _ => {}

--- a/examples/query/temperature.rs
+++ b/examples/query/temperature.rs
@@ -100,13 +100,13 @@ async fn process_change(query: &ContinuousQuery, change: SourceChange) {
     println!("Results affected: {:?}", result.len());
     for context in result {
         match context {
-            QueryPartEvaluationContext::Adding { after } => {
+            QueryPartEvaluationContext::Adding { after, .. } => {
                 println!("Adding: {after:?}");
             }
-            QueryPartEvaluationContext::Removing { before } => {
+            QueryPartEvaluationContext::Removing { before, .. } => {
                 println!("Removing: {before:?}");
             }
-            QueryPartEvaluationContext::Updating { before, after } => {
+            QueryPartEvaluationContext::Updating { before, after, .. } => {
                 println!("Updating: {before:?} -> {after:?}");
             }
             _ => {}

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -673,14 +673,14 @@ impl Query for DrasiQuery {
                                         let mut result_set = current_results_clone.write().await;
                                         for ctx in &results {
                                             match ctx {
-                                                QueryPartEvaluationContext::Adding { after } => {
+                                                QueryPartEvaluationContext::Adding { after, .. } => {
                                                     result_set.push(convert_query_variables_to_json(after));
                                                 }
-                                                QueryPartEvaluationContext::Removing { before } => {
+                                                QueryPartEvaluationContext::Removing { before, .. } => {
                                                     let data = convert_query_variables_to_json(before);
                                                     result_set.retain(|item| item != &data);
                                                 }
-                                                QueryPartEvaluationContext::Updating { before, after } => {
+                                                QueryPartEvaluationContext::Updating { before, after, .. } => {
                                                     let before_json = convert_query_variables_to_json(before);
                                                     let after_json = convert_query_variables_to_json(after);
                                                     if let Some(pos) = result_set.iter().position(|item| item == &before_json) {
@@ -989,13 +989,13 @@ impl Query for DrasiQuery {
                                 let converted_results: Vec<ResultDiff> = results
                                     .iter()
                                     .map(|ctx| match ctx {
-                                        QueryPartEvaluationContext::Adding { after } => {
+                                        QueryPartEvaluationContext::Adding { after, .. } => {
                                             debug!("Query '{query_id}' got Adding context");
                                             ResultDiff::Add {
                                                 data: convert_query_variables_to_json(after),
                                             }
                                         }
-                                    QueryPartEvaluationContext::Removing { before } => {
+                                    QueryPartEvaluationContext::Removing { before, .. } => {
                                         debug!(
                                             "Query '{query_id}' got Removing context"
                                         );
@@ -1003,7 +1003,7 @@ impl Query for DrasiQuery {
                                             data: convert_query_variables_to_json(before),
                                         }
                                     }
-                                    QueryPartEvaluationContext::Updating { before, after } => {
+                                    QueryPartEvaluationContext::Updating { before, after, .. } => {
                                         debug!("Query '{query_id}' got Updating context");
                                         ResultDiff::Update {
                                             data: convert_query_variables_to_json(after),

--- a/shared-tests/src/use_cases/before/mod.rs
+++ b/shared-tests/src/use_cases/before/mod.rs
@@ -28,6 +28,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -118,12 +119,16 @@ pub async fn before_value(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "amount" => VariableValue::from(json!(105.0)),
-              "id" => VariableValue::from(json!("i1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "amount" => VariableValue::from(json!(105.0)),
+                  "id" => VariableValue::from(json!("i1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //update invoice 1 with increasing amount
@@ -148,16 +153,20 @@ pub async fn before_value(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "amount" => VariableValue::from(json!(105.0)),
-              "id" => VariableValue::from(json!("i1"))
-            ),
-            after: variablemap!(
-              "amount" => VariableValue::from(json!(110.0)),
-              "id" => VariableValue::from(json!("i1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "amount" => VariableValue::from(json!(105.0)),
+                  "id" => VariableValue::from(json!("i1"))
+                ),
+                after: variablemap!(
+                  "amount" => VariableValue::from(json!(110.0)),
+                  "id" => VariableValue::from(json!("i1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //update invoice 1 with decreasing amount
@@ -182,12 +191,16 @@ pub async fn before_value(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "amount" => VariableValue::from(json!(110.0)),
-              "id" => VariableValue::from(json!("i1"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "amount" => VariableValue::from(json!(110.0)),
+                  "id" => VariableValue::from(json!("i1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //update invoice 1 with increasing amount
@@ -212,12 +225,16 @@ pub async fn before_value(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "amount" => VariableValue::from(json!(95.0)),
-              "id" => VariableValue::from(json!("i1"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "amount" => VariableValue::from(json!(95.0)),
+                  "id" => VariableValue::from(json!("i1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -300,11 +317,15 @@ pub async fn before_sum(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "id" => VariableValue::from(json!("i1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "id" => VariableValue::from(json!("i1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add relation 2
@@ -353,10 +374,14 @@ pub async fn before_sum(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "id" => VariableValue::from(json!("i1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "id" => VariableValue::from(json!("i1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/building_comfort/mod.rs
+++ b/shared-tests/src/use_cases/building_comfort/mod.rs
@@ -30,6 +30,7 @@ use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -213,35 +214,43 @@ pub async fn building_comfort_use_case(config: &(impl QueryTestConfig + Send)) {
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                  "RoomId" =>  VariableValue::from(json!("room_01_01_01")),
-                  "ComfortLevel" =>  VariableValue::from(json!(50))
-                ),
-                after: variablemap!(
-                  "RoomId" => VariableValue::from(json!("room_01_01_01")),
-                  "ComfortLevel" =>  VariableValue::from(json!(54))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                      "RoomId" =>  VariableValue::from(json!("room_01_01_01")),
+                      "ComfortLevel" =>  VariableValue::from(json!(50))
+                    ),
+                    after: variablemap!(
+                      "RoomId" => VariableValue::from(json!("room_01_01_01")),
+                      "ComfortLevel" =>  VariableValue::from(json!(54))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = floor_comfort_level_calc_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-                default_before: false,
-                default_after: false,
-                before: Some(variablemap!(
-                  "FloorId" =>  VariableValue::from(json!("floor_01_01")),
-                  "ComfortLevel" =>  VariableValue::from(json!(50))
-                )),
-                after: variablemap!(
-                  "FloorId" => VariableValue::from(json!("floor_01_01")),
-                  "ComfortLevel" =>  VariableValue::from(json!(51))
-                ),
-                grouping_keys: vec!["FloorId".into()],
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Aggregation {
+                    default_before: false,
+                    default_after: false,
+                    before: Some(variablemap!(
+                      "FloorId" =>  VariableValue::from(json!("floor_01_01")),
+                      "ComfortLevel" =>  VariableValue::from(json!(50))
+                    )),
+                    after: variablemap!(
+                      "FloorId" => VariableValue::from(json!("floor_01_01")),
+                      "ComfortLevel" =>  VariableValue::from(json!(51))
+                    ),
+                    grouping_keys: vec!["FloorId".into()],
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = building_comfort_level_calc_query
                 .process_source_change(change.clone())
@@ -249,87 +258,107 @@ pub async fn building_comfort_use_case(config: &(impl QueryTestConfig + Send)) {
                 .unwrap();
             assert_eq!(result.len(), 1);
             // println!("res {:?}", result);
-            assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-                grouping_keys: vec!["BuildingId".into()],
-                default_before: false,
-                default_after: false,
-                before: Some(variablemap!(
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "ComfortLevel" => VariableValue::from(json!(50.0))
-                )),
-                after: variablemap!(
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "ComfortLevel" => VariableValue::from(json!(50.5))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Aggregation {
+                    grouping_keys: vec!["BuildingId".into()],
+                    default_before: false,
+                    default_after: false,
+                    before: Some(variablemap!(
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "ComfortLevel" => VariableValue::from(json!(50.0))
+                    )),
+                    after: variablemap!(
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "ComfortLevel" => VariableValue::from(json!(50.5))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = room_comfort_level_alert_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Adding {
-                after: variablemap!(
-                  "RoomId" => VariableValue::from(json!("room_01_01_01")),
-                  "ComfortLevel" => VariableValue::from(json!(54))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Adding {
+                    after: variablemap!(
+                      "RoomId" => VariableValue::from(json!("room_01_01_01")),
+                      "ComfortLevel" => VariableValue::from(json!(54))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = floor_comfort_level_alert_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Adding {
-                after: variablemap!(
-                  "FloorId" => VariableValue::from(json!("floor_01_01")),
-                  "ComfortLevel" => VariableValue::from(json!(51))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Adding {
+                    after: variablemap!(
+                      "FloorId" => VariableValue::from(json!("floor_01_01")),
+                      "ComfortLevel" => VariableValue::from(json!(51))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = building_comfort_level_alert_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Adding {
-                after: variablemap!(
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "ComfortLevel" => VariableValue::from(json!(50.5))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Adding {
+                    after: variablemap!(
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "ComfortLevel" => VariableValue::from(json!(50.5))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = ui_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                  "RoomId" => VariableValue::from(json!("room_01_01_01")),
-                  "RoomName" => VariableValue::from(json!("Room 01_01_01")),
-                  "FloorId" => VariableValue::from(json!("floor_01_01")),
-                  "FloorName" => VariableValue::from(json!("Floor 01_01")),
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "BuildingName" => VariableValue::from(json!("Building 01")),
-                  "Temperature" => VariableValue::from(json!(72)),
-                  "CO2" => VariableValue::from(json!(500)),
-                  "Humidity" => VariableValue::from(json!(42)),
-                  "ComfortLevel" => VariableValue::from(json!(50))
-                ),
-                after: variablemap!(
-                  "RoomId" => VariableValue::from(json!("room_01_01_01")),
-                  "RoomName" => VariableValue::from(json!("Room 01_01_01")),
-                  "FloorId" => VariableValue::from(json!("floor_01_01")),
-                  "FloorName" => VariableValue::from(json!("Floor 01_01")),
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "BuildingName" => VariableValue::from(json!("Building 01")),
-                  "Temperature" => VariableValue::from(json!(74)),
-                  "CO2" => VariableValue::from(json!(500)),
-                  "Humidity" => VariableValue::from(json!(44)),
-                  "ComfortLevel" => VariableValue::from(json!(54))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                      "RoomId" => VariableValue::from(json!("room_01_01_01")),
+                      "RoomName" => VariableValue::from(json!("Room 01_01_01")),
+                      "FloorId" => VariableValue::from(json!("floor_01_01")),
+                      "FloorName" => VariableValue::from(json!("Floor 01_01")),
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "BuildingName" => VariableValue::from(json!("Building 01")),
+                      "Temperature" => VariableValue::from(json!(72)),
+                      "CO2" => VariableValue::from(json!(500)),
+                      "Humidity" => VariableValue::from(json!(42)),
+                      "ComfortLevel" => VariableValue::from(json!(50))
+                    ),
+                    after: variablemap!(
+                      "RoomId" => VariableValue::from(json!("room_01_01_01")),
+                      "RoomName" => VariableValue::from(json!("Room 01_01_01")),
+                      "FloorId" => VariableValue::from(json!("floor_01_01")),
+                      "FloorName" => VariableValue::from(json!("Floor 01_01")),
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "BuildingName" => VariableValue::from(json!("Building 01")),
+                      "Temperature" => VariableValue::from(json!(74)),
+                      "CO2" => VariableValue::from(json!(500)),
+                      "Humidity" => VariableValue::from(json!(44)),
+                      "ComfortLevel" => VariableValue::from(json!(54))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
         }
     }
 
@@ -355,124 +384,152 @@ pub async fn building_comfort_use_case(config: &(impl QueryTestConfig + Send)) {
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                  "RoomId" => VariableValue::from(json!("room_01_01_01")),
-                  "ComfortLevel" => VariableValue::from(json!(54.0))
-                ),
-                after: variablemap!(
-                  "RoomId" => VariableValue::from(json!("room_01_01_01")),
-                  "ComfortLevel" => VariableValue::from(json!(50.0))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                      "RoomId" => VariableValue::from(json!("room_01_01_01")),
+                      "ComfortLevel" => VariableValue::from(json!(54.0))
+                    ),
+                    after: variablemap!(
+                      "RoomId" => VariableValue::from(json!("room_01_01_01")),
+                      "ComfortLevel" => VariableValue::from(json!(50.0))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = floor_comfort_level_calc_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-                grouping_keys: vec!["FloorId".into()],
-                default_before: false,
-                default_after: false,
-                before: Some(variablemap!(
-                  "FloorId" => VariableValue::from(json!("floor_01_01")),
-                  "ComfortLevel" => VariableValue::from(json!(51.0))
-                )),
-                after: variablemap!(
-                  "FloorId" => VariableValue::from(json!("floor_01_01")),
-                  "ComfortLevel" => VariableValue::from(json!(50.0))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Aggregation {
+                    grouping_keys: vec!["FloorId".into()],
+                    default_before: false,
+                    default_after: false,
+                    before: Some(variablemap!(
+                      "FloorId" => VariableValue::from(json!("floor_01_01")),
+                      "ComfortLevel" => VariableValue::from(json!(51.0))
+                    )),
+                    after: variablemap!(
+                      "FloorId" => VariableValue::from(json!("floor_01_01")),
+                      "ComfortLevel" => VariableValue::from(json!(50.0))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = building_comfort_level_calc_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-                grouping_keys: vec!["BuildingId".into()],
-                default_before: false,
-                default_after: false,
-                before: Some(variablemap!(
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "ComfortLevel" => VariableValue::from(json!(50.5))
-                )),
-                after: variablemap!(
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "ComfortLevel" => VariableValue::from(json!(50.0))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Aggregation {
+                    grouping_keys: vec!["BuildingId".into()],
+                    default_before: false,
+                    default_after: false,
+                    before: Some(variablemap!(
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "ComfortLevel" => VariableValue::from(json!(50.5))
+                    )),
+                    after: variablemap!(
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "ComfortLevel" => VariableValue::from(json!(50.0))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = room_comfort_level_alert_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Removing {
-                before: variablemap!(
-                  "RoomId" => VariableValue::from(json!("room_01_01_01")),
-                  "ComfortLevel" => VariableValue::from(json!(54))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Removing {
+                    before: variablemap!(
+                      "RoomId" => VariableValue::from(json!("room_01_01_01")),
+                      "ComfortLevel" => VariableValue::from(json!(54))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = floor_comfort_level_alert_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Removing {
-                before: variablemap!(
-                  "FloorId" => VariableValue::from(json!("floor_01_01")),
-                  "ComfortLevel" => VariableValue::from(json!(51))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Removing {
+                    before: variablemap!(
+                      "FloorId" => VariableValue::from(json!("floor_01_01")),
+                      "ComfortLevel" => VariableValue::from(json!(51))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = building_comfort_level_alert_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Removing {
-                before: variablemap!(
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "ComfortLevel" => VariableValue::from(json!(50.5))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Removing {
+                    before: variablemap!(
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "ComfortLevel" => VariableValue::from(json!(50.5))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
 
             let result = ui_query
                 .process_source_change(change.clone())
                 .await
                 .unwrap();
             assert_eq!(result.len(), 1);
-            assert!(result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                  "RoomId" => VariableValue::from(json!("room_01_01_01")),
-                  "RoomName" => VariableValue::from(json!("Room 01_01_01")),
-                  "FloorId" => VariableValue::from(json!("floor_01_01")),
-                  "FloorName" => VariableValue::from(json!("Floor 01_01")),
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "BuildingName" => VariableValue::from(json!("Building 01")),
-                  "ComfortLevel" => VariableValue::from(json!(54)),
-                  "Temperature" => VariableValue::from(json!(74)),
-                  "CO2" => VariableValue::from(json!(500)),
-                  "Humidity" => VariableValue::from(json!(44)),
-                  "ComfortLevel" => VariableValue::from(json!(54))
-                ),
-                after: variablemap!(
-                  "RoomId" => VariableValue::from(json!("room_01_01_01")),
-                  "RoomName" => VariableValue::from(json!("Room 01_01_01")),
-                  "FloorId" => VariableValue::from(json!("floor_01_01")),
-                  "FloorName" => VariableValue::from(json!("Floor 01_01")),
-                  "BuildingId" => VariableValue::from(json!("building_01")),
-                  "BuildingName" => VariableValue::from(json!("Building 01")),
-                  "ComfortLevel" => VariableValue::from(json!(50)),
-                  "Temperature" => VariableValue::from(json!(72)),
-                  "CO2" => VariableValue::from(json!(500)),
-                  "Humidity" => VariableValue::from(json!(42)),
-                  "ComfortLevel" => VariableValue::from(json!(50))
-                ),
-            }));
+            assert!(contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                      "RoomId" => VariableValue::from(json!("room_01_01_01")),
+                      "RoomName" => VariableValue::from(json!("Room 01_01_01")),
+                      "FloorId" => VariableValue::from(json!("floor_01_01")),
+                      "FloorName" => VariableValue::from(json!("Floor 01_01")),
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "BuildingName" => VariableValue::from(json!("Building 01")),
+                      "ComfortLevel" => VariableValue::from(json!(54)),
+                      "Temperature" => VariableValue::from(json!(74)),
+                      "CO2" => VariableValue::from(json!(500)),
+                      "Humidity" => VariableValue::from(json!(44)),
+                      "ComfortLevel" => VariableValue::from(json!(54))
+                    ),
+                    after: variablemap!(
+                      "RoomId" => VariableValue::from(json!("room_01_01_01")),
+                      "RoomName" => VariableValue::from(json!("Room 01_01_01")),
+                      "FloorId" => VariableValue::from(json!("floor_01_01")),
+                      "FloorName" => VariableValue::from(json!("Floor 01_01")),
+                      "BuildingId" => VariableValue::from(json!("building_01")),
+                      "BuildingName" => VariableValue::from(json!("Building 01")),
+                      "ComfortLevel" => VariableValue::from(json!(50)),
+                      "Temperature" => VariableValue::from(json!(72)),
+                      "CO2" => VariableValue::from(json!(500)),
+                      "Humidity" => VariableValue::from(json!(42)),
+                      "ComfortLevel" => VariableValue::from(json!(50))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ));
         }
     }
 }

--- a/shared-tests/src/use_cases/collect_aggregation/mod.rs
+++ b/shared-tests/src/use_cases/collect_aggregation/mod.rs
@@ -253,7 +253,7 @@ pub async fn collect_with_filter_test(config: &(impl QueryTestConfig + Send)) {
     for ctx in &all_results {
         match ctx {
             QueryPartEvaluationContext::Updating { after, .. }
-            | QueryPartEvaluationContext::Adding { after } => {
+            | QueryPartEvaluationContext::Adding { after, .. } => {
                 if let Some(product_id) = after.get("product_id").and_then(|v| v.as_str()) {
                     if let Some(VariableValue::List(high_ratings)) = after.get("high_ratings") {
                         println!(
@@ -304,7 +304,7 @@ pub async fn collect_objects_test(config: &(impl QueryTestConfig + Send)) {
     // Check that we're collecting objects properly
     for ctx in &bootstrap_results {
         match ctx {
-            QueryPartEvaluationContext::Adding { after } => {
+            QueryPartEvaluationContext::Adding { after, .. } => {
                 if let Some(product_id) = after.get("product_id").and_then(|v| v.as_str()) {
                     if let Some(VariableValue::List(review_details)) = after.get("review_details") {
                         println!(
@@ -360,7 +360,7 @@ pub async fn collect_mixed_types_test(config: &(impl QueryTestConfig + Send)) {
     // Verify that we collect different types (strings for order IDs, floats for ratings)
     for ctx in &bootstrap_results {
         match ctx {
-            QueryPartEvaluationContext::Adding { after } => {
+            QueryPartEvaluationContext::Adding { after, .. } => {
                 if let Some(product_id) = after.get("product_id").and_then(|v| v.as_str()) {
                     let order_ids = after.get("order_ids");
                     let ratings = after.get("ratings");
@@ -427,7 +427,7 @@ pub async fn multiple_collects_test(config: &(impl QueryTestConfig + Send)) {
 
     for ctx in &bootstrap_results {
         match ctx {
-            QueryPartEvaluationContext::Adding { after } => {
+            QueryPartEvaluationContext::Adding { after, .. } => {
                 if let Some(product_id) = after.get("product_id").and_then(|v| v.as_str()) {
                     let ratings = after
                         .get("ratings")

--- a/shared-tests/src/use_cases/crosses_above_a_threshold/mod.rs
+++ b/shared-tests/src/use_cases/crosses_above_a_threshold/mod.rs
@@ -30,6 +30,7 @@ use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -159,14 +160,18 @@ pub async fn crosses_above_a_threshold(config: &(impl QueryTestConfig + Send)) {
         // println!("Result - Invoice Status 10 days overdue: {:?}", result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "accountManagerName" => VariableValue::from(json!("Employee 01")),
-              "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
-              "customerName" => VariableValue::from(json!("Customer 01")),
-              "invoiceNumber" => VariableValue::from(json!("invoice_01"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "accountManagerName" => VariableValue::from(json!("Employee 01")),
+                  "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
+                  "customerName" => VariableValue::from(json!("Customer 01")),
+                  "invoiceNumber" => VariableValue::from(json!("invoice_01"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // Make invoice overdue by 11 days
@@ -237,14 +242,18 @@ pub async fn crosses_above_a_threshold(config: &(impl QueryTestConfig + Send)) {
         // println!("Result - Invoice Status PAID after 16 days: {:?}", result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "accountManagerName" => VariableValue::from(json!("Employee 01")),
-              "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
-              "customerName" => VariableValue::from(json!("Customer 01")),
-              "invoiceNumber" => VariableValue::from(json!("invoice_01"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "accountManagerName" => VariableValue::from(json!("Employee 01")),
+                  "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
+                  "customerName" => VariableValue::from(json!("Customer 01")),
+                  "invoiceNumber" => VariableValue::from(json!("invoice_01"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -359,13 +368,19 @@ pub async fn crosses_above_a_threshold_with_overdue_days(config: &(impl QueryTes
         // println!("Result - Invoice Status 10 days overdue: {:?}", result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding { after: variablemap!(
-        "accountManagerName" => VariableValue::from(json!("Employee 01")),
-        "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
-        "customerName" => VariableValue::from(json!("Customer 01")),
-        "invoiceNumber" => VariableValue::from(json!("invoice_01")),
-        "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(10), 0, 0))
-      )}));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "accountManagerName" => VariableValue::from(json!("Employee 01")),
+                  "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
+                  "customerName" => VariableValue::from(json!("Customer 01")),
+                  "invoiceNumber" => VariableValue::from(json!("invoice_01")),
+                  "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(10), 0, 0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // Make invoice overdue by 11 days
@@ -390,20 +405,26 @@ pub async fn crosses_above_a_threshold_with_overdue_days(config: &(impl QueryTes
         // println!("Result - Invoice Status 11 days overdue: {:?}", result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating { before: variablemap!(
-        "accountManagerName" => VariableValue::from(json!("Employee 01")),
-        "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
-        "customerName" => VariableValue::from(json!("Customer 01")),
-        "invoiceNumber" => VariableValue::from(json!("invoice_01")),
-        "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(10), 0, 0))
-      ),
-      after: variablemap!(
-        "accountManagerName" => VariableValue::from(json!("Employee 01")),
-        "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
-        "customerName" => VariableValue::from(json!("Customer 01")),
-        "invoiceNumber" => VariableValue::from(json!("invoice_01")),
-        "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(11), 0, 0))
-    )}));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "accountManagerName" => VariableValue::from(json!("Employee 01")),
+                  "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
+                  "customerName" => VariableValue::from(json!("Customer 01")),
+                  "invoiceNumber" => VariableValue::from(json!("invoice_01")),
+                  "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(10), 0, 0))
+                ),
+                after: variablemap!(
+                    "accountManagerName" => VariableValue::from(json!("Employee 01")),
+                    "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
+                    "customerName" => VariableValue::from(json!("Customer 01")),
+                    "invoiceNumber" => VariableValue::from(json!("invoice_01")),
+                    "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(11), 0, 0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // Make invoice overdue by 15 days
@@ -428,20 +449,26 @@ pub async fn crosses_above_a_threshold_with_overdue_days(config: &(impl QueryTes
         // println!("Result - Invoice Status 15 days overdue: {:?}", result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating { before: variablemap!(
-      "accountManagerName" => VariableValue::from(json!("Employee 01")),
-      "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
-      "customerName" => VariableValue::from(json!("Customer 01")),
-      "invoiceNumber" => VariableValue::from(json!("invoice_01")),
-      "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(11), 0, 0))
-    ),
-    after: variablemap!(
-      "accountManagerName" => VariableValue::from(json!("Employee 01")),
-      "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
-      "customerName" => VariableValue::from(json!("Customer 01")),
-      "invoiceNumber" => VariableValue::from(json!("invoice_01")),
-      "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(15), 0, 0))
-    )}));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "accountManagerName" => VariableValue::from(json!("Employee 01")),
+                  "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
+                  "customerName" => VariableValue::from(json!("Customer 01")),
+                  "invoiceNumber" => VariableValue::from(json!("invoice_01")),
+                  "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(11), 0, 0))
+                ),
+                after: variablemap!(
+                  "accountManagerName" => VariableValue::from(json!("Employee 01")),
+                  "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
+                  "customerName" => VariableValue::from(json!("Customer 01")),
+                  "invoiceNumber" => VariableValue::from(json!("invoice_01")),
+                  "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(15), 0, 0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // Make invoice PAID after 16 days
@@ -466,12 +493,18 @@ pub async fn crosses_above_a_threshold_with_overdue_days(config: &(impl QueryTes
         // println!("Result - Invoice Status PAID after 16 days: {:?}", result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing { before: variablemap!(
-      "accountManagerName" => VariableValue::from(json!("Employee 01")),
-      "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
-      "customerName" => VariableValue::from(json!("Customer 01")),
-      "invoiceNumber" => VariableValue::from(json!("invoice_01")),
-      "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(15), 0, 0))
-    )}));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "accountManagerName" => VariableValue::from(json!("Employee 01")),
+                  "accountManagerEmail" => VariableValue::from(json!("emp_01@reflex.com")),
+                  "customerName" => VariableValue::from(json!("Customer 01")),
+                  "invoiceNumber" => VariableValue::from(json!("invoice_01")),
+                  "overdueDays" => VariableValue::Duration(Duration::new(chrono::Duration::days(15), 0, 0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/crosses_above_and_stays_above/mod.rs
+++ b/shared-tests/src/use_cases/crosses_above_and_stays_above/mod.rs
@@ -29,6 +29,7 @@ use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -141,14 +142,18 @@ pub async fn crosses_above_and_stays_above(config: &(impl QueryTestConfig + Send
         // println!("Node Result - Update sensor value ({}): {:?}", timestamp, node_result);
         assert_eq!(node_result.len(), 1);
 
-        assert!(node_result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "freezerId" => VariableValue::from(json!("equip_01")),
-              // "timeRangeStart" => VariableValue::from(json!(1696150860)),
-              // "timeRangeEnd" => VariableValue::from(json!(1696151760)),
-              "minTempInTimeRange" => VariableValue::from(json!(36))
-            )
-        }));
+        assert!(contains_data(
+            &node_result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "freezerId" => VariableValue::from(json!("equip_01")),
+                  // "timeRangeStart" => VariableValue::from(json!(1696150860)),
+                  // "timeRangeEnd" => VariableValue::from(json!(1696151760)),
+                  "minTempInTimeRange" => VariableValue::from(json!(36))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         timestamp += 60;
     }
@@ -175,13 +180,17 @@ pub async fn crosses_above_and_stays_above(config: &(impl QueryTestConfig + Send
         // println!("Node Result - Update sensor value ({}): {:?}", timestamp, node_result);
         assert_eq!(node_result.len(), 1);
 
-        assert!(node_result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "freezerId" => VariableValue::from(json!("equip_01")),
-              // "timeRangeStart" => VariableValue::from(json!(1696150860)),
-              // "timeRangeEnd" => VariableValue::from(json!(1696151760)),
-              "minTempInTimeRange" => VariableValue::from(json!(36))
-            )
-        }));
+        assert!(contains_data(
+            &node_result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "freezerId" => VariableValue::from(json!("equip_01")),
+                  // "timeRangeStart" => VariableValue::from(json!(1696150860)),
+                  // "timeRangeEnd" => VariableValue::from(json!(1696151760)),
+                  "minTempInTimeRange" => VariableValue::from(json!(36))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/crosses_above_three_times_in_an_hour/mod.rs
+++ b/shared-tests/src/use_cases/crosses_above_three_times_in_an_hour/mod.rs
@@ -28,6 +28,7 @@ use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -217,12 +218,16 @@ pub async fn crosses_above_three_times_in_an_hour(config: &(impl QueryTestConfig
         // println!("Node Result - Update sensor value ({}): {:?}", timestamp, result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "freezerId" => VariableValue::from(json!("equip_01")),
-              "countTempExceededInTimeRange" => VariableValue::from(json!(3))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "freezerId" => VariableValue::from(json!("equip_01")),
+                  "countTempExceededInTimeRange" => VariableValue::from(json!(3))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         timestamp += 60;
     }
@@ -249,15 +254,19 @@ pub async fn crosses_above_three_times_in_an_hour(config: &(impl QueryTestConfig
         println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "freezerId" => VariableValue::from(json!("equip_01")),
-              "countTempExceededInTimeRange" => VariableValue::from(json!(3))
-            ),
-            after: variablemap!(
-              "freezerId" => VariableValue::from(json!("equip_01")),
-              "countTempExceededInTimeRange" => VariableValue::from(json!(4))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "freezerId" => VariableValue::from(json!("equip_01")),
+                  "countTempExceededInTimeRange" => VariableValue::from(json!(3))
+                ),
+                after: variablemap!(
+                  "freezerId" => VariableValue::from(json!("equip_01")),
+                  "countTempExceededInTimeRange" => VariableValue::from(json!(4))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/curbside_pickup/mod.rs
+++ b/shared-tests/src/use_cases/curbside_pickup/mod.rs
@@ -29,6 +29,7 @@ use serde_json::json;
 
 use self::data::get_bootstrap_data;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -125,13 +126,17 @@ pub async fn order_ready_then_vehicle_arrives(config: &(impl QueryTestConfig + S
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "DriverName" => VariableValue::from(json!("Driver 01")),
-              "OrderNumber" => VariableValue::from(json!("order_01")),
-              "LicensePlate" => VariableValue::from(json!("ABC123"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "DriverName" => VariableValue::from(json!("Driver 01")),
+                  "OrderNumber" => VariableValue::from(json!("order_01")),
+                  "LicensePlate" => VariableValue::from(json!("ABC123"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Order Delivered to Waiting Vehicle - order complete
@@ -151,13 +156,17 @@ pub async fn order_ready_then_vehicle_arrives(config: &(impl QueryTestConfig + S
 
         let result = query.process_source_change(change.clone()).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "DriverName" => VariableValue::from(json!("Driver 01")),
-              "OrderNumber" => VariableValue::from(json!("order_01")),
-              "LicensePlate" => VariableValue::from(json!("ABC123"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "DriverName" => VariableValue::from(json!("Driver 01")),
+                  "OrderNumber" => VariableValue::from(json!("order_01")),
+                  "LicensePlate" => VariableValue::from(json!("ABC123"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -234,13 +243,17 @@ pub async fn vehicle_arrives_then_order_ready(config: &(impl QueryTestConfig + S
 
         let result = query.process_source_change(change.clone()).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "DriverName" => VariableValue::from(json!("Driver 02")),
-              "OrderNumber" => VariableValue::from(json!("order_02")),
-              "LicensePlate" => VariableValue::from(json!("XYZ789"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "DriverName" => VariableValue::from(json!("Driver 02")),
+                  "OrderNumber" => VariableValue::from(json!("order_02")),
+                  "LicensePlate" => VariableValue::from(json!("XYZ789"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Order Delivered to Waiting Vehicle - order complete
@@ -260,13 +273,17 @@ pub async fn vehicle_arrives_then_order_ready(config: &(impl QueryTestConfig + S
 
         let result = query.process_source_change(change.clone()).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "DriverName" => VariableValue::from(json!("Driver 02")),
-              "OrderNumber" => VariableValue::from(json!("order_02")),
-              "LicensePlate" => VariableValue::from(json!("XYZ789"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "DriverName" => VariableValue::from(json!("Driver 02")),
+                  "OrderNumber" => VariableValue::from(json!("order_02")),
+                  "LicensePlate" => VariableValue::from(json!("XYZ789"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -343,13 +360,17 @@ pub async fn vehicle_arrives_then_order_ready_duplicate(config: &(impl QueryTest
         let result = query.process_source_change(change.clone()).await.unwrap();
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "DriverName" => VariableValue::from(json!("Driver 03")),
-              "OrderNumber" => VariableValue::from(json!("order_03")),
-              "LicensePlate" => VariableValue::from(json!("drasi"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "DriverName" => VariableValue::from(json!("Driver 03")),
+                  "OrderNumber" => VariableValue::from(json!("order_03")),
+                  "LicensePlate" => VariableValue::from(json!("drasi"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     {
@@ -368,13 +389,17 @@ pub async fn vehicle_arrives_then_order_ready_duplicate(config: &(impl QueryTest
 
         let result = query.process_source_change(change.clone()).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "DriverName" => VariableValue::from(json!("Driver 03")),
-              "OrderNumber" => VariableValue::from(json!("order_03")),
-              "LicensePlate" => VariableValue::from(json!("drasi"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "DriverName" => VariableValue::from(json!("Driver 03")),
+                  "OrderNumber" => VariableValue::from(json!("order_03")),
+                  "LicensePlate" => VariableValue::from(json!("drasi"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         let delete_vehicle = SourceChange::Delete {
             metadata: ElementMetadata {
@@ -446,12 +471,16 @@ pub async fn vehicle_arrives_then_order_ready_duplicate(config: &(impl QueryTest
 
         let result = query.process_source_change(change.clone()).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "DriverName" => VariableValue::from(json!("Driver 04")),
-              "OrderNumber" => VariableValue::from(json!("order_04")),
-              "LicensePlate" => VariableValue::from(json!("drasi"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "DriverName" => VariableValue::from(json!("Driver 04")),
+                  "OrderNumber" => VariableValue::from(json!("order_04")),
+                  "LicensePlate" => VariableValue::from(json!("drasi"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/dapr_state_store/mod.rs
+++ b/shared-tests/src/use_cases/dapr_state_store/mod.rs
@@ -37,6 +37,7 @@ use drasi_middleware::{
 use drasi_query_cypher::CypherParser;
 use serde_json::{json, Value as JsonValue};
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -215,9 +216,13 @@ async fn test_insert_basic_flow(config: &(impl QueryTestConfig + Send)) {
     );
 
     assert!(
-        result.contains(&QueryPartEvaluationContext::Adding {
-            after: expected_vars
-        }),
+        contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: expected_vars,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ),
         "Result did not contain expected Adding context. Got: {result:?}"
     );
 }
@@ -282,10 +287,14 @@ async fn test_update_basic_flow(config: &(impl QueryTestConfig + Send)) {
     );
 
     assert!(
-        update_result.contains(&QueryPartEvaluationContext::Updating {
-            before: expected_vars_before,
-            after: expected_vars_after
-        }),
+        contains_data(
+            &update_result,
+            &QueryPartEvaluationContext::Updating {
+                before: expected_vars_before,
+                after: expected_vars_after,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ),
         "Result did not contain expected Updating context. Got: {update_result:?}"
     );
 }
@@ -338,9 +347,13 @@ async fn test_delete_passthrough(config: &(impl QueryTestConfig + Send)) {
     );
 
     assert!(
-        delete_result.contains(&QueryPartEvaluationContext::Removing {
-            before: expected_vars_before_delete
-        }),
+        contains_data(
+            &delete_result,
+            &QueryPartEvaluationContext::Removing {
+                before: expected_vars_before_delete,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ),
         "Result did not contain expected Removing context. Got: {delete_result:?}"
     );
 }

--- a/shared-tests/src/use_cases/decoder/mod.rs
+++ b/shared-tests/src/use_cases/decoder/mod.rs
@@ -29,6 +29,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -95,15 +96,19 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
     let result1 = query1.process_source_change(insert1).await.unwrap();
     println!("Result 1 (Insert): {result1:?}");
     assert_eq!(result1.len(), 1);
-    assert!(result1.contains(&QueryPartEvaluationContext::Adding {
-        after: variablemap!(
-            "id" => VariableValue::from(json!("node1")),
-            // encoded_data is overwritten with the decoded value
-            "encoded_data" => VariableValue::from(json!("Hello World!")),
-            "decoded_data" => null_vv(),
-            "other_prop" => VariableValue::from(json!(123))
-        )
-    }));
+    assert!(contains_data(
+        &result1,
+        &QueryPartEvaluationContext::Adding {
+            after: variablemap!(
+                "id" => VariableValue::from(json!("node1")),
+                // encoded_data is overwritten with the decoded value
+                "encoded_data" => VariableValue::from(json!("Hello World!")),
+                "decoded_data" => null_vv(),
+                "other_prop" => VariableValue::from(json!(123))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }
+    ));
 
     // --- Test Case 2: Hex Decode, Output Property, Strip Quotes ---
     println!("\n--- Test Case 2: Hex Decode, Output Property, Strip Quotes ---");
@@ -148,16 +153,20 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
     let result2 = query2.process_source_change(insert2).await.unwrap();
     println!("Result 2 (Insert): {result2:?}");
     assert_eq!(result2.len(), 1);
-    assert!(result2.contains(&QueryPartEvaluationContext::Adding {
-        after: variablemap!(
-            "id" => VariableValue::from(json!("node2")),
-            // Original encoded_data remains
-            "encoded_data" => VariableValue::from(json!("\"4865782044617461\"")),
-            // decoded_data gets the result
-            "decoded_data" => VariableValue::from(json!("Hex Data")),
-            "other_prop" => VariableValue::from(json!(456))
-        )
-    }));
+    assert!(contains_data(
+        &result2,
+        &QueryPartEvaluationContext::Adding {
+            after: variablemap!(
+                "id" => VariableValue::from(json!("node2")),
+                // Original encoded_data remains
+                "encoded_data" => VariableValue::from(json!("\"4865782044617461\"")),
+                // decoded_data gets the result
+                "decoded_data" => VariableValue::from(json!("Hex Data")),
+                "other_prop" => VariableValue::from(json!(456))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }
+    ));
 
     // --- Test Case 3: URL Decode Failure, on_error: skip ---
     println!("\n--- Test Case 3: URL Decode Failure, on_error: skip ---");
@@ -202,14 +211,18 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
     println!("Result 3 (Insert - Invalid URL, Skip): {result3:?}");
     // Middleware should not modify the element
     assert_eq!(result3.len(), 1);
-    assert!(result3.contains(&QueryPartEvaluationContext::Adding {
-        after: variablemap!(
-            "id" => VariableValue::from(json!("node3")),
-            "encoded_data" => VariableValue::from(json!("invalid%80sequence")), // Unchanged
-            "decoded_data" => null_vv(), // Not set
-            "other_prop" => VariableValue::from(json!(789))
-        )
-    }));
+    assert!(contains_data(
+        &result3,
+        &QueryPartEvaluationContext::Adding {
+            after: variablemap!(
+                "id" => VariableValue::from(json!("node3")),
+                "encoded_data" => VariableValue::from(json!("invalid%80sequence")), // Unchanged
+                "decoded_data" => null_vv(), // Not set
+                "other_prop" => VariableValue::from(json!(789))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }
+    ));
 
     // --- Test Case 4: JSON Escape Decode ---
     println!("\n--- Test Case 4: JSON Escape Decode ---");
@@ -254,15 +267,19 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
     let result4 = query4.process_source_change(insert4).await.unwrap();
     println!("Result 4 (Insert - JSON Escape): {result4:?}");
     assert_eq!(result4.len(), 1);
-    assert!(result4.contains(&QueryPartEvaluationContext::Adding {
-        after: variablemap!(
-            "id" => VariableValue::from(json!("node4")),
-            "encoded_data" => VariableValue::from(json!("Line 1\\nLine 2 with \\\"quotes\\\" and \\\\ backslash")),
-            // Decoded value has a newline, quotes, and a backslash
-            "decoded_data" => VariableValue::from(json!("Line 1\nLine 2 with \"quotes\" and \\ backslash")),
-            "other_prop" => VariableValue::from(json!(101))
-        )
-    }));
+    assert!(contains_data(
+        &result4,
+        &QueryPartEvaluationContext::Adding {
+            after: variablemap!(
+                "id" => VariableValue::from(json!("node4")),
+                "encoded_data" => VariableValue::from(json!("Line 1\\nLine 2 with \\\"quotes\\\" and \\\\ backslash")),
+                // Decoded value has a newline, quotes, and a backslash
+                "decoded_data" => VariableValue::from(json!("Line 1\nLine 2 with \"quotes\" and \\ backslash")),
+                "other_prop" => VariableValue::from(json!(101))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }
+    ));
 
     // --- Test Case 5: Missing Target Property, on_error: fail ---
     println!("\n--- Test Case 5: Missing Target Property, on_error: fail ---");
@@ -355,14 +372,18 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
     println!("Result 6 (Insert - Wrong Type, Skip): {result6:?}");
     // Because on_error is skip, the element is added but not modified by middleware
     assert_eq!(result6.len(), 1);
-    assert!(result6.contains(&QueryPartEvaluationContext::Adding {
-        after: variablemap!(
-            "id" => VariableValue::from(json!("node6")),
-            "encoded_data" => VariableValue::from(json!(12345)), // Unchanged
-            "decoded_data" => null_vv(), // Not set
-            "other_prop" => VariableValue::from(json!(113))
-        )
-    }));
+    assert!(contains_data(
+        &result6,
+        &QueryPartEvaluationContext::Adding {
+            after: variablemap!(
+                "id" => VariableValue::from(json!("node6")),
+                "encoded_data" => VariableValue::from(json!(12345)), // Unchanged
+                "decoded_data" => null_vv(), // Not set
+                "other_prop" => VariableValue::from(json!(113))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }
+    ));
 
     // --- Test Case 7: Size Limit Exceeded, on_error: fail ---
     println!("\n--- Test Case 7: Size Limit Exceeded, on_error: fail ---");
@@ -431,16 +452,18 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
         },
     };
     let result8_initial = query1.process_source_change(insert8_initial).await.unwrap();
-    assert!(
-        result8_initial.contains(&QueryPartEvaluationContext::Adding {
+    assert!(contains_data(
+        &result8_initial,
+        &QueryPartEvaluationContext::Adding {
             after: variablemap!(
                 "id" => VariableValue::from(json!("node8")),
                 "encoded_data" => VariableValue::from(json!("Hello")), // Decoded
                 "decoded_data" => null_vv(),
                 "other_prop" => VariableValue::from(json!(200))
-            )
-        })
-    );
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }
+    ));
 
     // Update the node with new encoded data
     let update8 = SourceChange::Update {
@@ -460,8 +483,9 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
     let result8_update = query1.process_source_change(update8).await.unwrap();
     println!("Result 8 (Update): {result8_update:?}");
     assert_eq!(result8_update.len(), 1);
-    assert!(
-        result8_update.contains(&QueryPartEvaluationContext::Updating {
+    assert!(contains_data(
+        &result8_update,
+        &QueryPartEvaluationContext::Updating {
             before: variablemap!(
                 "id" => VariableValue::from(json!("node8")),
                 "encoded_data" => VariableValue::from(json!("Hello")),
@@ -473,9 +497,10 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
                 "encoded_data" => VariableValue::from(json!("Goodbye")),
                 "decoded_data" => null_vv(),
                 "other_prop" => VariableValue::from(json!(201))
-            )
-        })
-    );
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }
+    ));
 
     // --- Test Case 9: Delete node ---
     println!("\n--- Test Case 9: Delete node ---");
@@ -491,14 +516,16 @@ pub async fn decoder(config: &(impl QueryTestConfig + Send)) {
     let result9_delete = query1.process_source_change(delete9).await.unwrap();
     println!("Result 9 (Delete): {result9_delete:?}");
     assert_eq!(result9_delete.len(), 1);
-    assert!(
-        result9_delete.contains(&QueryPartEvaluationContext::Removing {
+    assert!(contains_data(
+        &result9_delete,
+        &QueryPartEvaluationContext::Removing {
             before: variablemap!(
                 "id" => VariableValue::from(json!("node8")),
                 "encoded_data" => VariableValue::from(json!("Goodbye")),
                 "decoded_data" => null_vv(),
                 "other_prop" => VariableValue::from(json!(201))
-            )
-        })
-    );
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }
+    ));
 }

--- a/shared-tests/src/use_cases/decrease_by_ten/mod.rs
+++ b/shared-tests/src/use_cases/decrease_by_ten/mod.rs
@@ -29,6 +29,7 @@ use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -164,14 +165,18 @@ pub async fn decrease_by_ten(config: &(impl QueryTestConfig + Send)) {
         // println!("Node Result - Decrease daily revenue amount to $90K ({}): {:?}", timestamp, result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "productId" => VariableValue::from(json!("prod_01")),
-              "productManagerId" => VariableValue::from(json!("emp_01")),
-              "previousDailyRevenue" => VariableValue::from(json!(101000.0)),
-              "dailyRevenue" => VariableValue::from(json!(90000.0))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "productId" => VariableValue::from(json!("prod_01")),
+                  "productManagerId" => VariableValue::from(json!("emp_01")),
+                  "previousDailyRevenue" => VariableValue::from(json!(101000.0)),
+                  "dailyRevenue" => VariableValue::from(json!(90000.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         timestamp += 24 * 60 * 60;
     }
@@ -198,20 +203,24 @@ pub async fn decrease_by_ten(config: &(impl QueryTestConfig + Send)) {
         // println!("Node Result - Decrease daily revenue amount to $80k ({}): {:?}", timestamp, result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "productId" => VariableValue::from(json!("prod_01")),
-              "productManagerId" => VariableValue::from(json!("emp_01")),
-              "previousDailyRevenue" => VariableValue::from(json!(101000.0)),
-              "dailyRevenue" => VariableValue::from(json!(90000.0))
-            ),
-            after: variablemap!(
-              "productId" => VariableValue::from(json!("prod_01")),
-              "productManagerId" => VariableValue::from(json!("emp_01")),
-              "previousDailyRevenue" => VariableValue::from(json!(90000.0)),
-              "dailyRevenue" => VariableValue::from(json!(75000.0))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "productId" => VariableValue::from(json!("prod_01")),
+                  "productManagerId" => VariableValue::from(json!("emp_01")),
+                  "previousDailyRevenue" => VariableValue::from(json!(101000.0)),
+                  "dailyRevenue" => VariableValue::from(json!(90000.0))
+                ),
+                after: variablemap!(
+                  "productId" => VariableValue::from(json!("prod_01")),
+                  "productManagerId" => VariableValue::from(json!("emp_01")),
+                  "previousDailyRevenue" => VariableValue::from(json!(90000.0)),
+                  "dailyRevenue" => VariableValue::from(json!(75000.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         timestamp += 24 * 60 * 60;
     }
@@ -238,14 +247,18 @@ pub async fn decrease_by_ten(config: &(impl QueryTestConfig + Send)) {
         // println!("Node Result - Update with same daily revenue amount of $80k ({}): {:?}", timestamp, result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "productId" => VariableValue::from(json!("prod_01")),
-              "productManagerId" => VariableValue::from(json!("emp_01")),
-              "previousDailyRevenue" => VariableValue::from(json!(90000.0)),
-              "dailyRevenue" => VariableValue::from(json!(75000.0))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "productId" => VariableValue::from(json!("prod_01")),
+                  "productManagerId" => VariableValue::from(json!("emp_01")),
+                  "previousDailyRevenue" => VariableValue::from(json!(90000.0)),
+                  "dailyRevenue" => VariableValue::from(json!(75000.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -360,14 +373,18 @@ pub async fn decrease_by_ten_percent(config: &(impl QueryTestConfig + Send)) {
         // println!("Node Result - Decrease daily revenue amount to $90K ({}): {:?}", timestamp, result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "productId" => VariableValue::from(json!("prod_01")),
-              "productManagerId" => VariableValue::from(json!("emp_01")),
-              "previousDailyRevenue" => VariableValue::from(json!(101000.0)),
-              "dailyRevenue" => VariableValue::from(json!(90000.0))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "productId" => VariableValue::from(json!("prod_01")),
+                  "productManagerId" => VariableValue::from(json!("emp_01")),
+                  "previousDailyRevenue" => VariableValue::from(json!(101000.0)),
+                  "dailyRevenue" => VariableValue::from(json!(90000.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         timestamp += 24 * 60 * 60;
     }
@@ -394,20 +411,24 @@ pub async fn decrease_by_ten_percent(config: &(impl QueryTestConfig + Send)) {
         // println!("Node Result - Decrease daily revenue amount to $80k ({}): {:?}", timestamp, result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "productId" => VariableValue::from(json!("prod_01")),
-              "productManagerId" => VariableValue::from(json!("emp_01")),
-              "previousDailyRevenue" => VariableValue::from(json!(101000.0)),
-              "dailyRevenue" => VariableValue::from(json!(90000.0))
-            ),
-            after: variablemap!(
-              "productId" => VariableValue::from(json!("prod_01")),
-              "productManagerId" => VariableValue::from(json!("emp_01")),
-              "previousDailyRevenue" => VariableValue::from(json!(90000.0)),
-              "dailyRevenue" => VariableValue::from(json!(75000.0))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "productId" => VariableValue::from(json!("prod_01")),
+                  "productManagerId" => VariableValue::from(json!("emp_01")),
+                  "previousDailyRevenue" => VariableValue::from(json!(101000.0)),
+                  "dailyRevenue" => VariableValue::from(json!(90000.0))
+                ),
+                after: variablemap!(
+                  "productId" => VariableValue::from(json!("prod_01")),
+                  "productManagerId" => VariableValue::from(json!("emp_01")),
+                  "previousDailyRevenue" => VariableValue::from(json!(90000.0)),
+                  "dailyRevenue" => VariableValue::from(json!(75000.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         timestamp += 24 * 60 * 60;
     }
@@ -434,13 +455,17 @@ pub async fn decrease_by_ten_percent(config: &(impl QueryTestConfig + Send)) {
         // println!("Node Result - Update with same daily revenue amount of $80k ({}): {:?}", timestamp, result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "productId" => VariableValue::from(json!("prod_01")),
-              "productManagerId" => VariableValue::from(json!("emp_01")),
-              "previousDailyRevenue" => VariableValue::from(json!(90000.0)),
-              "dailyRevenue" => VariableValue::from(json!(75000.0))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "productId" => VariableValue::from(json!("prod_01")),
+                  "productManagerId" => VariableValue::from(json!("emp_01")),
+                  "previousDailyRevenue" => VariableValue::from(json!(90000.0)),
+                  "dailyRevenue" => VariableValue::from(json!(75000.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/document/mod.rs
+++ b/shared-tests/src/use_cases/document/mod.rs
@@ -27,6 +27,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -146,17 +147,21 @@ pub async fn document(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("Node Result - Add t1: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "name" => VariableValue::from(json!("pod-1")),
-                "namespace" => VariableValue::from(json!("default")),
-                "app" => VariableValue::from(json!("nginx")),
-                "app_id" => VariableValue::from(json!("my-app")),
-                "app_id2" => VariableValue::from(json!("my-app")),
-                "container_0_image" => VariableValue::from(json!("nginx:latest")),
-                "total_restart_count" => VariableValue::from(json!(5)),
-                "sidecar_container_id" => VariableValue::from(json!("docker://0987654321"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "name" => VariableValue::from(json!("pod-1")),
+                    "namespace" => VariableValue::from(json!("default")),
+                    "app" => VariableValue::from(json!("nginx")),
+                    "app_id" => VariableValue::from(json!("my-app")),
+                    "app_id2" => VariableValue::from(json!("my-app")),
+                    "container_0_image" => VariableValue::from(json!("nginx:latest")),
+                    "total_restart_count" => VariableValue::from(json!(5)),
+                    "sidecar_container_id" => VariableValue::from(json!("docker://0987654321"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/future_aggregations/mod.rs
+++ b/shared-tests/src/use_cases/future_aggregations/mod.rs
@@ -32,6 +32,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -95,13 +96,17 @@ pub async fn truefor_sum(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         //println!("Result: {:?}", result);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            after: variablemap!("value"=>VariableValue::Float(Float::from(2.0))),
-            before: None,
-            grouping_keys: vec![],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                after: variablemap!("value"=>VariableValue::Float(Float::from(2.0))),
+                before: None,
+                grouping_keys: vec![],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //create order 2
@@ -124,13 +129,17 @@ pub async fn truefor_sum(config: &(impl QueryTestConfig + Send)) {
         let result = cq.process_source_change(change.clone()).await.unwrap();
         assert_eq!(result.len(), 1);
         println!("Result: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            after: variablemap!("value"=>VariableValue::Float(Float::from(3.0))),
-            before: Some(variablemap!("value"=>VariableValue::Float(Float::from(2.0))),),
-            grouping_keys: vec![],
-            default_before: true,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                after: variablemap!("value"=>VariableValue::Float(Float::from(3.0))),
+                before: Some(variablemap!("value"=>VariableValue::Float(Float::from(2.0))),),
+                grouping_keys: vec![],
+                default_before: true,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -186,16 +195,20 @@ pub async fn truefor_grouped_sum(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         //println!("Result: {:?}", result);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            after: variablemap!(
-                "value"=>VariableValue::Float(Float::from(2.0)),
-                "category"=>VariableValue::from("A")
-            ),
-            before: None,
-            grouping_keys: vec!["category".into()],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                after: variablemap!(
+                    "value"=>VariableValue::Float(Float::from(2.0)),
+                    "category"=>VariableValue::from("A")
+                ),
+                before: None,
+                grouping_keys: vec!["category".into()],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //create order 2
@@ -219,19 +232,23 @@ pub async fn truefor_grouped_sum(config: &(impl QueryTestConfig + Send)) {
         let result = cq.process_source_change(change.clone()).await.unwrap();
         assert_eq!(result.len(), 1);
         println!("Result: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            after: variablemap!(
-                "value"=>VariableValue::Float(Float::from(3.0)),
-                "category"=>VariableValue::from("A")
-            ),
-            before: Some(variablemap!(
-                "value"=>VariableValue::Float(Float::from(2.0)),
-                "category"=>VariableValue::from("A")
-            )),
-            grouping_keys: vec!["category".into()],
-            default_before: true,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                after: variablemap!(
+                    "value"=>VariableValue::Float(Float::from(3.0)),
+                    "category"=>VariableValue::from("A")
+                ),
+                before: Some(variablemap!(
+                    "value"=>VariableValue::Float(Float::from(2.0)),
+                    "category"=>VariableValue::from("A")
+                )),
+                grouping_keys: vec!["category".into()],
+                default_before: true,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -286,9 +303,13 @@ pub async fn truelater_max(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         println!("Result: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!("id"=>VariableValue::from("i1"))
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!("id"=>VariableValue::from("i1")),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //create Comment for Issue 1
@@ -327,8 +348,12 @@ pub async fn truelater_max(config: &(impl QueryTestConfig + Send)) {
         let result = cq.process_source_change(change.clone()).await.unwrap();
         assert_eq!(result.len(), 1);
         println!("Result: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!("id"=>VariableValue::from("i1"))
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!("id"=>VariableValue::from("i1")),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/greater_than_a_threshold/mod.rs
+++ b/shared-tests/src/use_cases/greater_than_a_threshold/mod.rs
@@ -29,6 +29,7 @@ use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -134,13 +135,17 @@ pub async fn greater_than_a_threshold(config: &(impl QueryTestConfig + Send)) {
         // println!("Node Result - Add call 11: {:?}", result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "callYear" => VariableValue::from(json!(2023)),
-              "callDayOfYear" => VariableValue::from(json!(274)),
-              "callCount" => VariableValue::from(json!(11))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "callYear" => VariableValue::from(json!(2023)),
+                  "callDayOfYear" => VariableValue::from(json!(274)),
+                  "callCount" => VariableValue::from(json!(11))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -231,15 +236,19 @@ pub async fn greater_than_a_threshold_by_customer(config: &(impl QueryTestConfig
         // println!("Rel Result - Add call 11: {:?}", result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "customerId" => VariableValue::from(json!("customer_01")),
-              "customerName" => VariableValue::from(json!("Customer 01")),
-              "callYear" => VariableValue::from(json!(2023)),
-              "callDayOfYear" => VariableValue::from(json!(274)),
-              "callCount" => VariableValue::from(json!(6))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "customerId" => VariableValue::from(json!("customer_01")),
+                  "customerName" => VariableValue::from(json!("Customer 01")),
+                  "callYear" => VariableValue::from(json!(2023)),
+                  "callDayOfYear" => VariableValue::from(json!(274)),
+                  "callCount" => VariableValue::from(json!(6))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // Add a 6th call by customer_02
@@ -265,14 +274,18 @@ pub async fn greater_than_a_threshold_by_customer(config: &(impl QueryTestConfig
         // println!("Rel Result - Add call 11: {:?}", result);
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "customerId" => VariableValue::from(json!("customer_02")),
-              "customerName" => VariableValue::from(json!("Customer 02")),
-              "callYear" => VariableValue::from(json!(2023)),
-              "callDayOfYear" => VariableValue::from(json!(274)),
-              "callCount" => VariableValue::from(json!(6))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "customerId" => VariableValue::from(json!("customer_02")),
+                  "customerName" => VariableValue::from(json!("Customer 02")),
+                  "callYear" => VariableValue::from(json!(2023)),
+                  "callDayOfYear" => VariableValue::from(json!(274)),
+                  "callCount" => VariableValue::from(json!(6))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/incident_alert/mod.rs
+++ b/shared-tests/src/use_cases/incident_alert/mod.rs
@@ -29,6 +29,7 @@ use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -179,93 +180,117 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 2);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Claire")),
-              "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Claire")),
+                  "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Bob")),
-              "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Bob")),
+                  "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         let result = employee_incident_alert_query
             .process_source_change(change.clone())
             .await
             .unwrap();
         assert_eq!(result.len(), 3);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Claire")),
-              "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Claire")),
+                  "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Bob")),
-              "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Bob")),
+                  "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Allen")),
-              "EmployeeEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Allen")),
+                  "EmployeeEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         let result = employees_at_risk_count_query
             .process_source_change(change.clone())
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            default_before: false,
-            default_after: false,
-            grouping_keys: vec![
-                "RegionName".into(),
-                "IncidentId".into(),
-                "IncidentSeverity".into(),
-                "IncidentDescription".into()
-            ],
-            before: None,
-            after: variablemap!(
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme")),
-              "EmployeeCount" => VariableValue::from(json!(3))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                default_before: false,
+                default_after: false,
+                grouping_keys: vec![
+                    "RegionName".into(),
+                    "IncidentId".into(),
+                    "IncidentSeverity".into(),
+                    "IncidentDescription".into()
+                ],
+                before: None,
+                after: variablemap!(
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme")),
+                  "EmployeeCount" => VariableValue::from(json!(3))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Remove LOCATED_IN relation between danny and b040
@@ -321,34 +346,42 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Danny")),
-              "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Danny")),
+                  "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         let result = employee_incident_alert_query
             .process_source_change(change.clone())
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Danny")),
-              "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Danny")),
+                  "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         let result = employees_at_risk_count_query
             .process_source_change(change.clone())
@@ -356,30 +389,34 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("getting result {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            default_before: true,
-            default_after: false,
-            grouping_keys: vec![
-                "RegionName".into(),
-                "IncidentId".into(),
-                "IncidentSeverity".into(),
-                "IncidentDescription".into()
-            ],
-            before: Some(variablemap!(
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme")),
-              "EmployeeCount" => VariableValue::from(json!(3))
-            )),
-            after: variablemap!(
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme")),
-              "EmployeeCount" => VariableValue::from(json!(4))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                default_before: true,
+                default_after: false,
+                grouping_keys: vec![
+                    "RegionName".into(),
+                    "IncidentId".into(),
+                    "IncidentSeverity".into(),
+                    "IncidentDescription".into()
+                ],
+                before: Some(variablemap!(
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme")),
+                  "EmployeeCount" => VariableValue::from(json!(3))
+                )),
+                after: variablemap!(
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme")),
+                  "EmployeeCount" => VariableValue::from(json!(4))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Incident becomes critical severity
@@ -402,155 +439,183 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 3);
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Claire")),
-              "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Claire")),
-              "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Claire")),
+                  "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Claire")),
+                  "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Bob")),
-              "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Bob")),
-              "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Bob")),
+                  "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Bob")),
+                  "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Danny")),
-              "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Danny")),
-              "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Danny")),
+                  "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Danny")),
+                  "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         let result = employee_incident_alert_query
             .process_source_change(change.clone())
             .await
             .unwrap();
         assert_eq!(result.len(), 4);
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Claire")),
-              "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Claire")),
-              "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Claire")),
+                  "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Claire")),
+                  "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Bob")),
-              "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Bob")),
-              "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Bob")),
+                  "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Bob")),
+                  "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Danny")),
-              "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Danny")),
-              "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Danny")),
+                  "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Danny")),
+                  "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Allen")),
-              "EmployeeEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("extreme"))
-            ),
-            after: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Allen")),
-              "EmployeeEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Allen")),
+                  "EmployeeEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("extreme"))
+                ),
+                after: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Allen")),
+                  "EmployeeEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         let result = employees_at_risk_count_query
             .process_source_change(change.clone())
@@ -558,54 +623,62 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 2);
         println!("getting result {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            default_before: false,
-            default_after: false,
-            grouping_keys: vec![
-                "RegionName".into(),
-                "IncidentId".into(),
-                "IncidentSeverity".into(),
-                "IncidentDescription".into()
-            ],
-            before: Some(variablemap!(
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical")),
-              "EmployeeCount" => VariableValue::from(json!(0))
-            )),
-            after: variablemap!(
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical")),
-              "EmployeeCount" => VariableValue::from(json!(4))
-            ),
-        }));
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            default_before: false,
-            default_after: false,
-            grouping_keys: vec![
-                "RegionName".into(),
-                "IncidentId".into(),
-                "IncidentSeverity".into(),
-                "IncidentDescription".into()
-            ],
-            before: Some(variablemap!(
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical")),
-              "EmployeeCount" => VariableValue::from(json!(0))
-            )),
-            after: variablemap!(
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical")),
-              "EmployeeCount" => VariableValue::from(json!(4))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                default_before: false,
+                default_after: false,
+                grouping_keys: vec![
+                    "RegionName".into(),
+                    "IncidentId".into(),
+                    "IncidentSeverity".into(),
+                    "IncidentDescription".into()
+                ],
+                before: Some(variablemap!(
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical")),
+                  "EmployeeCount" => VariableValue::from(json!(0))
+                )),
+                after: variablemap!(
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical")),
+                  "EmployeeCount" => VariableValue::from(json!(4))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                default_before: false,
+                default_after: false,
+                grouping_keys: vec![
+                    "RegionName".into(),
+                    "IncidentId".into(),
+                    "IncidentSeverity".into(),
+                    "IncidentDescription".into()
+                ],
+                before: Some(variablemap!(
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical")),
+                  "EmployeeCount" => VariableValue::from(json!(0))
+                )),
+                after: variablemap!(
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical")),
+                  "EmployeeCount" => VariableValue::from(json!(4))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Resolve Incident
@@ -634,122 +707,154 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 3);
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Claire")),
-              "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Claire")),
+                  "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Bob")),
-              "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Bob")),
+                  "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Danny")),
-              "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
-              "ManagerName" => VariableValue::from(json!("Allen")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Danny")),
+                  "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
+                  "ManagerName" => VariableValue::from(json!("Allen")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "ManagerEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         let result = employee_incident_alert_query
             .process_source_change(change.clone())
             .await
             .unwrap();
         assert_eq!(result.len(), 4);
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Claire")),
-              "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Claire")),
+                  "EmployeeEmail" => VariableValue::from(json!("claire@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Bob")),
-              "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Bob")),
+                  "EmployeeEmail" => VariableValue::from(json!("bob@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Danny")),
-              "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Danny")),
+                  "EmployeeEmail" => VariableValue::from(json!("danny@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "EmployeeName" => VariableValue::from(json!("Allen")),
-              "EmployeeEmail" => VariableValue::from(json!("allen@contoso.com")),
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "EmployeeName" => VariableValue::from(json!("Allen")),
+                  "EmployeeEmail" => VariableValue::from(json!("allen@contoso.com")),
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         let result = employees_at_risk_count_query
             .process_source_change(change.clone())
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            default_before: false,
-            default_after: false,
-            grouping_keys: vec![
-                "RegionName".into(),
-                "IncidentId".into(),
-                "IncidentSeverity".into(),
-                "IncidentDescription".into()
-            ],
-            before: Some(variablemap!(
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical")),
-              "EmployeeCount" => VariableValue::from(json!(4))
-            )),
-            after: variablemap!(
-              "IncidentId" => VariableValue::from(json!("in1000")),
-              "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
-              "RegionName" => VariableValue::from(json!("SoCal")),
-              "IncidentSeverity" => VariableValue::from(json!("critical")),
-              "EmployeeCount" => VariableValue::from(json!(0))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                default_before: false,
+                default_after: false,
+                grouping_keys: vec![
+                    "RegionName".into(),
+                    "IncidentId".into(),
+                    "IncidentSeverity".into(),
+                    "IncidentDescription".into()
+                ],
+                before: Some(variablemap!(
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical")),
+                  "EmployeeCount" => VariableValue::from(json!(4))
+                )),
+                after: variablemap!(
+                  "IncidentId" => VariableValue::from(json!("in1000")),
+                  "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
+                  "RegionName" => VariableValue::from(json!("SoCal")),
+                  "IncidentSeverity" => VariableValue::from(json!("critical")),
+                  "EmployeeCount" => VariableValue::from(json!(0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/linear_regression/mod.rs
+++ b/shared-tests/src/use_cases/linear_regression/mod.rs
@@ -28,6 +28,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -139,17 +140,21 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         println!("Node Result - Add p6: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec![],
-            default_before: true,
-            default_after: false,
-            before: Some(variablemap!(
-                "Gradient" => VariableValue::Float(Float::from_f64(1.5).unwrap())
-            )),
-            after: variablemap!(
-              "Gradient" => VariableValue::Float(Float::from_f64(6.771428571428571).unwrap())
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec![],
+                default_before: true,
+                default_after: false,
+                before: Some(variablemap!(
+                    "Gradient" => VariableValue::Float(Float::from_f64(1.5).unwrap())
+                )),
+                after: variablemap!(
+                  "Gradient" => VariableValue::Float(Float::from_f64(6.771428571428571).unwrap())
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // remove p2
@@ -167,17 +172,21 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         println!("Node Result - Remove p2: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec![],
-            default_before: false,
-            default_after: true,
-            before: Some(variablemap!(
-                "Gradient" => VariableValue::Float(Float::from_f64(6.771428571428571).unwrap())
-            )),
-            after: variablemap!(
-              "Gradient" => VariableValue::Float(Float::from_f64(6.972972972972973).unwrap())
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec![],
+                default_before: false,
+                default_after: true,
+                before: Some(variablemap!(
+                    "Gradient" => VariableValue::Float(Float::from_f64(6.771428571428571).unwrap())
+                )),
+                after: variablemap!(
+                  "Gradient" => VariableValue::Float(Float::from_f64(6.972972972972973).unwrap())
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // remove p6
@@ -195,17 +204,21 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         println!("Node Result - Remove p6: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec![],
-            default_before: false,
-            default_after: true,
-            before: Some(variablemap!(
-                "Gradient" => VariableValue::Float(Float::from_f64(6.972972972972973).unwrap())
-            )),
-            after: variablemap!(
-              "Gradient" => VariableValue::Float(Float::from_f64(1.4857142857142858).unwrap())
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec![],
+                default_before: false,
+                default_after: true,
+                before: Some(variablemap!(
+                    "Gradient" => VariableValue::Float(Float::from_f64(6.972972972972973).unwrap())
+                )),
+                after: variablemap!(
+                  "Gradient" => VariableValue::Float(Float::from_f64(1.4857142857142858).unwrap())
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //remove p1, p3, p4, p5
@@ -347,16 +360,20 @@ pub async fn linear_gradient(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         println!("Node Result - Add p6: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec![],
-            default_before: true,
-            default_after: false,
-            before: Some(variablemap!(
-                "Gradient" => VariableValue::Float(Float::from_f64(1.5).unwrap())
-            )),
-            after: variablemap!(
-              "Gradient" => VariableValue::Float(Float::from_f64(6.771428571428571).unwrap())
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec![],
+                default_before: true,
+                default_after: false,
+                before: Some(variablemap!(
+                    "Gradient" => VariableValue::Float(Float::from_f64(1.5).unwrap())
+                )),
+                after: variablemap!(
+                  "Gradient" => VariableValue::Float(Float::from_f64(6.771428571428571).unwrap())
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/logical_conditions/mod.rs
+++ b/shared-tests/src/use_cases/logical_conditions/mod.rs
@@ -28,6 +28,7 @@ use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -163,11 +164,15 @@ pub async fn logical_conditions(config: &(impl QueryTestConfig + Send)) {
         println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "freezerId" => VariableValue::from(json!("equip_01"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "freezerId" => VariableValue::from(json!("equip_01"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         timestamp += 60;
     }
@@ -194,11 +199,15 @@ pub async fn logical_conditions(config: &(impl QueryTestConfig + Send)) {
         println!("Node Result - Update sensor value ({timestamp}): {result:?}");
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-              "freezerId" => VariableValue::from(json!("equip_01"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                  "freezerId" => VariableValue::from(json!("equip_01"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
         timestamp += 60;
     }

--- a/shared-tests/src/use_cases/min_value/mod.rs
+++ b/shared-tests/src/use_cases/min_value/mod.rs
@@ -28,6 +28,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -69,17 +70,21 @@ pub async fn min_value(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         //println!("Node Result - Add t1: {:?}", result);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec![],
-            default_before: true,
-            default_after: false,
-            before: Some(variablemap!(
-                "min_value" => VariableValue::Null
-            )),
-            after: variablemap!(
-              "min_value" => VariableValue::from(json!(5.0))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec![],
+                default_before: true,
+                default_after: false,
+                before: Some(variablemap!(
+                    "min_value" => VariableValue::Null
+                )),
+                after: variablemap!(
+                  "min_value" => VariableValue::from(json!(5.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add lower value
@@ -101,17 +106,21 @@ pub async fn min_value(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         //println!("Node Result - Add t3: {:?}", result);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec![],
-            default_before: true,
-            default_after: false,
-            before: Some(variablemap!(
-              "min_value" => VariableValue::from(json!(5.0))
-            )),
-            after: variablemap!(
-              "min_value" => VariableValue::from(json!(3.0))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec![],
+                default_before: true,
+                default_after: false,
+                before: Some(variablemap!(
+                  "min_value" => VariableValue::from(json!(5.0))
+                )),
+                after: variablemap!(
+                  "min_value" => VariableValue::from(json!(3.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Increment lower value
@@ -132,17 +141,21 @@ pub async fn min_value(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec![],
-            default_before: false,
-            default_after: false,
-            before: Some(variablemap!(
-              "min_value" => VariableValue::from(json!(3.0))
-            )),
-            after: variablemap!(
-              "min_value" => VariableValue::from(json!(4.0))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec![],
+                default_before: false,
+                default_after: false,
+                before: Some(variablemap!(
+                  "min_value" => VariableValue::from(json!(3.0))
+                )),
+                after: variablemap!(
+                  "min_value" => VariableValue::from(json!(4.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Increment higher value

--- a/shared-tests/src/use_cases/mod.rs
+++ b/shared-tests/src/use_cases/mod.rs
@@ -13,7 +13,19 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use drasi_core::query::QueryBuilder;
+use drasi_core::{evaluation::context::QueryPartEvaluationContext, query::QueryBuilder};
+
+/// Placeholder for `row_signature` in test assertions. The `data_eq()` method
+/// and `contains_data()` helper ignore this field when comparing results.
+pub const IGNORED_ROW_SIGNATURE: u64 = 0;
+
+/// Checks if any result context matches the expected data, ignoring `row_signature`.
+pub fn contains_data(
+    results: &[QueryPartEvaluationContext],
+    expected: &QueryPartEvaluationContext,
+) -> bool {
+    results.iter().any(|ctx| ctx.data_eq(expected))
+}
 
 pub mod building_comfort;
 pub mod collect_aggregation;

--- a/shared-tests/src/use_cases/optional_match/mod.rs
+++ b/shared-tests/src/use_cases/optional_match/mod.rs
@@ -28,6 +28,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -71,13 +72,17 @@ pub async fn optional_match(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "amount" => VariableValue::from(json!(100.0)),
-              "id" => VariableValue::from(json!("i1")),
-              "payment_amount" => VariableValue::Null
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "amount" => VariableValue::from(json!(100.0)),
+                  "id" => VariableValue::from(json!("i1")),
+                  "payment_amount" => VariableValue::Null
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add relation 1
@@ -125,18 +130,22 @@ pub async fn optional_match(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "amount" => VariableValue::from(json!(100.0)),
-              "id" => VariableValue::from(json!("i1")),
-              "payment_amount" => VariableValue::Null
-            ),
-            after: variablemap!(
-              "amount" => VariableValue::from(json!(100.0)),
-              "id" => VariableValue::from(json!("i1")),
-              "payment_amount" => VariableValue::from(json!(70.0))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "amount" => VariableValue::from(json!(100.0)),
+                  "id" => VariableValue::from(json!("i1")),
+                  "payment_amount" => VariableValue::Null
+                ),
+                after: variablemap!(
+                  "amount" => VariableValue::from(json!(100.0)),
+                  "id" => VariableValue::from(json!("i1")),
+                  "payment_amount" => VariableValue::from(json!(70.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add relation 2
@@ -184,18 +193,22 @@ pub async fn optional_match(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "amount" => VariableValue::from(json!(100.0)),
-              "id" => VariableValue::from(json!("i1")),
-              "payment_amount" => VariableValue::Null
-            ),
-            after: variablemap!(
-              "amount" => VariableValue::from(json!(100.0)),
-              "id" => VariableValue::from(json!("i1")),
-              "payment_amount" => VariableValue::from(json!(10.0))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "amount" => VariableValue::from(json!(100.0)),
+                  "id" => VariableValue::from(json!("i1")),
+                  "payment_amount" => VariableValue::Null
+                ),
+                after: variablemap!(
+                  "amount" => VariableValue::from(json!(100.0)),
+                  "id" => VariableValue::from(json!("i1")),
+                  "payment_amount" => VariableValue::from(json!(10.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //update payment 2
@@ -219,18 +232,22 @@ pub async fn optional_match(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "amount" => VariableValue::from(json!(100.0)),
-              "id" => VariableValue::from(json!("i1")),
-                "payment_amount" => VariableValue::from(json!(10.0))
-            ),
-            after: variablemap!(
-              "amount" => VariableValue::from(json!(100.0)),
-              "id" => VariableValue::from(json!("i1")),
-              "payment_amount" => VariableValue::from(json!(15.0))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "amount" => VariableValue::from(json!(100.0)),
+                  "id" => VariableValue::from(json!("i1")),
+                    "payment_amount" => VariableValue::from(json!(10.0))
+                ),
+                after: variablemap!(
+                  "amount" => VariableValue::from(json!(100.0)),
+                  "id" => VariableValue::from(json!("i1")),
+                  "payment_amount" => VariableValue::from(json!(15.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //delete payment 2
@@ -248,18 +265,22 @@ pub async fn optional_match(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "amount" => VariableValue::from(json!(100.0)),
-              "id" => VariableValue::from(json!("i1")),
-                "payment_amount" => VariableValue::from(json!(15.0))
-            ),
-            after: variablemap!(
-              "amount" => VariableValue::from(json!(100.0)),
-              "id" => VariableValue::from(json!("i1")),
-              "payment_amount" => VariableValue::Null
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "amount" => VariableValue::from(json!(100.0)),
+                  "id" => VariableValue::from(json!("i1")),
+                    "payment_amount" => VariableValue::from(json!(15.0))
+                ),
+                after: variablemap!(
+                  "amount" => VariableValue::from(json!(100.0)),
+                  "id" => VariableValue::from(json!("i1")),
+                  "payment_amount" => VariableValue::Null
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -294,24 +315,28 @@ pub async fn optional_match_aggregating(config: &(impl QueryTestConfig + Send)) 
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec!["id".to_string(), "amount".to_string()],
-            default_before: true,
-            default_after: false,
-            before: Some(variablemap!(
-                "amount" => VariableValue::from(json!(100.0)),
-                "balance" => VariableValue::from(json!(100.0)),
-                "payment_amount" => VariableValue::from(json!(0.0)),
-                "id" => VariableValue::from(json!("i1"))
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec!["id".to_string(), "amount".to_string()],
+                default_before: true,
+                default_after: false,
+                before: Some(variablemap!(
+                    "amount" => VariableValue::from(json!(100.0)),
+                    "balance" => VariableValue::from(json!(100.0)),
+                    "payment_amount" => VariableValue::from(json!(0.0)),
+                    "id" => VariableValue::from(json!("i1"))
 
-            )),
-            after: variablemap!(
-                "amount" => VariableValue::from(json!(100.0)),
-                "balance" => VariableValue::from(json!(100.0)),
-                "payment_amount" => VariableValue::from(json!(0.0)),
-                "id" => VariableValue::from(json!("i1"))
-            ),
-        }));
+                )),
+                after: variablemap!(
+                    "amount" => VariableValue::from(json!(100.0)),
+                    "balance" => VariableValue::from(json!(100.0)),
+                    "payment_amount" => VariableValue::from(json!(0.0)),
+                    "id" => VariableValue::from(json!("i1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add relation 1
@@ -359,24 +384,28 @@ pub async fn optional_match_aggregating(config: &(impl QueryTestConfig + Send)) 
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec!["id".to_string(), "amount".to_string()],
-            default_before: false,
-            default_after: false,
-            before: Some(variablemap!(
-                "amount" => VariableValue::from(json!(100.0)),
-                "balance" => VariableValue::from(json!(100.0)),
-                "payment_amount" => VariableValue::from(json!(0.0)),
-                "id" => VariableValue::from(json!("i1"))
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec!["id".to_string(), "amount".to_string()],
+                default_before: false,
+                default_after: false,
+                before: Some(variablemap!(
+                    "amount" => VariableValue::from(json!(100.0)),
+                    "balance" => VariableValue::from(json!(100.0)),
+                    "payment_amount" => VariableValue::from(json!(0.0)),
+                    "id" => VariableValue::from(json!("i1"))
 
-            )),
-            after: variablemap!(
-                "amount" => VariableValue::from(json!(100.0)),
-                "balance" => VariableValue::from(json!(30.0)),
-                "payment_amount" => VariableValue::from(json!(70.0)),
-                "id" => VariableValue::from(json!("i1"))
-            ),
-        }));
+                )),
+                after: variablemap!(
+                    "amount" => VariableValue::from(json!(100.0)),
+                    "balance" => VariableValue::from(json!(30.0)),
+                    "payment_amount" => VariableValue::from(json!(70.0)),
+                    "id" => VariableValue::from(json!("i1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add relation 2
@@ -424,24 +453,28 @@ pub async fn optional_match_aggregating(config: &(impl QueryTestConfig + Send)) 
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec!["id".to_string(), "amount".to_string()],
-            default_before: false,
-            default_after: false,
-            before: Some(variablemap!(
-                "amount" => VariableValue::from(json!(100.0)),
-                "balance" => VariableValue::from(json!(30.0)),
-                "payment_amount" => VariableValue::from(json!(70.0)),
-                "id" => VariableValue::from(json!("i1"))
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec!["id".to_string(), "amount".to_string()],
+                default_before: false,
+                default_after: false,
+                before: Some(variablemap!(
+                    "amount" => VariableValue::from(json!(100.0)),
+                    "balance" => VariableValue::from(json!(30.0)),
+                    "payment_amount" => VariableValue::from(json!(70.0)),
+                    "id" => VariableValue::from(json!("i1"))
 
-            )),
-            after: variablemap!(
-                "amount" => VariableValue::from(json!(100.0)),
-                "balance" => VariableValue::from(json!(0.0)),
-                "payment_amount" => VariableValue::from(json!(100.0)),
-                "id" => VariableValue::from(json!("i1"))
-            ),
-        }));
+                )),
+                after: variablemap!(
+                    "amount" => VariableValue::from(json!(100.0)),
+                    "balance" => VariableValue::from(json!(0.0)),
+                    "payment_amount" => VariableValue::from(json!(100.0)),
+                    "id" => VariableValue::from(json!("i1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -475,13 +508,17 @@ pub async fn multi_optional_match(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "customer_id" => VariableValue::from(json!("c1")),
-                "invoice_id" => VariableValue::Null,
-                "payment_id" => VariableValue::Null
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "customer_id" => VariableValue::from(json!("c1")),
+                    "invoice_id" => VariableValue::Null,
+                    "payment_id" => VariableValue::Null
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add has 1
@@ -529,18 +566,22 @@ pub async fn multi_optional_match(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-                "customer_id" => VariableValue::from(json!("c1")),
-                "invoice_id" => VariableValue::Null,
-                "payment_id" => VariableValue::Null
-            ),
-            after: variablemap!(
-                "customer_id" => VariableValue::from(json!("c1")),
-                "invoice_id" => VariableValue::from(json!("i1")),
-                "payment_id" => VariableValue::Null
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "customer_id" => VariableValue::from(json!("c1")),
+                    "invoice_id" => VariableValue::Null,
+                    "payment_id" => VariableValue::Null
+                ),
+                after: variablemap!(
+                    "customer_id" => VariableValue::from(json!("c1")),
+                    "invoice_id" => VariableValue::from(json!("i1")),
+                    "payment_id" => VariableValue::Null
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add relation 1
@@ -588,17 +629,21 @@ pub async fn multi_optional_match(config: &(impl QueryTestConfig + Send)) {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-                "customer_id" => VariableValue::from(json!("c1")),
-                "invoice_id" => VariableValue::from(json!("i1")),
-                "payment_id" => VariableValue::Null
-            ),
-            after: variablemap!(
-                "customer_id" => VariableValue::from(json!("c1")),
-                "invoice_id" => VariableValue::from(json!("i1")),
-                "payment_id" => VariableValue::from(json!("p1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "customer_id" => VariableValue::from(json!("c1")),
+                    "invoice_id" => VariableValue::from(json!("i1")),
+                    "payment_id" => VariableValue::Null
+                ),
+                after: variablemap!(
+                    "customer_id" => VariableValue::from(json!("c1")),
+                    "invoice_id" => VariableValue::from(json!("i1")),
+                    "payment_id" => VariableValue::from(json!("p1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/overdue_invoice/mod.rs
+++ b/shared-tests/src/use_cases/overdue_invoice/mod.rs
@@ -31,6 +31,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -94,12 +95,16 @@ pub async fn overdue_invoice(config: &(impl QueryTestConfig + Send)) {
         let result = fqc.recv(std::time::Duration::from_secs(5)).await.unwrap();
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "invoiceNumber" => VariableValue::String("INV1".into()),
-                "invoiceDate" => VariableValue::String("2020-01-01".into())
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "invoiceNumber" => VariableValue::String("INV1".into()),
+                    "invoiceDate" => VariableValue::String("2020-01-01".into())
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //pay invoice
@@ -120,12 +125,16 @@ pub async fn overdue_invoice(config: &(impl QueryTestConfig + Send)) {
         let result = cq.process_source_change(change.clone()).await.unwrap();
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-                "invoiceNumber" => VariableValue::String("INV1".into()),
-                "invoiceDate" => VariableValue::String("2020-01-01".into())
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                    "invoiceNumber" => VariableValue::String("INV1".into()),
+                    "invoiceDate" => VariableValue::String("2020-01-01".into())
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -221,11 +230,15 @@ pub async fn overdue_count_persistent(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         println!("later: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "count" => VariableValue::Integer(3.into())
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "count" => VariableValue::Integer(3.into())
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //pay invoice
@@ -246,10 +259,14 @@ pub async fn overdue_count_persistent(config: &(impl QueryTestConfig + Send)) {
         let result = cq.process_source_change(change.clone()).await.unwrap();
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-                "count" => VariableValue::Integer(3.into())
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                    "count" => VariableValue::Integer(3.into())
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/prev_distinct/mod.rs
+++ b/shared-tests/src/use_cases/prev_distinct/mod.rs
@@ -28,6 +28,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -98,13 +99,17 @@ pub async fn prev_unique(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "tags" => VariableValue::from(json!("tag1")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "tags" => VariableValue::from(json!("tag1")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //update contract 1 tags
@@ -131,18 +136,22 @@ pub async fn prev_unique(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "tags" => VariableValue::from(json!("tag1")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-            after: variablemap!(
-              "tags" => VariableValue::from(json!("tag2")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "tags" => VariableValue::from(json!("tag1")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                after: variablemap!(
+                  "tags" => VariableValue::from(json!("tag2")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add contract 2
@@ -193,18 +202,22 @@ pub async fn prev_unique(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "tags" => VariableValue::from(json!("tag2")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-            after: variablemap!(
-              "tags" => VariableValue::from(json!("tag3")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "tags" => VariableValue::from(json!("tag2")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                after: variablemap!(
+                  "tags" => VariableValue::from(json!("tag3")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //update contract 2 with active status
@@ -280,13 +293,17 @@ pub async fn prev_unique(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "tags" => VariableValue::from(json!("tag1")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c2"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "tags" => VariableValue::from(json!("tag1")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c2"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -348,13 +365,17 @@ pub async fn prev_unique_with_match(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "tags" => VariableValue::from(json!("tag1")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "tags" => VariableValue::from(json!("tag1")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //update contract 1 tags
@@ -381,18 +402,22 @@ pub async fn prev_unique_with_match(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "tags" => VariableValue::from(json!("tag1")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-            after: variablemap!(
-              "tags" => VariableValue::from(json!("tag2")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "tags" => VariableValue::from(json!("tag1")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                after: variablemap!(
+                  "tags" => VariableValue::from(json!("tag2")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add contract 2
@@ -443,18 +468,22 @@ pub async fn prev_unique_with_match(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-              "tags" => VariableValue::from(json!("tag2")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-            after: variablemap!(
-              "tags" => VariableValue::from(json!("tag3")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c1"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                  "tags" => VariableValue::from(json!("tag2")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                after: variablemap!(
+                  "tags" => VariableValue::from(json!("tag3")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c1"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //update contract 2 with active status
@@ -530,12 +559,16 @@ pub async fn prev_unique_with_match(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "tags" => VariableValue::from(json!("tag1")),
-              "status" => VariableValue::from(json!("active")),
-              "id" => VariableValue::from(json!("c2"))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "tags" => VariableValue::from(json!("tag1")),
+                  "status" => VariableValue::from(json!("active")),
+                  "id" => VariableValue::from(json!("c2"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/relabel/mod.rs
+++ b/shared-tests/src/use_cases/relabel/mod.rs
@@ -29,6 +29,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -84,13 +85,17 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("Node Result - Add Person (should be User): {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "userName" => VariableValue::from(json!("John Doe")),
-                "userEmail" => VariableValue::from(json!("john.doe@example.com")),
-                "userRole" => VariableValue::from(json!("Developer"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "userName" => VariableValue::from(json!("John Doe")),
+                    "userEmail" => VariableValue::from(json!("john.doe@example.com")),
+                    "userRole" => VariableValue::from(json!("Developer"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // Insert an Employee node (should be relabeled to Staff)
@@ -142,18 +147,22 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("Node Result - Update Person: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-                "userName" => VariableValue::from(json!("John Doe")),
-                "userEmail" => VariableValue::from(json!("john.doe@example.com")),
-                "userRole" => VariableValue::from(json!("Developer"))
-            ),
-            after: variablemap!(
-                "userName" => VariableValue::from(json!("John Doe")),
-                "userEmail" => VariableValue::from(json!("john.doe@company.com")),
-                "userRole" => VariableValue::from(json!("Senior Developer"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "userName" => VariableValue::from(json!("John Doe")),
+                    "userEmail" => VariableValue::from(json!("john.doe@example.com")),
+                    "userRole" => VariableValue::from(json!("Developer"))
+                ),
+                after: variablemap!(
+                    "userName" => VariableValue::from(json!("John Doe")),
+                    "userEmail" => VariableValue::from(json!("john.doe@company.com")),
+                    "userRole" => VariableValue::from(json!("Senior Developer"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // Insert a node with multiple labels (Person and Employee)
@@ -180,13 +189,17 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("Node Result - Add Person+Employee (becomes User+Staff): {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "userName" => VariableValue::from(json!("Alice Johnson")),
-                "userEmail" => VariableValue::from(json!("alice@example.com")),
-                "userRole" => VariableValue::from(json!("Lead"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "userName" => VariableValue::from(json!("Alice Johnson")),
+                    "userEmail" => VariableValue::from(json!("alice@example.com")),
+                    "userRole" => VariableValue::from(json!("Lead"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // Insert a Company node (should be relabeled to Organization)
@@ -231,13 +244,17 @@ pub async fn relabel(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("Node Result - Delete Person: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-                "userName" => VariableValue::from(json!("John Doe")),
-                "userEmail" => VariableValue::from(json!("john.doe@company.com")),
-                "userRole" => VariableValue::from(json!("Senior Developer"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                    "userName" => VariableValue::from(json!("John Doe")),
+                    "userEmail" => VariableValue::from(json!("john.doe@company.com")),
+                    "userRole" => VariableValue::from(json!("Senior Developer"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     // Insert a node with an unmapped label (should remain unchanged)

--- a/shared-tests/src/use_cases/remap/mod.rs
+++ b/shared-tests/src/use_cases/remap/mod.rs
@@ -29,6 +29,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -100,12 +101,16 @@ pub async fn remap(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("Node Result - Add t1: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "id" => VariableValue::from(json!("v1")),
-                "currentSpeed" => VariableValue::from(json!("119"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("v1")),
+                    "currentSpeed" => VariableValue::from(json!("119"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add next value
@@ -147,16 +152,20 @@ pub async fn remap(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("Node Result - Add t2: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-                "id" => VariableValue::from(json!("v1")),
-                "currentSpeed" => VariableValue::from(json!("119"))
-            ),
-            after: variablemap!(
-                "id" => VariableValue::from(json!("v1")),
-                "currentSpeed" => VariableValue::from(json!("121"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "id" => VariableValue::from(json!("v1")),
+                    "currentSpeed" => VariableValue::from(json!("119"))
+                ),
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("v1")),
+                    "currentSpeed" => VariableValue::from(json!("121"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add another vehicle
@@ -198,12 +207,16 @@ pub async fn remap(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("Node Result - Add t3: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "id" => VariableValue::from(json!("v2")),
-                "currentSpeed" => VariableValue::from(json!("110"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "id" => VariableValue::from(json!("v2")),
+                    "currentSpeed" => VariableValue::from(json!("110"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 

--- a/shared-tests/src/use_cases/rolling_average_decrease_by_ten/mod.rs
+++ b/shared-tests/src/use_cases/rolling_average_decrease_by_ten/mod.rs
@@ -28,6 +28,7 @@ use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
+use super::IGNORED_ROW_SIGNATURE;
 use crate::QueryTestConfig;
 
 mod data;
@@ -157,16 +158,14 @@ pub async fn rolling_average_decrease_by_ten(config: &(impl QueryTestConfig + Se
             .unwrap();
         // println!("Node Result - Update sensor value in loop ({}): {:?}", timestamp, node_result);
         assert_eq!(node_result.len(), 1);
-        assert_eq!(
-            node_result[0],
-            QueryPartEvaluationContext::Adding {
-                after: variablemap! (
-                    "currentAverageTemp" => VariableValue::from(json!(37.857142857142854)),
-                    "freezerId" => VariableValue::from(json!("equip_01")),
-                    "previousAverageTemp" => VariableValue::from(json!(42.5))
-                )
-            }
-        );
+        assert!(node_result[0].data_eq(&QueryPartEvaluationContext::Adding {
+            after: variablemap! (
+                "currentAverageTemp" => VariableValue::from(json!(37.857142857142854)),
+                "freezerId" => VariableValue::from(json!("equip_01")),
+                "previousAverageTemp" => VariableValue::from(json!(42.5))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }));
     }
 
     //Adding a new temperature that causes the average to go up

--- a/shared-tests/src/use_cases/sensor_heartbeat/mod.rs
+++ b/shared-tests/src/use_cases/sensor_heartbeat/mod.rs
@@ -33,6 +33,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 use self::data::get_bootstrap_data;
@@ -132,29 +133,41 @@ pub async fn not_reported(config: &(impl QueryTestConfig + Send)) {
         assert_eq!(fqc.recv(std::time::Duration::from_millis(100)).await, None); // no more results
         assert_eq!(results.len(), 3);
 
-        assert!(results.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "equipment" => VariableValue::String("Turbine 1".into()),
-                "sensor" => VariableValue::String("Temp".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
-            ),
-        }));
+        assert!(contains_data(
+            &results,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "equipment" => VariableValue::String("Turbine 1".into()),
+                    "sensor" => VariableValue::String("Temp".into()),
+                    "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(results.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "equipment" => VariableValue::String("Turbine 2".into()),
-                "sensor" => VariableValue::String("Temp".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
-            ),
-        }));
+        assert!(contains_data(
+            &results,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "equipment" => VariableValue::String("Turbine 2".into()),
+                    "sensor" => VariableValue::String("Temp".into()),
+                    "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(results.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "equipment" => VariableValue::String("Turbine 2".into()),
-                "sensor" => VariableValue::String("RPM".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
-            ),
-        }));
+        assert!(contains_data(
+            &results,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "equipment" => VariableValue::String("Turbine 2".into()),
+                    "sensor" => VariableValue::String("RPM".into()),
+                    "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //add sensor value for Turbine 2 / RPM
@@ -191,13 +204,17 @@ pub async fn not_reported(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-                "equipment" => VariableValue::String("Turbine 2".into()),
-                "sensor" => VariableValue::String("RPM".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(init_time.and_utc().timestamp_millis()))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                    "equipment" => VariableValue::String("Turbine 2".into()),
+                    "sensor" => VariableValue::String("RPM".into()),
+                    "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(init_time.and_utc().timestamp_millis()))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //jump forward another 30 minutes
@@ -207,13 +224,17 @@ pub async fn not_reported(config: &(impl QueryTestConfig + Send)) {
         assert_eq!(fqc.recv(std::time::Duration::from_millis(100)).await, None); // no additional results
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "equipment" => VariableValue::String("Turbine 1".into()),
-                "sensor" => VariableValue::String("RPM".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time1 as i64))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "equipment" => VariableValue::String("Turbine 1".into()),
+                    "sensor" => VariableValue::String("RPM".into()),
+                    "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time1 as i64))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //add sensor value for for each sensor
@@ -404,29 +425,41 @@ pub async fn not_reported_with_true_now_or_later(config: &(impl QueryTestConfig 
         assert_eq!(fqc.recv(std::time::Duration::from_millis(100)).await, None); // no more results
         assert_eq!(results.len(), 3);
 
-        assert!(results.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "equipment" => VariableValue::String("Turbine 1".into()),
-                "sensor" => VariableValue::String("Temp".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
-            ),
-        }));
+        assert!(contains_data(
+            &results,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "equipment" => VariableValue::String("Turbine 1".into()),
+                    "sensor" => VariableValue::String("Temp".into()),
+                    "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(results.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "equipment" => VariableValue::String("Turbine 2".into()),
-                "sensor" => VariableValue::String("Temp".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
-            ),
-        }));
+        assert!(contains_data(
+            &results,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "equipment" => VariableValue::String("Turbine 2".into()),
+                    "sensor" => VariableValue::String("Temp".into()),
+                    "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(results.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "equipment" => VariableValue::String("Turbine 2".into()),
-                "sensor" => VariableValue::String("RPM".into()),
-                "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
-            ),
-        }));
+        assert!(contains_data(
+            &results,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "equipment" => VariableValue::String("Turbine 2".into()),
+                    "sensor" => VariableValue::String("RPM".into()),
+                    "last_ts" => VariableValue::ZonedDateTime(ZonedDateTime::from_epoch_millis(time0 as i64))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -472,27 +505,25 @@ pub async fn percent_not_reported(config: &(impl QueryTestConfig + Send)) {
         }
 
         assert_eq!(fqc.recv(std::time::Duration::from_millis(100)).await, None); // no more results
-        assert_eq!(
-            results,
-            vec![
-                QueryPartEvaluationContext::Updating {
-                    before: variablemap!(
-                        "percent_not_reporting" => VariableValue::from(json!(0.0))
-                    ),
-                    after: variablemap!(
-                        "percent_not_reporting" => VariableValue::from(json!(50.0))
-                    )
-                },
-                QueryPartEvaluationContext::Updating {
-                    before: variablemap!(
-                        "percent_not_reporting" => VariableValue::from(json!(50.0))
-                    ),
-                    after: variablemap!(
-                        "percent_not_reporting" => VariableValue::from(json!(100.0))
-                    )
-                },
-            ]
-        );
+        assert_eq!(results.len(), 2);
+        assert!(results[0].data_eq(&QueryPartEvaluationContext::Updating {
+            before: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(0.0))
+            ),
+            after: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(50.0))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }));
+        assert!(results[1].data_eq(&QueryPartEvaluationContext::Updating {
+            before: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(50.0))
+            ),
+            after: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(100.0))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }));
     }
 
     //add sensor value for Turbine 1 - RPM
@@ -528,14 +559,18 @@ pub async fn percent_not_reported(config: &(impl QueryTestConfig + Send)) {
         let result = cq.process_source_change(value_rel.clone()).await.unwrap();
 
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-                "percent_not_reporting" => VariableValue::from(json!(100.0))
-            ),
-            after: variablemap!(
-                "percent_not_reporting" => VariableValue::from(json!(50.0))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "percent_not_reporting" => VariableValue::from(json!(100.0))
+                ),
+                after: variablemap!(
+                    "percent_not_reporting" => VariableValue::from(json!(50.0))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //add sensor value for Turbine 1 - Temp
@@ -613,17 +648,16 @@ pub async fn percent_not_reported(config: &(impl QueryTestConfig + Send)) {
 
         let result = cq.process_source_change(value_rel.clone()).await.unwrap();
 
-        assert_eq!(
-            result,
-            vec![QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "percent_not_reporting" => VariableValue::from(json!(50.0))
-                ),
-                after: variablemap!(
-                    "percent_not_reporting" => VariableValue::from(json!(0.0))
-                )
-            }]
-        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0].data_eq(&QueryPartEvaluationContext::Updating {
+            before: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(50.0))
+            ),
+            after: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(0.0))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }));
     }
 
     //jump forward another 30 minutes
@@ -632,17 +666,16 @@ pub async fn percent_not_reported(config: &(impl QueryTestConfig + Send)) {
         let result = fqc.recv(std::time::Duration::from_secs(5)).await.unwrap();
         assert_eq!(fqc.recv(std::time::Duration::from_millis(100)).await, None); // no additional results
 
-        assert_eq!(
-            result,
-            vec![QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "percent_not_reporting" => VariableValue::from(json!(0.0))
-                ),
-                after: variablemap!(
-                    "percent_not_reporting" => VariableValue::from(json!(50.0))
-                )
-            }]
-        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0].data_eq(&QueryPartEvaluationContext::Updating {
+            before: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(0.0))
+            ),
+            after: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(50.0))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }));
     }
 
     //jump forward another 30 minutes
@@ -651,17 +684,16 @@ pub async fn percent_not_reported(config: &(impl QueryTestConfig + Send)) {
         let result = fqc.recv(std::time::Duration::from_secs(5)).await.unwrap();
         assert_eq!(fqc.recv(std::time::Duration::from_millis(100)).await, None); // no additional results
 
-        assert_eq!(
-            result,
-            vec![QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "percent_not_reporting" => VariableValue::from(json!(50.0))
-                ),
-                after: variablemap!(
-                    "percent_not_reporting" => VariableValue::from(json!(100.0))
-                )
-            }]
-        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0].data_eq(&QueryPartEvaluationContext::Updating {
+            before: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(50.0))
+            ),
+            after: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(100.0))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }));
     }
 
     println!("-----------------------------------");
@@ -730,16 +762,15 @@ pub async fn percent_not_reported(config: &(impl QueryTestConfig + Send)) {
 
         let result = cq.process_source_change(value_rel.clone()).await.unwrap();
 
-        assert_eq!(
-            result,
-            vec![QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "percent_not_reporting" => VariableValue::from(json!(100.0))
-                ),
-                after: variablemap!(
-                    "percent_not_reporting" => VariableValue::from(json!(50.0))
-                )
-            }]
-        );
+        assert_eq!(result.len(), 1);
+        assert!(result[0].data_eq(&QueryPartEvaluationContext::Updating {
+            before: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(100.0))
+            ),
+            after: variablemap!(
+                "percent_not_reporting" => VariableValue::from(json!(50.0))
+            ),
+            row_signature: IGNORED_ROW_SIGNATURE,
+        }));
     }
 }

--- a/shared-tests/src/use_cases/source_update_upsert/mod.rs
+++ b/shared-tests/src/use_cases/source_update_upsert/mod.rs
@@ -28,6 +28,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -73,14 +74,18 @@ pub async fn test_upsert_semantics(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1, "Should have exactly one result");
         assert!(
-            result.contains(&QueryPartEvaluationContext::Adding {
-                after: variablemap!(
-                    "id" => VariableValue::from(json!("entity1")),
-                    "name" => VariableValue::from(json!("Entity One")),
-                    "status" => VariableValue::from(json!("active")),
-                    "value" => VariableValue::from(json!(100))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Adding {
+                    after: variablemap!(
+                        "id" => VariableValue::from(json!("entity1")),
+                        "name" => VariableValue::from(json!("Entity One")),
+                        "status" => VariableValue::from(json!("active")),
+                        "value" => VariableValue::from(json!(100))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "First SourceUpdate should ADD the entity"
         );
         //println!("✓ First SourceUpdate created new entity");
@@ -112,20 +117,24 @@ pub async fn test_upsert_semantics(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1, "Should have exactly one result");
         assert!(
-            result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "id" => VariableValue::from(json!("entity1")),
-                    "name" => VariableValue::from(json!("Entity One")),
-                    "status" => VariableValue::from(json!("active")),
-                    "value" => VariableValue::from(json!(100))
-                ),
-                after: variablemap!(
-                    "id" => VariableValue::from(json!("entity1")),
-                    "name" => VariableValue::from(json!("Entity One Updated")),
-                    "status" => VariableValue::from(json!("inactive")),
-                    "value" => VariableValue::from(json!(200))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                        "id" => VariableValue::from(json!("entity1")),
+                        "name" => VariableValue::from(json!("Entity One")),
+                        "status" => VariableValue::from(json!("active")),
+                        "value" => VariableValue::from(json!(100))
+                    ),
+                    after: variablemap!(
+                        "id" => VariableValue::from(json!("entity1")),
+                        "name" => VariableValue::from(json!("Entity One Updated")),
+                        "status" => VariableValue::from(json!("inactive")),
+                        "value" => VariableValue::from(json!(200))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "Second SourceUpdate should UPDATE the existing entity"
         );
         //println!("✓ Second SourceUpdate updated existing entity");
@@ -196,20 +205,24 @@ pub async fn test_partial_updates(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         assert!(
-            result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "id" => VariableValue::from(json!("entity2")),
-                    "name" => VariableValue::from(json!("Full Entity")),
-                    "status" => VariableValue::from(json!("online")),
-                    "value" => VariableValue::from(json!(42))
-                ),
-                after: variablemap!(
-                    "id" => VariableValue::from(json!("entity2")),
-                    "name" => VariableValue::from(json!("Full Entity")),  // Preserved
-                    "status" => VariableValue::from(json!("online")),     // Preserved
-                    "value" => VariableValue::from(json!(84))              // Updated
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                        "id" => VariableValue::from(json!("entity2")),
+                        "name" => VariableValue::from(json!("Full Entity")),
+                        "status" => VariableValue::from(json!("online")),
+                        "value" => VariableValue::from(json!(42))
+                    ),
+                    after: variablemap!(
+                        "id" => VariableValue::from(json!("entity2")),
+                        "name" => VariableValue::from(json!("Full Entity")),  // Preserved
+                        "status" => VariableValue::from(json!("online")),     // Preserved
+                        "value" => VariableValue::from(json!(84))              // Updated
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "Partial update should preserve unspecified properties"
         );
         //println!("✓ Partial update preserved unspecified properties");
@@ -249,14 +262,18 @@ pub async fn test_stateless_processing(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         assert!(
-            result.contains(&QueryPartEvaluationContext::Adding {
-                after: variablemap!(
-                    "id" => VariableValue::from(json!("sensor1")),
-                    "temp" => VariableValue::from(json!(20)),
-                    "humidity" => VariableValue::from(json!(60)),
-                    "battery" => VariableValue::from(json!(100))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Adding {
+                    after: variablemap!(
+                        "id" => VariableValue::from(json!("sensor1")),
+                        "temp" => VariableValue::from(json!(20)),
+                        "humidity" => VariableValue::from(json!(60)),
+                        "battery" => VariableValue::from(json!(100))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "First event should create the sensor"
         );
         //println!("✓ Event 1: Created new sensor node");
@@ -285,20 +302,24 @@ pub async fn test_stateless_processing(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         assert!(
-            result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "id" => VariableValue::from(json!("sensor1")),
-                    "temp" => VariableValue::from(json!(20)),
-                    "humidity" => VariableValue::from(json!(60)),
-                    "battery" => VariableValue::from(json!(100))
-                ),
-                after: variablemap!(
-                    "id" => VariableValue::from(json!("sensor1")),
-                    "temp" => VariableValue::from(json!(21)),
-                    "humidity" => VariableValue::from(json!(61)),
-                    "battery" => VariableValue::from(json!(99))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                        "id" => VariableValue::from(json!("sensor1")),
+                        "temp" => VariableValue::from(json!(20)),
+                        "humidity" => VariableValue::from(json!(60)),
+                        "battery" => VariableValue::from(json!(100))
+                    ),
+                    after: variablemap!(
+                        "id" => VariableValue::from(json!("sensor1")),
+                        "temp" => VariableValue::from(json!(21)),
+                        "humidity" => VariableValue::from(json!(61)),
+                        "battery" => VariableValue::from(json!(99))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "Second event should update existing sensor"
         );
         //println!("✓ Event 2: Updated existing sensor node");
@@ -327,20 +348,24 @@ pub async fn test_stateless_processing(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         assert!(
-            result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "id" => VariableValue::from(json!("sensor1")),
-                    "temp" => VariableValue::from(json!(21)),
-                    "humidity" => VariableValue::from(json!(61)),
-                    "battery" => VariableValue::from(json!(99))
-                ),
-                after: variablemap!(
-                    "id" => VariableValue::from(json!("sensor1")),
-                    "temp" => VariableValue::from(json!(22)),
-                    "humidity" => VariableValue::from(json!(62)),
-                    "battery" => VariableValue::from(json!(98))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                        "id" => VariableValue::from(json!("sensor1")),
+                        "temp" => VariableValue::from(json!(21)),
+                        "humidity" => VariableValue::from(json!(61)),
+                        "battery" => VariableValue::from(json!(99))
+                    ),
+                    after: variablemap!(
+                        "id" => VariableValue::from(json!("sensor1")),
+                        "temp" => VariableValue::from(json!(22)),
+                        "humidity" => VariableValue::from(json!(62)),
+                        "battery" => VariableValue::from(json!(98))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "Third event should update existing sensor"
         );
         //println!("✓ Event 3: Updated existing sensor node");
@@ -380,14 +405,18 @@ pub async fn test_query_matching(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         assert!(
-            result.contains(&QueryPartEvaluationContext::Adding {
-                after: variablemap!(
-                    "id" => VariableValue::from(json!("device1")),
-                    "name" => VariableValue::from(json!("Test Device")),
-                    "temp" => VariableValue::from(json!(25)),
-                    "humidity" => VariableValue::from(json!(50))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Adding {
+                    after: variablemap!(
+                        "id" => VariableValue::from(json!("device1")),
+                        "name" => VariableValue::from(json!("Test Device")),
+                        "temp" => VariableValue::from(json!(25)),
+                        "humidity" => VariableValue::from(json!(50))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "Device with status='online' should match query"
         );
         //println!("✓ Device created and matched query");
@@ -417,14 +446,18 @@ pub async fn test_query_matching(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         assert!(
-            result.contains(&QueryPartEvaluationContext::Removing {
-                before: variablemap!(
-                    "id" => VariableValue::from(json!("device1")),
-                    "name" => VariableValue::from(json!("Test Device")),
-                    "temp" => VariableValue::from(json!(25)),
-                    "humidity" => VariableValue::from(json!(50))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Removing {
+                    before: variablemap!(
+                        "id" => VariableValue::from(json!("device1")),
+                        "name" => VariableValue::from(json!("Test Device")),
+                        "temp" => VariableValue::from(json!(25)),
+                        "humidity" => VariableValue::from(json!(50))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "Device with status='offline' should be removed from results"
         );
         //println!("✓ Device updated and removed from query results");
@@ -454,14 +487,18 @@ pub async fn test_query_matching(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         assert!(
-            result.contains(&QueryPartEvaluationContext::Adding {
-                after: variablemap!(
-                    "id" => VariableValue::from(json!("device1")),
-                    "name" => VariableValue::from(json!("Test Device")),
-                    "temp" => VariableValue::from(json!(26)),
-                    "humidity" => VariableValue::from(json!(51))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Adding {
+                    after: variablemap!(
+                        "id" => VariableValue::from(json!("device1")),
+                        "name" => VariableValue::from(json!("Test Device")),
+                        "temp" => VariableValue::from(json!(26)),
+                        "humidity" => VariableValue::from(json!(51))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "Device with status='online' should match query again"
         );
         //println!("✓ Device re-added to query results");
@@ -532,20 +569,24 @@ pub async fn test_multiple_entities(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1, "Should only affect entity2");
         assert!(
-            result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "id" => VariableValue::from(json!("entity2")),
-                    "name" => VariableValue::from(json!("Entity 2")),
-                    "status" => VariableValue::from(json!("active")),
-                    "value" => VariableValue::from(json!(20))
-                ),
-                after: variablemap!(
-                    "id" => VariableValue::from(json!("entity2")),
-                    "name" => VariableValue::from(json!("Entity 2 Updated")),
-                    "status" => VariableValue::from(json!("inactive")),
-                    "value" => VariableValue::from(json!(99))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                        "id" => VariableValue::from(json!("entity2")),
+                        "name" => VariableValue::from(json!("Entity 2")),
+                        "status" => VariableValue::from(json!("active")),
+                        "value" => VariableValue::from(json!(20))
+                    ),
+                    after: variablemap!(
+                        "id" => VariableValue::from(json!("entity2")),
+                        "name" => VariableValue::from(json!("Entity 2 Updated")),
+                        "status" => VariableValue::from(json!("inactive")),
+                        "value" => VariableValue::from(json!(99))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "Should update only entity2"
         );
         //println!("✓ Updated only entity2, others unaffected");
@@ -600,13 +641,17 @@ pub async fn test_relationship_upsert(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         assert!(
-            result.contains(&QueryPartEvaluationContext::Adding {
-                after: variablemap!(
-                    "from_id" => VariableValue::from(json!("device1")),
-                    "to_id" => VariableValue::from(json!("device2")),
-                    "strength" => VariableValue::from(json!(50))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Adding {
+                    after: variablemap!(
+                        "from_id" => VariableValue::from(json!("device1")),
+                        "to_id" => VariableValue::from(json!("device2")),
+                        "strength" => VariableValue::from(json!(50))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "First relationship SourceUpdate should create it"
         );
         //println!("✓ Relationship created");
@@ -634,18 +679,22 @@ pub async fn test_relationship_upsert(config: &(impl QueryTestConfig + Send)) {
 
         assert_eq!(result.len(), 1);
         assert!(
-            result.contains(&QueryPartEvaluationContext::Updating {
-                before: variablemap!(
-                    "from_id" => VariableValue::from(json!("device1")),
-                    "to_id" => VariableValue::from(json!("device2")),
-                    "strength" => VariableValue::from(json!(50))
-                ),
-                after: variablemap!(
-                    "from_id" => VariableValue::from(json!("device1")),
-                    "to_id" => VariableValue::from(json!("device2")),
-                    "strength" => VariableValue::from(json!(75))
-                ),
-            }),
+            contains_data(
+                &result,
+                &QueryPartEvaluationContext::Updating {
+                    before: variablemap!(
+                        "from_id" => VariableValue::from(json!("device1")),
+                        "to_id" => VariableValue::from(json!("device2")),
+                        "strength" => VariableValue::from(json!(50))
+                    ),
+                    after: variablemap!(
+                        "from_id" => VariableValue::from(json!("device1")),
+                        "to_id" => VariableValue::from(json!("device2")),
+                        "strength" => VariableValue::from(json!(75))
+                    ),
+                    row_signature: IGNORED_ROW_SIGNATURE,
+                }
+            ),
             "Second relationship SourceUpdate should update it"
         );
         //println!("✓ Relationship updated");
@@ -680,19 +729,23 @@ pub async fn test_aggregation_with_upserts(config: &(impl QueryTestConfig + Send
 
         let result = count_query.process_source_change(change).await.unwrap();
         assert_eq!(result.len(), 1);
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            grouping_keys: vec!["status".to_string()],
-            default_before: true,
-            default_after: false,
-            before: Some(variablemap!(
-                "status" => VariableValue::from(json!("active")),
-                "count" => VariableValue::from(json!(0))
-            )),
-            after: variablemap!(
-                "status" => VariableValue::from(json!("active")),
-                "count" => VariableValue::from(json!(1))
-            ),
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                grouping_keys: vec!["status".to_string()],
+                default_before: true,
+                default_after: false,
+                before: Some(variablemap!(
+                    "status" => VariableValue::from(json!("active")),
+                    "count" => VariableValue::from(json!(0))
+                )),
+                after: variablemap!(
+                    "status" => VariableValue::from(json!("active")),
+                    "count" => VariableValue::from(json!(1))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
         //println!("✓ Count for 'active' = 1");
     }
 

--- a/shared-tests/src/use_cases/steps_happen_in_any_order/mod.rs
+++ b/shared-tests/src/use_cases/steps_happen_in_any_order/mod.rs
@@ -28,6 +28,7 @@ use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
 use self::data::get_bootstrap_data;
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod data;
@@ -220,11 +221,15 @@ pub async fn steps_happen_in_any_order(config: &(impl QueryTestConfig + Send)) {
         println!("Node Result - Add Completed Step ({timestamp}): {result:?}");
         assert_eq!(result.len(), 1);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-              "customerId" => VariableValue::from(json!("cust_02")),
-              "customerEmail" => VariableValue::from(json!("cust_02@reflex.org"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                  "customerId" => VariableValue::from(json!("cust_02")),
+                  "customerEmail" => VariableValue::from(json!("cust_02@reflex.org"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }

--- a/shared-tests/src/use_cases/unwind/mod.rs
+++ b/shared-tests/src/use_cases/unwind/mod.rs
@@ -29,6 +29,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -101,20 +102,28 @@ pub async fn unwind(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 2);
         println!("Node Result - Add p1: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "pod" => VariableValue::from(json!("pod-1")),
-                "containerID" => VariableValue::from(json!("c1")),
-                "name" => VariableValue::from(json!("nginx"))
-            )
-        }));
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "pod" => VariableValue::from(json!("pod-1")),
-                "containerID" => VariableValue::from(json!("c2")),
-                "name" => VariableValue::from(json!("redis"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "pod" => VariableValue::from(json!("pod-1")),
+                    "containerID" => VariableValue::from(json!("c1")),
+                    "name" => VariableValue::from(json!("nginx"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "pod" => VariableValue::from(json!("pod-1")),
+                    "containerID" => VariableValue::from(json!("c2")),
+                    "name" => VariableValue::from(json!("redis"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add additional container
@@ -161,13 +170,17 @@ pub async fn unwind(config: &(impl QueryTestConfig + Send)) {
             .unwrap();
         assert_eq!(result.len(), 1);
         println!("Node Result - Update p1: {result:?}");
-        assert!(result.contains(&QueryPartEvaluationContext::Adding {
-            after: variablemap!(
-                "pod" => VariableValue::from(json!("pod-1")),
-                "containerID" => VariableValue::from(json!("c3")),
-                "name" => VariableValue::from(json!("dapr"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Adding {
+                after: variablemap!(
+                    "pod" => VariableValue::from(json!("pod-1")),
+                    "containerID" => VariableValue::from(json!("c3")),
+                    "name" => VariableValue::from(json!("dapr"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //remove container / update container
@@ -211,26 +224,34 @@ pub async fn unwind(config: &(impl QueryTestConfig + Send)) {
         println!("Node Result - Update p1: {result:?}");
         assert_eq!(result.len(), 2);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-                "pod" => VariableValue::from(json!("pod-1")),
-                "containerID" => VariableValue::from(json!("c2")),
-                "name" => VariableValue::from(json!("redis"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                    "pod" => VariableValue::from(json!("pod-1")),
+                    "containerID" => VariableValue::from(json!("c2")),
+                    "name" => VariableValue::from(json!("redis"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Updating {
-            before: variablemap!(
-                "pod" => VariableValue::from(json!("pod-1")),
-                "containerID" => VariableValue::from(json!("c1")),
-                "name" => VariableValue::from(json!("nginx"))
-            ),
-            after: variablemap!(
-                "pod" => VariableValue::from(json!("pod-1")),
-                "containerID" => VariableValue::from(json!("c1")),
-                "name" => VariableValue::from(json!("nginx2"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Updating {
+                before: variablemap!(
+                    "pod" => VariableValue::from(json!("pod-1")),
+                    "containerID" => VariableValue::from(json!("c1")),
+                    "name" => VariableValue::from(json!("nginx"))
+                ),
+                after: variablemap!(
+                    "pod" => VariableValue::from(json!("pod-1")),
+                    "containerID" => VariableValue::from(json!("c1")),
+                    "name" => VariableValue::from(json!("nginx2"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //remove pod
@@ -250,21 +271,29 @@ pub async fn unwind(config: &(impl QueryTestConfig + Send)) {
         println!("Node Result - Delete p1: {result:?}");
         assert_eq!(result.len(), 2);
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-                "pod" => VariableValue::from(json!("pod-1")),
-                "containerID" => VariableValue::from(json!("c1")),
-                "name" => VariableValue::from(json!("nginx2"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                    "pod" => VariableValue::from(json!("pod-1")),
+                    "containerID" => VariableValue::from(json!("c1")),
+                    "name" => VariableValue::from(json!("nginx2"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Removing {
-            before: variablemap!(
-                "pod" => VariableValue::from(json!("pod-1")),
-                "containerID" => VariableValue::from(json!("c3")),
-                "name" => VariableValue::from(json!("dapr"))
-            )
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Removing {
+                before: variablemap!(
+                    "pod" => VariableValue::from(json!("pod-1")),
+                    "containerID" => VariableValue::from(json!("c3")),
+                    "name" => VariableValue::from(json!("dapr"))
+                ),
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 

--- a/shared-tests/src/use_cases/windows/mod.rs
+++ b/shared-tests/src/use_cases/windows/mod.rs
@@ -33,6 +33,7 @@ use drasi_core::{
 use drasi_functions_cypher::CypherFunctionSet;
 use drasi_query_cypher::CypherParser;
 
+use super::{contains_data, IGNORED_ROW_SIGNATURE};
 use crate::QueryTestConfig;
 
 mod queries;
@@ -85,13 +86,17 @@ pub async fn sliding_window_max(config: &(impl QueryTestConfig + Send)) {
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!("slidingMax"=>VariableValue::Null)),
-            after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(50.0))),
-            grouping_keys: vec![],
-            default_before: true,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!("slidingMax"=>VariableValue::Null)),
+                after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(50.0))),
+                grouping_keys: vec![],
+                default_before: true,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //jump to 5 minutes later, add sensor 2
@@ -127,13 +132,17 @@ pub async fn sliding_window_max(config: &(impl QueryTestConfig + Send)) {
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!("slidingMax"=>VariableValue::Float(Float::from(50.0)))),
-            after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(30.0))),
-            grouping_keys: vec![],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!("slidingMax"=>VariableValue::Float(Float::from(50.0)))),
+                after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(30.0))),
+                grouping_keys: vec![],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //jump to 2 minutes later, add sensor 3
@@ -161,13 +170,17 @@ pub async fn sliding_window_max(config: &(impl QueryTestConfig + Send)) {
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!("slidingMax"=>VariableValue::Float(Float::from(30.0)))),
-            after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(45.0))),
-            grouping_keys: vec![],
-            default_before: true,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!("slidingMax"=>VariableValue::Float(Float::from(30.0)))),
+                after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(45.0))),
+                grouping_keys: vec![],
+                default_before: true,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //jump to 2 minutes later, update sensor 2
@@ -195,13 +208,17 @@ pub async fn sliding_window_max(config: &(impl QueryTestConfig + Send)) {
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!("slidingMax"=>VariableValue::Float(Float::from(45.0)))),
-            after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(65.0))),
-            grouping_keys: vec![],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!("slidingMax"=>VariableValue::Float(Float::from(45.0)))),
+                after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(65.0))),
+                grouping_keys: vec![],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //jump to 8 minutes later
@@ -224,13 +241,17 @@ pub async fn sliding_window_max(config: &(impl QueryTestConfig + Send)) {
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!("slidingMax"=>VariableValue::Float(Float::from(65.0)))),
-            after: variablemap!("slidingMax"=>VariableValue::Null),
-            grouping_keys: vec![],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!("slidingMax"=>VariableValue::Float(Float::from(65.0)))),
+                after: variablemap!("slidingMax"=>VariableValue::Null),
+                grouping_keys: vec![],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //jump to 2 minutes later, update sensor 2
@@ -258,13 +279,17 @@ pub async fn sliding_window_max(config: &(impl QueryTestConfig + Send)) {
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!("slidingMax"=>VariableValue::Null)),
-            after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(15.0))),
-            grouping_keys: vec![],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!("slidingMax"=>VariableValue::Null)),
+                after: variablemap!("slidingMax"=>VariableValue::Float(Float::from(15.0))),
+                grouping_keys: vec![],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }
 
@@ -309,19 +334,23 @@ pub async fn sliding_window_avg_grouped(config: &(impl QueryTestConfig + Send)) 
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            )),
-            after: variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(50.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            ),
-            grouping_keys: vec!["sensorGroup".to_string()],
-            default_before: true,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                )),
+                after: variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(50.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                ),
+                grouping_keys: vec!["sensorGroup".to_string()],
+                default_before: true,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //jump to 5 minutes later, add sensor 2
@@ -349,19 +378,23 @@ pub async fn sliding_window_avg_grouped(config: &(impl QueryTestConfig + Send)) 
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(50.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            )),
-            after: variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(40.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            ),
-            grouping_keys: vec!["sensorGroup".to_string()],
-            default_before: true,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(50.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                )),
+                after: variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(40.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                ),
+                grouping_keys: vec!["sensorGroup".to_string()],
+                default_before: true,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //Add sensor 3
@@ -385,19 +418,23 @@ pub async fn sliding_window_avg_grouped(config: &(impl QueryTestConfig + Send)) 
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
-                "sensorGroup"=>VariableValue::String("B".to_string())
-            )),
-            after: variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(10.0)),
-                "sensorGroup"=>VariableValue::String("B".to_string())
-            ),
-            grouping_keys: vec!["sensorGroup".to_string()],
-            default_before: true,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
+                    "sensorGroup"=>VariableValue::String("B".to_string())
+                )),
+                after: variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(10.0)),
+                    "sensorGroup"=>VariableValue::String("B".to_string())
+                ),
+                grouping_keys: vec!["sensorGroup".to_string()],
+                default_before: true,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //jump to 5 minutes later
@@ -410,19 +447,23 @@ pub async fn sliding_window_avg_grouped(config: &(impl QueryTestConfig + Send)) 
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(40.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            )),
-            after: variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(30.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            ),
-            grouping_keys: vec!["sensorGroup".to_string()],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(40.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                )),
+                after: variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(30.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                ),
+                grouping_keys: vec!["sensorGroup".to_string()],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //jump to 5 minutes later
@@ -441,33 +482,41 @@ pub async fn sliding_window_avg_grouped(config: &(impl QueryTestConfig + Send)) 
         assert_eq!(result.len(), 2);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(10.0)),
-                "sensorGroup"=>VariableValue::String("B".to_string())
-            )),
-            after: variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
-                "sensorGroup"=>VariableValue::String("B".to_string())
-            ),
-            grouping_keys: vec!["sensorGroup".to_string()],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(10.0)),
+                    "sensorGroup"=>VariableValue::String("B".to_string())
+                )),
+                after: variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
+                    "sensorGroup"=>VariableValue::String("B".to_string())
+                ),
+                grouping_keys: vec!["sensorGroup".to_string()],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(30.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            )),
-            after: variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            ),
-            grouping_keys: vec!["sensorGroup".to_string()],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(30.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                )),
+                after: variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                ),
+                grouping_keys: vec!["sensorGroup".to_string()],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //update sensor 2
@@ -491,19 +540,23 @@ pub async fn sliding_window_avg_grouped(config: &(impl QueryTestConfig + Send)) 
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            )),
-            after: variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(5.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            ),
-            grouping_keys: vec!["sensorGroup".to_string()],
-            default_before: false,
-            default_after: false
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                )),
+                after: variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(5.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                ),
+                grouping_keys: vec!["sensorGroup".to_string()],
+                default_before: false,
+                default_after: false,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 
     //delete sensor 2
@@ -520,18 +573,22 @@ pub async fn sliding_window_avg_grouped(config: &(impl QueryTestConfig + Send)) 
         assert_eq!(result.len(), 1);
         println!("result: {result:#?}");
 
-        assert!(result.contains(&QueryPartEvaluationContext::Aggregation {
-            before: Some(variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(5.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            )),
-            after: variablemap!(
-                "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
-                "sensorGroup"=>VariableValue::String("A".to_string())
-            ),
-            grouping_keys: vec!["sensorGroup".to_string()],
-            default_before: false,
-            default_after: true
-        }));
+        assert!(contains_data(
+            &result,
+            &QueryPartEvaluationContext::Aggregation {
+                before: Some(variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(5.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                )),
+                after: variablemap!(
+                    "slidingAvg"=>VariableValue::Float(Float::from(0.0)),
+                    "sensorGroup"=>VariableValue::String("A".to_string())
+                ),
+                grouping_keys: vec!["sensorGroup".to_string()],
+                default_before: false,
+                default_after: true,
+                row_signature: IGNORED_ROW_SIGNATURE,
+            }
+        ));
     }
 }


### PR DESCRIPTION
# Description

Surface the already-computed result row identity on `QueryPartEvaluationContext` (core engine's public result type).

The core query engine internally computes stable row identity for every result: `SolutionSignature` (u64 SpookyHash of matched graph elements) for non-aggregating queries and grouping key value hashes for aggregating queries. This identity is used for delta computation but discarded before results reach consumers, forcing every downstream materialized-view consumer to reinvent row identity via fragile content-hashing.

This changeset adds a `row_id: u64` field to each data-carrying variant of `QueryPartEvaluationContext` (`Adding`, `Updating`, `Removing`, `Aggregation`) and makes the already-computed identity available through the evaluation pipeline in `project_solution`.

### Changes

**Core engine (`core/src/evaluation/context.rs`)**
- Added `row_id: u64` field to `Adding`, `Updating`, `Removing`, and `Aggregation` variants
- Added `row_id()` accessor method
- Added `data_eq()` method for comparing all fields except `row_id` (used by test helpers)

**Pipeline threading (`core/src/query/continuous_query.rs`)**
- `project_solution`: maps `SolutionSignature` → `row_id` for non-aggregating queries, `after_grouping_hash` → `row_id` for aggregating queries
- `build_solution_changes`: sets placeholder `row_id: 0` on intermediate contexts
- `CollapsedAggregationResults`: sets `row_id` from the grouping key hash

**Evaluation pipeline (`core/src/evaluation/parts/mod.rs`)**
- Added `row_id: 0` placeholder to all ~15 construction sites in `evaluate()`
- Added `..` to destructuring patterns to accommodate the new field

**Downstream pattern matches**
- Updated 5 downstream files (`lib/src/queries/manager.rs`, `components/reactions/platform/src/types.rs`, `drasi-platform/query-container/query-host/src/api.rs`, `examples/query/temperature.rs`, `examples/query/process_monitor.rs`) to add `..` to pattern matches

**Tests**
- New `core/src/query/tests/row_id_tests.rs` with 7 tests verifying row_id behavior (non-zero on insert, stable across update/delete, different for different solutions, correct for aggregations)
- Updated ~130 construction sites in `core/src/evaluation/parts/tests/` with `row_id: 0`
- Updated ~170 construction sites in `shared-tests/src/use_cases/` with `row_id: 0`
- Added `contains_data()` helper to `shared-tests/src/use_cases/mod.rs` that uses `data_eq()` to compare results ignoring `row_id`
- Changed `result.contains(...)` → `contains_data(&result, ...)` in shared-tests where needed

### Key design decisions

1. **Direct field, not a wrapper**: `row_id` is a plain `u64` field on each variant, not a separate struct. This is pre-release with no external consumers.
2. **Derived `PartialEq` includes `row_id`**: Tests use `data_eq()` when they need to ignore row_id.
3. **No downstream integration yet**: `ResultDiff`, `current_results`, and platform `ResultChangeEvent` are future work.

## Type of change

- This pull request adds or changes features of Drasi and has an approved issue (issue link required).

Fixes: #263 
