### PR TITLE
fix: replace `unreachable!()` panics with proper error returns and upgrade `mysql_async`

### DIFF
--- a/components/reactions/platform/src/publisher.rs
+++ b/components/reactions/platform/src/publisher.rs
@@ -63,7 +63,7 @@ impl RedisStreamPublisher {
             }
         }
 
-        unreachable!("Loop should have returned or errored");
+        Err(anyhow::anyhow!("Failed to connect to Redis after {max_retries} attempts"))
     }
 
     /// Publish a CloudEvent to a Redis Stream
@@ -129,7 +129,7 @@ impl RedisStreamPublisher {
             }
         }
 
-        unreachable!("Loop should have returned or errored");
+        Err(anyhow::anyhow!("Failed to publish CloudEvent after {max_retries} attempts"))
     }
 
     /// Publish multiple CloudEvents in a single Redis pipeline
@@ -239,7 +239,7 @@ impl RedisStreamPublisher {
             }
         }
 
-        unreachable!("Loop should have returned or errored");
+        Err(anyhow::anyhow!("Failed to publish batch after {max_retries} attempts"))
     }
 }
 

--- a/components/reactions/storedproc-mysql/Cargo.toml
+++ b/components/reactions/storedproc-mysql/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.0", features = ["full"] }
 async-trait = "0.1"
 
 # MySQL
-mysql_async = { version = "0.34", default-features = false, features = ["default"] }
+mysql_async = { version = "0.36", default-features = false, features = ["default"] }
 
 # Utilities
 serde = { version = "1.0", features = ["derive"] }

--- a/components/sources/platform/src/lib.rs
+++ b/components/sources/platform/src/lib.rs
@@ -635,7 +635,9 @@ impl PlatformSource {
             }
         }
 
-        unreachable!()
+        Err(anyhow::anyhow!(
+            "Failed to connect to Redis after {max_retries} attempts"
+        ))
     }
 
     /// Create or recreate consumer group based on configuration


### PR DESCRIPTION
## Summary

This PR addresses two security/stability concerns identified by `cargo audit` and manual review:

1. **Vulnerable dependency upgrade**: `mysql_async` upgraded from `0.34` → `0.36` in `storedproc-mysql`, resolving [RUSTSEC-2026-0002](https://rustsec.org/advisories/RUSTSEC-2026-0002) (`lru` crate unsoundness).

2. **Panic prevention**: Replaced four `unreachable!()` macro calls with proper `Err(anyhow::anyhow!(...))` returns in retry loops. If `max_retries` is 0, the loop body never executes and hits `unreachable!()`, causing a panic. This is a potential denial-of-service vector.

## Changes

| File | Change |
|---|---|
| `components/sources/platform/src/lib.rs` | `connect_with_retry`: `unreachable!()` → proper error |
| `components/reactions/platform/src/publisher.rs` | `get_connection`: `unreachable!()` → proper error |
| `components/reactions/platform/src/publisher.rs` | `publish_with_retry`: `unreachable!()` → proper error |
| `components/reactions/platform/src/publisher.rs` | `publish_batch_with_retry`: `unreachable!()` → proper error |
| `components/reactions/storedproc-mysql/Cargo.toml` | `mysql_async` `0.34` → `0.36` |

## Verification

- `cargo check` passes on all affected components (`drasi-reaction-platform`, `drasi-source-platform`, `drasi-reaction-storedproc-mysql`).
- `cargo audit` no longer reports `lru 0.12.5`.

Closes #278