### PR TITLE
ci(resolved release-plz issue): Fix circular dependency between mssql source and bootstrap crates 

### DIFF
--- a/components/bootstrappers/mssql/Cargo.toml
+++ b/components/bootstrappers/mssql/Cargo.toml
@@ -29,7 +29,6 @@ workspace = true
 [dependencies]
 drasi-lib.workspace = true
 drasi-core.workspace = true
-drasi-source-mssql.workspace = true
 tiberius = { version = "0.12", features = ["chrono", "rust_decimal"] }
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
@@ -37,7 +36,9 @@ async-trait = "0.1"
 anyhow = "1.0"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 chrono = "0.4"
 uuid = { version = "1.0", features = ["v4"] }
 rust_decimal = "1.34"
 ordered-float = "3.7.0"
+hex = "0.4"

--- a/components/bootstrappers/mssql/src/config.rs
+++ b/components/bootstrappers/mssql/src/config.rs
@@ -1,0 +1,219 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Configuration types for the MS SQL bootstrap provider.
+//!
+//! These types are defined locally to keep this component independent
+//! and self-contained, without dependencies on the source component.
+
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+
+/// Maximum length for SQL identifiers (SQL Server limit is 128)
+const MAX_IDENTIFIER_LENGTH: usize = 128;
+
+/// Validate a SQL identifier to prevent SQL injection
+///
+/// Valid identifiers contain only:
+/// - Alphanumeric characters (a-z, A-Z, 0-9)
+/// - Underscores (_)
+/// - Dots (.) for schema.table notation
+pub fn validate_sql_identifier(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() {
+        return Err(anyhow!("SQL identifier cannot be empty"));
+    }
+
+    if name.len() > MAX_IDENTIFIER_LENGTH {
+        return Err(anyhow!(
+            "SQL identifier exceeds maximum length of {MAX_IDENTIFIER_LENGTH} characters"
+        ));
+    }
+
+    for (i, c) in name.chars().enumerate() {
+        if !c.is_ascii_alphanumeric() && c != '_' && c != '.' {
+            return Err(anyhow!(
+                "Invalid character '{c}' at position {i} in SQL identifier '{name}'. \
+                 Only alphanumeric characters, underscores, and dots are allowed."
+            ));
+        }
+    }
+
+    if name.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return Err(anyhow!("SQL identifier '{name}' cannot start with a digit"));
+    }
+
+    if name.starts_with('.') || name.ends_with('.') || name.contains("..") {
+        return Err(anyhow!("SQL identifier '{name}' has invalid dot placement"));
+    }
+
+    Ok(())
+}
+
+/// Authentication mode for MS SQL Server
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthMode {
+    /// SQL Server authentication (username/password)
+    SqlServer,
+    /// Windows integrated authentication (Kerberos)
+    Windows,
+    /// Azure AD authentication
+    AzureAd,
+}
+
+impl Default for AuthMode {
+    fn default() -> Self {
+        Self::SqlServer
+    }
+}
+
+/// TLS/SSL encryption mode
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EncryptionMode {
+    /// No encryption
+    Off,
+    /// Require encryption
+    On,
+    /// Encrypt if supported, otherwise allow unencrypted
+    NotSupported,
+}
+
+impl Default for EncryptionMode {
+    fn default() -> Self {
+        Self::NotSupported
+    }
+}
+
+/// Table key configuration for custom primary keys
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TableKeyConfig {
+    /// Table name
+    pub table: String,
+    /// Column names that form the primary key
+    pub key_columns: Vec<String>,
+}
+
+/// MS SQL bootstrap provider configuration
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MsSqlBootstrapConfig {
+    /// MS SQL server hostname or IP address
+    #[serde(default = "default_host")]
+    pub host: String,
+
+    /// MS SQL server port
+    #[serde(default = "default_port")]
+    pub port: u16,
+
+    /// Database name
+    pub database: String,
+
+    /// Database user
+    pub user: String,
+
+    /// Database password
+    #[serde(default)]
+    pub password: String,
+
+    /// Authentication mode
+    #[serde(default)]
+    pub auth_mode: AuthMode,
+
+    /// Tables to bootstrap
+    #[serde(default)]
+    pub tables: Vec<String>,
+
+    /// TLS/SSL encryption mode
+    #[serde(default)]
+    pub encryption: EncryptionMode,
+
+    /// Trust server certificate (for self-signed certificates)
+    #[serde(default)]
+    pub trust_server_certificate: bool,
+
+    /// Custom primary key configuration
+    #[serde(default)]
+    pub table_keys: Vec<TableKeyConfig>,
+}
+
+fn default_host() -> String {
+    "localhost".to_string()
+}
+
+fn default_port() -> u16 {
+    1433
+}
+
+impl Default for MsSqlBootstrapConfig {
+    fn default() -> Self {
+        Self {
+            host: default_host(),
+            port: default_port(),
+            database: String::new(),
+            user: String::new(),
+            password: String::new(),
+            auth_mode: AuthMode::default(),
+            tables: Vec::new(),
+            encryption: EncryptionMode::default(),
+            trust_server_certificate: false,
+            table_keys: Vec::new(),
+        }
+    }
+}
+
+impl MsSqlBootstrapConfig {
+    /// Validate the configuration and return an error if invalid.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.database.is_empty() {
+            return Err(anyhow!("Database name is required"));
+        }
+        if self.user.is_empty() {
+            return Err(anyhow!("Database user is required"));
+        }
+        if self.port == 0 {
+            return Err(anyhow!("Port cannot be 0"));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = MsSqlBootstrapConfig::default();
+        assert_eq!(config.host, "localhost");
+        assert_eq!(config.port, 1433);
+        assert_eq!(config.auth_mode, AuthMode::SqlServer);
+        assert_eq!(config.encryption, EncryptionMode::NotSupported);
+        assert!(!config.trust_server_certificate);
+    }
+
+    #[test]
+    fn test_validate_sql_identifier_valid() {
+        assert!(validate_sql_identifier("orders").is_ok());
+        assert!(validate_sql_identifier("dbo.orders").is_ok());
+        assert!(validate_sql_identifier("order_items").is_ok());
+    }
+
+    #[test]
+    fn test_validate_sql_identifier_invalid() {
+        assert!(validate_sql_identifier("").is_err());
+        assert!(validate_sql_identifier("orders; DROP TABLE users--").is_err());
+        assert!(validate_sql_identifier("123table").is_err());
+        assert!(validate_sql_identifier(".orders").is_err());
+    }
+}

--- a/components/bootstrappers/mssql/src/connection.rs
+++ b/components/bootstrappers/mssql/src/connection.rs
@@ -1,0 +1,93 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! MS SQL connection management for the bootstrap provider
+
+use crate::config::{AuthMode, EncryptionMode, MsSqlBootstrapConfig};
+use anyhow::{anyhow, Result};
+use log::{debug, info};
+use tiberius::{AuthMethod, Client, Config, EncryptionLevel};
+use tokio::net::TcpStream;
+use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
+
+/// MS SQL connection wrapper for bootstrap operations
+pub struct MsSqlBootstrapConnection {
+    client: Client<Compat<TcpStream>>,
+}
+
+impl MsSqlBootstrapConnection {
+    /// Create a new connection to MS SQL Server
+    pub async fn connect(config: &MsSqlBootstrapConfig) -> Result<Self> {
+        info!(
+            "Connecting to MS SQL Server at {}:{} database '{}'",
+            config.host, config.port, config.database
+        );
+
+        let mut tiberius_config = Config::new();
+        tiberius_config.host(&config.host);
+        tiberius_config.port(config.port);
+        tiberius_config.database(&config.database);
+
+        match config.auth_mode {
+            AuthMode::SqlServer => {
+                debug!("Using SQL Server authentication");
+                tiberius_config
+                    .authentication(AuthMethod::sql_server(&config.user, &config.password));
+            }
+            AuthMode::Windows => {
+                return Err(anyhow!("Windows authentication not yet implemented"));
+            }
+            AuthMode::AzureAd => {
+                return Err(anyhow!("Azure AD authentication not yet implemented"));
+            }
+        }
+
+        let encryption_level = match config.encryption {
+            EncryptionMode::Off => EncryptionLevel::Off,
+            EncryptionMode::On => EncryptionLevel::Required,
+            EncryptionMode::NotSupported => EncryptionLevel::NotSupported,
+        };
+        tiberius_config.encryption(encryption_level);
+
+        if config.trust_server_certificate {
+            tiberius_config.trust_cert();
+        }
+
+        let tcp = TcpStream::connect((config.host.as_str(), config.port))
+            .await
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to connect to {}:{}: {}",
+                    config.host,
+                    config.port,
+                    e
+                )
+            })?;
+
+        tcp.set_nodelay(true)?;
+
+        let client = Client::connect(tiberius_config, tcp.compat_write())
+            .await
+            .map_err(|e| anyhow!("Failed to authenticate with MS SQL Server: {e}"))?;
+
+        info!("Successfully connected to MS SQL Server");
+
+        Ok(Self { client })
+    }
+
+    /// Get mutable reference to the underlying Tiberius client
+    pub fn client_mut(&mut self) -> &mut Client<Compat<TcpStream>> {
+        &mut self.client
+    }
+}

--- a/components/bootstrappers/mssql/src/keys.rs
+++ b/components/bootstrappers/mssql/src/keys.rs
@@ -1,0 +1,311 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Primary key discovery and element ID generation for bootstrap
+
+use crate::config::{MsSqlBootstrapConfig, TableKeyConfig};
+use anyhow::{anyhow, Result};
+use drasi_core::models::ElementValue;
+use log::warn;
+use ordered_float::OrderedFloat;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tiberius::{Client, Row};
+use tokio::net::TcpStream;
+use tokio_util::compat::Compat;
+
+/// Cache of primary keys for tables
+pub struct PrimaryKeyCache {
+    /// Map of table name -> ordered list of primary key column names
+    keys: HashMap<String, Vec<String>>,
+}
+
+impl PrimaryKeyCache {
+    /// Create a new empty cache
+    pub fn new() -> Self {
+        Self {
+            keys: HashMap::new(),
+        }
+    }
+
+    /// Discover primary keys from MS SQL system catalogs
+    pub async fn discover_keys(
+        &mut self,
+        client: &mut Client<Compat<TcpStream>>,
+        config: &MsSqlBootstrapConfig,
+    ) -> Result<()> {
+        let query = "
+            SELECT 
+                t.name AS table_name,
+                c.name AS column_name,
+                ic.key_ordinal
+            FROM sys.indexes i
+            INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id 
+                AND i.index_id = ic.index_id
+            INNER JOIN sys.columns c ON ic.object_id = c.object_id 
+                AND ic.column_id = c.column_id
+            INNER JOIN sys.tables t ON i.object_id = t.object_id
+            WHERE i.is_primary_key = 1
+            ORDER BY t.name, ic.key_ordinal
+        ";
+
+        let stream = client.query(query, &[]).await?;
+        let rows = stream.into_first_result().await?;
+
+        for row in rows {
+            let table_name: &str = row.get(0).ok_or_else(|| anyhow!("Missing table_name"))?;
+            let column_name: &str = row.get(1).ok_or_else(|| anyhow!("Missing column_name"))?;
+
+            self.keys
+                .entry(table_name.to_string())
+                .or_default()
+                .push(column_name.to_string());
+        }
+
+        // Merge with configured table_keys (which take precedence)
+        for tk in &config.table_keys {
+            self.keys.insert(tk.table.clone(), tk.key_columns.clone());
+        }
+
+        log::info!("Discovered primary keys for {} tables", self.keys.len());
+        for (table, keys) in &self.keys {
+            log::debug!("Table '{table}' primary key: {keys:?}");
+        }
+
+        Ok(())
+    }
+
+    /// Get primary key columns for a table
+    /// Handles both "table" and "schema.table" formats
+    pub fn get(&self, table: &str) -> Option<&Vec<String>> {
+        if let Some(keys) = self.keys.get(table) {
+            return Some(keys);
+        }
+
+        // Try without schema prefix (e.g., "dbo.Orders" -> "Orders")
+        if let Some(table_only) = table.split('.').nth(1) {
+            if let Some(keys) = self.keys.get(table_only) {
+                return Some(keys);
+            }
+        }
+
+        None
+    }
+
+    /// Generate element ID from a row using primary key values
+    pub fn generate_element_id(&self, table: &str, row: &Row) -> Result<String> {
+        let keys = match self.get(table) {
+            Some(keys) => keys,
+            None => {
+                return Err(anyhow!(
+                    "No primary key configured for table '{table}'. \
+                     Add a 'table_keys' configuration entry to specify the primary key columns."
+                ));
+            }
+        };
+
+        let mut key_values = Vec::new();
+        let mut null_columns = Vec::new();
+
+        for pk_col in keys {
+            if let Some(col_idx) = row.columns().iter().position(|c| c.name() == pk_col) {
+                let value = extract_column_value(row, col_idx)?;
+
+                if !matches!(value, ElementValue::Null) {
+                    key_values.push(value_to_string(&value));
+                } else {
+                    null_columns.push(pk_col.clone());
+                }
+            } else {
+                return Err(anyhow!(
+                    "Primary key column '{pk_col}' not found in row for table '{table}'."
+                ));
+            }
+        }
+
+        if !key_values.is_empty() {
+            if !null_columns.is_empty() {
+                warn!(
+                    "NULL value(s) in primary key column(s) {null_columns:?} for table '{table}'. \
+                     Using remaining key columns for element ID."
+                );
+            }
+            Ok(format!("{}:{}", table, key_values.join("_")))
+        } else {
+            Err(anyhow!(
+                "All primary key values are NULL for table '{table}' (columns: {keys:?}). \
+                 Cannot generate a stable element ID."
+            ))
+        }
+    }
+}
+
+impl Default for PrimaryKeyCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extract a column value from a row by index and convert to ElementValue
+pub fn extract_column_value(row: &Row, col_idx: usize) -> Result<ElementValue> {
+    use tiberius::ColumnType;
+
+    let column = &row.columns()[col_idx];
+
+    match column.column_type() {
+        ColumnType::Bit | ColumnType::Bitn => {
+            if let Ok(Some(val)) = row.try_get::<bool, _>(col_idx) {
+                Ok(ElementValue::Bool(val))
+            } else {
+                Ok(ElementValue::Null)
+            }
+        }
+        ColumnType::Int1
+        | ColumnType::Int2
+        | ColumnType::Int4
+        | ColumnType::Int8
+        | ColumnType::Intn => {
+            if let Ok(Some(val)) = row.try_get::<i32, _>(col_idx) {
+                Ok(ElementValue::Integer(val as i64))
+            } else if let Ok(Some(val)) = row.try_get::<i64, _>(col_idx) {
+                Ok(ElementValue::Integer(val))
+            } else if let Ok(Some(val)) = row.try_get::<i16, _>(col_idx) {
+                Ok(ElementValue::Integer(val as i64))
+            } else if let Ok(Some(val)) = row.try_get::<u8, _>(col_idx) {
+                Ok(ElementValue::Integer(val as i64))
+            } else {
+                Ok(ElementValue::Null)
+            }
+        }
+        ColumnType::Float4 | ColumnType::Float8 | ColumnType::Floatn => {
+            if let Ok(Some(val)) = row.try_get::<f32, _>(col_idx) {
+                Ok(ElementValue::Float(OrderedFloat(val as f64)))
+            } else if let Ok(Some(val)) = row.try_get::<f64, _>(col_idx) {
+                Ok(ElementValue::Float(OrderedFloat(val)))
+            } else {
+                Ok(ElementValue::Null)
+            }
+        }
+        ColumnType::Numericn | ColumnType::Decimaln => {
+            if let Ok(Some(d)) = row.try_get::<rust_decimal::Decimal, _>(col_idx) {
+                let f = d.to_string().parse::<f64>().unwrap_or(0.0);
+                Ok(ElementValue::Float(OrderedFloat(f)))
+            } else {
+                Ok(ElementValue::Null)
+            }
+        }
+        ColumnType::BigVarChar
+        | ColumnType::BigChar
+        | ColumnType::NVarchar
+        | ColumnType::NChar
+        | ColumnType::Text
+        | ColumnType::NText => {
+            if let Ok(Some(val)) = row.try_get::<&str, _>(col_idx) {
+                Ok(ElementValue::String(Arc::from(val)))
+            } else {
+                Ok(ElementValue::Null)
+            }
+        }
+        ColumnType::Guid => {
+            if let Ok(Some(val)) = row.try_get::<uuid::Uuid, _>(col_idx) {
+                Ok(ElementValue::String(Arc::from(val.to_string())))
+            } else {
+                Ok(ElementValue::Null)
+            }
+        }
+        ColumnType::Datetime
+        | ColumnType::Datetime2
+        | ColumnType::Datetime4
+        | ColumnType::Datetimen
+        | ColumnType::Daten => {
+            if let Ok(Some(val)) = row.try_get::<chrono::NaiveDateTime, _>(col_idx) {
+                Ok(ElementValue::String(Arc::from(
+                    val.format("%Y-%m-%dT%H:%M:%S%.3f").to_string(),
+                )))
+            } else if let Ok(Some(val)) =
+                row.try_get::<chrono::DateTime<chrono::Utc>, _>(col_idx)
+            {
+                Ok(ElementValue::String(Arc::from(val.to_rfc3339())))
+            } else {
+                Ok(ElementValue::Null)
+            }
+        }
+        ColumnType::BigVarBin | ColumnType::BigBinary | ColumnType::Image => {
+            if let Ok(Some(bytes)) = row.try_get::<&[u8], _>(col_idx) {
+                Ok(ElementValue::String(Arc::from(format!(
+                    "0x{}",
+                    hex::encode(bytes)
+                ))))
+            } else {
+                Ok(ElementValue::Null)
+            }
+        }
+        _ => {
+            if let Ok(Some(val)) = row.try_get::<&str, _>(col_idx) {
+                Ok(ElementValue::String(Arc::from(val)))
+            } else {
+                warn!(
+                    "Unsupported column type {:?} for column {}, treating as NULL",
+                    column.column_type(),
+                    column.name()
+                );
+                Ok(ElementValue::Null)
+            }
+        }
+    }
+}
+
+/// Convert ElementValue to a string representation for element ID generation
+pub fn value_to_string(value: &ElementValue) -> String {
+    match value {
+        ElementValue::Integer(i) => i.to_string(),
+        ElementValue::Float(f) => f.to_string(),
+        ElementValue::String(s) => s.to_string(),
+        ElementValue::Bool(b) => b.to_string(),
+        ElementValue::Null => "null".to_string(),
+        _ => format!("{value:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_cache() {
+        let cache = PrimaryKeyCache::new();
+        assert!(cache.get("orders").is_none());
+    }
+
+    #[test]
+    fn test_insert_and_get() {
+        let mut cache = PrimaryKeyCache::new();
+        cache
+            .keys
+            .insert("orders".to_string(), vec!["order_id".to_string()]);
+
+        assert_eq!(cache.get("orders").unwrap(), &vec!["order_id"]);
+    }
+
+    #[test]
+    fn test_value_to_string() {
+        assert_eq!(value_to_string(&ElementValue::Integer(42)), "42");
+        assert_eq!(
+            value_to_string(&ElementValue::String(Arc::from("test"))),
+            "test"
+        );
+        assert_eq!(value_to_string(&ElementValue::Bool(true)), "true");
+        assert_eq!(value_to_string(&ElementValue::Null), "null");
+    }
+}

--- a/components/bootstrappers/mssql/src/lib.rs
+++ b/components/bootstrappers/mssql/src/lib.rs
@@ -34,7 +34,10 @@
 //! # }
 //! ```
 
+pub mod config;
+pub mod connection;
+pub mod keys;
 pub mod mssql;
 
-pub use drasi_source_mssql::{AuthMode, EncryptionMode, MsSqlSourceConfig, TableKeyConfig};
+pub use config::{AuthMode, EncryptionMode, MsSqlBootstrapConfig, TableKeyConfig};
 pub use mssql::{MsSqlBootstrapProvider, MsSqlBootstrapProviderBuilder};


### PR DESCRIPTION
# Description

### Problem
The `release-plz` workflow failed to publish `drasi-source-mssql` because `drasi-bootstrap-mssql` (a dev-dependency) didn't exist on crates.io yet — and `drasi-bootstrap-mssql` couldn't be published first because it depended on `drasi-source-mssql`. This circular dependency made it impossible to publish either crate.

### Fix
Gave `drasi-bootstrap-mssql` its own local config, connection, and key types — matching the pattern used by `drasi-bootstrap-postgres`. This removes the `drasi-source-mssql` dependency from the bootstrap crate, breaking the cycle.

**New files:**
- `config.rs` — `MsSqlBootstrapConfig`, `AuthMode`, `EncryptionMode`, `TableKeyConfig`, `validate_sql_identifier`
- `connection.rs` — `MsSqlBootstrapConnection`
- `keys.rs` — `PrimaryKeyCache`, type conversion utilities

**Publish order is now:** bootstrap first (no dep on source) → source second (bootstrap exists on crates.io).

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
