### PR TITLE
Session Transactions Phase 1: Add SessionControl trait with NoOp wiring

### DIFF
--- a/components/indexes/garnet/src/plugin.rs
+++ b/components/indexes/garnet/src/plugin.rs
@@ -31,7 +31,7 @@
 //! ```
 
 use async_trait::async_trait;
-use drasi_core::interface::{IndexBackendPlugin, IndexError, IndexSet};
+use drasi_core::interface::{IndexBackendPlugin, IndexError, IndexSet, NoOpSessionControl};
 use std::sync::Arc;
 
 use crate::element_index::GarnetElementIndex;
@@ -140,6 +140,7 @@ impl IndexBackendPlugin for GarnetIndexProvider {
             archive_index: element_index,
             result_index,
             future_queue,
+            session_control: Arc::new(NoOpSessionControl),
         })
     }
 

--- a/components/indexes/rocksdb/src/plugin.rs
+++ b/components/indexes/rocksdb/src/plugin.rs
@@ -31,7 +31,7 @@
 //! ```
 
 use async_trait::async_trait;
-use drasi_core::interface::{IndexBackendPlugin, IndexError, IndexSet};
+use drasi_core::interface::{IndexBackendPlugin, IndexError, IndexSet, NoOpSessionControl};
 use rocksdb::{OptimisticTransactionDB, Options};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -169,6 +169,7 @@ impl IndexBackendPlugin for RocksDbIndexProvider {
             archive_index: element_index,
             result_index,
             future_queue,
+            session_control: Arc::new(NoOpSessionControl),
         })
     }
 

--- a/core/src/interface/mod.rs
+++ b/core/src/interface/mod.rs
@@ -17,6 +17,7 @@ mod future_queue;
 mod index_backend;
 mod query_clock;
 mod result_index;
+mod session_control;
 mod source_middleware;
 
 use std::error::Error;
@@ -41,6 +42,9 @@ pub use result_index::ResultKey;
 pub use result_index::ResultOwner;
 pub use result_index::ResultSequence;
 pub use result_index::ResultSequenceCounter;
+pub use session_control::NoOpSessionControl;
+pub use session_control::SessionControl;
+pub use session_control::SessionGuard;
 pub use source_middleware::MiddlewareError;
 pub use source_middleware::MiddlewareSetupError;
 pub use source_middleware::SourceMiddleware;

--- a/core/src/interface/session_control.rs
+++ b/core/src/interface/session_control.rs
@@ -1,0 +1,190 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::IndexError;
+
+/// Backend-implemented lifecycle control for session-scoped transactions.
+///
+/// Implementations manage the begin/commit/rollback lifecycle for atomic
+/// writes across all indexes during a single source-change processing.
+/// Session state lives inside backend implementations, shared via `Arc`.
+#[async_trait]
+pub trait SessionControl: Send + Sync {
+    /// Begin a new session-scoped transaction.
+    async fn begin(&self) -> Result<(), IndexError>;
+
+    /// Commit the current session-scoped transaction.
+    async fn commit(&self) -> Result<(), IndexError>;
+
+    /// Roll back the current session-scoped transaction.
+    ///
+    /// This is synchronous to be safe for use in `Drop` implementations.
+    /// Returns an error if the rollback itself fails (e.g., mutex poisoned).
+    fn rollback(&self) -> Result<(), IndexError>;
+}
+
+/// No-op implementation of `SessionControl`.
+///
+/// All methods are no-ops that return `Ok(())`. Used for in-memory backends
+/// and as the default when no session control is configured.
+pub struct NoOpSessionControl;
+
+#[async_trait]
+impl SessionControl for NoOpSessionControl {
+    async fn begin(&self) -> Result<(), IndexError> {
+        Ok(())
+    }
+
+    async fn commit(&self) -> Result<(), IndexError> {
+        Ok(())
+    }
+
+    fn rollback(&self) -> Result<(), IndexError> {
+        Ok(())
+    }
+}
+
+/// RAII guard for session-scoped transactions.
+///
+/// Created via `SessionGuard::begin()`, which calls `control.begin()`.
+/// On drop, automatically calls `control.rollback()` unless `commit()`
+/// was called first.
+pub struct SessionGuard {
+    control: Arc<dyn SessionControl>,
+    committed: bool,
+}
+
+impl SessionGuard {
+    /// Begin a new session, returning an RAII guard.
+    ///
+    /// Calls `control.begin()` and returns a guard that will automatically
+    /// roll back on drop unless `commit()` is called.
+    pub async fn begin(control: Arc<dyn SessionControl>) -> Result<Self, IndexError> {
+        control.begin().await?;
+        Ok(Self {
+            control,
+            committed: false,
+        })
+    }
+
+    /// Commit the session-scoped transaction.
+    ///
+    /// Marks the guard as committed so that `Drop` will not roll back.
+    /// The committed flag is set only after a successful commit — if
+    /// `control.commit()` fails, `Drop` will still trigger rollback.
+    pub async fn commit(mut self) -> Result<(), IndexError> {
+        self.control.commit().await?;
+        self.committed = true;
+        Ok(())
+    }
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        if !self.committed {
+            if let Err(e) = self.control.rollback() {
+                log::error!("Session rollback failed: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Mock that records every method call for assertion.
+    struct MockSessionControl {
+        calls: Mutex<Vec<&'static str>>,
+        commit_result: Mutex<Option<Result<(), IndexError>>>,
+    }
+
+    impl MockSessionControl {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                commit_result: Mutex::new(None),
+            }
+        }
+
+        fn fail_commit(error: IndexError) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                commit_result: Mutex::new(Some(Err(error))),
+            }
+        }
+
+        fn calls(&self) -> Vec<&'static str> {
+            self.calls.lock().expect("lock poisoned").clone()
+        }
+    }
+
+    #[async_trait]
+    impl SessionControl for MockSessionControl {
+        async fn begin(&self) -> Result<(), IndexError> {
+            self.calls.lock().expect("lock poisoned").push("begin");
+            Ok(())
+        }
+
+        async fn commit(&self) -> Result<(), IndexError> {
+            self.calls.lock().expect("lock poisoned").push("commit");
+            match self.commit_result.lock().expect("lock poisoned").take() {
+                Some(result) => result,
+                None => Ok(()),
+            }
+        }
+
+        fn rollback(&self) -> Result<(), IndexError> {
+            self.calls.lock().expect("lock poisoned").push("rollback");
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn begin_calls_control_begin() {
+        let mock = Arc::new(MockSessionControl::new());
+        let _guard = SessionGuard::begin(mock.clone()).await.expect("begin");
+        assert_eq!(mock.calls()[0], "begin");
+    }
+
+    #[tokio::test]
+    async fn commit_suppresses_rollback_on_drop() {
+        let mock = Arc::new(MockSessionControl::new());
+        let guard = SessionGuard::begin(mock.clone()).await.expect("begin");
+        guard.commit().await.expect("commit");
+        assert_eq!(mock.calls(), vec!["begin", "commit"]);
+    }
+
+    #[tokio::test]
+    async fn drop_without_commit_triggers_rollback() {
+        let mock = Arc::new(MockSessionControl::new());
+        let guard = SessionGuard::begin(mock.clone()).await.expect("begin");
+        drop(guard);
+        assert_eq!(mock.calls(), vec!["begin", "rollback"]);
+    }
+
+    #[tokio::test]
+    async fn failed_commit_still_triggers_rollback() {
+        let mock = Arc::new(MockSessionControl::fail_commit(IndexError::CorruptedData));
+        let guard = SessionGuard::begin(mock.clone()).await.expect("begin");
+        let result = guard.commit().await;
+        assert!(result.is_err());
+        assert_eq!(mock.calls(), vec!["begin", "commit", "rollback"]);
+    }
+}

--- a/core/src/query/continuous_query.rs
+++ b/core/src/query/continuous_query.rs
@@ -34,7 +34,9 @@ use crate::{
         EvaluationError, ExpressionEvaluationContext, ExpressionEvaluator, InstantQueryClock,
         QueryPartEvaluator,
     },
-    interface::{ElementIndex, FutureQueue, FutureQueueConsumer, MiddlewareError, QueryClock},
+    interface::{
+        ElementIndex, FutureQueue, FutureQueueConsumer, MiddlewareError, QueryClock, SessionControl,
+    },
     middleware::SourceMiddlewarePipelineCollection,
     models::{Element, SourceChange},
     path_solver::{
@@ -56,6 +58,8 @@ pub struct ContinuousQuery {
     future_queue_task: Mutex<Option<JoinHandle<()>>>,
     change_lock: Mutex<()>,
     source_pipelines: SourceMiddlewarePipelineCollection,
+    #[allow(dead_code)]
+    session_control: Arc<dyn SessionControl>,
 }
 
 impl ContinuousQuery {
@@ -69,6 +73,7 @@ impl ContinuousQuery {
         part_evaluator: Arc<QueryPartEvaluator>,
         future_queue: Arc<dyn FutureQueue>,
         source_pipelines: SourceMiddlewarePipelineCollection,
+        session_control: Arc<dyn SessionControl>,
     ) -> Self {
         Self {
             expression_evaluator,
@@ -82,6 +87,7 @@ impl ContinuousQuery {
             future_queue_task: Mutex::new(None),
             change_lock: Mutex::new(()),
             source_pipelines,
+            session_control,
         }
     }
 

--- a/lib/src/indexes/factory.rs
+++ b/lib/src/indexes/factory.rs
@@ -17,7 +17,7 @@ use crate::indexes::IndexBackendPlugin;
 use drasi_core::in_memory_index::in_memory_element_index::InMemoryElementIndex;
 use drasi_core::in_memory_index::in_memory_future_queue::InMemoryFutureQueue;
 use drasi_core::in_memory_index::in_memory_result_index::InMemoryResultIndex;
-use drasi_core::interface::IndexSet;
+use drasi_core::interface::{IndexSet, NoOpSessionControl};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -189,6 +189,7 @@ impl IndexFactory {
             archive_index: element_index,
             result_index: Arc::new(result_index),
             future_queue: Arc::new(future_queue),
+            session_control: Arc::new(NoOpSessionControl),
         })
     }
 

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -306,7 +306,8 @@ impl Query for DrasiQuery {
                 .with_element_index(index_set.element_index)
                 .with_archive_index(index_set.archive_index)
                 .with_result_index(index_set.result_index)
-                .with_future_queue(index_set.future_queue);
+                .with_future_queue(index_set.future_queue)
+                .with_session_control(index_set.session_control);
 
             future_queue
         } else {


### PR DESCRIPTION
## Description

Implements **Phase 1** of session-scoped transactions for index backends ([#290](https://github.com/drasi-project/drasi-core/issues/290)).

Today, each index write during `process_source_change` auto-commits independently. A crash mid-pipeline leaves persistent backends (RocksDB, Garnet) in an inconsistent state requiring full re-bootstrap. The fix is session-scoped transactions that atomically commit all writes for a single source-change.

Phase 1 introduces the trait definitions and wires them through the system with **no-op implementations only** -- no behavioral change. All existing tests pass unchanged.

## Design approach

Interior-state pattern (per issue discussion): session state will live inside backend implementations shared via `Arc<BackendSpecificState>`. Index trait signatures (`ElementIndex`, `ResultIndex`, `FutureQueue`, `ElementArchiveIndex`) are **unchanged**.

## Type of change

- This pull request adds or changes features of Drasi and has an approved issue (issue link required).

Part of: #290
