### PR TITLE
fix: upgrade dependencies to resolve cargo-audit security vulnerabilities

### DIFF
--- a/components/reactions/storedproc-mssql/Cargo.toml
+++ b/components/reactions/storedproc-mssql/Cargo.toml
@@ -45,8 +45,8 @@ anyhow = "1.0"
 tokio-test = "0.4"
 env_logger = "0.10.0"
 serial_test = "3.0"
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["mssql_server"] }
+testcontainers = "0.26"
+testcontainers-modules = { version = "0.14", features = ["mssql_server"] }
 
 [lints]
 workspace = true

--- a/components/reactions/storedproc-mysql/Cargo.toml
+++ b/components/reactions/storedproc-mysql/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.0", features = ["full"] }
 async-trait = "0.1"
 
 # MySQL
-mysql_async = { version = "0.34", default-features = false, features = ["default"] }
+mysql_async = { version = "0.36", default-features = false, features = ["default"] }
 
 # Utilities
 serde = { version = "1.0", features = ["derive"] }
@@ -44,8 +44,8 @@ anyhow = "1.0"
 tokio-test = "0.4"
 env_logger = "0.10.0"
 serial_test = "3.0"
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["mysql"] }
+testcontainers = "0.26"
+testcontainers-modules = { version = "0.14", features = ["mysql"] }
 
 [lints]
 workspace = true

--- a/components/reactions/storedproc-postgres/Cargo.toml
+++ b/components/reactions/storedproc-postgres/Cargo.toml
@@ -47,8 +47,8 @@ chrono = "0.4"
 tokio-test = "0.4"
 env_logger = "0.10.0"
 serial_test = "3.0"
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["postgres"] }
+testcontainers = "0.26"
+testcontainers-modules = { version = "0.14", features = ["postgres"] }
 
 [lints]
 workspace = true

--- a/components/sources/postgres/Cargo.toml
+++ b/components/sources/postgres/Cargo.toml
@@ -59,5 +59,5 @@ drasi-bootstrap-postgres.workspace = true
 drasi-reaction-application.workspace = true
 env_logger = "0.10.0"
 serial_test = "3.0"
-testcontainers = "0.23"
+testcontainers = "0.26"
 tokio-test = "0.4"

--- a/lib-integration-tests/Cargo.toml
+++ b/lib-integration-tests/Cargo.toml
@@ -13,8 +13,8 @@ drasi-lib.workspace = true
 drasi-source-postgres.workspace = true
 
 tokio = { version = "1.6", features = ["full"] }
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["postgres"] }
+testcontainers = "0.26"
+testcontainers-modules = { version = "0.14", features = ["postgres"] }
 tokio-postgres = "0.7"
 async-trait = "0.1"
 chrono = "0.4"

--- a/shared-tests/Cargo.toml
+++ b/shared-tests/Cargo.toml
@@ -29,8 +29,8 @@ uuid = { version = "1.0", features = ["v4"] }
 
 # Redis testing utilities
 redis = { version = "0.27", features = ["tokio-comp"] }
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["redis"] }
+testcontainers = "0.26"
+testcontainers-modules = { version = "0.14", features = ["redis" ] }
 # For test utilities that need to create test sources/queries
 drasi-lib.workspace = true
 


### PR DESCRIPTION
# Description

Upgrade dependencies to resolve cargo-audit security vulnerabilities.

- Upgrade testcontainers 0.23 -> 0.26 to eliminate tokio-tar 0.3.1 transitive dependency (RUSTSEC-2025-0111 / CVE-2025-62518)
- Upgrade testcontainers-modules 0.11 -> 0.14
- Upgrade mysql_async 0.34 -> 0.36 in storedproc-mysql to mitigate lru unsoundness warning
- Uniformly upgrade testcontainers to 0.26 across workspace (drasi-source-postgres, lib-integration-tests) to resolve dependency conflicts

## Type of change

- [x] This pull request fixes a bug in Drasi and has an approved issue (issue link required).

Fixes: #281
