### PR TITLE
Unify query index storage into a single instance

### DIFF
--- a/components/indexes/garnet/Cargo.toml
+++ b/components/indexes/garnet/Cargo.toml
@@ -48,3 +48,4 @@ prost = "0.12.3"
 [dev-dependencies]
 shared-tests = { path = "../../../shared-tests" }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
+redis = { version = "0.25", features = ["tokio-comp"] }

--- a/components/indexes/garnet/src/element_index/archive_index.rs
+++ b/components/indexes/garnet/src/element_index/archive_index.rs
@@ -30,9 +30,9 @@ use crate::{
 
 use super::GarnetElementIndex;
 
-/// Redis key structure:
+/// Redis key structure (hash-tagged for cluster compatibility):
 ///
-/// archive:{query_id}:{source_id}:{element_id} -> [element (sorted by ts)]
+/// archive:{<query_id>}:{source_id}:{element_id} -> [element (sorted by ts)]
 #[async_trait]
 impl ElementArchiveIndex for GarnetElementIndex {
     async fn get_element_as_at(
@@ -130,7 +130,7 @@ impl ElementArchiveIndex for GarnetElementIndex {
 
     async fn clear(&self) -> Result<(), IndexError> {
         self.connection
-            .clear(format!("archive:{}:*", self.query_id))
+            .clear(format!("archive:{{{}}}:*", self.query_id))
             .await
     }
 }

--- a/components/indexes/garnet/src/lib.rs
+++ b/components/indexes/garnet/src/lib.rs
@@ -23,7 +23,7 @@
 //! use drasi_lib::DrasiLib;
 //! use std::sync::Arc;
 //!
-//! let provider = GarnetIndexProvider::new("redis://localhost:6379", None);
+//! let provider = GarnetIndexProvider::new("redis://localhost:6379", None, true);
 //! let drasi = DrasiLib::builder()
 //!     .with_index_provider(Arc::new(provider))
 //!     .build()?;

--- a/components/indexes/garnet/src/plugin.rs
+++ b/components/indexes/garnet/src/plugin.rs
@@ -24,16 +24,14 @@
 //! use drasi_lib::DrasiLib;
 //! use std::sync::Arc;
 //!
-//! let provider = GarnetIndexProvider::new("redis://localhost:6379", None);
+//! let provider = GarnetIndexProvider::new("redis://localhost:6379", None, true);
 //! let drasi = DrasiLib::builder()
 //!     .with_index_provider(Arc::new(provider))
 //!     .build()?;
 //! ```
 
 use async_trait::async_trait;
-use drasi_core::interface::{
-    ElementArchiveIndex, ElementIndex, FutureQueue, IndexBackendPlugin, IndexError, ResultIndex,
-};
+use drasi_core::interface::{IndexBackendPlugin, IndexError, IndexSet};
 use std::sync::Arc;
 
 use crate::element_index::GarnetElementIndex;
@@ -43,20 +41,23 @@ use crate::result_index::GarnetResultIndex;
 /// Garnet/Redis index backend provider.
 ///
 /// This provider creates Redis/Garnet-backed indexes for distributed storage.
-/// Data survives restarts and can be shared across multiple instances.
+/// All indexes for a query share a single `MultiplexedConnection`, reducing
+/// connection overhead.
 ///
 /// # Configuration
 ///
 /// - `connection_string`: Redis connection URL (e.g., "redis://localhost:6379")
 /// - `cache_size`: Optional local cache size for improved read performance
+/// - `enable_archive`: Enable archive index for `past()` function support
 ///
 /// # Key Structure
 ///
-/// The provider uses the following Redis key patterns:
+/// The provider uses Redis hash tags `{query_id}` so all keys for a query
+/// hash to the same Redis Cluster slot:
 /// ```text
-/// ei:{query_id}:{source_id}:{element_id}  - Element data
-/// ari:{query_id}:{set_id}                 - Accumulator/result data
-/// fqi:{query_id}                          - Future queue
+/// ei:{my-query}:source1:elem1   - Element data
+/// ari:{my-query}:42             - Accumulator/result data
+/// fqi:{my-query}                - Future queue
 /// ```
 ///
 /// # Caching
@@ -67,6 +68,7 @@ use crate::result_index::GarnetResultIndex;
 pub struct GarnetIndexProvider {
     connection_string: String,
     cache_size: Option<usize>,
+    enable_archive: bool,
 }
 
 impl GarnetIndexProvider {
@@ -76,20 +78,26 @@ impl GarnetIndexProvider {
     ///
     /// * `connection_string` - Redis connection URL (e.g., "redis://localhost:6379")
     /// * `cache_size` - Optional local cache size for improved read performance
+    /// * `enable_archive` - Enable archive index for point-in-time queries
     ///
     /// # Example
     ///
     /// ```ignore
     /// // Without caching
-    /// let provider = GarnetIndexProvider::new("redis://localhost:6379", None);
+    /// let provider = GarnetIndexProvider::new("redis://localhost:6379", None, true);
     ///
     /// // With caching (1000 element cache)
-    /// let provider = GarnetIndexProvider::new("redis://localhost:6379", Some(1000));
+    /// let provider = GarnetIndexProvider::new("redis://localhost:6379", Some(1000), false);
     /// ```
-    pub fn new(connection_string: impl Into<String>, cache_size: Option<usize>) -> Self {
+    pub fn new(
+        connection_string: impl Into<String>,
+        cache_size: Option<usize>,
+        enable_archive: bool,
+    ) -> Self {
         Self {
             connection_string: connection_string.into(),
             cache_size,
+            enable_archive,
         }
     }
 
@@ -102,89 +110,37 @@ impl GarnetIndexProvider {
     pub fn cache_size(&self) -> Option<usize> {
         self.cache_size
     }
+
+    /// Check if archive is enabled.
+    pub fn is_archive_enabled(&self) -> bool {
+        self.enable_archive
+    }
 }
 
 #[async_trait]
 impl IndexBackendPlugin for GarnetIndexProvider {
-    async fn create_element_index(
-        &self,
-        query_id: &str,
-    ) -> Result<Arc<dyn ElementIndex>, IndexError> {
-        let index = GarnetElementIndex::connect(query_id, &self.connection_string)
+    async fn create_index_set(&self, query_id: &str) -> Result<IndexSet, IndexError> {
+        let client = redis::Client::open(self.connection_string.as_str())
+            .map_err(IndexError::connection_failed)?;
+        let connection = client
+            .get_multiplexed_async_connection()
             .await
-            .map_err(|e| {
-                log::error!(
-                    "Failed to connect to Redis/Garnet element index for query '{}' at '{}': {}",
-                    query_id,
-                    self.connection_string,
-                    e
-                );
-                e
-            })?;
+            .map_err(IndexError::connection_failed)?;
 
-        // Note: Caching is handled at the factory level in lib, not here
-        // This allows the factory to wrap with CachedElementIndex if cache_size is set
-        Ok(Arc::new(index))
-    }
+        let element_index = Arc::new(GarnetElementIndex::new(
+            query_id,
+            connection.clone(),
+            self.enable_archive,
+        ));
+        let result_index = Arc::new(GarnetResultIndex::new(query_id, connection.clone()));
+        let future_queue = Arc::new(GarnetFutureQueue::new(query_id, connection));
 
-    async fn create_archive_index(
-        &self,
-        query_id: &str,
-    ) -> Result<Arc<dyn ElementArchiveIndex>, IndexError> {
-        // Garnet shares the element index and archive index
-        // Archive functionality is managed within GarnetElementIndex
-        let index = GarnetElementIndex::connect(query_id, &self.connection_string)
-            .await
-            .map_err(|e| {
-                log::error!(
-                    "Failed to connect to Redis/Garnet archive index for query '{}' at '{}': {}",
-                    query_id,
-                    self.connection_string,
-                    e
-                );
-                e
-            })?;
-
-        Ok(Arc::new(index))
-    }
-
-    async fn create_result_index(
-        &self,
-        query_id: &str,
-    ) -> Result<Arc<dyn ResultIndex>, IndexError> {
-        let index = GarnetResultIndex::connect(query_id, &self.connection_string)
-            .await
-            .map_err(|e| {
-                log::error!(
-                    "Failed to connect to Redis/Garnet result index for query '{}' at '{}': {}",
-                    query_id,
-                    self.connection_string,
-                    e
-                );
-                e
-            })?;
-
-        // Note: Caching is handled at the factory level if cache_size is set
-        Ok(Arc::new(index))
-    }
-
-    async fn create_future_queue(
-        &self,
-        query_id: &str,
-    ) -> Result<Arc<dyn FutureQueue>, IndexError> {
-        let queue = GarnetFutureQueue::connect(query_id, &self.connection_string)
-            .await
-            .map_err(|e| {
-                log::error!(
-                    "Failed to connect to Redis/Garnet future queue for query '{}' at '{}': {}",
-                    query_id,
-                    self.connection_string,
-                    e
-                );
-                e
-            })?;
-
-        Ok(Arc::new(queue))
+        Ok(IndexSet {
+            element_index: element_index.clone(),
+            archive_index: element_index,
+            result_index,
+            future_queue,
+        })
     }
 
     fn is_volatile(&self) -> bool {
@@ -198,47 +154,49 @@ mod tests {
 
     #[test]
     fn test_garnet_index_provider_new() {
-        let provider = GarnetIndexProvider::new("redis://localhost:6379", None); // DevSkim: ignore DS162092
+        let provider = GarnetIndexProvider::new("redis://localhost:6379", None, false); // DevSkim: ignore DS162092
         assert_eq!(provider.connection_string(), "redis://localhost:6379"); // DevSkim: ignore DS162092
         assert!(provider.cache_size().is_none());
+        assert!(!provider.is_archive_enabled());
     }
 
     #[test]
     fn test_garnet_index_provider_new_with_cache() {
-        let provider = GarnetIndexProvider::new("redis://localhost:6379", Some(1000)); // DevSkim: ignore DS162092
+        let provider = GarnetIndexProvider::new("redis://localhost:6379", Some(1000), true); // DevSkim: ignore DS162092
         assert_eq!(provider.connection_string(), "redis://localhost:6379"); // DevSkim: ignore DS162092
         assert_eq!(provider.cache_size(), Some(1000));
+        assert!(provider.is_archive_enabled());
     }
 
     #[test]
     fn test_garnet_index_provider_connection_string_from_string() {
-        let provider = GarnetIndexProvider::new(String::from("redis://myhost:1234"), None); // DevSkim: ignore DS162092
+        let provider = GarnetIndexProvider::new(String::from("redis://myhost:1234"), None, false); // DevSkim: ignore DS162092
         assert_eq!(provider.connection_string(), "redis://myhost:1234"); // DevSkim: ignore DS162092
     }
 
     #[test]
     fn test_garnet_index_provider_is_volatile() {
-        let provider = GarnetIndexProvider::new("redis://localhost:6379", None); // DevSkim: ignore DS162092
+        let provider = GarnetIndexProvider::new("redis://localhost:6379", None, false); // DevSkim: ignore DS162092
         assert!(!provider.is_volatile());
     }
 
     #[test]
     fn test_garnet_index_provider_large_cache_size() {
-        let provider = GarnetIndexProvider::new("redis://localhost:6379", Some(1_000_000)); // DevSkim: ignore DS162092
+        let provider = GarnetIndexProvider::new("redis://localhost:6379", Some(1_000_000), false); // DevSkim: ignore DS162092
         assert_eq!(provider.cache_size(), Some(1_000_000));
     }
 
     #[test]
     fn test_garnet_index_provider_zero_cache_size() {
         // Zero cache size should be valid (effectively no caching)
-        let provider = GarnetIndexProvider::new("redis://localhost:6379", Some(0)); // DevSkim: ignore DS162092
+        let provider = GarnetIndexProvider::new("redis://localhost:6379", Some(0), false); // DevSkim: ignore DS162092
         assert_eq!(provider.cache_size(), Some(0));
     }
 
     #[test]
     fn test_garnet_index_provider_connection_string_with_auth() {
         // Test connection string with authentication
-        let provider = GarnetIndexProvider::new("redis://:password@localhost:6379/0", None); // DevSkim: ignore DS137138 DS162092
+        let provider = GarnetIndexProvider::new("redis://:password@localhost:6379/0", None, false); // DevSkim: ignore DS137138 DS162092
         assert_eq!(
             provider.connection_string(),
             "redis://:password@localhost:6379/0" // DevSkim: ignore DS137138 DS162092
@@ -248,7 +206,7 @@ mod tests {
     #[test]
     fn test_garnet_index_provider_connection_string_with_tls() {
         // Test connection string with TLS
-        let provider = GarnetIndexProvider::new("rediss://localhost:6379", None); // DevSkim: ignore DS162092
+        let provider = GarnetIndexProvider::new("rediss://localhost:6379", None, false); // DevSkim: ignore DS162092
         assert_eq!(provider.connection_string(), "rediss://localhost:6379"); // DevSkim: ignore DS162092
     }
 }

--- a/components/indexes/rocksdb/src/element_index/archive_index.rs
+++ b/components/indexes/rocksdb/src/element_index/archive_index.rs
@@ -230,7 +230,7 @@ pub fn insert_archive(
     }
 }
 
-pub fn get_archive_cf_options() -> Options {
+pub(crate) fn get_archive_cf_options() -> Options {
     let mut opts = Options::default();
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(16));
     opts

--- a/components/indexes/rocksdb/src/lib.rs
+++ b/components/indexes/rocksdb/src/lib.rs
@@ -35,5 +35,6 @@ mod plugin;
 pub mod result_index;
 mod storage_models;
 
-// Re-export the plugin provider for easy access
+// Re-export the plugin provider and unified DB opener for easy access
+pub use plugin::open_unified_db;
 pub use plugin::RocksDbIndexProvider;

--- a/components/indexes/rocksdb/src/plugin.rs
+++ b/components/indexes/rocksdb/src/plugin.rs
@@ -31,21 +31,61 @@
 //! ```
 
 use async_trait::async_trait;
-use drasi_core::interface::{
-    ElementArchiveIndex, ElementIndex, FutureQueue, IndexBackendPlugin, IndexError, ResultIndex,
-};
+use drasi_core::interface::{IndexBackendPlugin, IndexError, IndexSet};
+use rocksdb::{OptimisticTransactionDB, Options};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::element_index::{RocksDbElementIndex, RocksIndexOptions};
-use crate::future_queue::RocksDbFutureQueue;
-use crate::result_index::RocksDbResultIndex;
+use crate::element_index::{self, RocksDbElementIndex, RocksIndexOptions};
+use crate::future_queue::{self, RocksDbFutureQueue};
+use crate::result_index::{self, RocksDbResultIndex};
+
+/// Open a unified RocksDB database with all column families needed for a query.
+///
+/// This creates a single `OptimisticTransactionDB` instance containing all
+/// column families for element index, result index, and future queue.
+///
+/// # Arguments
+///
+/// * `path` - Base directory for RocksDB data files
+/// * `query_id` - Unique identifier for the query
+/// * `options` - RocksDB index options (archive, direct I/O)
+///
+/// # Directory Structure
+///
+/// Data is stored at `{path}/{query_id}/` (single unified directory).
+pub fn open_unified_db(
+    path: &str,
+    query_id: &str,
+    options: &RocksIndexOptions,
+) -> Result<Arc<OptimisticTransactionDB>, IndexError> {
+    let mut db_opts = Options::default();
+    db_opts.create_if_missing(true);
+    db_opts.create_missing_column_families(true);
+    db_opts.set_db_write_buffer_size(128 * 1024 * 1024);
+    db_opts.set_use_direct_reads(options.direct_io);
+    db_opts.set_use_direct_io_for_flush_and_compaction(options.direct_io);
+
+    let db_path = PathBuf::from(path).join(query_id);
+    let db_path = match db_path.to_str() {
+        Some(p) => p.to_string(),
+        None => return Err(IndexError::NotSupported),
+    };
+
+    let mut cfs = element_index::element_cf_descriptors(options);
+    cfs.extend(result_index::result_cf_descriptors());
+    cfs.extend(future_queue::future_queue_cf_descriptors());
+
+    let db = OptimisticTransactionDB::open_cf_descriptors(&db_opts, db_path, cfs)
+        .map_err(IndexError::other)?;
+    Ok(Arc::new(db))
+}
 
 /// RocksDB index backend provider.
 ///
 /// This provider creates RocksDB-backed indexes for persistent storage.
-/// Data survives restarts, so queries using this backend do not require
-/// re-bootstrapping.
+/// All indexes for a query share a single `OptimisticTransactionDB` instance,
+/// reducing resource overhead and enabling cross-index atomic transactions.
 ///
 /// # Configuration
 ///
@@ -58,10 +98,7 @@ use crate::result_index::RocksDbResultIndex;
 /// RocksDB creates the following directory structure:
 /// ```text
 /// {path}/
-///   {query_id}/
-///     elements/    - Element index data
-///     aggregations/ - Result index data
-///     fqi/         - Future queue data
+///   {query_id}/   - Single unified database with all column families
 /// ```
 pub struct RocksDbIndexProvider {
     path: PathBuf,
@@ -109,78 +146,30 @@ impl RocksDbIndexProvider {
 
 #[async_trait]
 impl IndexBackendPlugin for RocksDbIndexProvider {
-    async fn create_element_index(
-        &self,
-        query_id: &str,
-    ) -> Result<Arc<dyn ElementIndex>, IndexError> {
+    async fn create_index_set(&self, query_id: &str) -> Result<IndexSet, IndexError> {
         let path = self.path.to_string_lossy().to_string();
         let options = RocksIndexOptions {
             archive_enabled: self.enable_archive,
             direct_io: self.direct_io,
         };
 
-        let index = RocksDbElementIndex::new(query_id, &path, options).map_err(|e| {
+        let db = open_unified_db(&path, query_id, &options).map_err(|e| {
             log::error!(
-                "Failed to create RocksDB element index for query '{query_id}' at path '{path}': {e}"
+                "Failed to open unified RocksDB for query '{query_id}' at path '{path}': {e}"
             );
             e
         })?;
 
-        Ok(Arc::new(index))
-    }
+        let element_index = Arc::new(RocksDbElementIndex::new(db.clone(), options));
+        let result_index = Arc::new(RocksDbResultIndex::new(db.clone()));
+        let future_queue = Arc::new(RocksDbFutureQueue::new(db));
 
-    async fn create_archive_index(
-        &self,
-        query_id: &str,
-    ) -> Result<Arc<dyn ElementArchiveIndex>, IndexError> {
-        // RocksDB shares the element index and archive index in the same instance
-        // The archive functionality is enabled/disabled via RocksIndexOptions
-        let path = self.path.to_string_lossy().to_string();
-        let options = RocksIndexOptions {
-            archive_enabled: self.enable_archive,
-            direct_io: self.direct_io,
-        };
-
-        let index = RocksDbElementIndex::new(query_id, &path, options).map_err(|e| {
-            log::error!(
-                "Failed to create RocksDB archive index for query '{query_id}' at path '{path}': {e}"
-            );
-            e
-        })?;
-
-        Ok(Arc::new(index))
-    }
-
-    async fn create_result_index(
-        &self,
-        query_id: &str,
-    ) -> Result<Arc<dyn ResultIndex>, IndexError> {
-        let path = self.path.to_string_lossy().to_string();
-
-        let index = RocksDbResultIndex::new(query_id, &path).map_err(|e| {
-            log::error!(
-                "Failed to create RocksDB result index for query '{query_id}' at path '{path}': {e}"
-            );
-            e
-        })?;
-
-        Ok(Arc::new(index))
-    }
-
-    async fn create_future_queue(
-        &self,
-        query_id: &str,
-    ) -> Result<Arc<dyn FutureQueue>, IndexError> {
-        let path = self.path.to_string_lossy().to_string();
-
-        let queue = RocksDbFutureQueue::new(query_id, &path).map_err(|e| {
-            log::error!(
-                "Failed to create RocksDB future queue for query '{query_id}' at path '{path}': {e}"
-            );
-            e
-        })?;
-
-        Ok(Arc::new(queue))
+        Ok(IndexSet {
+            element_index: element_index.clone(),
+            archive_index: element_index,
+            result_index,
+            future_queue,
+        })
     }
 
     fn is_volatile(&self) -> bool {
@@ -231,71 +220,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rocksdb_create_element_index() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDbIndexProvider::new(temp_dir.path(), false, false);
-
-        let result = provider.create_element_index("test_query").await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_rocksdb_create_archive_index() {
-        let temp_dir = TempDir::new().unwrap();
+    async fn test_rocksdb_create_index_set() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
 
-        let result = provider.create_archive_index("test_query").await;
+        let result = provider.create_index_set("test_query").await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
-    async fn test_rocksdb_create_result_index() {
-        let temp_dir = TempDir::new().unwrap();
+    async fn test_rocksdb_create_index_set_multiple_queries() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let provider = RocksDbIndexProvider::new(temp_dir.path(), false, false);
 
-        let result = provider.create_result_index("test_query").await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_rocksdb_create_future_queue() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDbIndexProvider::new(temp_dir.path(), false, false);
-
-        let result = provider.create_future_queue("test_query").await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_rocksdb_create_all_indexes() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
-
-        // Create all index types with unique query IDs to avoid conflicts
-        // since RocksDB creates separate directories per query
-        let element_result = provider.create_element_index("query_element").await;
-        let archive_result = provider.create_archive_index("query_archive").await;
-        let result_result = provider.create_result_index("query_result").await;
-        let queue_result = provider.create_future_queue("query_queue").await;
-
-        assert!(element_result.is_ok());
-        assert!(archive_result.is_ok());
-        assert!(result_result.is_ok());
-        assert!(queue_result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_rocksdb_multiple_queries() {
-        let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDbIndexProvider::new(temp_dir.path(), false, false);
-
-        // Create indexes for multiple queries
-        let result1 = provider.create_element_index("query1").await;
-        let result2 = provider.create_element_index("query2").await;
-        let result3 = provider.create_element_index("query3").await;
+        let result1 = provider.create_index_set("query1").await;
+        let result2 = provider.create_index_set("query2").await;
+        let result3 = provider.create_index_set("query3").await;
 
         assert!(result1.is_ok());
         assert!(result2.is_ok());
         assert!(result3.is_ok());
+    }
+
+    #[test]
+    fn test_open_unified_db() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let options = RocksIndexOptions {
+            archive_enabled: true,
+            direct_io: false,
+        };
+
+        let path = temp_dir.path().to_string_lossy().to_string();
+        let result = open_unified_db(&path, "test_query", &options);
+        assert!(result.is_ok());
     }
 }

--- a/core/src/interface/mod.rs
+++ b/core/src/interface/mod.rs
@@ -32,6 +32,7 @@ pub use future_queue::FutureQueue;
 pub use future_queue::FutureQueueConsumer;
 pub use future_queue::PushType;
 pub use index_backend::IndexBackendPlugin;
+pub use index_backend::IndexSet;
 pub use query_clock::QueryClock;
 pub use result_index::AccumulatorIndex;
 pub use result_index::LazySortedSetStore;

--- a/lib/src/indexes/factory.rs
+++ b/lib/src/indexes/factory.rs
@@ -17,7 +17,7 @@ use crate::indexes::IndexBackendPlugin;
 use drasi_core::in_memory_index::in_memory_element_index::InMemoryElementIndex;
 use drasi_core::in_memory_index::in_memory_future_queue::InMemoryFutureQueue;
 use drasi_core::in_memory_index::in_memory_result_index::InMemoryResultIndex;
-use drasi_core::interface::{ElementArchiveIndex, ElementIndex, FutureQueue, ResultIndex};
+use drasi_core::interface::IndexSet;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -64,29 +64,6 @@ impl std::error::Error for IndexError {}
 impl From<drasi_core::interface::IndexError> for IndexError {
     fn from(err: drasi_core::interface::IndexError) -> Self {
         IndexError::InitializationFailed(err.to_string())
-    }
-}
-
-/// Set of indexes for a query
-pub struct IndexSet {
-    /// Element index for storing graph elements
-    pub element_index: Arc<dyn ElementIndex>,
-    /// Archive index for storing historical elements (for past() function)
-    pub archive_index: Arc<dyn ElementArchiveIndex>,
-    /// Result index for storing query results
-    pub result_index: Arc<dyn ResultIndex>,
-    /// Future queue for temporal queries
-    pub future_queue: Arc<dyn FutureQueue>,
-}
-
-impl fmt::Debug for IndexSet {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("IndexSet")
-            .field("element_index", &"<trait object>")
-            .field("archive_index", &"<trait object>")
-            .field("result_index", &"<trait object>")
-            .field("future_queue", &"<trait object>")
-            .finish()
     }
 }
 
@@ -221,39 +198,11 @@ impl IndexFactory {
         plugin: &Arc<dyn IndexBackendPlugin>,
         query_id: &str,
     ) -> Result<IndexSet, IndexError> {
-        let element_index = plugin.create_element_index(query_id).await.map_err(|e| {
-            log::error!("Failed to create element index for query '{query_id}': {e}");
+        plugin.create_index_set(query_id).await.map_err(|e| {
+            log::error!("Failed to create index set for query '{query_id}': {e}");
             IndexError::InitializationFailed(format!(
-                "Failed to create element index for query '{query_id}': {e}"
+                "Failed to create index set for query '{query_id}': {e}"
             ))
-        })?;
-
-        let archive_index = plugin.create_archive_index(query_id).await.map_err(|e| {
-            log::error!("Failed to create archive index for query '{query_id}': {e}");
-            IndexError::InitializationFailed(format!(
-                "Failed to create archive index for query '{query_id}': {e}"
-            ))
-        })?;
-
-        let result_index = plugin.create_result_index(query_id).await.map_err(|e| {
-            log::error!("Failed to create result index for query '{query_id}': {e}");
-            IndexError::InitializationFailed(format!(
-                "Failed to create result index for query '{query_id}': {e}"
-            ))
-        })?;
-
-        let future_queue = plugin.create_future_queue(query_id).await.map_err(|e| {
-            log::error!("Failed to create future queue for query '{query_id}': {e}");
-            IndexError::InitializationFailed(format!(
-                "Failed to create future queue for query '{query_id}': {e}"
-            ))
-        })?;
-
-        Ok(IndexSet {
-            element_index,
-            archive_index,
-            result_index,
-            future_queue,
         })
     }
 
@@ -560,43 +509,11 @@ mod tests {
 
         #[async_trait]
         impl IndexBackendPlugin for MockPlugin {
-            async fn create_element_index(
+            async fn create_index_set(
                 &self,
                 _query_id: &str,
-            ) -> Result<
-                Arc<dyn drasi_core::interface::ElementIndex>,
-                drasi_core::interface::IndexError,
-            > {
-                unimplemented!()
-            }
-
-            async fn create_archive_index(
-                &self,
-                _query_id: &str,
-            ) -> Result<
-                Arc<dyn drasi_core::interface::ElementArchiveIndex>,
-                drasi_core::interface::IndexError,
-            > {
-                unimplemented!()
-            }
-
-            async fn create_result_index(
-                &self,
-                _query_id: &str,
-            ) -> Result<
-                Arc<dyn drasi_core::interface::ResultIndex>,
-                drasi_core::interface::IndexError,
-            > {
-                unimplemented!()
-            }
-
-            async fn create_future_queue(
-                &self,
-                _query_id: &str,
-            ) -> Result<
-                Arc<dyn drasi_core::interface::FutureQueue>,
-                drasi_core::interface::IndexError,
-            > {
+            ) -> Result<drasi_core::interface::IndexSet, drasi_core::interface::IndexError>
+            {
                 unimplemented!()
             }
 

--- a/lib/src/indexes/mod.rs
+++ b/lib/src/indexes/mod.rs
@@ -70,7 +70,8 @@ pub mod config;
 pub mod factory;
 
 pub use config::{StorageBackendConfig, StorageBackendRef, StorageBackendSpec};
-pub use factory::{IndexError, IndexFactory, IndexSet};
+pub use factory::{IndexError, IndexFactory};
 
-// Re-export IndexBackendPlugin from drasi_core for plugin developers
+// Re-export IndexSet and IndexBackendPlugin from drasi_core for plugin developers
 pub use drasi_core::interface::IndexBackendPlugin;
+pub use drasi_core::interface::IndexSet;

--- a/query-perf/Cargo.toml
+++ b/query-perf/Cargo.toml
@@ -16,6 +16,7 @@ drasi-query-cypher.workspace = true
 drasi-functions-cypher.workspace = true
 drasi-index-garnet.workspace = true
 drasi-index-rocksdb.workspace = true
+redis = { version = "0.25", features = ["tokio-comp"] }
 serde = "1.0.163"
 serde_json = "1.0.96"
 rand = "0.8.5"

--- a/query-perf/src/test_run.rs
+++ b/query-perf/src/test_run.rs
@@ -45,7 +45,7 @@ pub struct TestRunArgs {
     seed: Option<u64>,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum IndexType {
     Memory,
     Redis,

--- a/shared-tests/src/in_memory/mod.rs
+++ b/shared-tests/src/in_memory/mod.rs
@@ -349,6 +349,12 @@ mod index {
     }
 
     #[tokio::test]
+    async fn future_queue_clear_removes_all() {
+        let fqi = InMemoryFutureQueue::new();
+        index::future_queue::clear_removes_all(&fqi).await;
+    }
+
+    #[tokio::test]
     async fn future_queue_push_overwrite() {
         let fqi = InMemoryFutureQueue::new();
         fqi.clear().await.unwrap();

--- a/shared-tests/src/index/future_queue.rs
+++ b/shared-tests/src/index/future_queue.rs
@@ -158,6 +158,34 @@ pub async fn push_not_exists(subject: &impl FutureQueue) {
     assert_eq!(pop4, None);
 }
 
+pub async fn clear_removes_all(subject: &impl FutureQueue) {
+    let element1 = ElementReference::new("source1", "element1");
+
+    // Push items to populate both the main sorted set and secondary index keys
+    subject
+        .push(PushType::Always, 1, 1, &element1, 10, 20)
+        .await
+        .expect("push failed");
+    subject
+        .push(PushType::Always, 2, 2, &element1, 10, 30)
+        .await
+        .expect("push failed");
+
+    // Verify items are present
+    let peek = subject.peek_due_time().await.expect("peek failed");
+    assert_eq!(peek, Some(20));
+
+    // Clear everything
+    subject.clear().await.expect("clear failed");
+
+    // Verify queue is empty
+    let peek = subject.peek_due_time().await.expect("peek failed");
+    assert_eq!(peek, None);
+
+    let pop = subject.pop().await.expect("pop failed");
+    assert_eq!(pop, None);
+}
+
 pub async fn push_overwrite(subject: &impl FutureQueue) {
     let func1 = 1;
     let func2 = 2;


### PR DESCRIPTION
## Description

Unify per-query index storage so that all four index types (`ElementIndex`, `ElementArchiveIndex`, `ResultIndex`, `FutureQueue`) share a single backend instance instead of each opening its own.

**Before:** Each query opened 3 separate RocksDB databases (at `elements/`, `aggregations/`, `fqi/` subdirectories) and 3 separate Redis connections - one per index type. This tripled file descriptors, WAL files, background threads,
and network connections per query.

**After:** Each query opens a single RocksDB `OptimisticTransactionDB` (with all 11 column families) or a single Redis `MultiplexedConnection`, shared across all index types via `Arc`.

## What changed

**Pre-existing bugs fixed**

- **Garnet `FutureQueue::clear()` missed the main sorted set key:** The old pattern `fqi:{query_id}:*` only matched secondary index keys (e.g. `fqi:query1:0:12345`) but not the main sorted set `fqi:{query_id}`. Added an explicit `DEL` of the main key before pattern-clearing secondary keys. A `clear_removes_all` test is added to `shared-tests` and wired into all three backends.
- **query-perf RocksDB indexes were silently unused:** Both the element and result index `RocksDB` match arms created and cleared the index but returned `builder` without calling `.with_element_index()` / `.with_result_index()`, so benchmarks with `--element-index rocksdb` fell back to in-memory defaults.

**Core trait (`core/src/interface/index_backend.rs`)**

- Added `IndexSet` struct that groups the four index trait objects into one unit
- Replaced the four individual factory methods on `IndexBackendPlugin` (`create_element_index`, `create_archive_index`, `create_result_index`, `create_future_queue`) with a single `create_index_set()` method
- `IndexSet` is re-exported from `core::interface` so downstream crates can use it without reaching into submodules

**RocksDB backend (`components/indexes/rocksdb/`)**

- Added `open_unified_db()` — a public function that aggregates all column family descriptors from element, result, and future-queue modules and opens one `OptimisticTransactionDB` with all 11 CFs
- Changed `RocksDbElementIndex`, `RocksDbResultIndex`, and `RocksDbFutureQueue` constructors to accept an `Arc<OptimisticTransactionDB>` instead of opening their own database
- Made `RocksIndexOptions` `Clone + Copy` so it can be passed to the unified opener and then to individual constructors
- `element_index` and `archive_index` now share the same `Arc`, eliminating the previous bug where both opened separate DB instances at the same path

**Garnet/Redis backend (`components/indexes/garnet/`)**

- Added synchronous `new()` constructors on `GarnetElementIndex`, `GarnetResultIndex`, and `GarnetFutureQueue` that accept a `MultiplexedConnection`; the old `connect()` convenience constructors and `enable_archive()` mutator are removed since the trait signature change already breaks downstream callers
- `GarnetIndexProvider::new()` now takes a third parameter `enable_archive: bool`, and archive writes are actually wired through to `GarnetElementIndex`. Previously, archive was always disabled through the plugin path regardless of configuration.
- Added Redis hash tags (`{query_id}`) to all key patterns so that all keys for a given query hash to the same Redis Cluster slot. This is a prerequisite for cross-index `MULTI`/`EXEC` transactions in clustered deployments
- The plugin now opens a single connection and passes clones to each index

**Lib crate (`lib/src/indexes/`)**

- Removed the local `IndexSet` struct from `factory.rs` — it is now imported from `drasi_core::interface::IndexSet`
- Simplified `build_from_plugin()` from ~40 lines of per-index construction down to a single `plugin.create_index_set(query_id)` call

**Tests and tools**

- Updated `rocksdb/tests/scenario_tests.rs` to use `open_unified_db()` with a shared `Arc<OptimisticTransactionDB>` handle
- Updated `garnet/tests/scenario_tests.rs` to open one `redis::Client` connection and share it across all index constructors
- Updated `query-perf/src/main.rs` to use the new constructor signatures
- Updated query-perf Redis paths to share a single `MultiplexedConnection` (mirroring the RocksDB shared-handle pattern)
- Added `redis` as a dev-dependency for the garnet crate (needed by integration tests that open connections directly)

## Why this matters

1. **Resource reduction:** 3x fewer DB instances (RocksDB) or connections (Redis) per query. Fewer WAL files, background compaction threads, and file descriptors.
2. **Correctness:** Eliminates the bug where `element_index` and `archive_index` opened separate RocksDB instances at the same path.
3. **Foundation for transactions:** A shared backend instance is a prerequisite for cross-index atomic operations (checkpointing, outbox pattern, result-set snapshots).
4. **Simpler plugin API:** Plugin authors implement one method instead of four, and resource lifecycle is centralized.
5. **Cluster readiness (Garnet):** Hash tags ensure all keys for a query land on the same Redis Cluster shard, enabling `MULTI`/`EXEC` transactions.

## Not in scope
- Garnet `ResultIndex` atomicity improvements (`pipe().atomic()`, `WATCH`-based optimistic locking) are deferred to a follow-up. This commit establishes the prerequisite (shared connection, hash-tagged keys) but does not add transactional guarantees to `increment_value_count()` or `apply_sequence()`.

## Type of change

- This pull request adds or changes features of Drasi and has an approved issue (issue link required).

Fixes: #266 