### PR TITLE
feat: Sqlite source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 
   # Bootstrap Plugins
   "components/bootstrappers/postgres",
+  "components/bootstrappers/sqlite",
   "components/bootstrappers/platform",
   "components/bootstrappers/scriptfile",
   "components/bootstrappers/application",
@@ -23,6 +24,7 @@ members = [
 
   # Source Plugins
   "components/sources/postgres",
+  "components/sources/sqlite",
   "components/sources/http",
   "components/sources/grpc",
   "components/sources/platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 
   # Bootstrap Plugins
   "components/bootstrappers/postgres",
+  "components/bootstrappers/sqlite",
   "components/bootstrappers/platform",
   "components/bootstrappers/scriptfile",
   "components/bootstrappers/application",
@@ -25,6 +26,7 @@ members = [
 
   # Source Plugins
   "components/sources/postgres",
+  "components/sources/sqlite",
   "components/sources/http",
   "components/sources/grpc",
   "components/sources/platform",

--- a/components/bootstrappers/sqlite/Cargo.toml
+++ b/components/bootstrappers/sqlite/Cargo.toml
@@ -1,0 +1,42 @@
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-bootstrap-sqlite"
+version = "0.1.0"
+edition = "2021"
+authors = ["Drasi Project"]
+description = "SQLite bootstrap plugin for Drasi"
+license = "Apache-2.0"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi", "plugin", "bootstrap", "sqlite"]
+categories = ["database"]
+
+[lints]
+workspace = true
+
+[dependencies]
+drasi-lib.workspace = true
+drasi-core.workspace = true
+anyhow = "1.0"
+async-trait = "0.1"
+log = "0.4"
+tracing = "0.1"
+rusqlite = { version = "0.32", features = ["bundled", "column_decltype"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+ordered-float = "3.0"
+tokio = { version = "1.0", features = ["full"] }
+base64 = "0.22"
+chrono = { version = "0.4", features = ["serde"] }

--- a/components/bootstrappers/sqlite/Cargo.toml
+++ b/components/bootstrappers/sqlite/Cargo.toml
@@ -23,12 +23,20 @@ repository = "https://github.com/drasi-project/drasi-core"
 keywords = ["drasi", "plugin", "bootstrap", "sqlite"]
 categories = ["database"]
 
+[lib]
+crate-type = ["lib", "cdylib"]
+
 [lints]
 workspace = true
+
+[features]
+dynamic-plugin = []
 
 [dependencies]
 drasi-lib.workspace = true
 drasi-core.workspace = true
+drasi-plugin-sdk = { workspace = true }
+utoipa = { workspace = true }
 anyhow = "1.0"
 async-trait = "0.1"
 log = "0.4"

--- a/components/bootstrappers/sqlite/Makefile
+++ b/components/bootstrappers/sqlite/Makefile
@@ -1,0 +1,17 @@
+.PHONY: build test integration-test lint clean
+
+build:
+	cargo build --release
+
+test:
+	cargo test
+
+integration-test:
+	cargo test -- --ignored --nocapture
+
+lint:
+	cargo clippy -- -D warnings
+	cargo fmt --check
+
+clean:
+	cargo clean

--- a/components/bootstrappers/sqlite/README.md
+++ b/components/bootstrappers/sqlite/README.md
@@ -1,0 +1,45 @@
+# SQLite Bootstrap Provider
+
+## Overview
+
+`drasi-bootstrap-sqlite` provides initial snapshot loading for SQLite-backed sources by reading table rows and emitting `SourceChange::Insert` bootstrap events.
+
+Key capabilities:
+
+- file-backed SQLite snapshot loading
+- optional table allow-list
+- table key override support for stable element IDs
+- automatic PK detection via `PRAGMA table_info`
+
+## Usage
+
+```rust
+use drasi_bootstrap_sqlite::{SqliteBootstrapProvider, TableKeyConfig};
+
+let bootstrap = SqliteBootstrapProvider::builder()
+    .with_path("data/example.db")
+    .with_tables(vec!["sensors".to_string()])
+    .with_table_keys(vec![TableKeyConfig {
+        table: "sensors".to_string(),
+        key_columns: vec!["id".to_string()],
+    }])
+    .build();
+```
+
+Attach the provider in `SqliteSource::builder(...).with_bootstrap_provider(bootstrap)`.
+
+## Behavior
+
+- For file-backed databases, the provider opens a read-only connection and streams table rows.
+- For in-memory databases, bootstrap is skipped (no independent snapshot connection exists).
+- Labels map directly to table names.
+- Element IDs use configured keys first, then detected PK columns.
+
+## Testing
+
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+```
+
+Bootstrap behavior is also validated through `drasi-source-sqlite` ignored integration tests.

--- a/components/bootstrappers/sqlite/README.md
+++ b/components/bootstrappers/sqlite/README.md
@@ -28,6 +28,21 @@ let bootstrap = SqliteBootstrapProvider::builder()
 
 Attach the provider in `SqliteSource::builder(...).with_bootstrap_provider(bootstrap)`.
 
+## Configuration Options
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `path` | `String?` | `null` | SQLite file path. Omit for in-memory (bootstrap will be skipped) |
+| `tables` | `Vec<String>?` | `null` | Optional table allow-list. `null` means all user tables |
+| `tableKeys` | `Vec<TableKeyConfig>` | `[]` | Manual primary key configuration |
+
+### TableKeyConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `table` | `String` | Table name |
+| `keyColumns` | `Vec<String>` | Column names to use as primary key |
+
 ## Behavior
 
 - For file-backed databases, the provider opens a read-only connection and streams table rows.

--- a/components/bootstrappers/sqlite/src/descriptor.rs
+++ b/components/bootstrappers/sqlite/src/descriptor.rs
@@ -1,0 +1,121 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SQLite bootstrap plugin descriptor and configuration DTOs.
+
+use crate::{SqliteBootstrapProvider, TableKeyConfig};
+use drasi_plugin_sdk::prelude::*;
+use utoipa::OpenApi;
+
+// ── DTO types ────────────────────────────────────────────────────────────────
+
+/// SQLite bootstrap configuration DTO.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[schema(as = bootstrap::sqlite::SqliteBootstrapConfig)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SqliteBootstrapConfigDto {
+    /// SQLite file path. Omit or set to null for an in-memory database (bootstrap will be skipped).
+    #[serde(default)]
+    #[schema(value_type = Option<ConfigValueString>)]
+    pub path: Option<ConfigValue<String>>,
+
+    /// Optional table allow-list. Omit or set to null for all user tables.
+    #[serde(default)]
+    pub tables: Option<Vec<String>>,
+
+    /// Optional explicit key config for element ID generation.
+    #[serde(default)]
+    #[schema(value_type = Vec<bootstrap::sqlite::TableKeyConfig>)]
+    pub table_keys: Vec<TableKeyConfigDto>,
+}
+
+/// Table key configuration DTO.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[schema(as = bootstrap::sqlite::TableKeyConfig)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TableKeyConfigDto {
+    pub table: String,
+    pub key_columns: Vec<String>,
+}
+
+// ── OpenAPI schema ───────────────────────────────────────────────────────────
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(SqliteBootstrapConfigDto, TableKeyConfigDto,)))]
+struct SqliteBootstrapSchemas;
+
+// ── Descriptor ───────────────────────────────────────────────────────────────
+
+/// Plugin descriptor for the SQLite bootstrap provider.
+pub struct SqliteBootstrapDescriptor;
+
+#[async_trait]
+impl BootstrapPluginDescriptor for SqliteBootstrapDescriptor {
+    fn kind(&self) -> &str {
+        "sqlite"
+    }
+
+    fn config_version(&self) -> &str {
+        "1.0.0"
+    }
+
+    fn config_schema_name(&self) -> &str {
+        "bootstrap.sqlite.SqliteBootstrapConfig"
+    }
+
+    fn config_schema_json(&self) -> String {
+        let api = SqliteBootstrapSchemas::openapi();
+        serde_json::to_string(
+            &api.components
+                .as_ref()
+                .expect("OpenAPI components missing")
+                .schemas,
+        )
+        .expect("Failed to serialize config schema")
+    }
+
+    async fn create_bootstrap_provider(
+        &self,
+        config_json: &serde_json::Value,
+        _source_config_json: &serde_json::Value,
+    ) -> anyhow::Result<Box<dyn drasi_lib::bootstrap::BootstrapProvider>> {
+        let dto: SqliteBootstrapConfigDto = serde_json::from_value(config_json.clone())?;
+        let mapper = DtoMapper::new();
+
+        let mut builder = SqliteBootstrapProvider::builder();
+
+        if let Some(path_cv) = &dto.path {
+            builder = builder.with_path(mapper.resolve_string(path_cv)?);
+        }
+
+        if let Some(tables) = dto.tables {
+            builder = builder.with_tables(tables);
+        }
+
+        let table_keys = dto
+            .table_keys
+            .into_iter()
+            .map(|tk| TableKeyConfig {
+                table: tk.table,
+                key_columns: tk.key_columns,
+            })
+            .collect::<Vec<_>>();
+
+        if !table_keys.is_empty() {
+            builder = builder.with_table_keys(table_keys);
+        }
+
+        Ok(Box::new(builder.build()))
+    }
+}

--- a/components/bootstrappers/sqlite/src/lib.rs
+++ b/components/bootstrappers/sqlite/src/lib.rs
@@ -1,0 +1,290 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use base64::Engine;
+use drasi_core::models::{
+    Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
+};
+use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::channels::BootstrapEventSender;
+use log::{info, warn};
+use ordered_float::OrderedFloat;
+use rusqlite::types::ValueRef;
+use rusqlite::{Connection, OpenFlags};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Per-table key configuration for stable element IDs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TableKeyConfig {
+    pub table: String,
+    pub key_columns: Vec<String>,
+}
+
+/// SQLite bootstrap provider.
+#[derive(Clone)]
+pub struct SqliteBootstrapProvider {
+    path: Option<String>,
+    tables: Option<Vec<String>>,
+    table_keys: Vec<TableKeyConfig>,
+}
+
+impl SqliteBootstrapProvider {
+    pub fn builder() -> SqliteBootstrapBuilder {
+        SqliteBootstrapBuilder::new()
+    }
+
+    fn key_columns_for_table(&self, conn: &Connection, table: &str) -> Result<Vec<String>> {
+        if let Some(cfg) = self.table_keys.iter().find(|item| item.table == table) {
+            return Ok(cfg.key_columns.clone());
+        }
+        detect_primary_key(conn, table)
+    }
+}
+
+/// Builder for [`SqliteBootstrapProvider`].
+pub struct SqliteBootstrapBuilder {
+    path: Option<String>,
+    tables: Option<Vec<String>>,
+    table_keys: Vec<TableKeyConfig>,
+}
+
+impl SqliteBootstrapBuilder {
+    fn new() -> Self {
+        Self {
+            path: None,
+            tables: None,
+            table_keys: Vec::new(),
+        }
+    }
+
+    pub fn with_path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    pub fn in_memory(mut self) -> Self {
+        self.path = None;
+        self
+    }
+
+    pub fn with_tables(mut self, tables: Vec<String>) -> Self {
+        self.tables = Some(tables);
+        self
+    }
+
+    pub fn with_table_keys(mut self, table_keys: Vec<TableKeyConfig>) -> Self {
+        self.table_keys = table_keys;
+        self
+    }
+
+    pub fn build(self) -> SqliteBootstrapProvider {
+        SqliteBootstrapProvider {
+            path: self.path,
+            tables: self.tables,
+            table_keys: self.table_keys,
+        }
+    }
+}
+
+#[async_trait]
+impl BootstrapProvider for SqliteBootstrapProvider {
+    async fn bootstrap(
+        &self,
+        request: BootstrapRequest,
+        context: &BootstrapContext,
+        event_tx: BootstrapEventSender,
+        _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
+    ) -> Result<usize> {
+        info!("Starting SQLite bootstrap for query '{}'", request.query_id);
+
+        let changes = {
+            let Some(path) = &self.path else {
+                warn!("SQLite bootstrap skipped for in-memory database");
+                return Ok(0);
+            };
+
+            let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+            let tables = resolve_tables(&conn, self.tables.as_ref())?;
+            let mut changes = Vec::new();
+
+            for table in tables {
+                if !request.node_labels.is_empty() && !request.node_labels.contains(&table) {
+                    continue;
+                }
+
+                let key_columns = self.key_columns_for_table(&conn, &table)?;
+                let rows = read_table_rows(&conn, &table)?;
+
+                for row in rows {
+                    let element_id = generate_element_id(&table, &row, &key_columns);
+                    let mut properties = ElementPropertyMap::new();
+                    for (name, value) in row {
+                        properties.insert(&name, value);
+                    }
+
+                    let labels: Arc<[Arc<str>]> = vec![Arc::<str>::from(table.as_str())].into();
+                    let element = Element::Node {
+                        metadata: ElementMetadata {
+                            reference: ElementReference::new(&context.source_id, &element_id),
+                            labels,
+                            effective_from: chrono::Utc::now()
+                                .timestamp_nanos_opt()
+                                .unwrap_or_default()
+                                as u64,
+                        },
+                        properties,
+                    };
+
+                    changes.push(SourceChange::Insert { element });
+                }
+            }
+
+            changes
+        };
+
+        let mut count = 0usize;
+        for change in changes {
+            let event = drasi_lib::channels::BootstrapEvent {
+                source_id: context.source_id.clone(),
+                change,
+                timestamp: chrono::Utc::now(),
+                sequence: context.next_sequence(),
+            };
+            event_tx.send(event).await?;
+            count += 1;
+        }
+
+        info!(
+            "SQLite bootstrap completed for query '{}': {} rows",
+            request.query_id, count
+        );
+        Ok(count)
+    }
+}
+
+fn resolve_tables(
+    conn: &Connection,
+    configured_tables: Option<&Vec<String>>,
+) -> Result<Vec<String>> {
+    if let Some(tables) = configured_tables {
+        return Ok(tables.clone());
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+    )?;
+    let tables = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(tables)
+}
+
+fn read_table_rows(conn: &Connection, table: &str) -> Result<Vec<Vec<(String, ElementValue)>>> {
+    let query = format!("SELECT * FROM {}", quote_ident(table));
+    let mut stmt = conn.prepare(&query)?;
+    let column_count = stmt.column_count();
+    let column_names: Vec<String> = (0..column_count)
+        .map(|index| stmt.column_name(index).unwrap_or("").to_string())
+        .collect();
+
+    let mut rows = stmt.query([])?;
+    let mut result = Vec::new();
+    while let Some(row) = rows.next()? {
+        let mut values = Vec::with_capacity(column_names.len());
+        for (index, name) in column_names.iter().enumerate() {
+            let value_ref = row.get_ref(index)?;
+            values.push((name.clone(), value_ref_to_element_value(value_ref)));
+        }
+        result.push(values);
+    }
+    Ok(result)
+}
+
+fn detect_primary_key(conn: &Connection, table: &str) -> Result<Vec<String>> {
+    let sql = format!("PRAGMA table_info({})", quote_ident(table));
+    let mut stmt = conn.prepare(&sql)?;
+    let mut key_pairs = stmt
+        .query_map([], |row| {
+            let name: String = row.get(1)?;
+            let pk: i64 = row.get(5)?;
+            Ok((pk, name))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    key_pairs.retain(|(pk, _)| *pk > 0);
+    key_pairs.sort_by_key(|(pk, _)| *pk);
+    Ok(key_pairs.into_iter().map(|(_, name)| name).collect())
+}
+
+fn value_ref_to_element_value(value_ref: ValueRef<'_>) -> ElementValue {
+    match value_ref {
+        ValueRef::Null => ElementValue::Null,
+        ValueRef::Integer(i) => ElementValue::Integer(i),
+        ValueRef::Real(f) => ElementValue::Float(OrderedFloat(f)),
+        ValueRef::Text(t) => ElementValue::String(Arc::from(String::from_utf8_lossy(t).as_ref())),
+        ValueRef::Blob(b) => ElementValue::String(Arc::from(
+            base64::engine::general_purpose::STANDARD.encode(b),
+        )),
+    }
+}
+
+fn generate_element_id(
+    table: &str,
+    values: &[(String, ElementValue)],
+    key_columns: &[String],
+) -> String {
+    if key_columns.is_empty() {
+        let all_values = values
+            .iter()
+            .map(|(_, value)| value_to_id_fragment(value))
+            .collect::<Vec<_>>();
+        return format!("{table}:{}", all_values.join(":"));
+    }
+
+    let key_parts = key_columns
+        .iter()
+        .filter_map(|column| {
+            values
+                .iter()
+                .find(|(name, _)| name == column)
+                .map(|(_, v)| v)
+        })
+        .map(value_to_id_fragment)
+        .collect::<Vec<_>>();
+
+    if key_parts.is_empty() {
+        format!("{table}:missing-key")
+    } else {
+        format!("{table}:{}", key_parts.join(":"))
+    }
+}
+
+fn value_to_id_fragment(value: &ElementValue) -> String {
+    match value {
+        ElementValue::Null => "null".to_string(),
+        ElementValue::Bool(v) => v.to_string(),
+        ElementValue::Float(v) => v.to_string(),
+        ElementValue::Integer(v) => v.to_string(),
+        ElementValue::String(v) => v.to_string(),
+        ElementValue::List(v) => format!("{v:?}").replace(':', "%3A"),
+        ElementValue::Object(v) => format!("{v:?}").replace(':', "%3A"),
+    }
+}
+
+fn quote_ident(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}

--- a/components/bootstrappers/sqlite/src/lib.rs
+++ b/components/bootstrappers/sqlite/src/lib.rs
@@ -132,8 +132,8 @@ impl BootstrapProvider for SqliteBootstrapProvider {
                 let key_columns = self.key_columns_for_table(&conn, &table)?;
                 let rows = read_table_rows(&conn, &table)?;
 
-                for row in rows {
-                    let element_id = generate_element_id(&table, &row, &key_columns);
+                for (row, rowid) in rows {
+                    let element_id = generate_element_id(&table, &row, &key_columns, Some(rowid));
                     let mut properties = ElementPropertyMap::new();
                     for (name, value) in row {
                         properties.insert(&name, value);
@@ -144,10 +144,7 @@ impl BootstrapProvider for SqliteBootstrapProvider {
                         metadata: ElementMetadata {
                             reference: ElementReference::new(&context.source_id, &element_id),
                             labels,
-                            effective_from: chrono::Utc::now()
-                                .timestamp_nanos_opt()
-                                .unwrap_or_default()
-                                as u64,
+                            effective_from: chrono::Utc::now().timestamp_millis() as u64,
                         },
                         properties,
                     };
@@ -196,23 +193,28 @@ fn resolve_tables(
     Ok(tables)
 }
 
-fn read_table_rows(conn: &Connection, table: &str) -> Result<Vec<Vec<(String, ElementValue)>>> {
-    let query = format!("SELECT * FROM {}", quote_ident(table));
+fn read_table_rows(
+    conn: &Connection,
+    table: &str,
+) -> Result<Vec<(Vec<(String, ElementValue)>, i64)>> {
+    let query = format!("SELECT rowid, * FROM {}", quote_ident(table));
     let mut stmt = conn.prepare(&query)?;
     let column_count = stmt.column_count();
-    let column_names: Vec<String> = (0..column_count)
+    // First column is rowid, remaining are user columns
+    let column_names: Vec<String> = (1..column_count)
         .map(|index| stmt.column_name(index).unwrap_or("").to_string())
         .collect();
 
     let mut rows = stmt.query([])?;
     let mut result = Vec::new();
     while let Some(row) = rows.next()? {
+        let rowid: i64 = row.get(0)?;
         let mut values = Vec::with_capacity(column_names.len());
-        for (index, name) in column_names.iter().enumerate() {
-            let value_ref = row.get_ref(index)?;
+        for (i, name) in column_names.iter().enumerate() {
+            let value_ref = row.get_ref(i + 1)?;
             values.push((name.clone(), value_ref_to_element_value(value_ref)));
         }
-        result.push(values);
+        result.push((values, rowid));
     }
     Ok(result)
 }
@@ -249,31 +251,31 @@ fn generate_element_id(
     table: &str,
     values: &[(String, ElementValue)],
     key_columns: &[String],
+    rowid: Option<i64>,
 ) -> String {
-    if key_columns.is_empty() {
-        let all_values = values
+    if !key_columns.is_empty() {
+        let key_parts = key_columns
             .iter()
-            .map(|(_, value)| value_to_id_fragment(value))
+            .filter_map(|column| {
+                values
+                    .iter()
+                    .find(|(name, _)| name == column)
+                    .map(|(_, v)| v)
+            })
+            .map(value_to_id_fragment)
             .collect::<Vec<_>>();
-        return format!("{table}:{}", all_values.join(":"));
+
+        if !key_parts.is_empty() {
+            return format!("{table}:{}", key_parts.join(":"));
+        }
     }
 
-    let key_parts = key_columns
-        .iter()
-        .filter_map(|column| {
-            values
-                .iter()
-                .find(|(name, _)| name == column)
-                .map(|(_, v)| v)
-        })
-        .map(value_to_id_fragment)
-        .collect::<Vec<_>>();
-
-    if key_parts.is_empty() {
-        format!("{table}:missing-key")
-    } else {
-        format!("{table}:{}", key_parts.join(":"))
+    // Fall back to rowid, matching the source's CDC behavior
+    if let Some(id) = rowid {
+        return format!("{table}:{id}");
     }
+
+    format!("{table}:unknown")
 }
 
 fn value_to_id_fragment(value: &ElementValue) -> String {
@@ -290,6 +292,141 @@ fn value_to_id_fragment(value: &ElementValue) -> String {
 
 fn quote_ident(identifier: &str) -> String {
     format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_element_id_uses_key_columns_when_provided() {
+        let values = vec![
+            ("id".to_string(), ElementValue::Integer(42)),
+            ("name".to_string(), ElementValue::String(Arc::from("test"))),
+        ];
+        let keys = vec!["id".to_string()];
+        assert_eq!(
+            generate_element_id("sensors", &values, &keys, Some(1)),
+            "sensors:42"
+        );
+    }
+
+    #[test]
+    fn generate_element_id_uses_composite_keys() {
+        let values = vec![
+            ("tenant".to_string(), ElementValue::String(Arc::from("t1"))),
+            (
+                "event_id".to_string(),
+                ElementValue::String(Arc::from("e1")),
+            ),
+        ];
+        let keys = vec!["tenant".to_string(), "event_id".to_string()];
+        assert_eq!(
+            generate_element_id("events", &values, &keys, Some(99)),
+            "events:t1:e1"
+        );
+    }
+
+    #[test]
+    fn generate_element_id_falls_back_to_rowid_when_no_keys() {
+        let values = vec![
+            ("name".to_string(), ElementValue::String(Arc::from("test"))),
+            ("value".to_string(), ElementValue::Integer(100)),
+        ];
+        let keys: Vec<String> = vec![];
+        assert_eq!(
+            generate_element_id("data", &values, &keys, Some(7)),
+            "data:7"
+        );
+    }
+
+    #[test]
+    fn generate_element_id_returns_unknown_without_keys_or_rowid() {
+        let values = vec![("x".to_string(), ElementValue::Integer(1))];
+        let keys: Vec<String> = vec![];
+        assert_eq!(
+            generate_element_id("data", &values, &keys, None),
+            "data:unknown"
+        );
+    }
+
+    #[test]
+    fn read_table_rows_returns_rows_with_rowid() {
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch("CREATE TABLE items (name TEXT, value INTEGER); INSERT INTO items VALUES ('a', 1); INSERT INTO items VALUES ('b', 2);")
+            .expect("setup");
+
+        let rows = read_table_rows(&conn, "items").expect("read");
+        assert_eq!(rows.len(), 2);
+
+        let (first_row, first_rowid) = &rows[0];
+        assert_eq!(*first_rowid, 1);
+        assert_eq!(first_row.len(), 2);
+        assert_eq!(first_row[0].0, "name");
+
+        let (second_row, second_rowid) = &rows[1];
+        assert_eq!(*second_rowid, 2);
+        assert_eq!(second_row.len(), 2);
+        let _ = second_row;
+    }
+
+    #[test]
+    fn detect_primary_key_finds_pk_columns() {
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch("CREATE TABLE sensors (id INTEGER PRIMARY KEY, name TEXT)")
+            .expect("setup");
+
+        let pks = detect_primary_key(&conn, "sensors").expect("detect");
+        assert_eq!(pks, vec!["id".to_string()]);
+    }
+
+    #[test]
+    fn detect_primary_key_returns_empty_for_no_pk() {
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch("CREATE TABLE data (x TEXT, y TEXT)")
+            .expect("setup");
+
+        let pks = detect_primary_key(&conn, "data").expect("detect");
+        assert!(pks.is_empty());
+    }
+
+    #[test]
+    fn element_id_matches_between_bootstrap_and_source_with_pk() {
+        // Verifies that bootstrap and source produce the same element ID
+        // when a table has a declared PK.
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch("CREATE TABLE sensors (id INTEGER PRIMARY KEY, name TEXT); INSERT INTO sensors VALUES (42, 'test');")
+            .expect("setup");
+
+        let pks = detect_primary_key(&conn, "sensors").expect("detect pk");
+        let rows = read_table_rows(&conn, "sensors").expect("read");
+        let (row, rowid) = &rows[0];
+
+        let bootstrap_id = generate_element_id("sensors", row, &pks, Some(*rowid));
+        // Source would produce "sensors:42" via PK column "id"
+        assert_eq!(bootstrap_id, "sensors:42");
+    }
+
+    #[test]
+    fn element_id_matches_between_bootstrap_and_source_without_pk() {
+        // Verifies that bootstrap falls back to rowid just like source does
+        // when no PK is declared.
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch(
+            "CREATE TABLE data (x TEXT, y TEXT); INSERT INTO data VALUES ('a', 'b');",
+        )
+        .expect("setup");
+
+        let pks = detect_primary_key(&conn, "data").expect("detect pk");
+        assert!(pks.is_empty());
+
+        let rows = read_table_rows(&conn, "data").expect("read");
+        let (row, rowid) = &rows[0];
+
+        let bootstrap_id = generate_element_id("data", row, &pks, Some(*rowid));
+        // Source would produce "data:1" via rowid fallback
+        assert_eq!(bootstrap_id, "data:1");
+    }
 }
 
 /// Dynamic plugin entry point.

--- a/components/bootstrappers/sqlite/src/lib.rs
+++ b/components/bootstrappers/sqlite/src/lib.rs
@@ -26,13 +26,12 @@ use log::{info, warn};
 use ordered_float::OrderedFloat;
 use rusqlite::types::ValueRef;
 use rusqlite::{Connection, OpenFlags};
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 pub mod descriptor;
 
 /// Per-table key configuration for stable element IDs.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableKeyConfig {
     pub table: String,
     pub key_columns: Vec<String>,

--- a/components/bootstrappers/sqlite/src/lib.rs
+++ b/components/bootstrappers/sqlite/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(unexpected_cfgs)]
+
 use anyhow::Result;
 use async_trait::async_trait;
 use base64::Engine;
@@ -26,6 +28,8 @@ use rusqlite::types::ValueRef;
 use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+pub mod descriptor;
 
 /// Per-table key configuration for stable element IDs.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -288,3 +292,15 @@ fn value_to_id_fragment(value: &ElementValue) -> String {
 fn quote_ident(identifier: &str) -> String {
     format!("\"{}\"", identifier.replace('"', "\"\""))
 }
+
+/// Dynamic plugin entry point.
+#[cfg(feature = "dynamic-plugin")]
+drasi_plugin_sdk::export_plugin!(
+    plugin_id = "sqlite-bootstrap",
+    core_version = env!("CARGO_PKG_VERSION"),
+    lib_version = env!("CARGO_PKG_VERSION"),
+    plugin_version = env!("CARGO_PKG_VERSION"),
+    source_descriptors = [],
+    reaction_descriptors = [],
+    bootstrap_descriptors = [descriptor::SqliteBootstrapDescriptor],
+);

--- a/components/bootstrappers/sqlite/src/lib.rs
+++ b/components/bootstrappers/sqlite/src/lib.rs
@@ -20,7 +20,9 @@ use base64::Engine;
 use drasi_core::models::{
     Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
 };
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
 use drasi_lib::channels::BootstrapEventSender;
 use log::{info, warn};
 use ordered_float::OrderedFloat;
@@ -111,13 +113,13 @@ impl BootstrapProvider for SqliteBootstrapProvider {
         context: &BootstrapContext,
         event_tx: BootstrapEventSender,
         _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         info!("Starting SQLite bootstrap for query '{}'", request.query_id);
 
         let changes = {
             let Some(path) = &self.path else {
                 warn!("SQLite bootstrap skipped for in-memory database");
-                return Ok(0);
+                return Ok(BootstrapResult::default());
             };
 
             let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
@@ -172,7 +174,10 @@ impl BootstrapProvider for SqliteBootstrapProvider {
             "SQLite bootstrap completed for query '{}': {} rows",
             request.query_id, count
         );
-        Ok(count)
+        Ok(BootstrapResult {
+            event_count: count,
+            ..Default::default()
+        })
     }
 }
 

--- a/components/sources/sqlite/Cargo.toml
+++ b/components/sources/sqlite/Cargo.toml
@@ -1,0 +1,54 @@
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-source-sqlite"
+version = "0.1.0"
+edition = "2021"
+authors = ["Drasi Project"]
+description = "SQLite source plugin for Drasi"
+license = "Apache-2.0"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi", "plugin", "sqlite"]
+categories = ["database"]
+
+[lints]
+workspace = true
+
+[dependencies]
+drasi-lib.workspace = true
+drasi-core.workspace = true
+anyhow = "1.0"
+async-trait = "0.1"
+log = "0.4"
+tracing = "0.1"
+tokio = { version = "1.0", features = ["full"] }
+rusqlite = { version = "0.32", features = ["bundled", "column_decltype", "preupdate_hook"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+ordered-float = "3.0"
+base64 = "0.22"
+# REST API dependencies
+axum = "0.7"
+tower = "0.4"
+hyper = "1.0"
+tower-http = { version = "0.5", features = ["trace"] }
+
+[dev-dependencies]
+drasi-bootstrap-sqlite = { path = "../../bootstrappers/sqlite" }
+drasi-reaction-application.workspace = true
+tokio-test = "0.4"
+tempfile = "3"
+reqwest = { version = "0.11", features = ["json"] }

--- a/components/sources/sqlite/Cargo.toml
+++ b/components/sources/sqlite/Cargo.toml
@@ -23,12 +23,20 @@ repository = "https://github.com/drasi-project/drasi-core"
 keywords = ["drasi", "plugin", "sqlite"]
 categories = ["database"]
 
+[lib]
+crate-type = ["lib", "cdylib"]
+
 [lints]
 workspace = true
+
+[features]
+dynamic-plugin = []
 
 [dependencies]
 drasi-lib.workspace = true
 drasi-core.workspace = true
+drasi-plugin-sdk = { workspace = true }
+utoipa = { workspace = true }
 anyhow = "1.0"
 async-trait = "0.1"
 log = "0.4"

--- a/components/sources/sqlite/Makefile
+++ b/components/sources/sqlite/Makefile
@@ -1,0 +1,17 @@
+.PHONY: build test lint integration-test clean
+
+build:
+	cargo build --release
+
+test:
+	cargo test
+
+lint:
+	cargo clippy -- -D warnings
+	cargo fmt --check
+
+integration-test:
+	cargo test -- --ignored --nocapture
+
+clean:
+	cargo clean

--- a/components/sources/sqlite/README.md
+++ b/components/sources/sqlite/README.md
@@ -1,0 +1,96 @@
+# SQLite Source
+
+## Overview
+
+`drasi-source-sqlite` is a protocol/local source that owns an embedded SQLite connection and emits Drasi `SourceChange` events for row-level `INSERT`, `UPDATE`, and `DELETE` activity.
+
+Key capabilities:
+
+- Real-time CDC using `rusqlite` `preupdate_hook`
+- Transaction-aware dispatch (`commit_hook` flush, `rollback_hook` discard)
+- Savepoint-aware buffering for partial rollback support
+- Optional table filtering and explicit table key configuration
+- Optional REST API for table CRUD and transactional batch operations
+- Works with file-backed and in-memory SQLite databases
+
+## Quick Start
+
+```rust
+use drasi_source_sqlite::{SqliteSource, TableKeyConfig, RestApiConfig};
+
+let source = SqliteSource::builder("sqlite-source")
+    .with_path("data/example.db")
+    .with_table_keys(vec![TableKeyConfig {
+        table: "sensors".to_string(),
+        key_columns: vec!["id".to_string()],
+    }])
+    .with_rest_api(RestApiConfig {
+        host: "127.0.0.1".to_string(),
+        port: 9100,
+    })
+    .build()?;
+```
+
+## SQL Handle API
+
+Use `source.handle()` to execute statements through the source-owned SQLite connection:
+
+```rust
+let handle = source.handle();
+handle.execute("CREATE TABLE sensors(id INTEGER PRIMARY KEY, name TEXT, temp REAL)").await?;
+handle.execute("INSERT INTO sensors(id, name, temp) VALUES (1, 'sensor-a', 31.5)").await?;
+
+handle.transaction(|tx| async move {
+    tx.execute("INSERT INTO sensors(id, name, temp) VALUES (2, 'sensor-b', 30.0)").await?;
+    tx.execute("UPDATE sensors SET temp = 32.1 WHERE id = 1").await?;
+    Ok(())
+}).await?;
+```
+
+## REST API (Optional)
+
+When `with_rest_api()` is configured:
+
+- `GET /health`
+- `GET /api/tables`
+- `GET /api/tables/{table}`
+- `GET /api/tables/{table}/{id}`
+- `POST /api/tables/{table}`
+- `PUT /api/tables/{table}/{id}`
+- `DELETE /api/tables/{table}/{id}`
+- `POST /api/batch` (single SQLite transaction for all operations)
+
+## Configuration Notes
+
+- `tables: Option<Vec<String>>` filters monitored tables. `None` means all user tables.
+- `table_keys` defines element ID columns per table; if omitted, table PKs are detected from `PRAGMA table_info`.
+- If no configured/detected keys exist, rowid is used as fallback for streaming events.
+
+## Testing
+
+From this crate directory:
+
+```bash
+cargo test
+cargo test -- --ignored --nocapture
+cargo clippy --all-targets -- -D warnings
+```
+
+The ignored integration tests validate:
+
+- handle-driven INSERT/UPDATE/DELETE flow
+- REST CRUD and transactional batch behavior
+- bootstrap delivery into query results
+- multi-table query routing
+
+## Limitations
+
+- CDC only captures writes executed through the source-owned connection.
+- DDL (`CREATE/ALTER/DROP TABLE`) is not emitted as `SourceChange`.
+- BLOB values are emitted as base64-encoded strings.
+
+## Troubleshooting
+
+- `source ... is not running`: call `core.start()` before using `SqliteSourceHandle`.
+- no events after writes: verify writes go through the source handle or REST API, not an external SQLite connection.
+- REST 400 responses: table/column identifiers failed validation.

--- a/components/sources/sqlite/README.md
+++ b/components/sources/sqlite/README.md
@@ -60,11 +60,30 @@ When `with_rest_api()` is configured:
 - `DELETE /api/tables/{table}/{id}`
 - `POST /api/batch` (single SQLite transaction for all operations)
 
-## Configuration Notes
+## Configuration Options
 
-- `tables: Option<Vec<String>>` filters monitored tables. `None` means all user tables.
-- `table_keys` defines element ID columns per table; if omitted, table PKs are detected from `PRAGMA table_info`.
-- If no configured/detected keys exist, rowid is used as fallback for streaming events.
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `path` | `String?` | `null` | SQLite file path. Omit for in-memory database |
+| `tables` | `Vec<String>?` | `null` | Optional table allow-list. `null` means all user tables |
+| `tableKeys` | `Vec<TableKeyConfig>` | `[]` | Manual primary key configuration (see below) |
+| `restApi` | `RestApiConfig?` | `null` | Optional REST API configuration |
+
+### TableKeyConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `table` | `String` | Table name |
+| `keyColumns` | `Vec<String>` | Column names to use as primary key |
+
+Configured table keys override automatically detected primary keys from `PRAGMA table_info`. If no configured or detected keys exist, `rowid` is used as the fallback for streaming events.
+
+### RestApiConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host` | `String` | `"0.0.0.0"` | Address to bind |
+| `port` | `u16` | `8080` | Port to bind |
 
 ## Testing
 

--- a/components/sources/sqlite/src/config.rs
+++ b/components/sources/sqlite/src/config.rs
@@ -1,0 +1,273 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use drasi_lib::bootstrap::BootstrapProvider;
+use drasi_lib::channels::DispatchMode;
+use drasi_lib::sources::base::SourceBaseParams;
+use serde::{Deserialize, Serialize};
+
+use crate::SqliteSource;
+
+/// Element ID key configuration for a SQLite table.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TableKeyConfig {
+    /// Table name.
+    pub table: String,
+    /// Ordered key column names used to build element IDs.
+    pub key_columns: Vec<String>,
+}
+
+/// Runtime configuration for the optional REST API.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RestApiConfig {
+    /// Address to bind.
+    #[serde(default = "default_rest_host")]
+    pub host: String,
+    /// Port to bind.
+    #[serde(default = "default_rest_port")]
+    pub port: u16,
+}
+
+impl Default for RestApiConfig {
+    fn default() -> Self {
+        Self {
+            host: default_rest_host(),
+            port: default_rest_port(),
+        }
+    }
+}
+
+fn default_rest_host() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_rest_port() -> u16 {
+    8080
+}
+
+/// Initial start behavior. SQLite source does not use persisted cursors, but this
+/// is exposed for API consistency with other source plugins.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StartFrom {
+    /// Start immediately (default behavior).
+    #[default]
+    Beginning,
+    /// Semantically equivalent to `Beginning` for embedded SQLite source.
+    Now,
+    /// Semantically equivalent to `Beginning` for embedded SQLite source.
+    Timestamp(i64),
+}
+
+/// SQLite source configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SqliteSourceConfig {
+    /// SQLite file path. When `None`, an in-memory database is used.
+    #[serde(default)]
+    pub path: Option<String>,
+    /// Optional explicit table allow-list. `None` means all user tables.
+    #[serde(default)]
+    pub tables: Option<Vec<String>>,
+    /// Optional explicit key config for element ID generation.
+    #[serde(default)]
+    pub table_keys: Vec<TableKeyConfig>,
+    /// Optional REST API configuration.
+    #[serde(default)]
+    pub rest_api: Option<RestApiConfig>,
+    /// Initial start behavior.
+    #[serde(default)]
+    pub start_from: StartFrom,
+}
+
+impl Default for SqliteSourceConfig {
+    fn default() -> Self {
+        Self {
+            path: None,
+            tables: None,
+            table_keys: Vec::new(),
+            rest_api: None,
+            start_from: StartFrom::Beginning,
+        }
+    }
+}
+
+/// Builder for [`SqliteSource`].
+pub struct SqliteSourceBuilder {
+    pub(crate) id: String,
+    path: Option<String>,
+    tables: Option<Vec<String>>,
+    table_keys: Vec<TableKeyConfig>,
+    rest_api: Option<RestApiConfig>,
+    start_from: StartFrom,
+    dispatch_mode: Option<DispatchMode>,
+    dispatch_buffer_capacity: Option<usize>,
+    bootstrap_provider: Option<Box<dyn BootstrapProvider + 'static>>,
+    auto_start: bool,
+}
+
+impl SqliteSourceBuilder {
+    /// Create a new builder with defaults.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            path: None,
+            tables: None,
+            table_keys: Vec::new(),
+            rest_api: None,
+            start_from: StartFrom::Beginning,
+            dispatch_mode: None,
+            dispatch_buffer_capacity: None,
+            bootstrap_provider: None,
+            auto_start: true,
+        }
+    }
+
+    /// Use file-backed SQLite.
+    pub fn with_path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Use in-memory SQLite.
+    pub fn in_memory(mut self) -> Self {
+        self.path = None;
+        self
+    }
+
+    /// Set monitored tables.
+    pub fn with_tables(mut self, tables: Vec<String>) -> Self {
+        self.tables = Some(tables);
+        self
+    }
+
+    /// Set configured table keys.
+    pub fn with_table_keys(mut self, table_keys: Vec<TableKeyConfig>) -> Self {
+        self.table_keys = table_keys;
+        self
+    }
+
+    /// Enable REST API.
+    pub fn with_rest_api(mut self, config: RestApiConfig) -> Self {
+        self.rest_api = Some(config);
+        self
+    }
+
+    /// Set initial start behavior.
+    pub fn start_from(mut self, start_from: StartFrom) -> Self {
+        self.start_from = start_from;
+        self
+    }
+
+    /// Set dispatch mode.
+    pub fn with_dispatch_mode(mut self, mode: DispatchMode) -> Self {
+        self.dispatch_mode = Some(mode);
+        self
+    }
+
+    /// Set dispatch buffer capacity.
+    pub fn with_dispatch_buffer_capacity(mut self, capacity: usize) -> Self {
+        self.dispatch_buffer_capacity = Some(capacity);
+        self
+    }
+
+    /// Set bootstrap provider.
+    pub fn with_bootstrap_provider(mut self, provider: impl BootstrapProvider + 'static) -> Self {
+        self.bootstrap_provider = Some(Box::new(provider));
+        self
+    }
+
+    /// Set source auto-start.
+    pub fn auto_start(mut self, auto_start: bool) -> Self {
+        self.auto_start = auto_start;
+        self
+    }
+
+    /// Build source.
+    pub fn build(self) -> Result<SqliteSource> {
+        let config = SqliteSourceConfig {
+            path: self.path,
+            tables: self.tables,
+            table_keys: self.table_keys,
+            rest_api: self.rest_api,
+            start_from: self.start_from,
+        };
+
+        let mut params = SourceBaseParams::new(self.id);
+        if let Some(mode) = self.dispatch_mode {
+            params = params.with_dispatch_mode(mode);
+        }
+        if let Some(capacity) = self.dispatch_buffer_capacity {
+            params = params.with_dispatch_buffer_capacity(capacity);
+        }
+        if let Some(provider) = self.bootstrap_provider {
+            params = params.with_bootstrap_provider(provider);
+        }
+        params = params.with_auto_start(self.auto_start);
+
+        let base = drasi_lib::sources::base::SourceBase::new(params)?;
+        SqliteSource::from_parts(base, config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use drasi_lib::Source;
+
+    #[test]
+    fn sqlite_source_config_defaults_are_stable() {
+        let config = SqliteSourceConfig::default();
+        assert!(config.path.is_none());
+        assert!(config.tables.is_none());
+        assert!(config.table_keys.is_empty());
+        assert!(config.rest_api.is_none());
+        assert_eq!(config.start_from, StartFrom::Beginning);
+    }
+
+    #[test]
+    fn builder_applies_rest_and_dispatch_configuration() {
+        let source = SqliteSource::builder("test-source")
+            .with_path("/tmp/test.db")
+            .with_tables(vec!["sensors".to_string()])
+            .with_table_keys(vec![TableKeyConfig {
+                table: "sensors".to_string(),
+                key_columns: vec!["id".to_string()],
+            }])
+            .with_rest_api(RestApiConfig {
+                host: "127.0.0.1".to_string(),
+                port: 9001,
+            })
+            .with_dispatch_mode(DispatchMode::Channel)
+            .with_dispatch_buffer_capacity(42)
+            .auto_start(false)
+            .build()
+            .expect("failed to build sqlite source");
+
+        let properties = source.properties();
+        assert_eq!(
+            properties.get("path"),
+            Some(&serde_json::json!("/tmp/test.db"))
+        );
+        assert_eq!(
+            properties.get("tables"),
+            Some(&serde_json::json!(["sensors"]))
+        );
+        assert_eq!(
+            properties.get("rest_api_enabled"),
+            Some(&serde_json::Value::Bool(true))
+        );
+        assert!(!source.auto_start());
+    }
+}

--- a/components/sources/sqlite/src/config.rs
+++ b/components/sources/sqlite/src/config.rs
@@ -16,12 +16,11 @@ use anyhow::Result;
 use drasi_lib::bootstrap::BootstrapProvider;
 use drasi_lib::channels::DispatchMode;
 use drasi_lib::sources::base::SourceBaseParams;
-use serde::{Deserialize, Serialize};
 
 use crate::SqliteSource;
 
 /// Element ID key configuration for a SQLite table.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableKeyConfig {
     /// Table name.
     pub table: String,
@@ -30,13 +29,11 @@ pub struct TableKeyConfig {
 }
 
 /// Runtime configuration for the optional REST API.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RestApiConfig {
     /// Address to bind.
-    #[serde(default = "default_rest_host")]
     pub host: String,
     /// Port to bind.
-    #[serde(default = "default_rest_port")]
     pub port: u16,
 }
 
@@ -59,8 +56,7 @@ fn default_rest_port() -> u16 {
 
 /// Initial start behavior. SQLite source does not use persisted cursors, but this
 /// is exposed for API consistency with other source plugins.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum StartFrom {
     /// Start immediately (default behavior).
     #[default]
@@ -72,22 +68,17 @@ pub enum StartFrom {
 }
 
 /// SQLite source configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SqliteSourceConfig {
     /// SQLite file path. When `None`, an in-memory database is used.
-    #[serde(default)]
     pub path: Option<String>,
     /// Optional explicit table allow-list. `None` means all user tables.
-    #[serde(default)]
     pub tables: Option<Vec<String>>,
     /// Optional explicit key config for element ID generation.
-    #[serde(default)]
     pub table_keys: Vec<TableKeyConfig>,
     /// Optional REST API configuration.
-    #[serde(default)]
     pub rest_api: Option<RestApiConfig>,
     /// Initial start behavior.
-    #[serde(default)]
     pub start_from: StartFrom,
 }
 

--- a/components/sources/sqlite/src/config.rs
+++ b/components/sources/sqlite/src/config.rs
@@ -237,7 +237,7 @@ mod tests {
                 key_columns: vec!["id".to_string()],
             }])
             .with_rest_api(RestApiConfig {
-                host: "127.0.0.1".to_string(),
+                host: "127.0.0.1".to_string(), // DevSkim: ignore DS137138
                 port: 9001,
             })
             .with_dispatch_mode(DispatchMode::Channel)

--- a/components/sources/sqlite/src/config.rs
+++ b/components/sources/sqlite/src/config.rs
@@ -47,7 +47,7 @@ impl Default for RestApiConfig {
 }
 
 fn default_rest_host() -> String {
-    "0.0.0.0".to_string()
+    "127.0.0.1".to_string()
 }
 
 fn default_rest_port() -> u16 {

--- a/components/sources/sqlite/src/config.rs
+++ b/components/sources/sqlite/src/config.rs
@@ -255,10 +255,7 @@ mod tests {
             properties.get("tables"),
             Some(&serde_json::json!(["sensors"]))
         );
-        assert_eq!(
-            properties.get("rest_api_enabled"),
-            Some(&serde_json::Value::Bool(true))
-        );
+        assert!(properties.contains_key("restApi"));
         assert!(!source.auto_start());
     }
 }

--- a/components/sources/sqlite/src/convert.rs
+++ b/components/sources/sqlite/src/convert.rs
@@ -1,0 +1,261 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use drasi_core::models::{
+    Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
+};
+use ordered_float::OrderedFloat;
+use rusqlite::hooks::Action;
+use serde_json::Value;
+use std::sync::Arc;
+
+use crate::thread::ChangeEvent;
+
+pub fn json_value_to_element_value(value: &Value) -> ElementValue {
+    match value {
+        Value::Null => ElementValue::Null,
+        Value::Bool(v) => ElementValue::Bool(*v),
+        Value::Number(v) => {
+            if let Some(i) = v.as_i64() {
+                ElementValue::Integer(i)
+            } else if let Some(f) = v.as_f64() {
+                ElementValue::Float(OrderedFloat(f))
+            } else {
+                ElementValue::Null
+            }
+        }
+        Value::String(v) => ElementValue::String(Arc::from(v.as_str())),
+        Value::Array(values) => ElementValue::List(
+            values
+                .iter()
+                .map(json_value_to_element_value)
+                .collect::<Vec<_>>(),
+        ),
+        Value::Object(values) => {
+            let mut map = ElementPropertyMap::new();
+            for (key, value) in values {
+                map.insert(key, json_value_to_element_value(value));
+            }
+            ElementValue::Object(map)
+        }
+    }
+}
+
+fn to_property_map(values: &[(String, Value)]) -> ElementPropertyMap {
+    let mut map = ElementPropertyMap::new();
+    for (name, value) in values {
+        map.insert(name, json_value_to_element_value(value));
+    }
+    map
+}
+
+fn key_part(value: &Value) -> String {
+    match value {
+        Value::String(v) => v.clone(),
+        _ => value.to_string(),
+    }
+}
+
+fn generate_element_id(
+    table: &str,
+    values: &[(String, Value)],
+    configured_key_columns: Option<&[String]>,
+    fallback_pk_columns: &[String],
+    row_id: Option<i64>,
+) -> String {
+    let selected_keys = configured_key_columns
+        .filter(|keys| !keys.is_empty())
+        .unwrap_or(fallback_pk_columns);
+
+    let mut parts = Vec::new();
+    for key in selected_keys {
+        if let Some((_, value)) = values.iter().find(|(name, _)| name == key) {
+            parts.push(key_part(value));
+        }
+    }
+
+    if parts.is_empty() {
+        if let Some(id) = row_id {
+            return format!("{table}:{id}");
+        }
+        return format!("{table}:unknown");
+    }
+
+    format!("{table}:{}", parts.join(":"))
+}
+
+pub fn change_event_to_source_change(
+    event: ChangeEvent,
+    source_id: &str,
+    configured_key_columns: Option<&[String]>,
+) -> SourceChange {
+    let labels: Arc<[Arc<str>]> = Arc::from([Arc::from(event.table.as_str())]);
+    let effective_from = event.timestamp_ms;
+
+    match event.action {
+        Action::SQLITE_INSERT => {
+            let values = event.new_values.unwrap_or_default();
+            let element_id = generate_element_id(
+                &event.table,
+                &values,
+                configured_key_columns,
+                &event.table_pk_columns,
+                event.new_row_id,
+            );
+
+            SourceChange::Insert {
+                element: Element::Node {
+                    metadata: ElementMetadata {
+                        reference: ElementReference::new(source_id, &element_id),
+                        labels,
+                        effective_from,
+                    },
+                    properties: to_property_map(&values),
+                },
+            }
+        }
+        Action::SQLITE_UPDATE => {
+            let values = event.new_values.unwrap_or_default();
+            let element_id = generate_element_id(
+                &event.table,
+                &values,
+                configured_key_columns,
+                &event.table_pk_columns,
+                event.new_row_id.or(event.old_row_id),
+            );
+
+            SourceChange::Update {
+                element: Element::Node {
+                    metadata: ElementMetadata {
+                        reference: ElementReference::new(source_id, &element_id),
+                        labels,
+                        effective_from,
+                    },
+                    properties: to_property_map(&values),
+                },
+            }
+        }
+        Action::SQLITE_DELETE => {
+            let values = event.old_values.unwrap_or_default();
+            let element_id = generate_element_id(
+                &event.table,
+                &values,
+                configured_key_columns,
+                &event.table_pk_columns,
+                event.old_row_id,
+            );
+
+            SourceChange::Delete {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new(source_id, &element_id),
+                    labels,
+                    effective_from,
+                },
+            }
+        }
+        _ => SourceChange::Delete {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(source_id, "unknown"),
+                labels,
+                effective_from,
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_change_uses_configured_keys_for_reference_id() {
+        let event = ChangeEvent {
+            action: Action::SQLITE_INSERT,
+            table: "sensors".to_string(),
+            old_values: None,
+            new_values: Some(vec![
+                ("id".to_string(), serde_json::json!(7)),
+                ("name".to_string(), serde_json::json!("sensor-seven")),
+            ]),
+            old_row_id: None,
+            new_row_id: Some(99),
+            table_pk_columns: vec!["id".to_string()],
+            timestamp_ms: 123,
+        };
+
+        let change =
+            change_event_to_source_change(event, "sqlite-source", Some(&["id".to_string()]));
+        match change {
+            SourceChange::Insert {
+                element: Element::Node { metadata, .. },
+            } => {
+                assert_eq!(metadata.reference.source_id.as_ref(), "sqlite-source");
+                assert_eq!(metadata.reference.element_id.as_ref(), "sensors:7");
+                assert_eq!(metadata.effective_from, 123);
+            }
+            other => panic!("unexpected change type: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_change_falls_back_to_rowid_without_keys() {
+        let event = ChangeEvent {
+            action: Action::SQLITE_UPDATE,
+            table: "devices".to_string(),
+            old_values: Some(vec![("name".to_string(), serde_json::json!("before"))]),
+            new_values: Some(vec![("name".to_string(), serde_json::json!("after"))]),
+            old_row_id: Some(12),
+            new_row_id: Some(12),
+            table_pk_columns: Vec::new(),
+            timestamp_ms: 456,
+        };
+
+        let change = change_event_to_source_change(event, "sqlite-source", None);
+        match change {
+            SourceChange::Update {
+                element: Element::Node { metadata, .. },
+            } => {
+                assert_eq!(metadata.reference.element_id.as_ref(), "devices:12");
+                assert_eq!(metadata.effective_from, 456);
+            }
+            other => panic!("unexpected change type: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn delete_change_uses_old_values_for_id_generation() {
+        let event = ChangeEvent {
+            action: Action::SQLITE_DELETE,
+            table: "events".to_string(),
+            old_values: Some(vec![
+                ("tenant".to_string(), serde_json::json!("t1")),
+                ("event_id".to_string(), serde_json::json!("abc")),
+            ]),
+            new_values: None,
+            old_row_id: Some(88),
+            new_row_id: None,
+            table_pk_columns: vec!["tenant".to_string(), "event_id".to_string()],
+            timestamp_ms: 789,
+        };
+
+        let change = change_event_to_source_change(event, "sqlite-source", None);
+        match change {
+            SourceChange::Delete { metadata } => {
+                assert_eq!(metadata.reference.element_id.as_ref(), "events:t1:abc");
+                assert_eq!(metadata.effective_from, 789);
+            }
+            other => panic!("unexpected change type: {other:?}"),
+        }
+    }
+}

--- a/components/sources/sqlite/src/descriptor.rs
+++ b/components/sources/sqlite/src/descriptor.rs
@@ -1,0 +1,173 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SQLite source plugin descriptor and configuration DTOs.
+
+use crate::config::{RestApiConfig, SqliteSourceConfig, TableKeyConfig};
+use drasi_plugin_sdk::prelude::*;
+use utoipa::OpenApi;
+
+// ── DTO types ────────────────────────────────────────────────────────────────
+
+/// SQLite source configuration DTO.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[schema(as = source::sqlite::SqliteSourceConfig)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SqliteSourceConfigDto {
+    /// SQLite file path. Omit or set to null for an in-memory database.
+    #[serde(default)]
+    #[schema(value_type = Option<ConfigValueString>)]
+    pub path: Option<ConfigValue<String>>,
+
+    /// Optional explicit table allow-list. Omit or set to null for all user tables.
+    #[serde(default)]
+    pub tables: Option<Vec<String>>,
+
+    /// Optional explicit key config for element ID generation.
+    #[serde(default)]
+    #[schema(value_type = Vec<source::sqlite::TableKeyConfig>)]
+    pub table_keys: Vec<TableKeyConfigDto>,
+
+    /// Optional REST API configuration. When provided, CRUD endpoints are exposed.
+    #[serde(default)]
+    #[schema(value_type = Option<source::sqlite::RestApiConfig>)]
+    pub rest_api: Option<RestApiConfigDto>,
+}
+
+/// REST API configuration DTO.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[schema(as = source::sqlite::RestApiConfig)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RestApiConfigDto {
+    /// Address to bind (default: "0.0.0.0").
+    #[serde(default = "default_rest_host")]
+    #[schema(value_type = ConfigValueString)]
+    pub host: ConfigValue<String>,
+
+    /// Port to bind (default: 8080).
+    #[serde(default = "default_rest_port")]
+    #[schema(value_type = ConfigValueU16)]
+    pub port: ConfigValue<u16>,
+}
+
+/// Table key configuration DTO.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[schema(as = source::sqlite::TableKeyConfig)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TableKeyConfigDto {
+    pub table: String,
+    pub key_columns: Vec<String>,
+}
+
+fn default_rest_host() -> ConfigValue<String> {
+    ConfigValue::Static("0.0.0.0".to_string())
+}
+
+fn default_rest_port() -> ConfigValue<u16> {
+    ConfigValue::Static(8080)
+}
+
+// ── OpenAPI schema ───────────────────────────────────────────────────────────
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(SqliteSourceConfigDto, RestApiConfigDto, TableKeyConfigDto,)))]
+struct SqliteSourceSchemas;
+
+// ── Descriptor ───────────────────────────────────────────────────────────────
+
+/// Plugin descriptor for the SQLite source plugin.
+pub struct SqliteSourceDescriptor;
+
+#[async_trait]
+impl SourcePluginDescriptor for SqliteSourceDescriptor {
+    fn kind(&self) -> &str {
+        "sqlite"
+    }
+
+    fn config_version(&self) -> &str {
+        "1.0.0"
+    }
+
+    fn config_schema_name(&self) -> &str {
+        "source.sqlite.SqliteSourceConfig"
+    }
+
+    fn config_schema_json(&self) -> String {
+        let api = SqliteSourceSchemas::openapi();
+        serde_json::to_string(
+            &api.components
+                .as_ref()
+                .expect("OpenAPI components missing")
+                .schemas,
+        )
+        .expect("Failed to serialize config schema")
+    }
+
+    async fn create_source(
+        &self,
+        id: &str,
+        config_json: &serde_json::Value,
+        auto_start: bool,
+    ) -> anyhow::Result<Box<dyn drasi_lib::sources::Source>> {
+        let dto: SqliteSourceConfigDto = serde_json::from_value(config_json.clone())?;
+        let mapper = DtoMapper::new();
+
+        let path = match &dto.path {
+            Some(cv) => Some(mapper.resolve_string(cv)?),
+            None => None,
+        };
+
+        let rest_api = match &dto.rest_api {
+            Some(rest_dto) => Some(RestApiConfig {
+                host: mapper.resolve_string(&rest_dto.host)?,
+                port: mapper.resolve_typed(&rest_dto.port)?,
+            }),
+            None => None,
+        };
+
+        let table_keys = dto
+            .table_keys
+            .iter()
+            .map(|tk| TableKeyConfig {
+                table: tk.table.clone(),
+                key_columns: tk.key_columns.clone(),
+            })
+            .collect();
+
+        let config = SqliteSourceConfig {
+            path,
+            tables: dto.tables,
+            table_keys,
+            rest_api,
+            ..Default::default()
+        };
+
+        let mut builder = crate::SqliteSourceBuilder::new(id);
+        if let Some(p) = &config.path {
+            builder = builder.with_path(p);
+        }
+        if let Some(tables) = config.tables {
+            builder = builder.with_tables(tables);
+        }
+        if !config.table_keys.is_empty() {
+            builder = builder.with_table_keys(config.table_keys);
+        }
+        if let Some(rest) = config.rest_api {
+            builder = builder.with_rest_api(rest);
+        }
+        builder = builder.auto_start(auto_start);
+
+        Ok(Box::new(builder.build()?))
+    }
+}

--- a/components/sources/sqlite/src/descriptor.rs
+++ b/components/sources/sqlite/src/descriptor.rs
@@ -70,6 +70,41 @@ pub struct TableKeyConfigDto {
     pub key_columns: Vec<String>,
 }
 
+// ── From impls ───────────────────────────────────────────────────────────────
+
+impl From<&TableKeyConfig> for TableKeyConfigDto {
+    fn from(tk: &TableKeyConfig) -> Self {
+        Self {
+            table: tk.table.clone(),
+            key_columns: tk.key_columns.clone(),
+        }
+    }
+}
+
+impl From<&RestApiConfig> for RestApiConfigDto {
+    fn from(config: &RestApiConfig) -> Self {
+        Self {
+            host: ConfigValue::Static(config.host.clone()),
+            port: ConfigValue::Static(config.port),
+        }
+    }
+}
+
+impl From<&SqliteSourceConfig> for SqliteSourceConfigDto {
+    fn from(config: &SqliteSourceConfig) -> Self {
+        Self {
+            path: config.path.as_ref().map(|p| ConfigValue::Static(p.clone())),
+            tables: config.tables.clone(),
+            table_keys: config
+                .table_keys
+                .iter()
+                .map(TableKeyConfigDto::from)
+                .collect(),
+            rest_api: config.rest_api.as_ref().map(RestApiConfigDto::from),
+        }
+    }
+}
+
 fn default_rest_host() -> ConfigValue<String> {
     ConfigValue::Static("0.0.0.0".to_string())
 }
@@ -168,6 +203,9 @@ impl SourcePluginDescriptor for SqliteSourceDescriptor {
         }
         builder = builder.auto_start(auto_start);
 
-        Ok(Box::new(builder.build()?))
+        let mut source = builder.build()?;
+        source.base.set_raw_config(config_json.clone());
+
+        Ok(Box::new(source))
     }
 }

--- a/components/sources/sqlite/src/lib.rs
+++ b/components/sources/sqlite/src/lib.rs
@@ -1,0 +1,435 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SQLite source plugin for Drasi.
+//!
+//! This source owns an embedded SQLite connection running in a dedicated thread.
+//! Changes are captured through SQLite hooks:
+//! - `preupdate_hook` captures row-level INSERT/UPDATE/DELETE events
+//! - `commit_hook` flushes buffered changes
+//! - `rollback_hook` discards buffered changes
+//!
+//! The source supports:
+//! - file-backed and in-memory SQLite databases
+//! - optional table filtering
+//! - optional REST CRUD + transactional batch endpoints
+//! - bootstrap via pluggable bootstrap providers
+
+mod config;
+mod convert;
+mod rest_api;
+mod thread;
+
+pub use config::{
+    RestApiConfig, SqliteSourceBuilder, SqliteSourceConfig, StartFrom, TableKeyConfig,
+};
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use drasi_lib::channels::{ComponentStatus, SourceEvent, SourceEventWrapper, SubscriptionResponse};
+use drasi_lib::sources::base::SourceBase;
+use drasi_lib::Source;
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot, RwLock};
+use tracing::Instrument;
+
+use crate::thread::SqliteCommand;
+
+/// Cloneable handle for issuing SQL statements against the source-owned connection.
+#[derive(Clone)]
+pub struct SqliteSourceHandle {
+    command_tx: Arc<RwLock<Option<mpsc::UnboundedSender<SqliteCommand>>>>,
+    source_id: Arc<str>,
+}
+
+impl SqliteSourceHandle {
+    async fn sender(&self) -> Result<mpsc::UnboundedSender<SqliteCommand>> {
+        self.command_tx
+            .read()
+            .await
+            .clone()
+            .ok_or_else(|| anyhow!("source '{}' is not running", self.source_id))
+    }
+
+    /// Source ID this handle is associated with.
+    pub fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    /// Execute a SQL statement.
+    pub async fn execute(&self, sql: impl Into<String>) -> Result<usize> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender().await?.send(SqliteCommand::Execute {
+            sql: sql.into(),
+            response_tx,
+        })?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("sqlite thread closed response channel"))?
+    }
+
+    /// Execute a SQL script batch.
+    pub async fn execute_batch(&self, sql: impl Into<String>) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender().await?.send(SqliteCommand::ExecuteBatch {
+            sql: sql.into(),
+            response_tx,
+        })?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("sqlite thread closed response channel"))?
+    }
+
+    /// Execute a query and return rows as JSON objects.
+    pub async fn query(
+        &self,
+        sql: impl Into<String>,
+    ) -> Result<Vec<serde_json::Map<String, serde_json::Value>>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender().await?.send(SqliteCommand::QueryRows {
+            sql: sql.into(),
+            response_tx,
+        })?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("sqlite thread closed response channel"))?
+    }
+
+    async fn begin_transaction(&self) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender()
+            .await?
+            .send(SqliteCommand::BeginTransaction { response_tx })?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("sqlite thread closed response channel"))?
+    }
+
+    async fn commit_transaction(&self) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender()
+            .await?
+            .send(SqliteCommand::CommitTransaction { response_tx })?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("sqlite thread closed response channel"))?
+    }
+
+    async fn rollback_transaction(&self) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender()
+            .await?
+            .send(SqliteCommand::RollbackTransaction { response_tx })?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("sqlite thread closed response channel"))?
+    }
+
+    /// Execute a sequence of SQL statements atomically.
+    pub async fn execute_statements_in_transaction(&self, statements: Vec<String>) -> Result<()> {
+        self.begin_transaction().await?;
+
+        for statement in statements {
+            if let Err(err) = self.execute(statement).await {
+                let _ = self.rollback_transaction().await;
+                return Err(err);
+            }
+        }
+
+        self.commit_transaction().await
+    }
+
+    /// Execute user logic in a transaction scope.
+    pub async fn transaction<F, Fut, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(SqliteTxHandle) -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        self.begin_transaction().await?;
+        let tx_handle = SqliteTxHandle {
+            handle: self.clone(),
+        };
+
+        match f(tx_handle).await {
+            Ok(value) => {
+                self.commit_transaction().await?;
+                Ok(value)
+            }
+            Err(err) => {
+                let _ = self.rollback_transaction().await;
+                Err(err)
+            }
+        }
+    }
+}
+
+/// Transaction-scoped SQL handle.
+#[derive(Clone)]
+pub struct SqliteTxHandle {
+    handle: SqliteSourceHandle,
+}
+
+impl SqliteTxHandle {
+    pub async fn execute(&self, sql: impl Into<String>) -> Result<usize> {
+        self.handle.execute(sql).await
+    }
+
+    pub async fn execute_batch(&self, sql: impl Into<String>) -> Result<()> {
+        self.handle.execute_batch(sql).await
+    }
+}
+
+/// SQLite source implementation.
+pub struct SqliteSource {
+    base: SourceBase,
+    config: SqliteSourceConfig,
+    command_tx: Arc<RwLock<Option<mpsc::UnboundedSender<SqliteCommand>>>>,
+    thread_handle: Arc<RwLock<Option<std::thread::JoinHandle<()>>>>,
+    rest_shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
+}
+
+impl SqliteSource {
+    pub fn builder(id: impl Into<String>) -> SqliteSourceBuilder {
+        SqliteSourceBuilder::new(id)
+    }
+
+    pub(crate) fn from_parts(base: SourceBase, config: SqliteSourceConfig) -> Result<Self> {
+        Ok(Self {
+            base,
+            config,
+            command_tx: Arc::new(RwLock::new(None)),
+            thread_handle: Arc::new(RwLock::new(None)),
+            rest_shutdown_tx: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// Get a handle for issuing SQL operations against this source.
+    pub fn handle(&self) -> SqliteSourceHandle {
+        SqliteSourceHandle {
+            command_tx: self.command_tx.clone(),
+            source_id: Arc::from(self.base.id.as_str()),
+        }
+    }
+}
+
+#[async_trait]
+impl Source for SqliteSource {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "sqlite"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        let mut props = HashMap::new();
+        props.insert(
+            "path".to_string(),
+            match &self.config.path {
+                Some(path) => serde_json::Value::String(path.clone()),
+                None => serde_json::Value::String(":memory:".to_string()),
+            },
+        );
+
+        if let Some(tables) = &self.config.tables {
+            props.insert(
+                "tables".to_string(),
+                serde_json::Value::Array(
+                    tables
+                        .iter()
+                        .map(|table| serde_json::Value::String(table.clone()))
+                        .collect(),
+                ),
+            );
+        }
+        props.insert(
+            "rest_api_enabled".to_string(),
+            serde_json::Value::Bool(self.config.rest_api.is_some()),
+        );
+        props
+    }
+
+    fn auto_start(&self) -> bool {
+        self.base.get_auto_start()
+    }
+
+    async fn start(&self) -> Result<()> {
+        if self.base.get_status().await == ComponentStatus::Running {
+            return Ok(());
+        }
+
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Starting,
+                Some("Starting SQLite source".to_string()),
+            )
+            .await?;
+
+        let (command_tx, command_rx) = mpsc::unbounded_channel::<SqliteCommand>();
+        *self.command_tx.write().await = Some(command_tx.clone());
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel::<thread::ChangeEvent>();
+
+        let thread_config = thread::SqliteThreadConfig {
+            path: self.config.path.clone(),
+            tables: self.config.tables.clone(),
+        };
+        let source_id_for_thread = self.base.id.clone();
+        let handle = std::thread::spawn(move || {
+            if let Err(err) = thread::run_sqlite_thread(thread_config, command_rx, event_tx) {
+                log::error!("sqlite source thread '{source_id_for_thread}' failed: {err}");
+            }
+        });
+        *self.thread_handle.write().await = Some(handle);
+
+        let configured_keys = self
+            .config
+            .table_keys
+            .iter()
+            .map(|item| (item.table.clone(), item.key_columns.clone()))
+            .collect::<HashMap<_, _>>();
+
+        let source_id = self.base.id.clone();
+        let dispatchers = self.base.dispatchers.clone();
+        let instance_id = self
+            .base
+            .context()
+            .await
+            .map(|ctx| ctx.instance_id)
+            .unwrap_or_default();
+
+        let span = tracing::info_span!(
+            "sqlite_source_dispatcher",
+            instance_id = %instance_id,
+            component_id = %source_id,
+            component_type = "source"
+        );
+        let task = tokio::spawn(
+            async move {
+                while let Some(event) = event_rx.recv().await {
+                    let configured = configured_keys.get(&event.table).map(|v| v.as_slice());
+                    let change =
+                        convert::change_event_to_source_change(event, &source_id, configured);
+                    let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
+                    profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
+
+                    let wrapper = SourceEventWrapper::with_profiling(
+                        source_id.clone(),
+                        SourceEvent::Change(change),
+                        chrono::Utc::now(),
+                        profiling,
+                    );
+                    if let Err(err) =
+                        SourceBase::dispatch_from_task(dispatchers.clone(), wrapper, &source_id)
+                            .await
+                    {
+                        log::debug!("failed dispatching sqlite change for '{source_id}': {err}");
+                    }
+                }
+            }
+            .instrument(span),
+        );
+        *self.base.task_handle.write().await = Some(task);
+
+        if let Some(rest_config) = &self.config.rest_api {
+            let (shutdown_tx, shutdown_rx) = oneshot::channel();
+            rest_api::start_rest_api(
+                rest_config.clone(),
+                self.handle(),
+                self.config.tables.clone(),
+                self.config.table_keys.clone(),
+                shutdown_rx,
+            )
+            .await?;
+            *self.rest_shutdown_tx.write().await = Some(shutdown_tx);
+        }
+
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Running,
+                Some("SQLite source running".to_string()),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        if self.base.get_status().await != ComponentStatus::Running {
+            return Ok(());
+        }
+
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Stopping,
+                Some("Stopping SQLite source".to_string()),
+            )
+            .await?;
+
+        if let Some(rest_shutdown_tx) = self.rest_shutdown_tx.write().await.take() {
+            let _ = rest_shutdown_tx.send(());
+        }
+
+        if let Some(sender) = self.command_tx.write().await.take() {
+            let _ = sender.send(SqliteCommand::Shutdown);
+        }
+
+        if let Some(handle) = self.thread_handle.write().await.take() {
+            let _ = tokio::task::spawn_blocking(move || handle.join()).await;
+        }
+
+        if let Some(task) = self.base.task_handle.write().await.take() {
+            task.abort();
+        }
+
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Stopped,
+                Some("SQLite source stopped".to_string()),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn subscribe(
+        &self,
+        settings: drasi_lib::config::SourceSubscriptionSettings,
+    ) -> Result<SubscriptionResponse> {
+        self.base
+            .subscribe_with_bootstrap(&settings, "SQLite")
+            .await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn initialize(&self, context: drasi_lib::context::SourceRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn set_bootstrap_provider(
+        &self,
+        provider: Box<dyn drasi_lib::bootstrap::BootstrapProvider + 'static>,
+    ) {
+        self.base.set_bootstrap_provider(provider).await;
+    }
+}

--- a/components/sources/sqlite/src/lib.rs
+++ b/components/sources/sqlite/src/lib.rs
@@ -332,11 +332,11 @@ impl Source for SqliteSource {
         }
 
         self.base
-            .set_status_with_event(
+            .set_status(
                 ComponentStatus::Starting,
                 Some("Starting SQLite source".to_string()),
             )
-            .await?;
+            .await;
 
         let (command_tx, command_rx) = mpsc::unbounded_channel::<SqliteCommand>();
         *self.command_tx.write().await = Some(command_tx.clone());
@@ -417,11 +417,11 @@ impl Source for SqliteSource {
         }
 
         self.base
-            .set_status_with_event(
+            .set_status(
                 ComponentStatus::Running,
                 Some("SQLite source running".to_string()),
             )
-            .await?;
+            .await;
 
         Ok(())
     }
@@ -432,11 +432,11 @@ impl Source for SqliteSource {
         }
 
         self.base
-            .set_status_with_event(
+            .set_status(
                 ComponentStatus::Stopping,
                 Some("Stopping SQLite source".to_string()),
             )
-            .await?;
+            .await;
 
         if let Some(rest_shutdown_tx) = self.rest_shutdown_tx.write().await.take() {
             let _ = rest_shutdown_tx.send(());
@@ -455,11 +455,11 @@ impl Source for SqliteSource {
         }
 
         self.base
-            .set_status_with_event(
+            .set_status(
                 ComponentStatus::Stopped,
                 Some("SQLite source stopped".to_string()),
             )
-            .await?;
+            .await;
 
         Ok(())
     }

--- a/components/sources/sqlite/src/lib.rs
+++ b/components/sources/sqlite/src/lib.rs
@@ -37,6 +37,7 @@ mod thread;
 pub use config::{
     RestApiConfig, SqliteSourceBuilder, SqliteSourceConfig, StartFrom, TableKeyConfig,
 };
+pub use thread::SqliteParam;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -84,6 +85,25 @@ impl SqliteSourceHandle {
             .map_err(|_| anyhow!("sqlite thread closed response channel"))?
     }
 
+    /// Execute a parameterized SQL statement with bind parameters.
+    pub async fn execute_parameterized(
+        &self,
+        sql: impl Into<String>,
+        params: Vec<SqliteParam>,
+    ) -> Result<usize> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender()
+            .await?
+            .send(SqliteCommand::ExecuteParameterized {
+                sql: sql.into(),
+                params,
+                response_tx,
+            })?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("sqlite thread closed response channel"))?
+    }
+
     /// Execute a SQL script batch.
     pub async fn execute_batch(&self, sql: impl Into<String>) -> Result<()> {
         let (response_tx, response_rx) = oneshot::channel();
@@ -106,6 +126,25 @@ impl SqliteSourceHandle {
             sql: sql.into(),
             response_tx,
         })?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("sqlite thread closed response channel"))?
+    }
+
+    /// Execute a parameterized query and return rows as JSON objects.
+    pub async fn query_parameterized(
+        &self,
+        sql: impl Into<String>,
+        params: Vec<SqliteParam>,
+    ) -> Result<Vec<serde_json::Map<String, serde_json::Value>>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender()
+            .await?
+            .send(SqliteCommand::QueryRowsParameterized {
+                sql: sql.into(),
+                params,
+                response_tx,
+            })?;
         response_rx
             .await
             .map_err(|_| anyhow!("sqlite thread closed response channel"))?
@@ -147,6 +186,23 @@ impl SqliteSourceHandle {
 
         for statement in statements {
             if let Err(err) = self.execute(statement).await {
+                let _ = self.rollback_transaction().await;
+                return Err(err);
+            }
+        }
+
+        self.commit_transaction().await
+    }
+
+    /// Execute multiple parameterized statements atomically in a transaction.
+    pub async fn execute_parameterized_in_transaction(
+        &self,
+        statements: Vec<(String, Vec<SqliteParam>)>,
+    ) -> Result<()> {
+        self.begin_transaction().await?;
+
+        for (sql, params) in statements {
+            if let Err(err) = self.execute_parameterized(sql, params).await {
                 let _ = self.rollback_transaction().await;
                 return Err(err);
             }

--- a/components/sources/sqlite/src/lib.rs
+++ b/components/sources/sqlite/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(unexpected_cfgs)]
+
 //! SQLite source plugin for Drasi.
 //!
 //! This source owns an embedded SQLite connection running in a dedicated thread.
@@ -28,6 +30,7 @@
 
 mod config;
 mod convert;
+pub mod descriptor;
 mod rest_api;
 mod thread;
 
@@ -433,3 +436,15 @@ impl Source for SqliteSource {
         self.base.set_bootstrap_provider(provider).await;
     }
 }
+
+/// Dynamic plugin entry point.
+#[cfg(feature = "dynamic-plugin")]
+drasi_plugin_sdk::export_plugin!(
+    plugin_id = "sqlite-source",
+    core_version = env!("CARGO_PKG_VERSION"),
+    lib_version = env!("CARGO_PKG_VERSION"),
+    plugin_version = env!("CARGO_PKG_VERSION"),
+    source_descriptors = [descriptor::SqliteSourceDescriptor],
+    reaction_descriptors = [],
+    bootstrap_descriptors = [],
+);

--- a/components/sources/sqlite/src/lib.rs
+++ b/components/sources/sqlite/src/lib.rs
@@ -295,31 +295,10 @@ impl Source for SqliteSource {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        let mut props = HashMap::new();
-        props.insert(
-            "path".to_string(),
-            match &self.config.path {
-                Some(path) => serde_json::Value::String(path.clone()),
-                None => serde_json::Value::String(":memory:".to_string()),
-            },
-        );
+        use crate::descriptor::SqliteSourceConfigDto;
 
-        if let Some(tables) = &self.config.tables {
-            props.insert(
-                "tables".to_string(),
-                serde_json::Value::Array(
-                    tables
-                        .iter()
-                        .map(|table| serde_json::Value::String(table.clone()))
-                        .collect(),
-                ),
-            );
-        }
-        props.insert(
-            "rest_api_enabled".to_string(),
-            serde_json::Value::Bool(self.config.rest_api.is_some()),
-        );
-        props
+        self.base
+            .properties_or_serialize(&SqliteSourceConfigDto::from(&self.config))
     }
 
     fn auto_start(&self) -> bool {

--- a/components/sources/sqlite/src/rest_api.rs
+++ b/components/sources/sqlite/src/rest_api.rs
@@ -1,0 +1,469 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{anyhow, Result};
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{delete, get, post, put};
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+
+use crate::{RestApiConfig, SqliteSourceHandle, TableKeyConfig};
+
+#[derive(Clone)]
+struct RestApiState {
+    handle: SqliteSourceHandle,
+    allowed_tables: Option<HashSet<String>>,
+    table_keys: Vec<TableKeyConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BatchRequest {
+    pub operations: Vec<BatchOperation>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "op", rename_all = "lowercase")]
+pub enum BatchOperation {
+    Insert {
+        table: String,
+        data: serde_json::Map<String, Value>,
+    },
+    Update {
+        table: String,
+        id: String,
+        data: serde_json::Map<String, Value>,
+    },
+    Delete {
+        table: String,
+        id: String,
+    },
+}
+
+pub async fn start_rest_api(
+    config: RestApiConfig,
+    handle: SqliteSourceHandle,
+    tables: Option<Vec<String>>,
+    table_keys: Vec<TableKeyConfig>,
+    shutdown_rx: oneshot::Receiver<()>,
+) -> Result<()> {
+    let allowed_tables = tables.map(|items| items.into_iter().collect::<HashSet<_>>());
+    let state = Arc::new(RestApiState {
+        handle,
+        allowed_tables,
+        table_keys,
+    });
+
+    let router = Router::new()
+        .route("/health", get(health_check))
+        .route("/api/tables", get(list_tables))
+        .route("/api/tables/:table", get(list_rows).post(insert_row))
+        .route(
+            "/api/tables/:table/:id",
+            get(get_row).put(update_row).delete(delete_row),
+        )
+        .route("/api/batch", post(batch_operations))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind((config.host.as_str(), config.port)).await?;
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+
+    Ok(())
+}
+
+async fn health_check() -> Json<Value> {
+    Json(serde_json::json!({ "status": "ok" }))
+}
+
+async fn list_tables(State(state): State<Arc<RestApiState>>) -> Result<Json<Value>, StatusCode> {
+    let rows = state
+        .handle
+        .query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        )
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let names = rows
+        .into_iter()
+        .filter_map(|row| {
+            row.get("name")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+        .filter(|name| {
+            if let Some(allowed) = &state.allowed_tables {
+                allowed.contains(name)
+            } else {
+                true
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Json(serde_json::json!(names)))
+}
+
+async fn list_rows(
+    State(state): State<Arc<RestApiState>>,
+    Path(table): Path<String>,
+) -> Result<Json<Value>, StatusCode> {
+    validate_table(&state, &table).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let sql = format!("SELECT * FROM {}", quote_ident(&table));
+    let rows = state
+        .handle
+        .query(sql)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(serde_json::json!(rows)))
+}
+
+async fn get_row(
+    State(state): State<Arc<RestApiState>>,
+    Path((table, id)): Path<(String, String)>,
+) -> Result<Json<Value>, StatusCode> {
+    validate_table(&state, &table).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let where_clause = build_where_by_id(&state, &table, &id)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    let sql = format!(
+        "SELECT * FROM {} WHERE {}",
+        quote_ident(&table),
+        where_clause
+    );
+    let mut rows = state
+        .handle
+        .query(sql)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if let Some(row) = rows.pop() {
+        Ok(Json(serde_json::json!(row)))
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+async fn insert_row(
+    State(state): State<Arc<RestApiState>>,
+    Path(table): Path<String>,
+    Json(data): Json<serde_json::Map<String, Value>>,
+) -> Result<Json<Value>, StatusCode> {
+    validate_table(&state, &table).map_err(|_| StatusCode::BAD_REQUEST)?;
+    validate_columns(&data).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let columns = data.keys().map(|c| quote_ident(c)).collect::<Vec<_>>();
+    let values = data.values().map(value_to_sql_literal).collect::<Vec<_>>();
+
+    let sql = format!(
+        "INSERT INTO {} ({}) VALUES ({})",
+        quote_ident(&table),
+        columns.join(", "),
+        values.join(", ")
+    );
+
+    state
+        .handle
+        .execute(sql)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(serde_json::json!({ "success": true })))
+}
+
+async fn update_row(
+    State(state): State<Arc<RestApiState>>,
+    Path((table, id)): Path<(String, String)>,
+    Json(data): Json<serde_json::Map<String, Value>>,
+) -> Result<Json<Value>, StatusCode> {
+    validate_table(&state, &table).map_err(|_| StatusCode::BAD_REQUEST)?;
+    validate_columns(&data).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let where_clause = build_where_by_id(&state, &table, &id)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let set_clause = data
+        .iter()
+        .map(|(col, value)| format!("{} = {}", quote_ident(col), value_to_sql_literal(value)))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let sql = format!(
+        "UPDATE {} SET {} WHERE {}",
+        quote_ident(&table),
+        set_clause,
+        where_clause
+    );
+
+    state
+        .handle
+        .execute(sql)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(serde_json::json!({ "success": true })))
+}
+
+async fn delete_row(
+    State(state): State<Arc<RestApiState>>,
+    Path((table, id)): Path<(String, String)>,
+) -> Result<Json<Value>, StatusCode> {
+    validate_table(&state, &table).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let where_clause = build_where_by_id(&state, &table, &id)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let sql = format!("DELETE FROM {} WHERE {}", quote_ident(&table), where_clause);
+    state
+        .handle
+        .execute(sql)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(serde_json::json!({ "success": true })))
+}
+
+async fn batch_operations(
+    State(state): State<Arc<RestApiState>>,
+    Json(request): Json<BatchRequest>,
+) -> Result<Json<Value>, StatusCode> {
+    let mut statements = Vec::new();
+    for op in &request.operations {
+        let sql = operation_to_sql(&state, op)
+            .await
+            .map_err(|_| StatusCode::BAD_REQUEST)?;
+        statements.push(sql);
+    }
+
+    state
+        .handle
+        .execute_statements_in_transaction(statements)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(serde_json::json!({ "success": true })))
+}
+
+async fn operation_to_sql(state: &RestApiState, operation: &BatchOperation) -> Result<String> {
+    match operation {
+        BatchOperation::Insert { table, data } => {
+            validate_table_ref(state, table)?;
+            validate_columns(data)?;
+            let columns = data.keys().map(|c| quote_ident(c)).collect::<Vec<_>>();
+            let values = data.values().map(value_to_sql_literal).collect::<Vec<_>>();
+            Ok(format!(
+                "INSERT INTO {} ({}) VALUES ({})",
+                quote_ident(table),
+                columns.join(", "),
+                values.join(", ")
+            ))
+        }
+        BatchOperation::Update { table, id, data } => {
+            validate_table_ref(state, table)?;
+            validate_columns(data)?;
+            let where_clause = build_where_by_id_ref(state, table, id).await?;
+            let set_clause = data
+                .iter()
+                .map(|(col, value)| {
+                    format!("{} = {}", quote_ident(col), value_to_sql_literal(value))
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            Ok(format!(
+                "UPDATE {} SET {} WHERE {}",
+                quote_ident(table),
+                set_clause,
+                where_clause
+            ))
+        }
+        BatchOperation::Delete { table, id } => {
+            validate_table_ref(state, table)?;
+            let where_clause = build_where_by_id_ref(state, table, id).await?;
+            Ok(format!(
+                "DELETE FROM {} WHERE {}",
+                quote_ident(table),
+                where_clause
+            ))
+        }
+    }
+}
+
+async fn build_where_by_id(state: &RestApiState, table: &str, id: &str) -> Result<String> {
+    build_where_by_id_ref(state, table, id).await
+}
+
+async fn build_where_by_id_ref(state: &RestApiState, table: &str, id: &str) -> Result<String> {
+    let key_columns = if let Some(found) = state.table_keys.iter().find(|k| k.table == table) {
+        found.key_columns.clone()
+    } else {
+        detect_primary_keys(&state.handle, table).await?
+    };
+
+    if key_columns.is_empty() {
+        return Err(anyhow!("table has no configured or detected primary key"));
+    }
+
+    let id_parts = id.split(':').collect::<Vec<_>>();
+    if id_parts.len() != key_columns.len() {
+        return Err(anyhow!("id parts do not match primary key columns"));
+    }
+
+    let where_parts = key_columns
+        .iter()
+        .zip(id_parts.iter())
+        .map(|(column, part)| {
+            format!(
+                "{} = {}",
+                quote_ident(column),
+                value_to_sql_literal(&Value::String((*part).to_string()))
+            )
+        })
+        .collect::<Vec<_>>();
+
+    Ok(where_parts.join(" AND "))
+}
+
+async fn detect_primary_keys(handle: &SqliteSourceHandle, table: &str) -> Result<Vec<String>> {
+    let sql = format!("PRAGMA table_info({})", quote_ident(table));
+    let rows = handle.query(sql).await?;
+    let mut keys = rows
+        .into_iter()
+        .filter_map(|row| {
+            let name = row.get("name").and_then(Value::as_str)?;
+            let pk = row.get("pk").and_then(Value::as_i64).unwrap_or_default();
+            if pk > 0 {
+                Some((pk, name.to_string()))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    keys.sort_by_key(|(order, _)| *order);
+    Ok(keys.into_iter().map(|(_, name)| name).collect())
+}
+
+fn validate_table(state: &RestApiState, table: &str) -> Result<()> {
+    validate_table_ref(state, table)
+}
+
+fn validate_table_ref(state: &RestApiState, table: &str) -> Result<()> {
+    if !is_identifier(table) {
+        return Err(anyhow!("invalid table name"));
+    }
+
+    if let Some(allowed) = &state.allowed_tables {
+        if !allowed.contains(table) {
+            return Err(anyhow!("table not allowed"));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_columns(data: &serde_json::Map<String, Value>) -> Result<()> {
+    for key in data.keys() {
+        if !is_identifier(key) {
+            return Err(anyhow!("invalid column name"));
+        }
+    }
+    Ok(())
+}
+
+fn is_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(c) if c == '_' || c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+fn quote_ident(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn value_to_sql_literal(value: &Value) -> String {
+    match value {
+        Value::Null => "NULL".to_string(),
+        Value::Bool(v) => {
+            if *v {
+                "1".to_string()
+            } else {
+                "0".to_string()
+            }
+        }
+        Value::Number(v) => v.to_string(),
+        Value::String(v) => format!("'{}'", v.replace('\'', "''")),
+        Value::Array(_) | Value::Object(_) => {
+            format!("'{}'", value.to_string().replace('\'', "''"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifier_validation_accepts_and_rejects_expected_values() {
+        assert!(is_identifier("sensors"));
+        assert!(is_identifier("_events"));
+        assert!(!is_identifier("9table"));
+        assert!(!is_identifier("table-name"));
+        assert!(!is_identifier("table name"));
+    }
+
+    #[test]
+    fn quote_ident_escapes_double_quotes() {
+        assert_eq!(quote_ident("simple"), "\"simple\"");
+        assert_eq!(quote_ident("my\"table"), "\"my\"\"table\"");
+    }
+
+    #[test]
+    fn value_to_sql_literal_handles_core_types() {
+        assert_eq!(value_to_sql_literal(&Value::Null), "NULL");
+        assert_eq!(value_to_sql_literal(&Value::Bool(true)), "1");
+        assert_eq!(value_to_sql_literal(&Value::Bool(false)), "0");
+        assert_eq!(value_to_sql_literal(&Value::Number(42.into())), "42");
+        assert_eq!(
+            value_to_sql_literal(&Value::String("O'Reilly".to_string())),
+            "'O''Reilly'"
+        );
+        assert_eq!(
+            value_to_sql_literal(&serde_json::json!({"x": "y"})),
+            "'{\"x\":\"y\"}'"
+        );
+    }
+
+    #[test]
+    fn validate_columns_rejects_invalid_column_names() {
+        let mut valid = serde_json::Map::new();
+        valid.insert("col_1".to_string(), Value::String("ok".to_string()));
+        assert!(validate_columns(&valid).is_ok());
+
+        let mut invalid = serde_json::Map::new();
+        invalid.insert("bad-column".to_string(), Value::String("oops".to_string()));
+        assert!(validate_columns(&invalid).is_err());
+    }
+}

--- a/components/sources/sqlite/src/rest_api.rs
+++ b/components/sources/sqlite/src/rest_api.rs
@@ -23,6 +23,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
+use crate::thread::SqliteParam;
 use crate::{RestApiConfig, SqliteSourceHandle, TableKeyConfig};
 
 #[derive(Clone)]
@@ -144,7 +145,7 @@ async fn get_row(
     Path((table, id)): Path<(String, String)>,
 ) -> Result<Json<Value>, StatusCode> {
     validate_table(&state, &table).map_err(|_| StatusCode::BAD_REQUEST)?;
-    let where_clause = build_where_by_id(&state, &table, &id)
+    let (where_clause, params) = build_where_by_id(&state, &table, &id)
         .await
         .map_err(|_| StatusCode::BAD_REQUEST)?;
     let sql = format!(
@@ -154,7 +155,7 @@ async fn get_row(
     );
     let mut rows = state
         .handle
-        .query(sql)
+        .query_parameterized(sql, params)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -174,18 +175,19 @@ async fn insert_row(
     validate_columns(&data).map_err(|_| StatusCode::BAD_REQUEST)?;
 
     let columns = data.keys().map(|c| quote_ident(c)).collect::<Vec<_>>();
-    let values = data.values().map(value_to_sql_literal).collect::<Vec<_>>();
+    let placeholders = (0..data.len()).map(|_| "?").collect::<Vec<_>>();
+    let params = data.values().map(json_value_to_param).collect::<Vec<_>>();
 
     let sql = format!(
         "INSERT INTO {} ({}) VALUES ({})",
         quote_ident(&table),
         columns.join(", "),
-        values.join(", ")
+        placeholders.join(", ")
     );
 
     state
         .handle
-        .execute(sql)
+        .execute_parameterized(sql, params)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -199,15 +201,18 @@ async fn update_row(
 ) -> Result<Json<Value>, StatusCode> {
     validate_table(&state, &table).map_err(|_| StatusCode::BAD_REQUEST)?;
     validate_columns(&data).map_err(|_| StatusCode::BAD_REQUEST)?;
-    let where_clause = build_where_by_id(&state, &table, &id)
+    let (where_clause, where_params) = build_where_by_id(&state, &table, &id)
         .await
         .map_err(|_| StatusCode::BAD_REQUEST)?;
 
     let set_clause = data
-        .iter()
-        .map(|(col, value)| format!("{} = {}", quote_ident(col), value_to_sql_literal(value)))
+        .keys()
+        .map(|col| format!("{} = ?", quote_ident(col)))
         .collect::<Vec<_>>()
         .join(", ");
+
+    let mut params: Vec<SqliteParam> = data.values().map(json_value_to_param).collect();
+    params.extend(where_params);
 
     let sql = format!(
         "UPDATE {} SET {} WHERE {}",
@@ -218,7 +223,7 @@ async fn update_row(
 
     state
         .handle
-        .execute(sql)
+        .execute_parameterized(sql, params)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -230,14 +235,14 @@ async fn delete_row(
     Path((table, id)): Path<(String, String)>,
 ) -> Result<Json<Value>, StatusCode> {
     validate_table(&state, &table).map_err(|_| StatusCode::BAD_REQUEST)?;
-    let where_clause = build_where_by_id(&state, &table, &id)
+    let (where_clause, params) = build_where_by_id(&state, &table, &id)
         .await
         .map_err(|_| StatusCode::BAD_REQUEST)?;
 
     let sql = format!("DELETE FROM {} WHERE {}", quote_ident(&table), where_clause);
     state
         .handle
-        .execute(sql)
+        .execute_parameterized(sql, params)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -250,70 +255,87 @@ async fn batch_operations(
 ) -> Result<Json<Value>, StatusCode> {
     let mut statements = Vec::new();
     for op in &request.operations {
-        let sql = operation_to_sql(&state, op)
+        let (sql, params) = operation_to_parameterized_sql(&state, op)
             .await
             .map_err(|_| StatusCode::BAD_REQUEST)?;
-        statements.push(sql);
+        statements.push((sql, params));
     }
 
     state
         .handle
-        .execute_statements_in_transaction(statements)
+        .execute_parameterized_in_transaction(statements)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(serde_json::json!({ "success": true })))
 }
 
-async fn operation_to_sql(state: &RestApiState, operation: &BatchOperation) -> Result<String> {
+async fn operation_to_parameterized_sql(
+    state: &RestApiState,
+    operation: &BatchOperation,
+) -> Result<(String, Vec<SqliteParam>)> {
     match operation {
         BatchOperation::Insert { table, data } => {
             validate_table_ref(state, table)?;
             validate_columns(data)?;
             let columns = data.keys().map(|c| quote_ident(c)).collect::<Vec<_>>();
-            let values = data.values().map(value_to_sql_literal).collect::<Vec<_>>();
-            Ok(format!(
-                "INSERT INTO {} ({}) VALUES ({})",
-                quote_ident(table),
-                columns.join(", "),
-                values.join(", ")
+            let placeholders = (0..data.len()).map(|_| "?").collect::<Vec<_>>();
+            let params = data.values().map(json_value_to_param).collect();
+            Ok((
+                format!(
+                    "INSERT INTO {} ({}) VALUES ({})",
+                    quote_ident(table),
+                    columns.join(", "),
+                    placeholders.join(", ")
+                ),
+                params,
             ))
         }
         BatchOperation::Update { table, id, data } => {
             validate_table_ref(state, table)?;
             validate_columns(data)?;
-            let where_clause = build_where_by_id_ref(state, table, id).await?;
+            let (where_clause, where_params) = build_where_by_id_ref(state, table, id).await?;
             let set_clause = data
-                .iter()
-                .map(|(col, value)| {
-                    format!("{} = {}", quote_ident(col), value_to_sql_literal(value))
-                })
+                .keys()
+                .map(|col| format!("{} = ?", quote_ident(col)))
                 .collect::<Vec<_>>()
                 .join(", ");
-            Ok(format!(
-                "UPDATE {} SET {} WHERE {}",
-                quote_ident(table),
-                set_clause,
-                where_clause
+            let mut params: Vec<SqliteParam> = data.values().map(json_value_to_param).collect();
+            params.extend(where_params);
+            Ok((
+                format!(
+                    "UPDATE {} SET {} WHERE {}",
+                    quote_ident(table),
+                    set_clause,
+                    where_clause
+                ),
+                params,
             ))
         }
         BatchOperation::Delete { table, id } => {
             validate_table_ref(state, table)?;
-            let where_clause = build_where_by_id_ref(state, table, id).await?;
-            Ok(format!(
-                "DELETE FROM {} WHERE {}",
-                quote_ident(table),
-                where_clause
+            let (where_clause, params) = build_where_by_id_ref(state, table, id).await?;
+            Ok((
+                format!("DELETE FROM {} WHERE {}", quote_ident(table), where_clause),
+                params,
             ))
         }
     }
 }
 
-async fn build_where_by_id(state: &RestApiState, table: &str, id: &str) -> Result<String> {
+async fn build_where_by_id(
+    state: &RestApiState,
+    table: &str,
+    id: &str,
+) -> Result<(String, Vec<SqliteParam>)> {
     build_where_by_id_ref(state, table, id).await
 }
 
-async fn build_where_by_id_ref(state: &RestApiState, table: &str, id: &str) -> Result<String> {
+async fn build_where_by_id_ref(
+    state: &RestApiState,
+    table: &str,
+    id: &str,
+) -> Result<(String, Vec<SqliteParam>)> {
     let key_columns = if let Some(found) = state.table_keys.iter().find(|k| k.table == table) {
         found.key_columns.clone()
     } else {
@@ -331,17 +353,15 @@ async fn build_where_by_id_ref(state: &RestApiState, table: &str, id: &str) -> R
 
     let where_parts = key_columns
         .iter()
-        .zip(id_parts.iter())
-        .map(|(column, part)| {
-            format!(
-                "{} = {}",
-                quote_ident(column),
-                value_to_sql_literal(&Value::String((*part).to_string()))
-            )
-        })
+        .map(|column| format!("{} = ?", quote_ident(column)))
         .collect::<Vec<_>>();
 
-    Ok(where_parts.join(" AND "))
+    let params = id_parts
+        .iter()
+        .map(|part| SqliteParam::Text((*part).to_string()))
+        .collect();
+
+    Ok((where_parts.join(" AND "), params))
 }
 
 async fn detect_primary_keys(handle: &SqliteSourceHandle, table: &str) -> Result<Vec<String>> {
@@ -403,21 +423,21 @@ fn quote_ident(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\"\""))
 }
 
-fn value_to_sql_literal(value: &Value) -> String {
+fn json_value_to_param(value: &Value) -> SqliteParam {
     match value {
-        Value::Null => "NULL".to_string(),
-        Value::Bool(v) => {
-            if *v {
-                "1".to_string()
+        Value::Null => SqliteParam::Null,
+        Value::Bool(v) => SqliteParam::Bool(*v),
+        Value::Number(v) => {
+            if let Some(i) = v.as_i64() {
+                SqliteParam::Integer(i)
+            } else if let Some(f) = v.as_f64() {
+                SqliteParam::Real(f)
             } else {
-                "0".to_string()
+                SqliteParam::Text(v.to_string())
             }
         }
-        Value::Number(v) => v.to_string(),
-        Value::String(v) => format!("'{}'", v.replace('\'', "''")),
-        Value::Array(_) | Value::Object(_) => {
-            format!("'{}'", value.to_string().replace('\'', "''"))
-        }
+        Value::String(v) => SqliteParam::Text(v.clone()),
+        Value::Array(_) | Value::Object(_) => SqliteParam::Text(value.to_string()),
     }
 }
 
@@ -441,19 +461,39 @@ mod tests {
     }
 
     #[test]
-    fn value_to_sql_literal_handles_core_types() {
-        assert_eq!(value_to_sql_literal(&Value::Null), "NULL");
-        assert_eq!(value_to_sql_literal(&Value::Bool(true)), "1");
-        assert_eq!(value_to_sql_literal(&Value::Bool(false)), "0");
-        assert_eq!(value_to_sql_literal(&Value::Number(42.into())), "42");
-        assert_eq!(
-            value_to_sql_literal(&Value::String("O'Reilly".to_string())),
-            "'O''Reilly'"
-        );
-        assert_eq!(
-            value_to_sql_literal(&serde_json::json!({"x": "y"})),
-            "'{\"x\":\"y\"}'"
-        );
+    fn json_value_to_param_handles_core_types() {
+        assert!(matches!(
+            json_value_to_param(&Value::Null),
+            SqliteParam::Null
+        ));
+        assert!(matches!(
+            json_value_to_param(&Value::Bool(true)),
+            SqliteParam::Bool(true)
+        ));
+        assert!(matches!(
+            json_value_to_param(&Value::Bool(false)),
+            SqliteParam::Bool(false)
+        ));
+        assert!(matches!(
+            json_value_to_param(&Value::Number(42.into())),
+            SqliteParam::Integer(42)
+        ));
+        match json_value_to_param(&Value::String("hello".to_string())) {
+            SqliteParam::Text(s) => assert_eq!(s, "hello"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+        match json_value_to_param(&serde_json::json!({"x": "y"})) {
+            SqliteParam::Text(s) => assert!(s.contains("\"x\"")),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_value_to_param_handles_strings_with_quotes() {
+        match json_value_to_param(&Value::String("O'Reilly".to_string())) {
+            SqliteParam::Text(s) => assert_eq!(s, "O'Reilly"),
+            other => panic!("expected Text, got {other:?}"),
+        }
     }
 
     #[test]

--- a/components/sources/sqlite/src/thread.rs
+++ b/components/sources/sqlite/src/thread.rs
@@ -1,0 +1,678 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{anyhow, Result};
+use base64::Engine;
+use rusqlite::hooks::{Action, PreUpdateCase};
+use rusqlite::types::ValueRef;
+use rusqlite::{Connection, OpenFlags};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+use tokio::sync::{mpsc, oneshot};
+
+pub type JsonRow = serde_json::Map<String, Value>;
+
+#[derive(Debug)]
+pub enum SqliteCommand {
+    Execute {
+        sql: String,
+        response_tx: oneshot::Sender<Result<usize>>,
+    },
+    ExecuteBatch {
+        sql: String,
+        response_tx: oneshot::Sender<Result<()>>,
+    },
+    QueryRows {
+        sql: String,
+        response_tx: oneshot::Sender<Result<Vec<JsonRow>>>,
+    },
+    BeginTransaction {
+        response_tx: oneshot::Sender<Result<()>>,
+    },
+    CommitTransaction {
+        response_tx: oneshot::Sender<Result<()>>,
+    },
+    RollbackTransaction {
+        response_tx: oneshot::Sender<Result<()>>,
+    },
+    Shutdown,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChangeEvent {
+    pub action: Action,
+    pub table: String,
+    pub old_values: Option<Vec<(String, Value)>>,
+    pub new_values: Option<Vec<(String, Value)>>,
+    pub old_row_id: Option<i64>,
+    pub new_row_id: Option<i64>,
+    pub table_pk_columns: Vec<String>,
+    pub timestamp_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct SqliteThreadConfig {
+    pub path: Option<String>,
+    pub tables: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct TableSchema {
+    columns: Vec<String>,
+    pk_columns: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+struct TransactionBuffer {
+    events: Vec<ChangeEvent>,
+    savepoint_markers: Vec<(String, usize)>,
+}
+
+impl TransactionBuffer {
+    fn push(&mut self, event: ChangeEvent) {
+        self.events.push(event);
+    }
+
+    fn begin_savepoint(&mut self, name: String) {
+        self.savepoint_markers.push((name, self.events.len()));
+    }
+
+    fn rollback_to_savepoint(&mut self, name: &str) {
+        if let Some(index) = self
+            .savepoint_markers
+            .iter()
+            .rposition(|(marker_name, _)| marker_name.eq_ignore_ascii_case(name))
+        {
+            let marker = self.savepoint_markers[index].1;
+            self.events.truncate(marker);
+            self.savepoint_markers.truncate(index + 1);
+        }
+    }
+
+    fn release_savepoint(&mut self, name: &str) {
+        if let Some(index) = self
+            .savepoint_markers
+            .iter()
+            .rposition(|(marker_name, _)| marker_name.eq_ignore_ascii_case(name))
+        {
+            self.savepoint_markers.remove(index);
+        }
+    }
+
+    fn take_all(&mut self) -> Vec<ChangeEvent> {
+        self.savepoint_markers.clear();
+        std::mem::take(&mut self.events)
+    }
+
+    fn clear(&mut self) {
+        self.events.clear();
+        self.savepoint_markers.clear();
+    }
+}
+
+#[derive(Debug, Clone)]
+enum SavepointCommand {
+    Savepoint(String),
+    RollbackTo(String),
+    Release(String),
+}
+
+pub fn run_sqlite_thread(
+    config: SqliteThreadConfig,
+    mut command_rx: mpsc::UnboundedReceiver<SqliteCommand>,
+    event_tx: mpsc::UnboundedSender<ChangeEvent>,
+) -> Result<()> {
+    let conn = if let Some(path) = config.path {
+        Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE,
+        )?
+    } else {
+        Connection::open_in_memory()?
+    };
+
+    let allowed_tables = config
+        .tables
+        .map(|tables| tables.into_iter().collect::<HashSet<_>>());
+    let schema_cache: Arc<Mutex<HashMap<String, TableSchema>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    let tx_buffer = Arc::new(Mutex::new(TransactionBuffer::default()));
+
+    {
+        let mut cache = schema_cache
+            .lock()
+            .map_err(|_| anyhow!("schema cache poisoned"))?;
+        refresh_schema_cache(&conn, &mut cache, allowed_tables.as_ref())?;
+    }
+
+    let schema_cache_pre = Arc::clone(&schema_cache);
+    let tx_buffer_pre = Arc::clone(&tx_buffer);
+    let allowed_tables_pre = allowed_tables.clone();
+
+    conn.preupdate_hook(Some(
+        move |action: Action, db_name: &str, table_name: &str, case: &PreUpdateCase| {
+            if db_name != "main" {
+                return;
+            }
+
+            if let Some(allowed) = &allowed_tables_pre {
+                if !allowed.contains(table_name) {
+                    return;
+                }
+            }
+
+            let schema = schema_cache_pre
+                .lock()
+                .ok()
+                .and_then(|cache| cache.get(table_name).cloned())
+                .unwrap_or_default();
+
+            let mut old_values: Option<Vec<(String, Value)>> = None;
+            let mut new_values: Option<Vec<(String, Value)>> = None;
+            let mut old_row_id = None;
+            let mut new_row_id = None;
+
+            match case {
+                PreUpdateCase::Insert(accessor) => {
+                    let mut values = Vec::new();
+                    for idx in 0..accessor.get_column_count() {
+                        if let Ok(v) = accessor.get_new_column_value(idx) {
+                            values.push((column_name(&schema, idx), value_ref_to_json(v)));
+                        }
+                    }
+                    new_values = Some(values);
+                    new_row_id = Some(accessor.get_new_row_id());
+                }
+                PreUpdateCase::Delete(accessor) => {
+                    let mut values = Vec::new();
+                    for idx in 0..accessor.get_column_count() {
+                        if let Ok(v) = accessor.get_old_column_value(idx) {
+                            values.push((column_name(&schema, idx), value_ref_to_json(v)));
+                        }
+                    }
+                    old_values = Some(values);
+                    old_row_id = Some(accessor.get_old_row_id());
+                }
+                PreUpdateCase::Update {
+                    old_value_accessor,
+                    new_value_accessor,
+                } => {
+                    let mut old = Vec::new();
+                    let mut new = Vec::new();
+                    for idx in 0..old_value_accessor.get_column_count() {
+                        let name = column_name(&schema, idx);
+                        if let Ok(v) = old_value_accessor.get_old_column_value(idx) {
+                            old.push((name.clone(), value_ref_to_json(v)));
+                        }
+                        if let Ok(v) = new_value_accessor.get_new_column_value(idx) {
+                            new.push((name, value_ref_to_json(v)));
+                        }
+                    }
+                    old_values = Some(old);
+                    new_values = Some(new);
+                    old_row_id = Some(old_value_accessor.get_old_row_id());
+                    new_row_id = Some(new_value_accessor.get_new_row_id());
+                }
+                PreUpdateCase::Unknown => {}
+            }
+
+            let event = ChangeEvent {
+                action,
+                table: table_name.to_string(),
+                old_values,
+                new_values,
+                old_row_id,
+                new_row_id,
+                table_pk_columns: schema.pk_columns,
+                timestamp_ms: chrono::Utc::now().timestamp_millis() as u64,
+            };
+
+            if let Ok(mut buffer) = tx_buffer_pre.lock() {
+                buffer.push(event);
+            }
+        },
+    ));
+
+    let tx_buffer_commit = Arc::clone(&tx_buffer);
+    let event_tx_commit = event_tx.clone();
+    conn.commit_hook(Some(move || {
+        if let Ok(mut buffer) = tx_buffer_commit.lock() {
+            for event in buffer.take_all() {
+                let _ = event_tx_commit.send(event);
+            }
+        }
+        false
+    }));
+
+    let tx_buffer_rollback = Arc::clone(&tx_buffer);
+    conn.rollback_hook(Some(move || {
+        if let Ok(mut buffer) = tx_buffer_rollback.lock() {
+            buffer.clear();
+        }
+    }));
+
+    while let Some(command) = command_rx.blocking_recv() {
+        match command {
+            SqliteCommand::Execute { sql, response_tx } => {
+                let savepoint_command = parse_savepoint_command(sql.as_str());
+                let result = conn.execute(sql.as_str(), []).map_err(anyhow::Error::from);
+                if result.is_ok() {
+                    if let Some(command) = savepoint_command {
+                        apply_savepoint_command(&tx_buffer, command);
+                    }
+                    let _ = refresh_schema_cache_for_runtime(
+                        &conn,
+                        &schema_cache,
+                        allowed_tables.as_ref(),
+                    );
+                }
+                let _ = response_tx.send(result);
+            }
+            SqliteCommand::ExecuteBatch { sql, response_tx } => {
+                let result = conn
+                    .execute_batch(sql.as_str())
+                    .map_err(anyhow::Error::from);
+                if result.is_ok() {
+                    let _ = refresh_schema_cache_for_runtime(
+                        &conn,
+                        &schema_cache,
+                        allowed_tables.as_ref(),
+                    );
+                }
+                let _ = response_tx.send(result);
+            }
+            SqliteCommand::QueryRows { sql, response_tx } => {
+                let _ = response_tx.send(query_rows(&conn, sql.as_str()));
+            }
+            SqliteCommand::BeginTransaction { response_tx } => {
+                let result = conn
+                    .execute("BEGIN TRANSACTION", [])
+                    .map(|_| ())
+                    .map_err(anyhow::Error::from);
+                let _ = response_tx.send(result);
+            }
+            SqliteCommand::CommitTransaction { response_tx } => {
+                let result = conn
+                    .execute("COMMIT", [])
+                    .map(|_| ())
+                    .map_err(anyhow::Error::from);
+                let _ = response_tx.send(result);
+            }
+            SqliteCommand::RollbackTransaction { response_tx } => {
+                let result = conn
+                    .execute("ROLLBACK", [])
+                    .map(|_| ())
+                    .map_err(anyhow::Error::from);
+                let _ = response_tx.send(result);
+            }
+            SqliteCommand::Shutdown => break,
+        }
+    }
+
+    Ok(())
+}
+
+fn refresh_schema_cache_for_runtime(
+    conn: &Connection,
+    schema_cache: &Arc<Mutex<HashMap<String, TableSchema>>>,
+    allowed_tables: Option<&HashSet<String>>,
+) -> Result<()> {
+    let mut cache = schema_cache
+        .lock()
+        .map_err(|_| anyhow!("schema cache poisoned"))?;
+    refresh_schema_cache(conn, &mut cache, allowed_tables)
+}
+
+fn refresh_schema_cache(
+    conn: &Connection,
+    cache: &mut HashMap<String, TableSchema>,
+    allowed_tables: Option<&HashSet<String>>,
+) -> Result<()> {
+    let mut stmt = conn.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    )?;
+    let table_names = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    for table in table_names {
+        if let Some(allowed) = allowed_tables {
+            if !allowed.contains(&table) {
+                continue;
+            }
+        }
+        let schema = load_table_schema(conn, &table)?;
+        cache.insert(table, schema);
+    }
+    Ok(())
+}
+
+fn load_table_schema(conn: &Connection, table: &str) -> Result<TableSchema> {
+    let escaped = table.replace('\'', "''");
+    let sql = format!("PRAGMA table_info('{escaped}')");
+    let mut stmt = conn.prepare(sql.as_str())?;
+
+    let mut columns = Vec::new();
+    let mut pk_pairs: Vec<(i64, String)> = Vec::new();
+
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        let pk_order: i64 = row.get(5)?;
+        columns.push(name.clone());
+        if pk_order > 0 {
+            pk_pairs.push((pk_order, name));
+        }
+    }
+
+    pk_pairs.sort_by_key(|(order, _)| *order);
+    let pk_columns = pk_pairs
+        .into_iter()
+        .map(|(_, name)| name)
+        .collect::<Vec<_>>();
+
+    Ok(TableSchema {
+        columns,
+        pk_columns,
+    })
+}
+
+fn column_name(schema: &TableSchema, index: i32) -> String {
+    schema
+        .columns
+        .get(index as usize)
+        .cloned()
+        .unwrap_or_else(|| format!("col_{index}"))
+}
+
+fn value_ref_to_json(value: ValueRef<'_>) -> Value {
+    match value {
+        ValueRef::Null => Value::Null,
+        ValueRef::Integer(v) => Value::Number(v.into()),
+        ValueRef::Real(v) => serde_json::Number::from_f64(v)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+        ValueRef::Text(v) => Value::String(String::from_utf8_lossy(v).to_string()),
+        ValueRef::Blob(v) => Value::String(base64::engine::general_purpose::STANDARD.encode(v)),
+    }
+}
+
+fn query_rows(conn: &Connection, sql: &str) -> Result<Vec<JsonRow>> {
+    let mut stmt = conn.prepare(sql)?;
+    let columns = stmt
+        .column_names()
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect::<Vec<_>>();
+
+    let mut rows = stmt.query([])?;
+    let mut result = Vec::new();
+    while let Some(row) = rows.next()? {
+        let mut item = serde_json::Map::new();
+        for (index, name) in columns.iter().enumerate() {
+            let value = row.get_ref(index)?;
+            item.insert(name.clone(), value_ref_to_json(value));
+        }
+        result.push(item);
+    }
+    Ok(result)
+}
+
+fn parse_savepoint_command(sql: &str) -> Option<SavepointCommand> {
+    let trimmed = sql.trim().trim_end_matches(';').trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if let Some(name) = lower.strip_prefix("savepoint ") {
+        return extract_identifier(trimmed, name.len()).map(SavepointCommand::Savepoint);
+    }
+    if let Some(name) = lower.strip_prefix("rollback to savepoint ") {
+        return extract_identifier(trimmed, name.len()).map(SavepointCommand::RollbackTo);
+    }
+    if let Some(name) = lower.strip_prefix("rollback to ") {
+        return extract_identifier(trimmed, name.len()).map(SavepointCommand::RollbackTo);
+    }
+    if let Some(name) = lower.strip_prefix("release savepoint ") {
+        return extract_identifier(trimmed, name.len()).map(SavepointCommand::Release);
+    }
+    if let Some(name) = lower.strip_prefix("release ") {
+        return extract_identifier(trimmed, name.len()).map(SavepointCommand::Release);
+    }
+    None
+}
+
+fn extract_identifier(original_sql: &str, suffix_len: usize) -> Option<String> {
+    let sql = original_sql.trim().trim_end_matches(';').trim();
+    let start = sql.len().checked_sub(suffix_len)?;
+    let remainder = sql.get(start..)?.trim();
+    let token = remainder
+        .split_whitespace()
+        .next()
+        .map(|value| value.trim_matches('"').trim_matches('\'').to_string())?;
+    if token.is_empty() {
+        None
+    } else {
+        Some(token)
+    }
+}
+
+fn apply_savepoint_command(tx_buffer: &Arc<Mutex<TransactionBuffer>>, command: SavepointCommand) {
+    if let Ok(mut buffer) = tx_buffer.lock() {
+        match command {
+            SavepointCommand::Savepoint(name) => buffer.begin_savepoint(name),
+            SavepointCommand::RollbackTo(name) => buffer.rollback_to_savepoint(&name),
+            SavepointCommand::Release(name) => buffer.release_savepoint(&name),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{timeout, Duration};
+
+    fn start_thread() -> (
+        mpsc::UnboundedSender<SqliteCommand>,
+        mpsc::UnboundedReceiver<ChangeEvent>,
+        std::thread::JoinHandle<()>,
+    ) {
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let join_handle = std::thread::spawn(move || {
+            run_sqlite_thread(
+                SqliteThreadConfig {
+                    path: None,
+                    tables: None,
+                },
+                command_rx,
+                event_tx,
+            )
+            .expect("sqlite thread failed");
+        });
+        (command_tx, event_rx, join_handle)
+    }
+
+    async fn exec(command_tx: &mpsc::UnboundedSender<SqliteCommand>, sql: &str) -> Result<usize> {
+        let (response_tx, response_rx) = oneshot::channel();
+        command_tx
+            .send(SqliteCommand::Execute {
+                sql: sql.to_string(),
+                response_tx,
+            })
+            .expect("failed to send execute command");
+        response_rx.await.expect("response channel closed")
+    }
+
+    async fn begin_tx(command_tx: &mpsc::UnboundedSender<SqliteCommand>) {
+        let (response_tx, response_rx) = oneshot::channel();
+        command_tx
+            .send(SqliteCommand::BeginTransaction { response_tx })
+            .expect("failed to send begin transaction");
+        response_rx
+            .await
+            .expect("begin response closed")
+            .expect("begin failed");
+    }
+
+    async fn commit_tx(command_tx: &mpsc::UnboundedSender<SqliteCommand>) {
+        let (response_tx, response_rx) = oneshot::channel();
+        command_tx
+            .send(SqliteCommand::CommitTransaction { response_tx })
+            .expect("failed to send commit transaction");
+        response_rx
+            .await
+            .expect("commit response closed")
+            .expect("commit failed");
+    }
+
+    async fn rollback_tx(command_tx: &mpsc::UnboundedSender<SqliteCommand>) {
+        let (response_tx, response_rx) = oneshot::channel();
+        command_tx
+            .send(SqliteCommand::RollbackTransaction { response_tx })
+            .expect("failed to send rollback transaction");
+        response_rx
+            .await
+            .expect("rollback response closed")
+            .expect("rollback failed");
+    }
+
+    #[tokio::test]
+    async fn committed_transaction_dispatches_events() {
+        let (command_tx, mut event_rx, join_handle) = start_thread();
+
+        exec(
+            &command_tx,
+            "CREATE TABLE sensors(id INTEGER PRIMARY KEY, name TEXT)",
+        )
+        .await
+        .expect("create table failed");
+
+        begin_tx(&command_tx).await;
+        exec(&command_tx, "INSERT INTO sensors(id, name) VALUES (1, 'a')")
+            .await
+            .expect("insert 1 failed");
+        exec(&command_tx, "INSERT INTO sensors(id, name) VALUES (2, 'b')")
+            .await
+            .expect("insert 2 failed");
+        commit_tx(&command_tx).await;
+
+        let first = timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .expect("timeout waiting first event")
+            .expect("missing first event");
+        let second = timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .expect("timeout waiting second event")
+            .expect("missing second event");
+
+        assert_eq!(first.action, Action::SQLITE_INSERT);
+        assert_eq!(second.action, Action::SQLITE_INSERT);
+
+        command_tx
+            .send(SqliteCommand::Shutdown)
+            .expect("failed to send shutdown");
+        join_handle.join().expect("thread join failed");
+    }
+
+    #[tokio::test]
+    async fn rolled_back_transaction_discards_events() {
+        let (command_tx, mut event_rx, join_handle) = start_thread();
+
+        exec(
+            &command_tx,
+            "CREATE TABLE sensors(id INTEGER PRIMARY KEY, name TEXT)",
+        )
+        .await
+        .expect("create table failed");
+
+        begin_tx(&command_tx).await;
+        exec(&command_tx, "INSERT INTO sensors(id, name) VALUES (1, 'a')")
+            .await
+            .expect("insert failed");
+        rollback_tx(&command_tx).await;
+
+        let receive = timeout(Duration::from_millis(200), event_rx.recv()).await;
+        assert!(receive.is_err(), "expected no event after rollback");
+
+        command_tx
+            .send(SqliteCommand::Shutdown)
+            .expect("failed to send shutdown");
+        join_handle.join().expect("thread join failed");
+    }
+
+    #[tokio::test]
+    async fn rollback_to_savepoint_discards_partial_events() {
+        let (command_tx, mut event_rx, join_handle) = start_thread();
+
+        exec(
+            &command_tx,
+            "CREATE TABLE sensors(id INTEGER PRIMARY KEY, name TEXT)",
+        )
+        .await
+        .expect("create table failed");
+
+        begin_tx(&command_tx).await;
+        exec(&command_tx, "INSERT INTO sensors(id, name) VALUES (1, 'a')")
+            .await
+            .expect("insert 1 failed");
+        exec(&command_tx, "SAVEPOINT s1")
+            .await
+            .expect("savepoint failed");
+        exec(&command_tx, "INSERT INTO sensors(id, name) VALUES (2, 'b')")
+            .await
+            .expect("insert 2 failed");
+        exec(&command_tx, "ROLLBACK TO SAVEPOINT s1")
+            .await
+            .expect("rollback savepoint failed");
+        exec(&command_tx, "INSERT INTO sensors(id, name) VALUES (3, 'c')")
+            .await
+            .expect("insert 3 failed");
+        commit_tx(&command_tx).await;
+
+        let first = timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .expect("timeout waiting first event")
+            .expect("missing first event");
+        let second = timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .expect("timeout waiting second event")
+            .expect("missing second event");
+        let third = timeout(Duration::from_millis(200), event_rx.recv()).await;
+
+        let first_id = first
+            .new_values
+            .as_ref()
+            .and_then(|values| values.iter().find(|(k, _)| k == "id").map(|(_, v)| v))
+            .cloned()
+            .unwrap_or_default();
+        let second_id = second
+            .new_values
+            .as_ref()
+            .and_then(|values| values.iter().find(|(k, _)| k == "id").map(|(_, v)| v))
+            .cloned()
+            .unwrap_or_default();
+
+        assert_eq!(first_id, serde_json::json!(1));
+        assert_eq!(second_id, serde_json::json!(3));
+        assert!(third.is_err(), "expected no third committed event");
+
+        command_tx
+            .send(SqliteCommand::Shutdown)
+            .expect("failed to send shutdown");
+        join_handle.join().expect("thread join failed");
+    }
+}

--- a/components/sources/sqlite/src/thread.rs
+++ b/components/sources/sqlite/src/thread.rs
@@ -30,12 +30,22 @@ pub enum SqliteCommand {
         sql: String,
         response_tx: oneshot::Sender<Result<usize>>,
     },
+    ExecuteParameterized {
+        sql: String,
+        params: Vec<SqliteParam>,
+        response_tx: oneshot::Sender<Result<usize>>,
+    },
     ExecuteBatch {
         sql: String,
         response_tx: oneshot::Sender<Result<()>>,
     },
     QueryRows {
         sql: String,
+        response_tx: oneshot::Sender<Result<Vec<JsonRow>>>,
+    },
+    QueryRowsParameterized {
+        sql: String,
+        params: Vec<SqliteParam>,
         response_tx: oneshot::Sender<Result<Vec<JsonRow>>>,
     },
     BeginTransaction {
@@ -48,6 +58,16 @@ pub enum SqliteCommand {
         response_tx: oneshot::Sender<Result<()>>,
     },
     Shutdown,
+}
+
+/// A parameter value for parameterized SQL execution.
+#[derive(Debug, Clone)]
+pub enum SqliteParam {
+    Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Bool(bool),
 }
 
 #[derive(Debug, Clone)]
@@ -280,6 +300,27 @@ pub fn run_sqlite_thread(
                 }
                 let _ = response_tx.send(result);
             }
+            SqliteCommand::ExecuteParameterized {
+                sql,
+                params,
+                response_tx,
+            } => {
+                let rusqlite_params: Vec<Box<dyn rusqlite::types::ToSql>> =
+                    params.iter().map(sqlite_param_to_rusqlite).collect();
+                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                    rusqlite_params.iter().map(|p| p.as_ref()).collect();
+                let result = conn
+                    .execute(sql.as_str(), param_refs.as_slice())
+                    .map_err(anyhow::Error::from);
+                if result.is_ok() {
+                    let _ = refresh_schema_cache_for_runtime(
+                        &conn,
+                        &schema_cache,
+                        allowed_tables.as_ref(),
+                    );
+                }
+                let _ = response_tx.send(result);
+            }
             SqliteCommand::ExecuteBatch { sql, response_tx } => {
                 let result = conn
                     .execute_batch(sql.as_str())
@@ -294,7 +335,18 @@ pub fn run_sqlite_thread(
                 let _ = response_tx.send(result);
             }
             SqliteCommand::QueryRows { sql, response_tx } => {
-                let _ = response_tx.send(query_rows(&conn, sql.as_str()));
+                let _ = response_tx.send(query_rows(&conn, sql.as_str(), &[]));
+            }
+            SqliteCommand::QueryRowsParameterized {
+                sql,
+                params,
+                response_tx,
+            } => {
+                let rusqlite_params: Vec<Box<dyn rusqlite::types::ToSql>> =
+                    params.iter().map(sqlite_param_to_rusqlite).collect();
+                let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                    rusqlite_params.iter().map(|p| p.as_ref()).collect();
+                let _ = response_tx.send(query_rows(&conn, sql.as_str(), param_refs.as_slice()));
             }
             SqliteCommand::BeginTransaction { response_tx } => {
                 let result = conn
@@ -394,7 +446,13 @@ fn column_name(schema: &TableSchema, index: i32) -> String {
         .columns
         .get(index as usize)
         .cloned()
-        .unwrap_or_else(|| format!("col_{index}"))
+        .unwrap_or_else(|| {
+            log::warn!(
+                "Column index {index} out of range (schema has {} columns), using fallback name",
+                schema.columns.len()
+            );
+            format!("col_{index}")
+        })
 }
 
 fn value_ref_to_json(value: ValueRef<'_>) -> Value {
@@ -409,7 +467,21 @@ fn value_ref_to_json(value: ValueRef<'_>) -> Value {
     }
 }
 
-fn query_rows(conn: &Connection, sql: &str) -> Result<Vec<JsonRow>> {
+fn sqlite_param_to_rusqlite(p: &SqliteParam) -> Box<dyn rusqlite::types::ToSql> {
+    match p {
+        SqliteParam::Null => Box::new(rusqlite::types::Null) as Box<dyn rusqlite::types::ToSql>,
+        SqliteParam::Integer(v) => Box::new(*v),
+        SqliteParam::Real(v) => Box::new(*v),
+        SqliteParam::Text(v) => Box::new(v.clone()),
+        SqliteParam::Bool(v) => Box::new(*v),
+    }
+}
+
+fn query_rows(
+    conn: &Connection,
+    sql: &str,
+    params: &[&dyn rusqlite::types::ToSql],
+) -> Result<Vec<JsonRow>> {
     let mut stmt = conn.prepare(sql)?;
     let columns = stmt
         .column_names()
@@ -417,7 +489,7 @@ fn query_rows(conn: &Connection, sql: &str) -> Result<Vec<JsonRow>> {
         .map(|name| (*name).to_string())
         .collect::<Vec<_>>();
 
-    let mut rows = stmt.query([])?;
+    let mut rows = stmt.query(params)?;
     let mut result = Vec::new();
     while let Some(row) = rows.next()? {
         let mut item = serde_json::Map::new();

--- a/components/sources/sqlite/tests/integration_test.rs
+++ b/components/sources/sqlite/tests/integration_test.rs
@@ -1,0 +1,508 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use drasi_bootstrap_sqlite::{SqliteBootstrapProvider, TableKeyConfig as BootstrapTableKeyConfig};
+use drasi_core::models::{Element, ElementValue, SourceChange};
+use drasi_lib::channels::ResultDiff;
+use drasi_lib::config::SourceSubscriptionSettings;
+use drasi_lib::Source;
+use drasi_lib::{DrasiLib, Query};
+use drasi_reaction_application::subscription::{Subscription, SubscriptionOptions};
+use drasi_reaction_application::ApplicationReactionBuilder;
+use drasi_source_sqlite::{RestApiConfig, SqliteSource, TableKeyConfig};
+use reqwest::Client;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+async fn find_available_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    sleep(Duration::from_millis(50)).await;
+    port
+}
+
+fn id_matches(value: &serde_json::Value, expected: i64) -> bool {
+    value
+        .as_i64()
+        .map(|id| id == expected)
+        .or_else(|| value.as_str().map(|id| id == expected.to_string()))
+        .unwrap_or(false)
+}
+
+fn count_from_rows(rows: &[serde_json::Map<String, serde_json::Value>]) -> i64 {
+    rows.first()
+        .and_then(|row| row.get("count"))
+        .and_then(|value| {
+            value
+                .as_i64()
+                .or_else(|| value.as_str().and_then(|count| count.parse::<i64>().ok()))
+        })
+        .unwrap_or_default()
+}
+
+async fn wait_for_diff<F>(subscription: &mut Subscription, description: &str, predicate: F)
+where
+    F: Fn(&ResultDiff) -> bool,
+{
+    for _ in 0..20 {
+        if let Some(result) = subscription.recv().await {
+            if result.results.iter().any(&predicate) {
+                return;
+            }
+        }
+    }
+
+    panic!("timed out waiting for {description}");
+}
+
+async fn wait_for_query_results<F>(
+    core: &Arc<DrasiLib>,
+    query_id: &str,
+    description: &str,
+    predicate: F,
+) where
+    F: Fn(&[serde_json::Value]) -> bool,
+{
+    for _ in 0..20 {
+        let rows = core.get_query_results(query_id).await.unwrap();
+        if predicate(&rows) {
+            return;
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    panic!("timed out waiting for {description}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn sqlite_handle_create_update_delete_flow() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("handle.db");
+
+    let source = SqliteSource::builder("sqlite-handle-source")
+        .with_path(db_path.to_string_lossy().to_string())
+        .with_table_keys(vec![TableKeyConfig {
+            table: "sensors".to_string(),
+            key_columns: vec!["id".to_string()],
+        }])
+        .build()
+        .unwrap();
+    let handle = source.handle();
+
+    let query = Query::cypher("sqlite-handle-query")
+        .query("MATCH (s:sensors) RETURN s.id AS id, s.name AS name, s.temp AS temp")
+        .from_source("sqlite-handle-source")
+        .auto_start(true)
+        .build();
+
+    let (reaction, reaction_handle) = ApplicationReactionBuilder::new("sqlite-handle-reaction")
+        .with_query("sqlite-handle-query")
+        .build();
+
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("sqlite-handle-core")
+            .with_source(source)
+            .with_query(query)
+            .with_reaction(reaction)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    core.start().await.unwrap();
+    sleep(Duration::from_millis(200)).await;
+
+    let mut subscription = reaction_handle
+        .subscribe_with_options(SubscriptionOptions::default().with_timeout(Duration::from_secs(1)))
+        .await
+        .unwrap();
+
+    handle
+        .execute("CREATE TABLE sensors(id INTEGER PRIMARY KEY, name TEXT, temp REAL)")
+        .await
+        .unwrap();
+
+    handle
+        .execute("INSERT INTO sensors(id, name, temp) VALUES (1, 'sensor-a', 31.5)")
+        .await
+        .unwrap();
+    wait_for_diff(&mut subscription, "insert add diff", |diff| match diff {
+        ResultDiff::Add { data } => data.get("name") == Some(&json!("sensor-a")),
+        _ => false,
+    })
+    .await;
+
+    handle
+        .execute("UPDATE sensors SET name = 'sensor-a-updated', temp = 33.1 WHERE id = 1")
+        .await
+        .unwrap();
+    wait_for_diff(&mut subscription, "update diff", |diff| match diff {
+        ResultDiff::Update { after, .. } => {
+            after.get("name") == Some(&json!("sensor-a-updated"))
+                && id_matches(after.get("id").unwrap_or(&serde_json::Value::Null), 1)
+        }
+        _ => false,
+    })
+    .await;
+
+    handle
+        .execute("DELETE FROM sensors WHERE id = 1")
+        .await
+        .unwrap();
+    wait_for_diff(&mut subscription, "delete diff", |diff| match diff {
+        ResultDiff::Delete { data } => {
+            data.get("name") == Some(&json!("sensor-a-updated"))
+                && id_matches(data.get("id").unwrap_or(&serde_json::Value::Null), 1)
+        }
+        _ => false,
+    })
+    .await;
+
+    core.stop().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn sqlite_rest_crud_and_batch_flow() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("rest.db");
+    let rest_port = find_available_port().await;
+
+    let source = SqliteSource::builder("sqlite-rest-source")
+        .with_path(db_path.to_string_lossy().to_string())
+        .with_table_keys(vec![TableKeyConfig {
+            table: "sensors".to_string(),
+            key_columns: vec!["id".to_string()],
+        }])
+        .with_rest_api(RestApiConfig {
+            host: "127.0.0.1".to_string(),
+            port: rest_port,
+        })
+        .build()
+        .unwrap();
+    let handle = source.handle();
+
+    let query = Query::cypher("sqlite-rest-query")
+        .query("MATCH (s:sensors) RETURN s.id AS id, s.name AS name, s.temp AS temp")
+        .from_source("sqlite-rest-source")
+        .auto_start(true)
+        .build();
+
+    let (reaction, reaction_handle) = ApplicationReactionBuilder::new("sqlite-rest-reaction")
+        .with_query("sqlite-rest-query")
+        .build();
+
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("sqlite-rest-core")
+            .with_source(source)
+            .with_query(query)
+            .with_reaction(reaction)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    core.start().await.unwrap();
+    sleep(Duration::from_millis(250)).await;
+
+    handle
+        .execute("CREATE TABLE sensors(id INTEGER PRIMARY KEY, name TEXT, temp REAL)")
+        .await
+        .unwrap();
+
+    let mut subscription = reaction_handle
+        .subscribe_with_options(SubscriptionOptions::default().with_timeout(Duration::from_secs(1)))
+        .await
+        .unwrap();
+    let client = Client::new();
+    let base = format!("http://127.0.0.1:{rest_port}");
+
+    let insert_response = client
+        .post(format!("{base}/api/tables/sensors"))
+        .json(&json!({"id": 10, "name": "rest-insert", "temp": 40.0}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(insert_response.status(), 200);
+    wait_for_diff(
+        &mut subscription,
+        "rest insert add diff",
+        |diff| match diff {
+            ResultDiff::Add { data } => data.get("name") == Some(&json!("rest-insert")),
+            _ => false,
+        },
+    )
+    .await;
+
+    let update_response = client
+        .put(format!("{base}/api/tables/sensors/10"))
+        .json(&json!({"name": "rest-updated", "temp": 41.5}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(update_response.status(), 200);
+    wait_for_diff(&mut subscription, "rest update diff", |diff| match diff {
+        ResultDiff::Update { after, .. } => after.get("name") == Some(&json!("rest-updated")),
+        _ => false,
+    })
+    .await;
+
+    let delete_response = client
+        .delete(format!("{base}/api/tables/sensors/10"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(delete_response.status(), 200);
+    wait_for_diff(&mut subscription, "rest delete diff", |diff| match diff {
+        ResultDiff::Delete { data } => data.get("name") == Some(&json!("rest-updated")),
+        _ => false,
+    })
+    .await;
+
+    let failed_batch = client
+        .post(format!("{base}/api/batch"))
+        .json(&json!({
+            "operations": [
+                {"op": "insert", "table": "sensors", "data": {"id": 20, "name": "rollback-me", "temp": 50.0}},
+                {"op": "update", "table": "sensors", "id": "20", "data": {"missing_column": 1}}
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(failed_batch.status(), 500);
+
+    let rolled_back_rows = handle
+        .query("SELECT COUNT(*) AS count FROM sensors WHERE id = 20")
+        .await
+        .unwrap();
+    assert_eq!(count_from_rows(&rolled_back_rows), 0);
+
+    let successful_batch = client
+        .post(format!("{base}/api/batch"))
+        .json(&json!({
+            "operations": [
+                {"op": "insert", "table": "sensors", "data": {"id": 30, "name": "batch-a", "temp": 60.0}},
+                {"op": "insert", "table": "sensors", "data": {"id": 31, "name": "batch-b", "temp": 61.0}}
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(successful_batch.status(), 200);
+
+    wait_for_query_results(
+        &core,
+        "sqlite-rest-query",
+        "batch rows in query results",
+        |rows| {
+            let has_30 = rows
+                .iter()
+                .any(|row| row.get("id").map(|id| id_matches(id, 30)).unwrap_or(false));
+            let has_31 = rows
+                .iter()
+                .any(|row| row.get("id").map(|id| id_matches(id, 31)).unwrap_or(false));
+            has_30 && has_31
+        },
+    )
+    .await;
+
+    core.stop().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn sqlite_bootstrap_loads_existing_rows() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("bootstrap.db");
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sensors(id INTEGER PRIMARY KEY, name TEXT, temp REAL);
+            INSERT INTO sensors(id, name, temp) VALUES (1, 'bootstrap-sensor', 29.0);
+            "#,
+        )
+        .unwrap();
+    }
+
+    let bootstrap_provider = SqliteBootstrapProvider::builder()
+        .with_path(db_path.to_string_lossy().to_string())
+        .with_tables(vec!["sensors".to_string()])
+        .with_table_keys(vec![BootstrapTableKeyConfig {
+            table: "sensors".to_string(),
+            key_columns: vec!["id".to_string()],
+        }])
+        .build();
+
+    let source = SqliteSource::builder("sqlite-bootstrap-source")
+        .with_path(db_path.to_string_lossy().to_string())
+        .with_table_keys(vec![TableKeyConfig {
+            table: "sensors".to_string(),
+            key_columns: vec!["id".to_string()],
+        }])
+        .with_bootstrap_provider(bootstrap_provider)
+        .build()
+        .unwrap();
+
+    let settings = SourceSubscriptionSettings {
+        source_id: "sqlite-bootstrap-source".to_string(),
+        enable_bootstrap: true,
+        query_id: "sqlite-bootstrap-query".to_string(),
+        nodes: HashSet::from(["sensors".to_string()]),
+        relations: HashSet::new(),
+    };
+
+    let response = source.subscribe(settings).await.unwrap();
+    let mut bootstrap_rx = response
+        .bootstrap_receiver
+        .expect("missing bootstrap receiver");
+    let bootstrap_event = tokio::time::timeout(Duration::from_secs(2), bootstrap_rx.recv())
+        .await
+        .expect("timed out waiting for bootstrap event")
+        .expect("bootstrap channel closed");
+
+    assert_eq!(bootstrap_event.source_id, "sqlite-bootstrap-source");
+    match bootstrap_event.change {
+        SourceChange::Insert {
+            element: Element::Node { properties, .. },
+        } => match properties.get("name") {
+            Some(ElementValue::String(value)) => assert_eq!(value.as_ref(), "bootstrap-sensor"),
+            other => panic!("unexpected name value: {other:?}"),
+        },
+        other => panic!("unexpected bootstrap change: {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn sqlite_multi_table_changes_flow_to_queries() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("multi-table.db");
+
+    let source = SqliteSource::builder("sqlite-multi-source")
+        .with_path(db_path.to_string_lossy().to_string())
+        .with_table_keys(vec![
+            TableKeyConfig {
+                table: "sensors".to_string(),
+                key_columns: vec!["id".to_string()],
+            },
+            TableKeyConfig {
+                table: "devices".to_string(),
+                key_columns: vec!["id".to_string()],
+            },
+        ])
+        .build()
+        .unwrap();
+    let handle = source.handle();
+
+    let sensors_query = Query::cypher("sqlite-sensors-query")
+        .query("MATCH (s:sensors) RETURN s.id AS id, s.name AS name")
+        .from_source("sqlite-multi-source")
+        .auto_start(true)
+        .build();
+    let devices_query = Query::cypher("sqlite-devices-query")
+        .query("MATCH (d:devices) RETURN d.id AS id, d.name AS name")
+        .from_source("sqlite-multi-source")
+        .auto_start(true)
+        .build();
+
+    let (reaction, reaction_handle) = ApplicationReactionBuilder::new("sqlite-multi-reaction")
+        .with_queries(vec![
+            "sqlite-sensors-query".to_string(),
+            "sqlite-devices-query".to_string(),
+        ])
+        .build();
+
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("sqlite-multi-core")
+            .with_source(source)
+            .with_query(sensors_query)
+            .with_query(devices_query)
+            .with_reaction(reaction)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    core.start().await.unwrap();
+    sleep(Duration::from_millis(250)).await;
+
+    let mut subscription = reaction_handle
+        .subscribe_with_options(SubscriptionOptions::default().with_timeout(Duration::from_secs(1)))
+        .await
+        .unwrap();
+
+    handle
+        .execute_batch(
+            r#"
+            CREATE TABLE sensors(id INTEGER PRIMARY KEY, name TEXT);
+            CREATE TABLE devices(id INTEGER PRIMARY KEY, name TEXT);
+            "#,
+        )
+        .await
+        .unwrap();
+    handle
+        .execute("INSERT INTO sensors(id, name) VALUES (1, 'sensor-one')")
+        .await
+        .unwrap();
+    handle
+        .execute("INSERT INTO devices(id, name) VALUES (9, 'device-nine')")
+        .await
+        .unwrap();
+
+    let mut saw_sensor_query = false;
+    let mut saw_device_query = false;
+    for _ in 0..20 {
+        if let Some(result) = subscription.recv().await {
+            match result.query_id.as_str() {
+                "sqlite-sensors-query" => {
+                    saw_sensor_query = result.results.iter().any(|diff| match diff {
+                        ResultDiff::Add { data } => data.get("name") == Some(&json!("sensor-one")),
+                        _ => false,
+                    });
+                }
+                "sqlite-devices-query" => {
+                    saw_device_query = result.results.iter().any(|diff| match diff {
+                        ResultDiff::Add { data } => data.get("name") == Some(&json!("device-nine")),
+                        _ => false,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        if saw_sensor_query && saw_device_query {
+            break;
+        }
+    }
+
+    assert!(saw_sensor_query, "did not receive sensors query result");
+    assert!(saw_device_query, "did not receive devices query result");
+
+    core.stop().await.unwrap();
+}

--- a/components/sources/sqlite/tests/integration_test.rs
+++ b/components/sources/sqlite/tests/integration_test.rs
@@ -33,7 +33,7 @@ use tempfile::TempDir;
 use tokio::time::sleep;
 
 async fn find_available_port() -> u16 {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap(); // DevSkim: ignore DS137138
     let port = listener.local_addr().unwrap().port();
     drop(listener);
     sleep(Duration::from_millis(50)).await;
@@ -196,7 +196,7 @@ async fn sqlite_rest_crud_and_batch_flow() {
             key_columns: vec!["id".to_string()],
         }])
         .with_rest_api(RestApiConfig {
-            host: "127.0.0.1".to_string(),
+            host: "127.0.0.1".to_string(), // DevSkim: ignore DS137138
             port: rest_port,
         })
         .build()
@@ -237,7 +237,7 @@ async fn sqlite_rest_crud_and_batch_flow() {
         .await
         .unwrap();
     let client = Client::new();
-    let base = format!("http://127.0.0.1:{rest_port}");
+    let base = format!("http://127.0.0.1:{rest_port}"); // DevSkim: ignore DS137138
 
     let insert_response = client
         .post(format!("{base}/api/tables/sensors"))

--- a/components/sources/sqlite/tests/integration_test.rs
+++ b/components/sources/sqlite/tests/integration_test.rs
@@ -376,6 +376,7 @@ async fn sqlite_bootstrap_loads_existing_rows() {
         relations: HashSet::new(),
         resume_from: None,
         request_position_handle: false,
+        last_sequence: None,
     };
 
     let response = source.subscribe(settings).await.unwrap();

--- a/components/sources/sqlite/tests/integration_test.rs
+++ b/components/sources/sqlite/tests/integration_test.rs
@@ -148,7 +148,7 @@ async fn sqlite_handle_create_update_delete_flow() {
         .await
         .unwrap();
     wait_for_diff(&mut subscription, "insert add diff", |diff| match diff {
-        ResultDiff::Add { data } => data.get("name") == Some(&json!("sensor-a")),
+        ResultDiff::Add { data, .. } => data.get("name") == Some(&json!("sensor-a")),
         _ => false,
     })
     .await;
@@ -171,7 +171,7 @@ async fn sqlite_handle_create_update_delete_flow() {
         .await
         .unwrap();
     wait_for_diff(&mut subscription, "delete diff", |diff| match diff {
-        ResultDiff::Delete { data } => {
+        ResultDiff::Delete { data, .. } => {
             data.get("name") == Some(&json!("sensor-a-updated"))
                 && id_matches(data.get("id").unwrap_or(&serde_json::Value::Null), 1)
         }
@@ -250,7 +250,7 @@ async fn sqlite_rest_crud_and_batch_flow() {
         &mut subscription,
         "rest insert add diff",
         |diff| match diff {
-            ResultDiff::Add { data } => data.get("name") == Some(&json!("rest-insert")),
+            ResultDiff::Add { data, .. } => data.get("name") == Some(&json!("rest-insert")),
             _ => false,
         },
     )
@@ -276,7 +276,7 @@ async fn sqlite_rest_crud_and_batch_flow() {
         .unwrap();
     assert_eq!(delete_response.status(), 200);
     wait_for_diff(&mut subscription, "rest delete diff", |diff| match diff {
-        ResultDiff::Delete { data } => data.get("name") == Some(&json!("rest-updated")),
+        ResultDiff::Delete { data, .. } => data.get("name") == Some(&json!("rest-updated")),
         _ => false,
     })
     .await;
@@ -374,6 +374,8 @@ async fn sqlite_bootstrap_loads_existing_rows() {
         query_id: "sqlite-bootstrap-query".to_string(),
         nodes: HashSet::from(["sensors".to_string()]),
         relations: HashSet::new(),
+        resume_from: None,
+        request_position_handle: false,
     };
 
     let response = source.subscribe(settings).await.unwrap();
@@ -482,13 +484,17 @@ async fn sqlite_multi_table_changes_flow_to_queries() {
             match result.query_id.as_str() {
                 "sqlite-sensors-query" => {
                     saw_sensor_query = result.results.iter().any(|diff| match diff {
-                        ResultDiff::Add { data } => data.get("name") == Some(&json!("sensor-one")),
+                        ResultDiff::Add { data, .. } => {
+                            data.get("name") == Some(&json!("sensor-one"))
+                        }
                         _ => false,
                     });
                 }
                 "sqlite-devices-query" => {
                     saw_device_query = result.results.iter().any(|diff| match diff {
-                        ResultDiff::Add { data } => data.get("name") == Some(&json!("device-nine")),
+                        ResultDiff::Add { data, .. } => {
+                            data.get("name") == Some(&json!("device-nine"))
+                        }
                         _ => false,
                     });
                 }


### PR DESCRIPTION
# SQLite Source

## Overview

`drasi-source-sqlite` is a protocol/local source that owns an embedded SQLite connection and emits Drasi `SourceChange` events for row-level `INSERT`, `UPDATE`, and `DELETE` activity.

Key capabilities:

- Real-time CDC using `rusqlite` `preupdate_hook`
- Transaction-aware dispatch (`commit_hook` flush, `rollback_hook` discard)
- Savepoint-aware buffering for partial rollback support
- Optional table filtering and explicit table key configuration
- Optional REST API for table CRUD and transactional batch operations
- Works with file-backed and in-memory SQLite databases

## Quick Start

```rust
use drasi_source_sqlite::{SqliteSource, TableKeyConfig, RestApiConfig};

let source = SqliteSource::builder("sqlite-source")
    .with_path("data/example.db")
    .with_table_keys(vec![TableKeyConfig {
        table: "sensors".to_string(),
        key_columns: vec!["id".to_string()],
    }])
    .with_rest_api(RestApiConfig {
        host: "127.0.0.1".to_string(),
        port: 9100,
    })
    .build()?;
```

## SQL Handle API

Use `source.handle()` to execute statements through the source-owned SQLite connection:

```rust
let handle = source.handle();
handle.execute("CREATE TABLE sensors(id INTEGER PRIMARY KEY, name TEXT, temp REAL)").await?;
handle.execute("INSERT INTO sensors(id, name, temp) VALUES (1, 'sensor-a', 31.5)").await?;

handle.transaction(|tx| async move {
    tx.execute("INSERT INTO sensors(id, name, temp) VALUES (2, 'sensor-b', 30.0)").await?;
    tx.execute("UPDATE sensors SET temp = 32.1 WHERE id = 1").await?;
    Ok(())
}).await?;
```

## REST API (Optional)

When `with_rest_api()` is configured:

- `GET /health`
- `GET /api/tables`
- `GET /api/tables/{table}`
- `GET /api/tables/{table}/{id}`
- `POST /api/tables/{table}`
- `PUT /api/tables/{table}/{id}`
- `DELETE /api/tables/{table}/{id}`
- `POST /api/batch` (single SQLite transaction for all operations)

## Configuration Notes

- `tables: Option<Vec<String>>` filters monitored tables. `None` means all user tables.
- `table_keys` defines element ID columns per table; if omitted, table PKs are detected from `PRAGMA table_info`.
- If no configured/detected keys exist, rowid is used as fallback for streaming events.

## Testing

From this crate directory:

```bash
cargo test
cargo test -- --ignored --nocapture
cargo clippy --all-targets -- -D warnings
```

The integration tests validate:

- handle-driven INSERT/UPDATE/DELETE flow
- REST CRUD and transactional batch behavior
- bootstrap delivery into query results
- multi-table query routing

## Limitations

- CDC only captures writes executed through the source-owned connection.
- DDL (`CREATE/ALTER/DROP TABLE`) is not emitted as `SourceChange`.
- BLOB values are emitted as base64-encoded strings.
