### PR TITLE
File Reaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
   "components/reactions/profiler",
   "components/reactions/application",
   "components/reactions/log",
+  "components/reactions/file",
   "components/reactions/storedproc-mssql",
   "components/reactions/storedproc-mysql",
   "components/reactions/storedproc-postgres",
@@ -118,6 +119,7 @@ drasi-source-application = { version = "0.1.12", path = "components/sources/appl
 drasi-bootstrap-application = { version = "0.1.11", path = "components/bootstrappers/application" }
 drasi-reaction-http = { version = "0.1.12", path = "components/reactions/http" }
 drasi-reaction-grpc = { version = "0.2.9", path = "components/reactions/grpc" }
+drasi-reaction-file = { version = "0.1.0", path = "components/reactions/file" }
 drasi-mssql-common = { version = "0.1.1", path = "components/mssql-common" }
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
   "components/reactions/application",
   "components/reactions/log",
   "components/reactions/loki",
+  "components/reactions/file",
   "components/reactions/storedproc-mssql",
   "components/reactions/storedproc-mysql",
   "components/reactions/storedproc-postgres",
@@ -137,6 +138,7 @@ drasi-source-hyperliquid = { version = "0.1.0", path = "components/sources/hyper
 drasi-bootstrap-application = { version = "0.2.1", path = "components/bootstrappers/application" }
 drasi-reaction-http = { version = "0.2.1", path = "components/reactions/http" }
 drasi-reaction-grpc = { version = "0.3.1", path = "components/reactions/grpc" }
+drasi-reaction-file = { version = "0.1.0", path = "components/reactions/file" }
 drasi-mssql-common = { version = "0.2.1", path = "components/mssql-common" }
 drasi-source-ris-live = { version = "0.1.0", path = "components/sources/ris-live" }
 

--- a/components/reactions/file/Cargo.toml
+++ b/components/reactions/file/Cargo.toml
@@ -1,0 +1,56 @@
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-reaction-file"
+version = "0.1.0"
+edition = "2021"
+authors = ["Drasi Project"]
+description = "File reaction plugin for Drasi"
+license = "Apache-2.0"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi", "plugin", "reaction", "file"]
+categories = ["filesystem"]
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+drasi-lib.workspace = true
+drasi-core.workspace = true
+anyhow = "1.0"
+async-trait = "0.1"
+log = "0.4"
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = "0.4"
+uuid = { version = "1.0", features = ["v4"] }
+tokio-stream = "0.1"
+prost-types = "0.12"
+ordered-float = "3.0"
+handlebars = "5.1"
+drasi-plugin-sdk = { workspace = true }
+utoipa = { workspace = true }
+
+[dev-dependencies]
+tokio-test = "0.4"
+tempfile = "3.0"
+drasi-source-application.workspace = true
+
+[features]
+dynamic-plugin = []

--- a/components/reactions/file/Cargo.toml
+++ b/components/reactions/file/Cargo.toml
@@ -44,6 +44,7 @@ tokio-stream = "0.1"
 prost-types = "0.12"
 ordered-float = "3.0"
 handlebars = "5.1"
+lru = "0.12"
 drasi-plugin-sdk = { workspace = true }
 utoipa = { workspace = true }
 

--- a/components/reactions/file/Cargo.toml
+++ b/components/reactions/file/Cargo.toml
@@ -44,7 +44,6 @@ tokio-stream = "0.1"
 prost-types = "0.12"
 ordered-float = "3.0"
 handlebars = "5.1"
-lru = "0.12"
 drasi-plugin-sdk = { workspace = true }
 utoipa = { workspace = true }
 

--- a/components/reactions/file/Makefile
+++ b/components/reactions/file/Makefile
@@ -1,0 +1,11 @@
+build:
+	cargo build -p drasi-reaction-file
+
+test:
+	cargo test -p drasi-reaction-file
+
+integration-test:
+	cargo test -p drasi-reaction-file --test integration_test -- --ignored --nocapture
+
+lint:
+	cargo clippy -p drasi-reaction-file --all-targets --all-features -- -D warnings

--- a/components/reactions/file/Makefile
+++ b/components/reactions/file/Makefile
@@ -5,7 +5,7 @@ test:
 	cargo test -p drasi-reaction-file
 
 integration-test:
-	cargo test -p drasi-reaction-file --test integration_test -- --ignored --nocapture
+	cargo test -p drasi-reaction-file --test integration_test -- --nocapture
 
 lint:
 	cargo clippy -p drasi-reaction-file --all-targets --all-features -- -D warnings

--- a/components/reactions/file/README.md
+++ b/components/reactions/file/README.md
@@ -68,11 +68,15 @@ and `DELETE` result diffs in timestamp order.
 |---|---|---|---|
 | `after` | ✅ | ✅ | ❌ |
 | `before` | ❌ | ✅ | ✅ |
-| `data` | ❌ | ✅ | ❌ |
+| `data` | ✅ | ✅ | ✅ |
 | `operation` | ✅ | ✅ | ✅ |
 | `query_name` | ✅ | ✅ | ✅ |
 | `timestamp` | ✅ | ✅ | ✅ |
 | `uuid` | ✅ | ✅ | ✅ |
+
+For ADD, `data` is equivalent to `after`; for DELETE, `data` is equivalent to `before`.
+
+Aggregation diffs use the `updated` template and populate `before`, `after`, and `data` (equivalent to `after`). The `operation` variable is set to `"AGGREGATION"`.
 
 `{{json value}}` helper serializes any value as JSON.
 
@@ -103,9 +107,10 @@ Integration tests use:
 - `ApplicationSource` for deterministic change injection
 - `TempDir` for isolated filesystem assertions
 
-The ignored integration suite verifies:
+The integration suite verifies:
 
 1. INSERT/UPDATE/DELETE written in append mode
 2. overwrite mode keeps latest state
 3. per_change mode creates payload-derived filenames
 4. raw JSON fallback when no templates are configured
+5. aggregation diffs use the `updated` template

--- a/components/reactions/file/README.md
+++ b/components/reactions/file/README.md
@@ -1,0 +1,111 @@
+# File Reaction
+
+File Reaction writes query result diffs to local or mounted filesystem paths.
+Each diff can be formatted with Handlebars templates and persisted with append,
+overwrite, or per-change behavior.
+
+## Overview
+
+This reaction subscribes to one or more queries and processes `ADD`, `UPDATE`,
+and `DELETE` result diffs in timestamp order.
+
+### Key capabilities
+
+- `append` mode: append each rendered diff to a file
+- `overwrite` mode: rewrite a single file with the latest rendered diff
+- `per_change` mode: write each rendered diff to a unique file
+- Handlebars templates per operation (`added`, `updated`, `deleted`)
+- Filename templating including payload fields such as `{{after.id}}`
+- Filename sanitization for filesystem safety
+
+## Configuration
+
+```json
+{
+  "outputPath": "/data/drasi-out",
+  "writeMode": "append",
+  "filenameTemplate": "{{query_name}}.ndjson",
+  "routes": {
+    "orders-query": {
+      "added": {
+        "template": "{\"op\":\"add\",\"order\":{{json after}}}"
+      },
+      "updated": {
+        "template": "{\"op\":\"update\",\"before\":{{json before}},\"after\":{{json after}}}"
+      },
+      "deleted": {
+        "template": "{\"op\":\"delete\",\"order\":{{json before}}}"
+      }
+    }
+  },
+  "defaultTemplate": {
+    "added": {
+      "template": "{\"op\":\"add-default\",\"data\":{{json after}}}"
+    }
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `outputPath` | string | Base directory for output files |
+| `writeMode` | `append` \| `overwrite` \| `per_change` | File persistence strategy |
+| `filenameTemplate` | string (optional) | Handlebars filename template |
+| `routes` | map | Per-query templates |
+| `defaultTemplate` | object (optional) | Fallback templates when no route template is present |
+
+### Default filename templates
+
+- append: `{{query_name}}.log`
+- overwrite: `{{query_name}}.json`
+- per_change: `{{query_name}}_{{operation}}_{{uuid}}.json`
+
+## Template context
+
+| Variable | ADD | UPDATE | DELETE |
+|---|---|---|---|
+| `after` | ✅ | ✅ | ❌ |
+| `before` | ❌ | ✅ | ✅ |
+| `data` | ❌ | ✅ | ❌ |
+| `operation` | ✅ | ✅ | ✅ |
+| `query_name` | ✅ | ✅ | ✅ |
+| `timestamp` | ✅ | ✅ | ✅ |
+| `uuid` | ✅ | ✅ | ✅ |
+
+`{{json value}}` helper serializes any value as JSON.
+
+## Filename safety
+
+Rendered filenames are sanitized before write. The following characters are
+replaced with `_`:
+
+`/ \ : * ? " < > |` and `\0`
+
+This allows payload-derived filenames like `item_{{after.id}}.json` while
+preventing invalid or unsafe file names.
+
+## Running checks
+
+```bash
+make build
+make test
+make integration-test
+make lint
+```
+
+## Integration test strategy
+
+Integration tests use:
+
+- `DrasiLib` as runtime host
+- `ApplicationSource` for deterministic change injection
+- `TempDir` for isolated filesystem assertions
+
+The ignored integration suite verifies:
+
+1. INSERT/UPDATE/DELETE written in append mode
+2. overwrite mode keeps latest state
+3. per_change mode creates payload-derived filenames
+4. raw JSON fallback when no templates are configured

--- a/components/reactions/file/README.md
+++ b/components/reactions/file/README.md
@@ -17,6 +17,7 @@ and `DELETE` result diffs in timestamp order.
 - Handlebars templates per operation (`added`, `updated`, `deleted`)
 - Filename templating including payload fields such as `{{after.id}}`
 - Filename sanitization for filesystem safety
+- Raw JSON fallback when no templates are configured: each diff is serialized as a JSON object containing `operation`, `query_name`, `timestamp`, and the relevant data fields
 
 ## Configuration
 

--- a/components/reactions/file/src/config.rs
+++ b/components/reactions/file/src/config.rs
@@ -1,0 +1,79 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Configuration types for file reaction.
+
+use drasi_lib::reactions::common::{self, TemplateRouting};
+use std::collections::HashMap;
+
+pub use common::{QueryConfig, TemplateSpec};
+
+/// File write behavior for emitted query result diffs.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum WriteMode {
+    /// Appends each rendered record to the destination file.
+    #[default]
+    Append,
+    /// Replaces destination file content with the latest rendered record.
+    Overwrite,
+    /// Writes each rendered record to a unique file.
+    PerChange,
+}
+
+fn default_output_path() -> String {
+    ".".to_string()
+}
+
+/// Configuration for the file reaction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FileReactionConfig {
+    /// Base directory for all output files.
+    pub output_path: String,
+
+    /// How output should be persisted.
+    pub write_mode: WriteMode,
+
+    /// Handlebars filename template.
+    ///
+    /// If omitted, the reaction uses a default template based on `write_mode`.
+    pub filename_template: Option<String>,
+
+    /// Query-specific templates.
+    pub routes: HashMap<String, QueryConfig>,
+
+    /// Default templates used when no query-specific route is configured.
+    pub default_template: Option<QueryConfig>,
+}
+
+impl Default for FileReactionConfig {
+    fn default() -> Self {
+        Self {
+            output_path: default_output_path(),
+            write_mode: WriteMode::Append,
+            filename_template: None,
+            routes: HashMap::new(),
+            default_template: None,
+        }
+    }
+}
+
+impl TemplateRouting for FileReactionConfig {
+    fn routes(&self) -> &HashMap<String, QueryConfig> {
+        &self.routes
+    }
+
+    fn default_template(&self) -> Option<&QueryConfig> {
+        self.default_template.as_ref()
+    }
+}

--- a/components/reactions/file/src/descriptor.rs
+++ b/components/reactions/file/src/descriptor.rs
@@ -1,0 +1,173 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Descriptor for the file reaction plugin.
+
+use crate::{FileReactionBuilder, WriteMode};
+use drasi_lib::reactions::Reaction;
+use drasi_plugin_sdk::prelude::*;
+use std::collections::HashMap;
+use utoipa::OpenApi;
+
+/// DTO for a template specification.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[schema(as = reaction::file::FileTemplateSpec)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct TemplateSpecDto {
+    /// Handlebars template string.
+    #[serde(default)]
+    pub template: String,
+}
+
+/// DTO for per-query template configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[schema(as = reaction::file::FileQueryConfig)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct QueryConfigDto {
+    /// Template for ADD operations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub added: Option<TemplateSpecDto>,
+    /// Template for UPDATE operations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated: Option<TemplateSpecDto>,
+    /// Template for DELETE operations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted: Option<TemplateSpecDto>,
+}
+
+/// DTO for write mode.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[schema(as = reaction::file::WriteMode)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteModeDto {
+    Append,
+    Overwrite,
+    PerChange,
+}
+
+/// Configuration DTO for the file reaction plugin.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[schema(as = reaction::file::FileReactionConfig)]
+#[serde(rename_all = "camelCase")]
+pub struct FileReactionConfigDto {
+    /// Base directory for generated files.
+    #[schema(value_type = ConfigValueString)]
+    pub output_path: ConfigValue<String>,
+    /// File write mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub write_mode: Option<WriteModeDto>,
+    /// Handlebars filename template.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<ConfigValueString>)]
+    pub filename_template: Option<ConfigValue<String>>,
+    /// Query-specific templates.
+    #[serde(default)]
+    pub routes: HashMap<String, QueryConfigDto>,
+    /// Default templates when route-specific templates are missing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_template: Option<QueryConfigDto>,
+}
+
+fn map_template_spec(dto: &TemplateSpecDto) -> crate::TemplateSpec {
+    crate::TemplateSpec::new(&dto.template)
+}
+
+fn map_query_config(dto: &QueryConfigDto) -> crate::QueryConfig {
+    crate::QueryConfig {
+        added: dto.added.as_ref().map(map_template_spec),
+        updated: dto.updated.as_ref().map(map_template_spec),
+        deleted: dto.deleted.as_ref().map(map_template_spec),
+    }
+}
+
+fn map_write_mode(dto: WriteModeDto) -> WriteMode {
+    match dto {
+        WriteModeDto::Append => WriteMode::Append,
+        WriteModeDto::Overwrite => WriteMode::Overwrite,
+        WriteModeDto::PerChange => WriteMode::PerChange,
+    }
+}
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(
+    FileReactionConfigDto,
+    QueryConfigDto,
+    TemplateSpecDto,
+    WriteModeDto
+)))]
+struct FileReactionSchemas;
+
+/// Descriptor for the file reaction plugin.
+pub struct FileReactionDescriptor;
+
+#[async_trait]
+impl ReactionPluginDescriptor for FileReactionDescriptor {
+    fn kind(&self) -> &str {
+        "file"
+    }
+
+    fn config_version(&self) -> &str {
+        "1.0.0"
+    }
+
+    fn config_schema_name(&self) -> &str {
+        "reaction.file.FileReactionConfig"
+    }
+
+    fn config_schema_json(&self) -> String {
+        let api = FileReactionSchemas::openapi();
+        serde_json::to_string(
+            &api.components
+                .as_ref()
+                .expect("OpenAPI components missing")
+                .schemas,
+        )
+        .expect("Failed to serialize config schema")
+    }
+
+    async fn create_reaction(
+        &self,
+        id: &str,
+        query_ids: Vec<String>,
+        config_json: &serde_json::Value,
+        auto_start: bool,
+    ) -> anyhow::Result<Box<dyn Reaction>> {
+        let dto: FileReactionConfigDto = serde_json::from_value(config_json.clone())?;
+        let mapper = DtoMapper::new();
+
+        let mut builder = FileReactionBuilder::new(id)
+            .with_queries(query_ids)
+            .with_auto_start(auto_start)
+            .with_output_path(mapper.resolve_string(&dto.output_path)?);
+
+        if let Some(write_mode) = dto.write_mode {
+            builder = builder.with_write_mode(map_write_mode(write_mode));
+        }
+
+        if let Some(filename_template) = dto.filename_template {
+            builder = builder.with_filename_template(mapper.resolve_string(&filename_template)?);
+        }
+
+        if let Some(default_template) = &dto.default_template {
+            builder = builder.with_default_template(map_query_config(default_template));
+        }
+
+        for (query_id, config) in &dto.routes {
+            builder = builder.with_route(query_id, map_query_config(config));
+        }
+
+        let reaction = builder.build()?;
+        Ok(Box::new(reaction))
+    }
+}

--- a/components/reactions/file/src/descriptor.rs
+++ b/components/reactions/file/src/descriptor.rs
@@ -61,9 +61,10 @@ pub enum WriteModeDto {
 #[schema(as = reaction::file::FileReactionConfig)]
 #[serde(rename_all = "camelCase")]
 pub struct FileReactionConfigDto {
-    /// Base directory for generated files.
-    #[schema(value_type = ConfigValueString)]
-    pub output_path: ConfigValue<String>,
+    /// Base directory for generated files. Defaults to `"."` (current directory).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<ConfigValueString>)]
+    pub output_path: Option<ConfigValue<String>>,
     /// File write mode.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_mode: Option<WriteModeDto>,
@@ -148,8 +149,11 @@ impl ReactionPluginDescriptor for FileReactionDescriptor {
 
         let mut builder = FileReactionBuilder::new(id)
             .with_queries(query_ids)
-            .with_auto_start(auto_start)
-            .with_output_path(mapper.resolve_string(&dto.output_path)?);
+            .with_auto_start(auto_start);
+
+        if let Some(output_path) = dto.output_path {
+            builder = builder.with_output_path(mapper.resolve_string(&output_path)?);
+        }
 
         if let Some(write_mode) = dto.write_mode {
             builder = builder.with_write_mode(map_write_mode(write_mode));

--- a/components/reactions/file/src/descriptor.rs
+++ b/components/reactions/file/src/descriptor.rs
@@ -51,8 +51,11 @@ pub struct QueryConfigDto {
 #[schema(as = reaction::file::WriteMode)]
 #[serde(rename_all = "snake_case")]
 pub enum WriteModeDto {
+    /// Appends each rendered record to the destination file.
     Append,
+    /// Replaces destination file content with the latest rendered record.
     Overwrite,
+    /// Writes each rendered record to a unique file.
     PerChange,
 }
 
@@ -65,7 +68,7 @@ pub struct FileReactionConfigDto {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<ConfigValueString>)]
     pub output_path: Option<ConfigValue<String>>,
-    /// File write mode.
+    /// File write mode. Defaults to `append`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_mode: Option<WriteModeDto>,
     /// Handlebars filename template.
@@ -80,15 +83,19 @@ pub struct FileReactionConfigDto {
     pub default_template: Option<QueryConfigDto>,
 }
 
-fn map_template_spec(dto: &TemplateSpecDto) -> crate::TemplateSpec {
-    crate::TemplateSpec::new(&dto.template)
+impl From<&TemplateSpecDto> for crate::TemplateSpec {
+    fn from(dto: &TemplateSpecDto) -> Self {
+        crate::TemplateSpec::new(&dto.template)
+    }
 }
 
-fn map_query_config(dto: &QueryConfigDto) -> crate::QueryConfig {
-    crate::QueryConfig {
-        added: dto.added.as_ref().map(map_template_spec),
-        updated: dto.updated.as_ref().map(map_template_spec),
-        deleted: dto.deleted.as_ref().map(map_template_spec),
+impl From<&QueryConfigDto> for crate::QueryConfig {
+    fn from(dto: &QueryConfigDto) -> Self {
+        crate::QueryConfig {
+            added: dto.added.as_ref().map(|s| s.into()),
+            updated: dto.updated.as_ref().map(|s| s.into()),
+            deleted: dto.deleted.as_ref().map(|s| s.into()),
+        }
     }
 }
 
@@ -164,14 +171,107 @@ impl ReactionPluginDescriptor for FileReactionDescriptor {
         }
 
         if let Some(default_template) = &dto.default_template {
-            builder = builder.with_default_template(map_query_config(default_template));
+            builder = builder.with_default_template(default_template.into());
         }
 
         for (query_id, config) in &dto.routes {
-            builder = builder.with_route(query_id, map_query_config(config));
+            builder = builder.with_route(query_id, crate::QueryConfig::from(config));
         }
 
         let reaction = builder.build()?;
         Ok(Box::new(reaction))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_mode_dto_roundtrip() {
+        assert!(matches!(
+            map_write_mode(WriteModeDto::Append),
+            WriteMode::Append
+        ));
+        assert!(matches!(
+            map_write_mode(WriteModeDto::Overwrite),
+            WriteMode::Overwrite
+        ));
+        assert!(matches!(
+            map_write_mode(WriteModeDto::PerChange),
+            WriteMode::PerChange
+        ));
+    }
+
+    #[test]
+    fn test_template_spec_dto_to_domain() {
+        let dto = TemplateSpecDto {
+            template: "{{after.id}}".to_string(),
+        };
+        let spec: crate::TemplateSpec = (&dto).into();
+        assert_eq!(spec.template, "{{after.id}}");
+    }
+
+    #[test]
+    fn test_query_config_dto_to_domain() {
+        let dto = QueryConfigDto {
+            added: Some(TemplateSpecDto {
+                template: "add-{{after.id}}".to_string(),
+            }),
+            updated: None,
+            deleted: Some(TemplateSpecDto {
+                template: "del-{{before.id}}".to_string(),
+            }),
+        };
+        let config: crate::QueryConfig = (&dto).into();
+        assert_eq!(config.added.unwrap().template, "add-{{after.id}}");
+        assert!(config.updated.is_none());
+        assert_eq!(config.deleted.unwrap().template, "del-{{before.id}}");
+    }
+
+    #[test]
+    fn test_full_config_dto_roundtrip() {
+        let json = serde_json::json!({
+            "outputPath": "/tmp/out",
+            "writeMode": "per_change",
+            "filenameTemplate": "{{query_name}}_{{uuid}}.json",
+            "routes": {
+                "orders": {
+                    "added": { "template": "order-add" },
+                    "updated": { "template": "order-update" }
+                }
+            },
+            "defaultTemplate": {
+                "deleted": { "template": "default-del" }
+            }
+        });
+
+        let dto: FileReactionConfigDto = serde_json::from_value(json).expect("parse dto");
+        assert!(matches!(dto.write_mode, Some(WriteModeDto::PerChange)));
+        assert_eq!(dto.routes.len(), 1);
+        assert!(dto.routes.contains_key("orders"));
+        assert!(dto.default_template.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_create_reaction_from_config_json() {
+        let json = serde_json::json!({
+            "outputPath": "/tmp/test-out",
+            "writeMode": "append",
+            "routes": {
+                "my-query": {
+                    "added": { "template": "added-{{after.id}}" }
+                }
+            }
+        });
+
+        let descriptor = FileReactionDescriptor;
+        let result = descriptor
+            .create_reaction("test-id", vec!["my-query".to_string()], &json, true)
+            .await;
+        assert!(result.is_ok(), "create_reaction failed: {:?}", result.err());
+        let reaction = result.unwrap();
+        assert_eq!(reaction.id(), "test-id");
+        assert_eq!(reaction.query_ids(), vec!["my-query".to_string()]);
     }
 }

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -393,14 +393,51 @@ impl FileReaction {
     }
 }
 
-/// Replaces unsafe filename characters with `_`.
+/// Replaces unsafe filename characters with `_` and escapes Windows reserved device names.
 pub(crate) fn sanitize_filename(name: &str) -> String {
-    name.chars()
+    let sanitized: String = name
+        .chars()
         .map(|c| match c {
             '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' | '\0' => '_',
+            c if c.is_control() => '_',
             _ => c,
         })
-        .collect()
+        .collect();
+
+    // Check for Windows reserved device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9).
+    // These are reserved with or without an extension (e.g. "CON.json" is also invalid).
+    let stem = sanitized.split('.').next().unwrap_or(&sanitized);
+    let is_reserved = matches!(
+        stem.to_ascii_uppercase().as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    );
+
+    if is_reserved {
+        format!("_{sanitized}")
+    } else {
+        sanitized
+    }
 }
 
 /// Builder for `FileReaction`.
@@ -628,6 +665,28 @@ mod tests {
             sanitize_filename(r#"bad/\:*?"<>|name"#),
             "bad_________name".to_string()
         );
+    }
+
+    #[test]
+    fn test_sanitize_filename_reserved_windows_names() {
+        assert_eq!(sanitize_filename("CON"), "_CON");
+        assert_eq!(sanitize_filename("con"), "_con");
+        assert_eq!(sanitize_filename("PRN"), "_PRN");
+        assert_eq!(sanitize_filename("AUX"), "_AUX");
+        assert_eq!(sanitize_filename("NUL"), "_NUL");
+        assert_eq!(sanitize_filename("COM1"), "_COM1");
+        assert_eq!(sanitize_filename("LPT9"), "_LPT9");
+        // Reserved names with extensions are also invalid on Windows
+        assert_eq!(sanitize_filename("CON.json"), "_CON.json");
+        assert_eq!(sanitize_filename("nul.txt"), "_nul.txt");
+        // Non-reserved names should pass through unchanged
+        assert_eq!(sanitize_filename("CONSOLE"), "CONSOLE");
+        assert_eq!(sanitize_filename("contact.json"), "contact.json");
+    }
+
+    #[test]
+    fn test_sanitize_filename_control_chars() {
+        assert_eq!(sanitize_filename("hello\x01world"), "hello_world");
     }
 
     #[test]

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -16,15 +16,15 @@ use crate::config::{FileReactionConfig, WriteMode};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use handlebars::Handlebars;
-use log::{debug, error};
+use log::{debug, error, warn};
 use lru::LruCache;
 use serde_json::{Map, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs::OpenOptions;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -41,6 +41,8 @@ pub struct FileReaction {
     config: FileReactionConfig,
     handlebars: Arc<Handlebars<'static>>,
     file_locks: Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
+    /// Tracks files that have been checked for partial trailing lines on first open.
+    repaired_files: Arc<Mutex<HashSet<String>>>,
 }
 
 impl FileReaction {
@@ -70,6 +72,7 @@ impl FileReaction {
             config,
             handlebars: Arc::new(Self::build_handlebars()),
             file_locks: Self::new_file_locks(),
+            repaired_files: Arc::new(Mutex::new(HashSet::new())),
         })
     }
 
@@ -90,6 +93,7 @@ impl FileReaction {
             config,
             handlebars: Arc::new(Self::build_handlebars()),
             file_locks: Self::new_file_locks(),
+            repaired_files: Arc::new(Mutex::new(HashSet::new())),
         })
     }
 
@@ -112,6 +116,7 @@ impl FileReaction {
             config,
             handlebars: Arc::new(Self::build_handlebars()),
             file_locks: Self::new_file_locks(),
+            repaired_files: Arc::new(Mutex::new(HashSet::new())),
         })
     }
 
@@ -221,6 +226,7 @@ impl FileReaction {
 
     async fn write_to_file(
         file_locks: &Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
+        repaired_files: &Arc<Mutex<HashSet<String>>>,
         mode: &WriteMode,
         output_file: &Path,
         content: &str,
@@ -235,12 +241,18 @@ impl FileReaction {
             WriteMode::Append => {
                 let lock = Self::get_file_lock(file_locks, output_file).await;
                 let _guard = lock.lock().await;
+
+                // On first append to this file, repair any partial trailing line
+                // left by a previous crash.
+                Self::repair_append_file_once(repaired_files, output_file).await?;
+
                 let mut file = OpenOptions::new()
                     .create(true)
                     .append(true)
                     .open(output_file)
                     .await?;
                 file.write_all(content.as_bytes()).await?;
+                file.sync_all().await?;
             }
             WriteMode::Overwrite => {
                 let lock = Self::get_file_lock(file_locks, output_file).await;
@@ -259,6 +271,80 @@ impl FileReaction {
                 tokio::fs::rename(&tmp_path, output_file).await?;
             }
         }
+
+        Ok(())
+    }
+
+    /// On first access to a file in append mode, check if it ends with a
+    /// newline. If not, the file was left with a partial trailing line from a
+    /// previous crash — truncate that incomplete line so subsequent appends
+    /// produce valid output.
+    async fn repair_append_file_once(
+        repaired_files: &Arc<Mutex<HashSet<String>>>,
+        path: &Path,
+    ) -> Result<()> {
+        let key = path.to_string_lossy().to_string();
+
+        {
+            let repaired = repaired_files.lock().await;
+            if repaired.contains(&key) {
+                return Ok(());
+            }
+        }
+
+        if path.exists() {
+            Self::repair_partial_line(path).await?;
+        }
+
+        let mut repaired = repaired_files.lock().await;
+        repaired.insert(key);
+        Ok(())
+    }
+
+    /// Truncates any incomplete trailing line (content after the last newline).
+    async fn repair_partial_line(path: &Path) -> Result<()> {
+        let mut file = OpenOptions::new().read(true).write(true).open(path).await?;
+
+        let file_len = file.metadata().await?.len();
+        if file_len == 0 {
+            return Ok(());
+        }
+
+        // Read the last byte to check if file ends with newline.
+        file.seek(std::io::SeekFrom::End(-1)).await?;
+        let mut buf = [0u8; 1];
+        file.read_exact(&mut buf).await?;
+
+        if buf[0] == b'\n' {
+            return Ok(());
+        }
+
+        // File doesn't end with newline — find the last newline and truncate after it.
+        // Read up to the last 8KB to find the last newline position.
+        let scan_len = file_len.min(8192);
+        let scan_start = file_len - scan_len;
+        file.seek(std::io::SeekFrom::Start(scan_start)).await?;
+        let mut scan_buf = vec![0u8; scan_len as usize];
+        file.read_exact(&mut scan_buf).await?;
+
+        let truncate_pos = if let Some(last_nl) = scan_buf.iter().rposition(|&b| b == b'\n') {
+            scan_start + last_nl as u64 + 1
+        } else {
+            // No newline found in the scanned region — the entire file content
+            // after scan_start is a partial line. If scan_start == 0, the whole
+            // file is one incomplete line; truncate to empty.
+            scan_start
+        };
+
+        file.set_len(truncate_pos).await?;
+        file.sync_all().await?;
+
+        warn!(
+            "Repaired partial trailing line in '{}': truncated from {} to {} bytes",
+            path.display(),
+            file_len,
+            truncate_pos
+        );
 
         Ok(())
     }
@@ -358,6 +444,7 @@ impl FileReaction {
         config: &FileReactionConfig,
         handlebars: &Handlebars<'static>,
         file_locks: &Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
+        repaired_files: &Arc<Mutex<HashSet<String>>>,
         query_result: &QueryResult,
         reaction_name: &str,
     ) {
@@ -373,9 +460,14 @@ impl FileReaction {
                 diff,
             ) {
                 Ok((output_file, content)) => {
-                    if let Err(e) =
-                        Self::write_to_file(file_locks, &config.write_mode, &output_file, &content)
-                            .await
+                    if let Err(e) = Self::write_to_file(
+                        file_locks,
+                        repaired_files,
+                        &config.write_mode,
+                        &output_file,
+                        &content,
+                    )
+                    .await
                     {
                         error!(
                             "[{}] Failed to write output to '{}': {}",
@@ -595,6 +687,7 @@ impl Reaction for FileReaction {
         let config = self.config.clone();
         let handlebars = self.handlebars.clone();
         let file_locks = self.file_locks.clone();
+        let repaired_files = self.repaired_files.clone();
         let mut shutdown_rx = self.base.create_shutdown_channel().await;
 
         let processing_task = tokio::spawn(async move {
@@ -612,6 +705,7 @@ impl Reaction for FileReaction {
                     &config,
                     &handlebars,
                     &file_locks,
+                    &repaired_files,
                     query_result_arc.as_ref(),
                     &reaction_name,
                 )
@@ -743,7 +837,7 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test").await;
+        FileReaction::process_result(&config, &handlebars, &file_locks, &Arc::new(Mutex::new(HashSet::new())), &result, "test").await;
 
         let output_file = temp_dir.path().join("order_a_b_ADD.json");
         assert!(output_file.exists());
@@ -768,7 +862,7 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test").await;
+        FileReaction::process_result(&config, &handlebars, &file_locks, &Arc::new(Mutex::new(HashSet::new())), &result, "test").await;
 
         let output_file = temp_dir.path().join("orders_ADD_1.log");
         let content = tokio::fs::read_to_string(output_file)
@@ -805,7 +899,7 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test").await;
+        FileReaction::process_result(&config, &handlebars, &file_locks, &Arc::new(Mutex::new(HashSet::new())), &result, "test").await;
 
         let output_file = temp_dir.path().join("unknown-query.log");
         let content = tokio::fs::read_to_string(output_file)
@@ -851,7 +945,7 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test").await;
+        FileReaction::process_result(&config, &handlebars, &file_locks, &Arc::new(Mutex::new(HashSet::new())), &result, "test").await;
 
         let output_file = temp_dir.path().join("orders.log");
         let content = tokio::fs::read_to_string(output_file)
@@ -865,5 +959,97 @@ mod tests {
             !content.contains("default-9"),
             "should not contain default template output, got: {content}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_repair_partial_line_truncates_incomplete_trailing_content() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let file_path = temp_dir.path().join("test.ndjson");
+
+        // Simulate a crash: write two complete lines followed by a partial third line.
+        tokio::fs::write(&file_path, b"{\"id\":1}\n{\"id\":2}\npartial")
+            .await
+            .unwrap();
+
+        FileReaction::repair_partial_line(&file_path).await.unwrap();
+
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, "{\"id\":1}\n{\"id\":2}\n");
+    }
+
+    #[tokio::test]
+    async fn test_repair_partial_line_no_op_when_file_ends_with_newline() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let file_path = temp_dir.path().join("test.ndjson");
+
+        let original = "{\"id\":1}\n{\"id\":2}\n";
+        tokio::fs::write(&file_path, original.as_bytes())
+            .await
+            .unwrap();
+
+        FileReaction::repair_partial_line(&file_path).await.unwrap();
+
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, original);
+    }
+
+    #[tokio::test]
+    async fn test_repair_partial_line_empty_file_is_no_op() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let file_path = temp_dir.path().join("test.ndjson");
+
+        tokio::fs::write(&file_path, b"").await.unwrap();
+
+        FileReaction::repair_partial_line(&file_path).await.unwrap();
+
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, "");
+    }
+
+    #[tokio::test]
+    async fn test_repair_partial_line_entire_file_is_partial() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let file_path = temp_dir.path().join("test.ndjson");
+
+        // File with no newlines at all — entire content is one incomplete line.
+        tokio::fs::write(&file_path, b"partial content without newline")
+            .await
+            .unwrap();
+
+        FileReaction::repair_partial_line(&file_path).await.unwrap();
+
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, "");
+    }
+
+    #[tokio::test]
+    async fn test_repair_append_file_once_only_repairs_first_time() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let file_path = temp_dir.path().join("test.ndjson");
+        let repaired_files = Arc::new(Mutex::new(HashSet::new()));
+
+        // Write file with partial trailing line.
+        tokio::fs::write(&file_path, b"{\"id\":1}\npartial")
+            .await
+            .unwrap();
+
+        // First call should repair.
+        FileReaction::repair_append_file_once(&repaired_files, &file_path)
+            .await
+            .unwrap();
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, "{\"id\":1}\n");
+
+        // Write a new partial line to simulate mid-write state.
+        tokio::fs::write(&file_path, b"{\"id\":1}\nnew partial")
+            .await
+            .unwrap();
+
+        // Second call should NOT repair (already marked as repaired).
+        FileReaction::repair_append_file_once(&repaired_files, &file_path)
+            .await
+            .unwrap();
+        let content = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(content, "{\"id\":1}\nnew partial");
     }
 }

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -17,8 +17,10 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use handlebars::Handlebars;
 use log::{debug, error};
+use lru::LruCache;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs::OpenOptions;
@@ -32,14 +34,22 @@ use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
 use drasi_lib::reactions::common::{OperationType, TemplateRouting};
 use drasi_lib::Reaction;
 
+const FILE_LOCK_CACHE_SIZE: usize = 1024;
+
 pub struct FileReaction {
     base: ReactionBase,
     config: FileReactionConfig,
     handlebars: Arc<Handlebars<'static>>,
-    file_locks: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+    file_locks: Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
 }
 
 impl FileReaction {
+    fn new_file_locks() -> Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>> {
+        Arc::new(Mutex::new(LruCache::new(
+            NonZeroUsize::new(FILE_LOCK_CACHE_SIZE).expect("FILE_LOCK_CACHE_SIZE must be > 0"),
+        )))
+    }
+
     /// Create a builder for FileReaction.
     pub fn builder(id: impl Into<String>) -> FileReactionBuilder {
         FileReactionBuilder::new(id)
@@ -59,7 +69,7 @@ impl FileReaction {
             base: ReactionBase::new(params),
             config,
             handlebars: Arc::new(Self::build_handlebars()),
-            file_locks: Arc::new(Mutex::new(HashMap::new())),
+            file_locks: Self::new_file_locks(),
         })
     }
 
@@ -79,7 +89,7 @@ impl FileReaction {
             base: ReactionBase::new(params),
             config,
             handlebars: Arc::new(Self::build_handlebars()),
-            file_locks: Arc::new(Mutex::new(HashMap::new())),
+            file_locks: Self::new_file_locks(),
         })
     }
 
@@ -101,7 +111,7 @@ impl FileReaction {
             base: ReactionBase::new(params),
             config,
             handlebars: Arc::new(Self::build_handlebars()),
-            file_locks: Arc::new(Mutex::new(HashMap::new())),
+            file_locks: Self::new_file_locks(),
         })
     }
 
@@ -199,19 +209,18 @@ impl FileReaction {
     }
 
     async fn get_file_lock(
-        file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+        file_locks: &Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
         path: &Path,
     ) -> Arc<Mutex<()>> {
         let key = path.to_string_lossy().to_string();
         let mut locks = file_locks.lock().await;
         locks
-            .entry(key)
-            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .get_or_insert(key, || Arc::new(Mutex::new(())))
             .clone()
     }
 
     async fn write_to_file(
-        file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+        file_locks: &Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
         mode: &WriteMode,
         output_file: &Path,
         content: &str,
@@ -236,15 +245,32 @@ impl FileReaction {
             WriteMode::Overwrite => {
                 let lock = Self::get_file_lock(file_locks, output_file).await;
                 let _guard = lock.lock().await;
-                tokio::fs::write(output_file, content.as_bytes()).await?;
+                // Write to a temporary file then atomically rename to avoid
+                // exposing partially-written files to readers.
+                let tmp_path = Self::tmp_path_for(output_file)?;
+                tokio::fs::write(&tmp_path, content.as_bytes()).await?;
+                tokio::fs::rename(&tmp_path, output_file).await?;
             }
             WriteMode::PerChange => {
-                // No lock needed — each file is unique (UUID-based filenames).
-                tokio::fs::write(output_file, content.as_bytes()).await?;
+                // No lock needed — each file is unique.
+                // Still write atomically to avoid truncated files on crash.
+                let tmp_path = Self::tmp_path_for(output_file)?;
+                tokio::fs::write(&tmp_path, content.as_bytes()).await?;
+                tokio::fs::rename(&tmp_path, output_file).await?;
             }
         }
 
         Ok(())
+    }
+
+    fn tmp_path_for(output_file: &Path) -> Result<PathBuf> {
+        let file_name = output_file
+            .file_name()
+            .ok_or_else(|| anyhow!("output_file has no file name"))?;
+        let tmp_file_name = format!("{}.tmp", file_name.to_string_lossy());
+        let mut tmp_path = output_file.to_path_buf();
+        tmp_path.set_file_name(tmp_file_name);
+        Ok(tmp_path)
     }
 
     fn render_output(
@@ -331,7 +357,7 @@ impl FileReaction {
     async fn process_result(
         config: &FileReactionConfig,
         handlebars: &Handlebars<'static>,
-        file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+        file_locks: &Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
         query_result: &QueryResult,
         reaction_name: &str,
     ) {
@@ -648,7 +674,7 @@ mod tests {
         };
 
         let handlebars = FileReaction::build_handlebars();
-        let file_locks = Arc::new(Mutex::new(HashMap::new()));
+        let file_locks = FileReaction::new_file_locks();
         let result = QueryResult::new(
             "orders".to_string(),
             chrono::Utc::now(),
@@ -673,7 +699,7 @@ mod tests {
         config.default_template = None;
 
         let handlebars = FileReaction::build_handlebars();
-        let file_locks = Arc::new(Mutex::new(HashMap::new()));
+        let file_locks = FileReaction::new_file_locks();
         let result = QueryResult::new(
             "orders".to_string(),
             chrono::Utc::now(),
@@ -710,7 +736,7 @@ mod tests {
         };
 
         let handlebars = FileReaction::build_handlebars();
-        let file_locks = Arc::new(Mutex::new(HashMap::new()));
+        let file_locks = FileReaction::new_file_locks();
         let result = QueryResult::new(
             "unknown-query".to_string(),
             chrono::Utc::now(),
@@ -753,7 +779,7 @@ mod tests {
         };
 
         let handlebars = FileReaction::build_handlebars();
-        let file_locks = Arc::new(Mutex::new(HashMap::new()));
+        let file_locks = FileReaction::new_file_locks();
         let result = QueryResult::new(
             "orders".to_string(),
             chrono::Utc::now(),

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -752,7 +752,10 @@ mod tests {
         let content = tokio::fs::read_to_string(output_file)
             .await
             .expect("read file");
-        assert!(content.contains("default-7"));
+        assert!(
+            content.contains("default-7"),
+            "expected rendered template 'default-7', got: {content}"
+        );
     }
 
     #[tokio::test]
@@ -795,7 +798,13 @@ mod tests {
         let content = tokio::fs::read_to_string(output_file)
             .await
             .expect("read file");
-        assert!(content.contains("route-9"));
-        assert!(!content.contains("default-9"));
+        assert!(
+            content.contains("route-9"),
+            "expected rendered template 'route-9', got: {content}"
+        );
+        assert!(
+            !content.contains("default-9"),
+            "should not contain default template output, got: {content}"
+        );
     }
 }

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -293,7 +293,12 @@ impl FileReaction {
                 context.insert("before".into(), data.clone());
                 context.insert("data".into(), data.clone());
             }
-            ResultDiff::Aggregation { .. } | ResultDiff::Noop => {}
+            ResultDiff::Aggregation { before, after } => {
+                context.insert("before".into(), before.clone().unwrap_or(Value::Null));
+                context.insert("after".into(), after.clone());
+                context.insert("data".into(), after.clone());
+            }
+            ResultDiff::Noop => {}
         }
 
         let filename_template = config
@@ -331,7 +336,7 @@ impl FileReaction {
         reaction_name: &str,
     ) {
         for diff in &query_result.results {
-            if matches!(diff, ResultDiff::Noop | ResultDiff::Aggregation { .. }) {
+            if matches!(diff, ResultDiff::Noop) {
                 continue;
             }
             match Self::render_output(

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -258,7 +258,7 @@ impl FileReaction {
             ResultDiff::Add { .. } => ("ADD", Some(OperationType::Add)),
             ResultDiff::Update { .. } => ("UPDATE", Some(OperationType::Update)),
             ResultDiff::Delete { .. } => ("DELETE", Some(OperationType::Delete)),
-            ResultDiff::Aggregation { .. } => ("AGGREGATION", None),
+            ResultDiff::Aggregation { .. } => ("AGGREGATION", Some(OperationType::Update)),
             ResultDiff::Noop => ("NOOP", None),
         };
 

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -220,12 +220,12 @@ impl FileReaction {
             tokio::fs::create_dir_all(parent).await?;
         }
 
-        let lock = Self::get_file_lock(file_locks, output_file).await;
-        let _guard = lock.lock().await;
         let content = format!("{content}\n");
 
         match mode {
             WriteMode::Append => {
+                let lock = Self::get_file_lock(file_locks, output_file).await;
+                let _guard = lock.lock().await;
                 let mut file = OpenOptions::new()
                     .create(true)
                     .append(true)
@@ -234,16 +234,13 @@ impl FileReaction {
                 file.write_all(content.as_bytes()).await?;
             }
             WriteMode::Overwrite => {
+                let lock = Self::get_file_lock(file_locks, output_file).await;
+                let _guard = lock.lock().await;
                 tokio::fs::write(output_file, content.as_bytes()).await?;
             }
             WriteMode::PerChange => {
-                let mut file = OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .truncate(true)
-                    .open(output_file)
-                    .await?;
-                file.write_all(content.as_bytes()).await?;
+                // No lock needed — each file is unique (UUID-based filenames).
+                tokio::fs::write(output_file, content.as_bytes()).await?;
             }
         }
 
@@ -280,6 +277,7 @@ impl FileReaction {
         match diff {
             ResultDiff::Add { data } => {
                 context.insert("after".into(), data.clone());
+                context.insert("data".into(), data.clone());
             }
             ResultDiff::Update {
                 before,
@@ -293,12 +291,9 @@ impl FileReaction {
             }
             ResultDiff::Delete { data } => {
                 context.insert("before".into(), data.clone());
+                context.insert("data".into(), data.clone());
             }
-            ResultDiff::Aggregation { before, after } => {
-                context.insert("before".into(), before.clone().unwrap_or(Value::Null));
-                context.insert("after".into(), after.clone());
-            }
-            ResultDiff::Noop => {}
+            ResultDiff::Aggregation { .. } | ResultDiff::Noop => {}
         }
 
         let filename_template = config
@@ -334,8 +329,11 @@ impl FileReaction {
         file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
         query_result: &QueryResult,
         reaction_name: &str,
-    ) -> Result<()> {
+    ) {
         for diff in &query_result.results {
+            if matches!(diff, ResultDiff::Noop | ResultDiff::Aggregation { .. }) {
+                continue;
+            }
             match Self::render_output(
                 config,
                 handlebars,
@@ -361,8 +359,6 @@ impl FileReaction {
                 }
             }
         }
-
-        Ok(())
     }
 }
 
@@ -402,11 +398,6 @@ impl FileReactionBuilder {
     }
 
     pub fn with_query(mut self, query_id: impl Into<String>) -> Self {
-        self.queries.push(query_id.into());
-        self
-    }
-
-    pub fn from_query(mut self, query_id: impl Into<String>) -> Self {
         self.queries.push(query_id.into());
         self
     }
@@ -549,17 +540,14 @@ impl Reaction for FileReaction {
                     result = priority_queue.dequeue() => result,
                 };
 
-                if let Err(e) = Self::process_result(
+                Self::process_result(
                     &config,
                     &handlebars,
                     &file_locks,
                     query_result_arc.as_ref(),
                     &reaction_name,
                 )
-                .await
-                {
-                    error!("[{reaction_name}] Failed processing query result: {e}");
-                }
+                .await;
             }
         });
 
@@ -665,9 +653,7 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test")
-            .await
-            .expect("process result");
+        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test").await;
 
         let output_file = temp_dir.path().join("order_a_b_ADD.json");
         assert!(output_file.exists());
@@ -692,9 +678,7 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test")
-            .await
-            .expect("process result");
+        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test").await;
 
         let output_file = temp_dir.path().join("orders_ADD_1.log");
         let content = tokio::fs::read_to_string(output_file)
@@ -731,9 +715,7 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test")
-            .await
-            .expect("process result");
+        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test").await;
 
         let output_file = temp_dir.path().join("unknown-query.log");
         let content = tokio::fs::read_to_string(output_file)
@@ -776,9 +758,7 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test")
-            .await
-            .expect("process result");
+        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test").await;
 
         let output_file = temp_dir.path().join("orders.log");
         let content = tokio::fs::read_to_string(output_file)

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -540,18 +540,18 @@ impl Reaction for FileReaction {
         log_component_start("File Reaction", &self.base.id);
 
         self.base
-            .set_status_with_event(
+            .set_status(
                 ComponentStatus::Starting,
                 Some("Starting file reaction".to_string()),
             )
-            .await?;
+            .await;
 
         self.base
-            .set_status_with_event(
+            .set_status(
                 ComponentStatus::Running,
                 Some("File reaction started".to_string()),
             )
-            .await?;
+            .await;
 
         let priority_queue = self.base.priority_queue.clone();
         let reaction_name = self.base.id.clone();
@@ -589,11 +589,11 @@ impl Reaction for FileReaction {
     async fn stop(&self) -> Result<()> {
         self.base.stop_common().await?;
         self.base
-            .set_status_with_event(
+            .set_status(
                 ComponentStatus::Stopped,
                 Some("File reaction stopped".to_string()),
             )
-            .await?;
+            .await;
         Ok(())
     }
 

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -1,0 +1,790 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::config::{FileReactionConfig, WriteMode};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use handlebars::Handlebars;
+use log::{debug, error};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use drasi_lib::channels::{ComponentStatus, QueryResult, ResultDiff};
+use drasi_lib::managers::log_component_start;
+use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
+use drasi_lib::reactions::common::{OperationType, TemplateRouting};
+use drasi_lib::Reaction;
+
+pub struct FileReaction {
+    base: ReactionBase,
+    config: FileReactionConfig,
+    handlebars: Arc<Handlebars<'static>>,
+    file_locks: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+}
+
+impl FileReaction {
+    /// Create a builder for FileReaction.
+    pub fn builder(id: impl Into<String>) -> FileReactionBuilder {
+        FileReactionBuilder::new(id)
+    }
+
+    /// Create a new file reaction.
+    pub fn new(
+        id: impl Into<String>,
+        queries: Vec<String>,
+        config: FileReactionConfig,
+    ) -> anyhow::Result<Self> {
+        let id = id.into();
+        Self::validate_config(&queries, &config)?;
+
+        let params = ReactionBaseParams::new(id, queries);
+        Ok(Self {
+            base: ReactionBase::new(params),
+            config,
+            handlebars: Arc::new(Self::build_handlebars()),
+            file_locks: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    /// Create a new file reaction with custom priority queue capacity.
+    pub fn with_priority_queue_capacity(
+        id: impl Into<String>,
+        queries: Vec<String>,
+        config: FileReactionConfig,
+        priority_queue_capacity: usize,
+    ) -> anyhow::Result<Self> {
+        let id = id.into();
+        Self::validate_config(&queries, &config)?;
+
+        let params = ReactionBaseParams::new(id, queries)
+            .with_priority_queue_capacity(priority_queue_capacity);
+        Ok(Self {
+            base: ReactionBase::new(params),
+            config,
+            handlebars: Arc::new(Self::build_handlebars()),
+            file_locks: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    pub(crate) fn from_builder(
+        id: String,
+        queries: Vec<String>,
+        config: FileReactionConfig,
+        priority_queue_capacity: Option<usize>,
+        auto_start: bool,
+    ) -> anyhow::Result<Self> {
+        Self::validate_config(&queries, &config)?;
+
+        let mut params = ReactionBaseParams::new(id, queries).with_auto_start(auto_start);
+        if let Some(capacity) = priority_queue_capacity {
+            params = params.with_priority_queue_capacity(capacity);
+        }
+
+        Ok(Self {
+            base: ReactionBase::new(params),
+            config,
+            handlebars: Arc::new(Self::build_handlebars()),
+            file_locks: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    fn build_handlebars() -> Handlebars<'static> {
+        let mut handlebars = Handlebars::new();
+        handlebars.register_helper(
+            "json",
+            Box::new(
+                |h: &handlebars::Helper,
+                 _: &Handlebars,
+                 _: &handlebars::Context,
+                 _: &mut handlebars::RenderContext,
+                 out: &mut dyn handlebars::Output|
+                 -> handlebars::HelperResult {
+                    if let Some(value) = h.param(0) {
+                        let json_str =
+                            serde_json::to_string(value.value()).unwrap_or_else(|_| "null".into());
+                        out.write(&json_str)?;
+                    }
+                    Ok(())
+                },
+            ),
+        );
+        handlebars
+    }
+
+    fn default_filename_template(write_mode: &WriteMode) -> &'static str {
+        match write_mode {
+            WriteMode::Append => "{{query_name}}.log",
+            WriteMode::Overwrite => "{{query_name}}.json",
+            WriteMode::PerChange => "{{query_name}}_{{operation}}_{{uuid}}.json",
+        }
+    }
+
+    fn validate_template(template: &str) -> anyhow::Result<()> {
+        if template.is_empty() {
+            return Ok(());
+        }
+
+        handlebars::Template::compile(template).map_err(|e| anyhow!("Invalid template: {e}"))?;
+        Ok(())
+    }
+
+    fn validate_query_config(config: &crate::config::QueryConfig) -> anyhow::Result<()> {
+        if let Some(added) = &config.added {
+            Self::validate_template(&added.template)?;
+        }
+        if let Some(updated) = &config.updated {
+            Self::validate_template(&updated.template)?;
+        }
+        if let Some(deleted) = &config.deleted {
+            Self::validate_template(&deleted.template)?;
+        }
+        Ok(())
+    }
+
+    fn validate_config(queries: &[String], config: &FileReactionConfig) -> anyhow::Result<()> {
+        if config.output_path.trim().is_empty() {
+            return Err(anyhow!("output_path must not be empty"));
+        }
+
+        if let Some(filename_template) = &config.filename_template {
+            Self::validate_template(filename_template)
+                .map_err(|e| anyhow!("Invalid filename template: {e}"))?;
+        } else {
+            Self::validate_template(Self::default_filename_template(&config.write_mode))
+                .map_err(|e| anyhow!("Invalid default filename template: {e}"))?;
+        }
+
+        for (query_id, route_config) in &config.routes {
+            Self::validate_query_config(route_config)
+                .map_err(|e| anyhow!("Invalid template in route '{query_id}': {e}"))?;
+        }
+
+        if let Some(default_template) = &config.default_template {
+            Self::validate_query_config(default_template)
+                .map_err(|e| anyhow!("Invalid default template: {e}"))?;
+        }
+
+        if !config.routes.is_empty() && !queries.is_empty() {
+            for route_query in config.routes.keys() {
+                let dotted_route = format!(".{route_query}");
+                let matches = queries
+                    .iter()
+                    .any(|q| q == route_query || q.ends_with(&dotted_route));
+                if !matches {
+                    return Err(anyhow!(
+                        "Route '{route_query}' does not match any subscribed query. Subscribed queries: {queries:?}"
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn get_file_lock(
+        file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+        path: &Path,
+    ) -> Arc<Mutex<()>> {
+        let key = path.to_string_lossy().to_string();
+        let mut locks = file_locks.lock().await;
+        locks
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
+    async fn write_to_file(
+        file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+        mode: &WriteMode,
+        output_file: &Path,
+        content: &str,
+    ) -> Result<()> {
+        if let Some(parent) = output_file.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let lock = Self::get_file_lock(file_locks, output_file).await;
+        let _guard = lock.lock().await;
+        let content = format!("{content}\n");
+
+        match mode {
+            WriteMode::Append => {
+                let mut file = OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(output_file)
+                    .await?;
+                file.write_all(content.as_bytes()).await?;
+            }
+            WriteMode::Overwrite => {
+                tokio::fs::write(output_file, content.as_bytes()).await?;
+            }
+            WriteMode::PerChange => {
+                let mut file = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(output_file)
+                    .await?;
+                file.write_all(content.as_bytes()).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn render_output(
+        config: &FileReactionConfig,
+        handlebars: &Handlebars<'static>,
+        query_id: &str,
+        event_timestamp: chrono::DateTime<chrono::Utc>,
+        diff: &ResultDiff,
+    ) -> Result<(PathBuf, String)> {
+        let (operation_name, operation_type) = match diff {
+            ResultDiff::Add { .. } => ("ADD", Some(OperationType::Add)),
+            ResultDiff::Update { .. } => ("UPDATE", Some(OperationType::Update)),
+            ResultDiff::Delete { .. } => ("DELETE", Some(OperationType::Delete)),
+            ResultDiff::Aggregation { .. } => ("AGGREGATION", None),
+            ResultDiff::Noop => ("NOOP", None),
+        };
+
+        let mut context = Map::new();
+        context.insert("query_name".into(), Value::String(query_id.to_string()));
+        context.insert(
+            "operation".into(),
+            Value::String(operation_name.to_string()),
+        );
+        context.insert(
+            "timestamp".into(),
+            Value::String(event_timestamp.to_rfc3339()),
+        );
+        context.insert("uuid".into(), Value::String(Uuid::new_v4().to_string()));
+
+        match diff {
+            ResultDiff::Add { data } => {
+                context.insert("after".into(), data.clone());
+            }
+            ResultDiff::Update {
+                before,
+                after,
+                data,
+                ..
+            } => {
+                context.insert("before".into(), before.clone());
+                context.insert("after".into(), after.clone());
+                context.insert("data".into(), data.clone());
+            }
+            ResultDiff::Delete { data } => {
+                context.insert("before".into(), data.clone());
+            }
+            ResultDiff::Aggregation { before, after } => {
+                context.insert("before".into(), before.clone().unwrap_or(Value::Null));
+                context.insert("after".into(), after.clone());
+            }
+            ResultDiff::Noop => {}
+        }
+
+        let filename_template = config
+            .filename_template
+            .as_deref()
+            .unwrap_or_else(|| Self::default_filename_template(&config.write_mode));
+
+        let rendered_filename = handlebars.render_template(filename_template, &context)?;
+        let sanitized_filename = sanitize_filename(&rendered_filename);
+        if sanitized_filename.trim().is_empty() {
+            return Err(anyhow!(
+                "Rendered filename '{rendered_filename}' is empty after sanitization"
+            ));
+        }
+
+        let content = if let Some(operation_type) = operation_type {
+            if let Some(template_spec) = config.get_template_spec(query_id, operation_type) {
+                handlebars.render_template(&template_spec.template, &context)?
+            } else {
+                serde_json::to_string(diff)?
+            }
+        } else {
+            serde_json::to_string(diff)?
+        };
+
+        let output_file = Path::new(&config.output_path).join(sanitized_filename);
+        Ok((output_file, content))
+    }
+
+    async fn process_result(
+        config: &FileReactionConfig,
+        handlebars: &Handlebars<'static>,
+        file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+        query_result: &QueryResult,
+        reaction_name: &str,
+    ) -> Result<()> {
+        for diff in &query_result.results {
+            match Self::render_output(
+                config,
+                handlebars,
+                &query_result.query_id,
+                query_result.timestamp,
+                diff,
+            ) {
+                Ok((output_file, content)) => {
+                    if let Err(e) =
+                        Self::write_to_file(file_locks, &config.write_mode, &output_file, &content)
+                            .await
+                    {
+                        error!(
+                            "[{}] Failed to write output to '{}': {}",
+                            reaction_name,
+                            output_file.to_string_lossy(),
+                            e
+                        );
+                    }
+                }
+                Err(e) => {
+                    error!("[{reaction_name}] Failed to render output: {e}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Replaces unsafe filename characters with `_`.
+pub(crate) fn sanitize_filename(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' | '\0' => '_',
+            _ => c,
+        })
+        .collect()
+}
+
+/// Builder for `FileReaction`.
+pub struct FileReactionBuilder {
+    id: String,
+    queries: Vec<String>,
+    config: FileReactionConfig,
+    priority_queue_capacity: Option<usize>,
+    auto_start: bool,
+}
+
+impl FileReactionBuilder {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            queries: Vec::new(),
+            config: FileReactionConfig::default(),
+            priority_queue_capacity: None,
+            auto_start: true,
+        }
+    }
+
+    pub fn with_queries(mut self, queries: Vec<String>) -> Self {
+        self.queries = queries;
+        self
+    }
+
+    pub fn with_query(mut self, query_id: impl Into<String>) -> Self {
+        self.queries.push(query_id.into());
+        self
+    }
+
+    pub fn from_query(mut self, query_id: impl Into<String>) -> Self {
+        self.queries.push(query_id.into());
+        self
+    }
+
+    pub fn with_output_path(mut self, output_path: impl Into<String>) -> Self {
+        self.config.output_path = output_path.into();
+        self
+    }
+
+    pub fn with_write_mode(mut self, mode: WriteMode) -> Self {
+        self.config.write_mode = mode;
+        self
+    }
+
+    pub fn with_filename_template(mut self, filename_template: impl Into<String>) -> Self {
+        self.config.filename_template = Some(filename_template.into());
+        self
+    }
+
+    pub fn with_default_template(mut self, template: crate::config::QueryConfig) -> Self {
+        self.config.default_template = Some(template);
+        self
+    }
+
+    pub fn with_route(
+        mut self,
+        query_id: impl Into<String>,
+        config: crate::config::QueryConfig,
+    ) -> Self {
+        self.config.routes.insert(query_id.into(), config);
+        self
+    }
+
+    pub fn with_priority_queue_capacity(mut self, capacity: usize) -> Self {
+        self.priority_queue_capacity = Some(capacity);
+        self
+    }
+
+    pub fn with_auto_start(mut self, auto_start: bool) -> Self {
+        self.auto_start = auto_start;
+        self
+    }
+
+    pub fn with_config(mut self, config: FileReactionConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn build(self) -> anyhow::Result<FileReaction> {
+        FileReaction::from_builder(
+            self.id,
+            self.queries,
+            self.config,
+            self.priority_queue_capacity,
+            self.auto_start,
+        )
+    }
+}
+
+#[async_trait]
+impl Reaction for FileReaction {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "file"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        let mut properties = HashMap::new();
+        properties.insert(
+            "output_path".to_string(),
+            Value::String(self.config.output_path.clone()),
+        );
+        properties.insert(
+            "write_mode".to_string(),
+            Value::String(
+                match self.config.write_mode {
+                    WriteMode::Append => "append",
+                    WriteMode::Overwrite => "overwrite",
+                    WriteMode::PerChange => "per_change",
+                }
+                .to_string(),
+            ),
+        );
+        if let Some(filename_template) = &self.config.filename_template {
+            properties.insert(
+                "filename_template".to_string(),
+                Value::String(filename_template.clone()),
+            );
+        }
+        properties
+    }
+
+    fn query_ids(&self) -> Vec<String> {
+        self.base.queries.clone()
+    }
+
+    fn auto_start(&self) -> bool {
+        self.base.get_auto_start()
+    }
+
+    async fn initialize(&self, context: drasi_lib::context::ReactionRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn start(&self) -> Result<()> {
+        log_component_start("File Reaction", &self.base.id);
+
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Starting,
+                Some("Starting file reaction".to_string()),
+            )
+            .await?;
+
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Running,
+                Some("File reaction started".to_string()),
+            )
+            .await?;
+
+        let priority_queue = self.base.priority_queue.clone();
+        let reaction_name = self.base.id.clone();
+        let config = self.config.clone();
+        let handlebars = self.handlebars.clone();
+        let file_locks = self.file_locks.clone();
+        let mut shutdown_rx = self.base.create_shutdown_channel().await;
+
+        let processing_task = tokio::spawn(async move {
+            loop {
+                let query_result_arc = tokio::select! {
+                    biased;
+                    _ = &mut shutdown_rx => {
+                        debug!("[{reaction_name}] Received shutdown signal, exiting processing loop");
+                        break;
+                    }
+                    result = priority_queue.dequeue() => result,
+                };
+
+                if let Err(e) = Self::process_result(
+                    &config,
+                    &handlebars,
+                    &file_locks,
+                    query_result_arc.as_ref(),
+                    &reaction_name,
+                )
+                .await
+                {
+                    error!("[{reaction_name}] Failed processing query result: {e}");
+                }
+            }
+        });
+
+        self.base.set_processing_task(processing_task).await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base.stop_common().await?;
+        self.base
+            .set_status_with_event(
+                ComponentStatus::Stopped,
+                Some("File reaction stopped".to_string()),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn enqueue_query_result(&self, result: QueryResult) -> anyhow::Result<()> {
+        self.base.enqueue_query_result(result).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{QueryConfig, TemplateSpec};
+    use tempfile::TempDir;
+
+    fn create_test_config() -> FileReactionConfig {
+        FileReactionConfig {
+            output_path: ".".to_string(),
+            write_mode: WriteMode::Append,
+            filename_template: Some("{{query_name}}_{{operation}}_{{after.id}}.log".to_string()),
+            routes: HashMap::new(),
+            default_template: None,
+        }
+    }
+
+    #[test]
+    fn test_sanitize_filename() {
+        assert_eq!(
+            sanitize_filename(r#"bad/\:*?"<>|name"#),
+            "bad_________name".to_string()
+        );
+    }
+
+    #[test]
+    fn test_invalid_template_fails_build() {
+        let result = FileReaction::builder("test")
+            .with_query("query1")
+            .with_default_template(QueryConfig {
+                added: Some(TemplateSpec::new("{{after.id")),
+                ..Default::default()
+            })
+            .build();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_route_fails_build() {
+        let result = FileReaction::builder("test")
+            .with_query("query1")
+            .with_route(
+                "non-existent-query",
+                QueryConfig {
+                    added: Some(TemplateSpec::new("{{after.id}}")),
+                    ..Default::default()
+                },
+            )
+            .build();
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_payload_filename_template_and_sanitization() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let config = FileReactionConfig {
+            output_path: temp_dir.path().to_string_lossy().to_string(),
+            write_mode: WriteMode::PerChange,
+            filename_template: Some("order_{{after.id}}_{{operation}}.json".to_string()),
+            routes: HashMap::new(),
+            default_template: Some(QueryConfig {
+                added: Some(TemplateSpec::new(r#"{"id":{{after.id}}}"#)),
+                ..Default::default()
+            }),
+        };
+
+        let handlebars = FileReaction::build_handlebars();
+        let file_locks = Arc::new(Mutex::new(HashMap::new()));
+        let result = QueryResult::new(
+            "orders".to_string(),
+            chrono::Utc::now(),
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": "a/b"}),
+            }],
+            HashMap::new(),
+        );
+
+        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test")
+            .await
+            .expect("process result");
+
+        let output_file = temp_dir.path().join("order_a_b_ADD.json");
+        assert!(output_file.exists());
+    }
+
+    #[tokio::test]
+    async fn test_fallback_to_raw_json_when_no_template() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let mut config = create_test_config();
+        config.output_path = temp_dir.path().to_string_lossy().to_string();
+        config.routes.clear();
+        config.default_template = None;
+
+        let handlebars = FileReaction::build_handlebars();
+        let file_locks = Arc::new(Mutex::new(HashMap::new()));
+        let result = QueryResult::new(
+            "orders".to_string(),
+            chrono::Utc::now(),
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": 1}),
+            }],
+            HashMap::new(),
+        );
+
+        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test")
+            .await
+            .expect("process result");
+
+        let output_file = temp_dir.path().join("orders_ADD_1.log");
+        let content = tokio::fs::read_to_string(output_file)
+            .await
+            .expect("read file");
+        assert!(
+            content.contains("\"ADD\"") && content.contains("\"id\""),
+            "expected raw JSON diff payload, got: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_template_route_lookup() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let config = FileReactionConfig {
+            output_path: temp_dir.path().to_string_lossy().to_string(),
+            write_mode: WriteMode::Append,
+            filename_template: Some("{{query_name}}.log".to_string()),
+            routes: HashMap::new(),
+            default_template: Some(QueryConfig {
+                added: Some(TemplateSpec::new("default-{{after.id}}")),
+                ..Default::default()
+            }),
+        };
+
+        let handlebars = FileReaction::build_handlebars();
+        let file_locks = Arc::new(Mutex::new(HashMap::new()));
+        let result = QueryResult::new(
+            "unknown-query".to_string(),
+            chrono::Utc::now(),
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": 7}),
+            }],
+            HashMap::new(),
+        );
+
+        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test")
+            .await
+            .expect("process result");
+
+        let output_file = temp_dir.path().join("unknown-query.log");
+        let content = tokio::fs::read_to_string(output_file)
+            .await
+            .expect("read file");
+        assert!(content.contains("default-7"));
+    }
+
+    #[tokio::test]
+    async fn test_query_route_overrides_default() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let mut routes = HashMap::new();
+        routes.insert(
+            "orders".to_string(),
+            QueryConfig {
+                added: Some(TemplateSpec::new("route-{{after.id}}")),
+                ..Default::default()
+            },
+        );
+
+        let config = FileReactionConfig {
+            output_path: temp_dir.path().to_string_lossy().to_string(),
+            write_mode: WriteMode::Append,
+            filename_template: Some("{{query_name}}.log".to_string()),
+            routes,
+            default_template: Some(QueryConfig {
+                added: Some(TemplateSpec::new("default-{{after.id}}")),
+                ..Default::default()
+            }),
+        };
+
+        let handlebars = FileReaction::build_handlebars();
+        let file_locks = Arc::new(Mutex::new(HashMap::new()));
+        let result = QueryResult::new(
+            "orders".to_string(),
+            chrono::Utc::now(),
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": 9}),
+            }],
+            HashMap::new(),
+        );
+
+        FileReaction::process_result(&config, &handlebars, &file_locks, &result, "test")
+            .await
+            .expect("process result");
+
+        let output_file = temp_dir.path().join("orders.log");
+        let content = tokio::fs::read_to_string(output_file)
+            .await
+            .expect("read file");
+        assert!(content.contains("route-9"));
+        assert!(!content.contains("default-9"));
+    }
+}

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -813,7 +813,15 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &Arc::new(Mutex::new(HashSet::new())), &result, "test").await;
+        FileReaction::process_result(
+            &config,
+            &handlebars,
+            &file_locks,
+            &Arc::new(Mutex::new(HashSet::new())),
+            &result,
+            "test",
+        )
+        .await;
 
         let output_file = temp_dir.path().join("order_a_b_ADD.json");
         assert!(output_file.exists());
@@ -838,7 +846,15 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &Arc::new(Mutex::new(HashSet::new())), &result, "test").await;
+        FileReaction::process_result(
+            &config,
+            &handlebars,
+            &file_locks,
+            &Arc::new(Mutex::new(HashSet::new())),
+            &result,
+            "test",
+        )
+        .await;
 
         let output_file = temp_dir.path().join("orders_ADD_1.log");
         let content = tokio::fs::read_to_string(output_file)
@@ -875,7 +891,15 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &Arc::new(Mutex::new(HashSet::new())), &result, "test").await;
+        FileReaction::process_result(
+            &config,
+            &handlebars,
+            &file_locks,
+            &Arc::new(Mutex::new(HashSet::new())),
+            &result,
+            "test",
+        )
+        .await;
 
         let output_file = temp_dir.path().join("unknown-query.log");
         let content = tokio::fs::read_to_string(output_file)
@@ -921,7 +945,15 @@ mod tests {
             HashMap::new(),
         );
 
-        FileReaction::process_result(&config, &handlebars, &file_locks, &Arc::new(Mutex::new(HashSet::new())), &result, "test").await;
+        FileReaction::process_result(
+            &config,
+            &handlebars,
+            &file_locks,
+            &Arc::new(Mutex::new(HashSet::new())),
+            &result,
+            "test",
+        )
+        .await;
 
         let output_file = temp_dir.path().join("orders.log");
         let content = tokio::fs::read_to_string(output_file)

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -34,6 +34,10 @@ use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
 use drasi_lib::reactions::common::{OperationType, TemplateRouting};
 use drasi_lib::Reaction;
 
+/// A Drasi reaction that writes query result diffs to the filesystem.
+///
+/// Use [`FileReaction::builder`] to construct an instance with the desired
+/// output path, write mode, and Handlebars templates.
 pub struct FileReaction {
     base: ReactionBase,
     config: FileReactionConfig,
@@ -51,46 +55,6 @@ impl FileReaction {
     /// Create a builder for FileReaction.
     pub fn builder(id: impl Into<String>) -> FileReactionBuilder {
         FileReactionBuilder::new(id)
-    }
-
-    /// Create a new file reaction.
-    pub fn new(
-        id: impl Into<String>,
-        queries: Vec<String>,
-        config: FileReactionConfig,
-    ) -> anyhow::Result<Self> {
-        let id = id.into();
-        Self::validate_config(&queries, &config)?;
-
-        let params = ReactionBaseParams::new(id, queries);
-        Ok(Self {
-            base: ReactionBase::new(params),
-            config,
-            handlebars: Arc::new(Self::build_handlebars()),
-            file_locks: Self::new_file_locks(),
-            repaired_files: Arc::new(Mutex::new(HashSet::new())),
-        })
-    }
-
-    /// Create a new file reaction with custom priority queue capacity.
-    pub fn with_priority_queue_capacity(
-        id: impl Into<String>,
-        queries: Vec<String>,
-        config: FileReactionConfig,
-        priority_queue_capacity: usize,
-    ) -> anyhow::Result<Self> {
-        let id = id.into();
-        Self::validate_config(&queries, &config)?;
-
-        let params = ReactionBaseParams::new(id, queries)
-            .with_priority_queue_capacity(priority_queue_capacity);
-        Ok(Self {
-            base: ReactionBase::new(params),
-            config,
-            handlebars: Arc::new(Self::build_handlebars()),
-            file_locks: Self::new_file_locks(),
-            repaired_files: Arc::new(Mutex::new(HashSet::new())),
-        })
     }
 
     pub(crate) fn from_builder(
@@ -289,7 +253,7 @@ impl FileReaction {
             }
         }
 
-        if path.exists() {
+        if tokio::fs::try_exists(path).await.unwrap_or(false) {
             Self::repair_partial_line(path).await?;
         }
 
@@ -529,7 +493,10 @@ pub(crate) fn sanitize_filename(name: &str) -> String {
     }
 }
 
-/// Builder for `FileReaction`.
+/// Builder for [`FileReaction`].
+///
+/// Construct via [`FileReaction::builder`], chain configuration methods,
+/// then call [`build`](Self::build) to create the reaction.
 pub struct FileReactionBuilder {
     id: String,
     queries: Vec<String>,
@@ -539,6 +506,7 @@ pub struct FileReactionBuilder {
 }
 
 impl FileReactionBuilder {
+    /// Creates a new builder with the given reaction ID.
     pub fn new(id: impl Into<String>) -> Self {
         Self {
             id: id.into(),
@@ -549,36 +517,43 @@ impl FileReactionBuilder {
         }
     }
 
+    /// Sets all query subscriptions at once.
     pub fn with_queries(mut self, queries: Vec<String>) -> Self {
         self.queries = queries;
         self
     }
 
+    /// Adds a single query subscription.
     pub fn with_query(mut self, query_id: impl Into<String>) -> Self {
         self.queries.push(query_id.into());
         self
     }
 
+    /// Sets the base output directory for generated files.
     pub fn with_output_path(mut self, output_path: impl Into<String>) -> Self {
         self.config.output_path = output_path.into();
         self
     }
 
+    /// Sets the file write mode (`Append`, `Overwrite`, or `PerChange`).
     pub fn with_write_mode(mut self, mode: WriteMode) -> Self {
         self.config.write_mode = mode;
         self
     }
 
+    /// Sets a custom Handlebars filename template.
     pub fn with_filename_template(mut self, filename_template: impl Into<String>) -> Self {
         self.config.filename_template = Some(filename_template.into());
         self
     }
 
+    /// Sets the default template used when no query-specific route matches.
     pub fn with_default_template(mut self, template: crate::config::QueryConfig) -> Self {
         self.config.default_template = Some(template);
         self
     }
 
+    /// Adds a query-specific template route.
     pub fn with_route(
         mut self,
         query_id: impl Into<String>,
@@ -588,21 +563,25 @@ impl FileReactionBuilder {
         self
     }
 
+    /// Sets the internal priority queue capacity.
     pub fn with_priority_queue_capacity(mut self, capacity: usize) -> Self {
         self.priority_queue_capacity = Some(capacity);
         self
     }
 
+    /// Sets whether the reaction starts automatically after initialization.
     pub fn with_auto_start(mut self, auto_start: bool) -> Self {
         self.auto_start = auto_start;
         self
     }
 
+    /// Replaces the entire configuration. Overwrites any previously set fields.
     pub fn with_config(mut self, config: FileReactionConfig) -> Self {
         self.config = config;
         self
     }
 
+    /// Validates configuration and builds the [`FileReaction`].
     pub fn build(self) -> anyhow::Result<FileReaction> {
         FileReaction::from_builder(
             self.id,
@@ -1048,5 +1027,252 @@ mod tests {
             .unwrap();
         let content = tokio::fs::read_to_string(&file_path).await.unwrap();
         assert_eq!(content, "{\"id\":1}\nnew partial");
+    }
+
+    #[test]
+    fn test_empty_output_path_fails_build() {
+        let result = FileReaction::builder("test")
+            .with_query("query1")
+            .with_output_path("   ")
+            .build();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_label_template_fails_build() {
+        let result = FileReaction::builder("test")
+            .with_query("query1")
+            .with_filename_template("{{unclosed")
+            .build();
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_render_output_update() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let config = FileReactionConfig {
+            output_path: temp_dir.path().to_string_lossy().to_string(),
+            write_mode: WriteMode::Append,
+            filename_template: Some("{{query_name}}.log".to_string()),
+            routes: HashMap::new(),
+            default_template: Some(QueryConfig {
+                updated: Some(TemplateSpec::new(
+                    r#"{"op":"update","before":{{json before}},"after":{{json after}}}"#,
+                )),
+                ..Default::default()
+            }),
+        };
+
+        let handlebars = FileReaction::build_handlebars();
+        let file_locks = FileReaction::new_file_locks();
+        let result = QueryResult::new(
+            "orders".to_string(),
+            0,
+            chrono::Utc::now(),
+            vec![ResultDiff::Update {
+                before: serde_json::json!({"id": 1, "status": "pending"}),
+                after: serde_json::json!({"id": 1, "status": "shipped"}),
+                data: serde_json::json!({"id": 1, "status": "shipped"}),
+                grouping_keys: None,
+                row_signature: 0,
+            }],
+            HashMap::new(),
+        );
+
+        FileReaction::process_result(
+            &config,
+            &handlebars,
+            &file_locks,
+            &Arc::new(Mutex::new(HashSet::new())),
+            &result,
+            "test",
+        )
+        .await;
+
+        let output_file = temp_dir.path().join("orders.log");
+        let content = tokio::fs::read_to_string(output_file)
+            .await
+            .expect("read file");
+        assert!(
+            content.contains(r#""op":"update""#),
+            "expected update template, got: {content}"
+        );
+        assert!(
+            content.contains(r#""status":"pending""#),
+            "expected before data, got: {content}"
+        );
+        assert!(
+            content.contains(r#""status":"shipped""#),
+            "expected after data, got: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_render_output_delete() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let config = FileReactionConfig {
+            output_path: temp_dir.path().to_string_lossy().to_string(),
+            write_mode: WriteMode::Append,
+            filename_template: Some("{{query_name}}.log".to_string()),
+            routes: HashMap::new(),
+            default_template: Some(QueryConfig {
+                deleted: Some(TemplateSpec::new(r#"{"op":"delete","data":{{json data}}}"#)),
+                ..Default::default()
+            }),
+        };
+
+        let handlebars = FileReaction::build_handlebars();
+        let file_locks = FileReaction::new_file_locks();
+        let result = QueryResult::new(
+            "orders".to_string(),
+            0,
+            chrono::Utc::now(),
+            vec![ResultDiff::Delete {
+                data: serde_json::json!({"id": 42}),
+                row_signature: 0,
+            }],
+            HashMap::new(),
+        );
+
+        FileReaction::process_result(
+            &config,
+            &handlebars,
+            &file_locks,
+            &Arc::new(Mutex::new(HashSet::new())),
+            &result,
+            "test",
+        )
+        .await;
+
+        let output_file = temp_dir.path().join("orders.log");
+        let content = tokio::fs::read_to_string(output_file)
+            .await
+            .expect("read file");
+        assert!(
+            content.contains(r#""op":"delete""#),
+            "expected delete template, got: {content}"
+        );
+        assert!(
+            content.contains(r#""id":42"#),
+            "expected deleted data, got: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_render_output_aggregation() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let config = FileReactionConfig {
+            output_path: temp_dir.path().to_string_lossy().to_string(),
+            write_mode: WriteMode::Append,
+            filename_template: Some("{{query_name}}.log".to_string()),
+            routes: HashMap::new(),
+            default_template: Some(QueryConfig {
+                updated: Some(TemplateSpec::new(
+                    r#"{"op":"{{operation}}","before":{{json before}},"after":{{json after}}}"#,
+                )),
+                ..Default::default()
+            }),
+        };
+
+        let handlebars = FileReaction::build_handlebars();
+        let file_locks = FileReaction::new_file_locks();
+        let result = QueryResult::new(
+            "stats".to_string(),
+            0,
+            chrono::Utc::now(),
+            vec![ResultDiff::Aggregation {
+                before: Some(serde_json::json!({"count": 5})),
+                after: serde_json::json!({"count": 6}),
+                row_signature: 0,
+            }],
+            HashMap::new(),
+        );
+
+        FileReaction::process_result(
+            &config,
+            &handlebars,
+            &file_locks,
+            &Arc::new(Mutex::new(HashSet::new())),
+            &result,
+            "test",
+        )
+        .await;
+
+        let output_file = temp_dir.path().join("stats.log");
+        let content = tokio::fs::read_to_string(output_file)
+            .await
+            .expect("read file");
+        assert!(
+            content.contains(r#""op":"AGGREGATION""#),
+            "expected AGGREGATION operation, got: {content}"
+        );
+        assert!(
+            content.contains(r#""count":5"#),
+            "expected before data, got: {content}"
+        );
+        assert!(
+            content.contains(r#""count":6"#),
+            "expected after data, got: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_route_no_match_falls_to_default() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let mut routes = HashMap::new();
+        routes.insert(
+            "orders".to_string(),
+            QueryConfig {
+                added: Some(TemplateSpec::new("matched-{{after.id}}")),
+                ..Default::default()
+            },
+        );
+
+        let config = FileReactionConfig {
+            output_path: temp_dir.path().to_string_lossy().to_string(),
+            write_mode: WriteMode::Append,
+            filename_template: Some("{{query_name}}.log".to_string()),
+            routes,
+            default_template: Some(QueryConfig {
+                added: Some(TemplateSpec::new("default-{{after.id}}")),
+                ..Default::default()
+            }),
+        };
+
+        let handlebars = FileReaction::build_handlebars();
+        let file_locks = FileReaction::new_file_locks();
+        // Query with dotted prefix does not match the "orders" route key exactly,
+        // so it falls through to default_template.
+        let result = QueryResult::new(
+            "ns.orders".to_string(),
+            0,
+            chrono::Utc::now(),
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": 5}),
+                row_signature: 0,
+            }],
+            HashMap::new(),
+        );
+
+        FileReaction::process_result(
+            &config,
+            &handlebars,
+            &file_locks,
+            &Arc::new(Mutex::new(HashSet::new())),
+            &result,
+            "test",
+        )
+        .await;
+
+        let output_file = temp_dir.path().join("ns.orders.log");
+        let content = tokio::fs::read_to_string(output_file)
+            .await
+            .expect("read file");
+        assert!(
+            content.contains("default-5"),
+            "expected default template fallback, got: {content}"
+        );
     }
 }

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -806,9 +806,11 @@ mod tests {
         let file_locks = FileReaction::new_file_locks();
         let result = QueryResult::new(
             "orders".to_string(),
+            0,
             chrono::Utc::now(),
             vec![ResultDiff::Add {
                 data: serde_json::json!({"id": "a/b"}),
+                row_signature: 0,
             }],
             HashMap::new(),
         );
@@ -839,9 +841,11 @@ mod tests {
         let file_locks = FileReaction::new_file_locks();
         let result = QueryResult::new(
             "orders".to_string(),
+            0,
             chrono::Utc::now(),
             vec![ResultDiff::Add {
                 data: serde_json::json!({"id": 1}),
+                row_signature: 0,
             }],
             HashMap::new(),
         );
@@ -884,9 +888,11 @@ mod tests {
         let file_locks = FileReaction::new_file_locks();
         let result = QueryResult::new(
             "unknown-query".to_string(),
+            0,
             chrono::Utc::now(),
             vec![ResultDiff::Add {
                 data: serde_json::json!({"id": 7}),
+                row_signature: 0,
             }],
             HashMap::new(),
         );
@@ -938,9 +944,11 @@ mod tests {
         let file_locks = FileReaction::new_file_locks();
         let result = QueryResult::new(
             "orders".to_string(),
+            0,
             chrono::Utc::now(),
             vec![ResultDiff::Add {
                 data: serde_json::json!({"id": 9}),
+                row_signature: 0,
             }],
             HashMap::new(),
         );

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -34,8 +34,6 @@ use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
 use drasi_lib::reactions::common::{OperationType, TemplateRouting};
 use drasi_lib::Reaction;
 
-
-
 pub struct FileReaction {
     base: ReactionBase,
     config: FileReactionConfig,

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -348,7 +348,7 @@ impl FileReaction {
         context.insert("uuid".into(), Value::String(Uuid::new_v4().to_string()));
 
         match diff {
-            ResultDiff::Add { data } => {
+            ResultDiff::Add { data, .. } => {
                 context.insert("after".into(), data.clone());
                 context.insert("data".into(), data.clone());
             }
@@ -362,11 +362,11 @@ impl FileReaction {
                 context.insert("after".into(), after.clone());
                 context.insert("data".into(), data.clone());
             }
-            ResultDiff::Delete { data } => {
+            ResultDiff::Delete { data, .. } => {
                 context.insert("before".into(), data.clone());
                 context.insert("data".into(), data.clone());
             }
-            ResultDiff::Aggregation { before, after } => {
+            ResultDiff::Aggregation { before, after, .. } => {
                 context.insert("before".into(), before.clone().unwrap_or(Value::Null));
                 context.insert("after".into(), after.clone());
                 context.insert("data".into(), after.clone());

--- a/components/reactions/file/src/file.rs
+++ b/components/reactions/file/src/file.rs
@@ -17,10 +17,10 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use handlebars::Handlebars;
 use log::{debug, error, warn};
-use lru::LruCache;
+
 use serde_json::{Map, Value};
 use std::collections::{HashMap, HashSet};
-use std::num::NonZeroUsize;
+
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs::OpenOptions;
@@ -34,22 +34,20 @@ use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
 use drasi_lib::reactions::common::{OperationType, TemplateRouting};
 use drasi_lib::Reaction;
 
-const FILE_LOCK_CACHE_SIZE: usize = 1024;
+
 
 pub struct FileReaction {
     base: ReactionBase,
     config: FileReactionConfig,
     handlebars: Arc<Handlebars<'static>>,
-    file_locks: Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
+    file_locks: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
     /// Tracks files that have been checked for partial trailing lines on first open.
     repaired_files: Arc<Mutex<HashSet<String>>>,
 }
 
 impl FileReaction {
-    fn new_file_locks() -> Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>> {
-        Arc::new(Mutex::new(LruCache::new(
-            NonZeroUsize::new(FILE_LOCK_CACHE_SIZE).expect("FILE_LOCK_CACHE_SIZE must be > 0"),
-        )))
+    fn new_file_locks() -> Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>> {
+        Arc::new(Mutex::new(HashMap::new()))
     }
 
     /// Create a builder for FileReaction.
@@ -214,18 +212,19 @@ impl FileReaction {
     }
 
     async fn get_file_lock(
-        file_locks: &Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
+        file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
         path: &Path,
     ) -> Arc<Mutex<()>> {
         let key = path.to_string_lossy().to_string();
         let mut locks = file_locks.lock().await;
         locks
-            .get_or_insert(key, || Arc::new(Mutex::new(())))
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
     }
 
     async fn write_to_file(
-        file_locks: &Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
+        file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
         repaired_files: &Arc<Mutex<HashSet<String>>>,
         mode: &WriteMode,
         output_file: &Path,
@@ -443,7 +442,7 @@ impl FileReaction {
     async fn process_result(
         config: &FileReactionConfig,
         handlebars: &Handlebars<'static>,
-        file_locks: &Arc<Mutex<LruCache<String, Arc<Mutex<()>>>>>,
+        file_locks: &Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
         repaired_files: &Arc<Mutex<HashSet<String>>>,
         query_result: &QueryResult,
         reaction_name: &str,

--- a/components/reactions/file/src/lib.rs
+++ b/components/reactions/file/src/lib.rs
@@ -1,0 +1,34 @@
+#![allow(unexpected_cfgs)]
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! File reaction plugin for Drasi.
+
+mod config;
+pub mod descriptor;
+mod file;
+
+pub use config::{FileReactionConfig, QueryConfig, TemplateSpec, WriteMode};
+pub use file::{FileReaction, FileReactionBuilder};
+
+#[cfg(feature = "dynamic-plugin")]
+drasi_plugin_sdk::export_plugin!(
+    plugin_id = "file-reaction",
+    core_version = env!("CARGO_PKG_VERSION"),
+    lib_version = env!("CARGO_PKG_VERSION"),
+    plugin_version = env!("CARGO_PKG_VERSION"),
+    source_descriptors = [],
+    reaction_descriptors = [descriptor::FileReactionDescriptor],
+    bootstrap_descriptors = [],
+);

--- a/components/reactions/file/tests/integration_test.rs
+++ b/components/reactions/file/tests/integration_test.rs
@@ -33,6 +33,24 @@ async fn wait_for_file(path: &Path, timeout: Duration) -> Result<String> {
     Err(anyhow!("Timed out waiting for file '{}'", path.display()))
 }
 
+async fn wait_for_content(path: &Path, needle: &str, timeout: Duration) -> Result<String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if path.exists() {
+            let content = tokio::fs::read_to_string(path).await?;
+            if content.contains(needle) {
+                return Ok(content);
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    Err(anyhow!(
+        "Timed out waiting for file '{}' to contain '{}'",
+        path.display(),
+        needle,
+    ))
+}
+
 async fn wait_for_line_count(
     path: &Path,
     expected_lines: usize,
@@ -372,6 +390,132 @@ async fn test_file_reaction_aggregation_uses_updated_template() -> Result<()> {
     assert!(
         last_line.contains("after_count"),
         "Expected aggregation with updated template, got: {last_line}"
+    );
+
+    drasi.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_file_reaction_append_recovers_from_partial_line() -> Result<()> {
+    let temp = TempDir::new()?;
+    let output_dir = temp.path().to_string_lossy().to_string();
+    let output_file = temp.path().join("test-query.ndjson");
+
+    // Pre-seed the output file with a complete line followed by a simulated
+    // crash (partial trailing line without a newline terminator).
+    tokio::fs::write(
+        &output_file,
+        b"{\"op\":\"add\",\"id\":\"item-0\"}\npartial crash",
+    )
+    .await?;
+
+    let default_template = QueryConfig {
+        added: Some(TemplateSpec::new(
+            r#"{"op":"add","id":"{{after.id}}","name":"{{after.name}}"}"#,
+        )),
+        updated: None,
+        deleted: None,
+    };
+
+    let (drasi, app_handle) = setup_drasi_for_mode(
+        &output_dir,
+        WriteMode::Append,
+        "{{query_name}}.ndjson",
+        Some(default_template),
+    )
+    .await?;
+
+    drasi.start().await?;
+
+    // Send a new event — the reaction should repair the file first, then append.
+    app_handle
+        .send_node_insert(
+            "item-1",
+            vec!["Item"],
+            PropertyMapBuilder::new()
+                .with_string("id", "item-1")
+                .with_string("name", "Widget")
+                .build(),
+        )
+        .await?;
+
+    let content = wait_for_content(&output_file, "item-1", Duration::from_secs(10)).await?;
+    let lines: Vec<&str> = content.lines().collect();
+
+    // The partial "partial crash" line should have been truncated.
+    // Line 1 should be the original complete line, line 2 the newly appended line.
+    assert_eq!(lines.len(), 2, "Expected exactly 2 lines, got: {content}");
+    assert!(
+        lines[0].contains("\"item-0\""),
+        "First line should be the pre-existing complete line"
+    );
+    assert!(
+        lines[1].contains("\"item-1\""),
+        "Second line should be the newly appended event, got: '{}'",
+        lines[1]
+    );
+    assert!(
+        !content.contains("partial crash"),
+        "Partial line should have been truncated"
+    );
+
+    drasi.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_file_reaction_append_fsync_produces_valid_ndjson() -> Result<()> {
+    let temp = TempDir::new()?;
+    let output_dir = temp.path().to_string_lossy().to_string();
+
+    let default_template = QueryConfig {
+        added: Some(TemplateSpec::new(r#"{"op":"add","id":"{{after.id}}"}"#)),
+        updated: None,
+        deleted: None,
+    };
+
+    let (drasi, app_handle) = setup_drasi_for_mode(
+        &output_dir,
+        WriteMode::Append,
+        "{{query_name}}.ndjson",
+        Some(default_template),
+    )
+    .await?;
+
+    drasi.start().await?;
+
+    // Send multiple events.
+    for i in 1..=5 {
+        let id = format!("item-{i}");
+        let name = format!("Widget {i}");
+        app_handle
+            .send_node_insert(
+                id.as_str(),
+                vec!["Item"],
+                PropertyMapBuilder::new()
+                    .with_string("id", &id)
+                    .with_string("name", &name)
+                    .build(),
+            )
+            .await?;
+    }
+
+    let output_file = temp.path().join("test-query.ndjson");
+    let content = wait_for_line_count(&output_file, 5, Duration::from_secs(10)).await?;
+
+    // Verify every line is valid JSON (valid NDJSON).
+    for (i, line) in content.lines().enumerate() {
+        assert!(
+            serde_json::from_str::<serde_json::Value>(line).is_ok(),
+            "Line {i} is not valid JSON: {line}"
+        );
+    }
+
+    // Verify the file ends with a newline (proper NDJSON termination).
+    assert!(
+        content.ends_with('\n'),
+        "File should end with a newline character"
     );
 
     drasi.stop().await?;

--- a/components/reactions/file/tests/integration_test.rs
+++ b/components/reactions/file/tests/integration_test.rs
@@ -291,3 +291,99 @@ async fn test_file_reaction_fallback_raw_json() -> Result<()> {
     drasi.stop().await?;
     Ok(())
 }
+
+#[tokio::test]
+#[ignore]
+async fn test_file_reaction_aggregation_uses_updated_template() -> Result<()> {
+    let temp = TempDir::new()?;
+    let output_dir = temp.path().to_string_lossy().to_string();
+
+    let (app_source, app_handle) = ApplicationSource::new(
+        "test-source",
+        ApplicationSourceConfig {
+            properties: HashMap::new(),
+        },
+    )?;
+
+    let default_template = QueryConfig {
+        added: Some(TemplateSpec::new(
+            r#"{"op":"add","count":{{after.item_count}}}"#,
+        )),
+        updated: Some(TemplateSpec::new(
+            r#"{"op":"update","before_count":{{before.item_count}},"after_count":{{after.item_count}}}"#,
+        )),
+        deleted: Some(TemplateSpec::new(
+            r#"{"op":"delete","count":{{before.item_count}}}"#,
+        )),
+    };
+
+    let file_reaction = FileReaction::builder("file-reaction")
+        .with_query("agg-query")
+        .with_output_path(&output_dir)
+        .with_write_mode(WriteMode::Append)
+        .with_filename_template("{{query_name}}.ndjson")
+        .with_default_template(default_template)
+        .build()?;
+
+    let query = Query::cypher("agg-query")
+        .query("MATCH (n:Item) RETURN n.category AS category, count(n) AS item_count")
+        .from_source("test-source")
+        .auto_start(true)
+        .enable_bootstrap(false)
+        .build();
+
+    let drasi = DrasiLib::builder()
+        .with_id("file-reaction-agg-test")
+        .with_source(app_source)
+        .with_query(query)
+        .with_reaction(file_reaction)
+        .build()
+        .await?;
+
+    drasi.start().await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // First insert produces an aggregation diff (before=None, after={category:"A", item_count:1})
+    app_handle
+        .send_node_insert(
+            "item-1",
+            vec!["Item"],
+            PropertyMapBuilder::new()
+                .with_string("id", "item-1")
+                .with_string("category", "A")
+                .build(),
+        )
+        .await?;
+
+    let output_file = temp.path().join("agg-query.ndjson");
+    let content = wait_for_file(&output_file, Duration::from_secs(10)).await?;
+    // The first aggregation has no before, so the updated template renders before.item_count as empty.
+    // But the after count should be present.
+    assert!(
+        content.contains("after_count") || content.contains("\"count\""),
+        "Expected aggregation output with count, got: {content}"
+    );
+
+    // Second insert to same category changes count from 1 to 2
+    app_handle
+        .send_node_insert(
+            "item-2",
+            vec!["Item"],
+            PropertyMapBuilder::new()
+                .with_string("id", "item-2")
+                .with_string("category", "A")
+                .build(),
+        )
+        .await?;
+
+    let content = wait_for_line_count(&output_file, 2, Duration::from_secs(10)).await?;
+    let lines: Vec<&str> = content.lines().collect();
+    let last_line = lines.last().expect("should have at least 2 lines");
+    assert!(
+        last_line.contains("after_count"),
+        "Expected aggregation with updated template, got: {last_line}"
+    );
+
+    drasi.stop().await?;
+    Ok(())
+}

--- a/components/reactions/file/tests/integration_test.rs
+++ b/components/reactions/file/tests/integration_test.rs
@@ -99,7 +99,6 @@ async fn setup_drasi_for_mode(
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_file_reaction_append_insert_update_delete() -> Result<()> {
     let temp = TempDir::new()?;
     let output_dir = temp.path().to_string_lossy().to_string();
@@ -125,7 +124,6 @@ async fn test_file_reaction_append_insert_update_delete() -> Result<()> {
     .await?;
 
     drasi.start().await?;
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     app_handle
         .send_node_insert(
@@ -163,7 +161,6 @@ async fn test_file_reaction_append_insert_update_delete() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_file_reaction_overwrite_mode_keeps_latest() -> Result<()> {
     let temp = TempDir::new()?;
     let output_dir = temp.path().to_string_lossy().to_string();
@@ -187,7 +184,6 @@ async fn test_file_reaction_overwrite_mode_keeps_latest() -> Result<()> {
     .await?;
 
     drasi.start().await?;
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     app_handle
         .send_node_insert(
@@ -220,7 +216,6 @@ async fn test_file_reaction_overwrite_mode_keeps_latest() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_file_reaction_per_change_and_payload_filename() -> Result<()> {
     let temp = TempDir::new()?;
     let output_dir = temp.path().to_string_lossy().to_string();
@@ -240,7 +235,6 @@ async fn test_file_reaction_per_change_and_payload_filename() -> Result<()> {
     .await?;
 
     drasi.start().await?;
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     app_handle
         .send_node_insert(
@@ -262,7 +256,6 @@ async fn test_file_reaction_per_change_and_payload_filename() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_file_reaction_fallback_raw_json() -> Result<()> {
     let temp = TempDir::new()?;
     let output_dir = temp.path().to_string_lossy().to_string();
@@ -271,7 +264,6 @@ async fn test_file_reaction_fallback_raw_json() -> Result<()> {
         setup_drasi_for_mode(&output_dir, WriteMode::Append, "{{query_name}}.log", None).await?;
 
     drasi.start().await?;
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     app_handle
         .send_node_insert(
@@ -293,7 +285,6 @@ async fn test_file_reaction_fallback_raw_json() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_file_reaction_aggregation_uses_updated_template() -> Result<()> {
     let temp = TempDir::new()?;
     let output_dir = temp.path().to_string_lossy().to_string();
@@ -341,7 +332,6 @@ async fn test_file_reaction_aggregation_uses_updated_template() -> Result<()> {
         .await?;
 
     drasi.start().await?;
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     // First insert produces an aggregation diff (before=None, after={category:"A", item_count:1})
     app_handle

--- a/components/reactions/file/tests/integration_test.rs
+++ b/components/reactions/file/tests/integration_test.rs
@@ -1,0 +1,293 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{anyhow, Result};
+use drasi_lib::{DrasiLib, Query};
+use drasi_reaction_file::{FileReaction, QueryConfig, TemplateSpec, WriteMode};
+use drasi_source_application::{ApplicationSource, ApplicationSourceConfig, PropertyMapBuilder};
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Duration;
+use tempfile::TempDir;
+
+async fn wait_for_file(path: &Path, timeout: Duration) -> Result<String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if path.exists() {
+            let content = tokio::fs::read_to_string(path).await?;
+            return Ok(content);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    Err(anyhow!("Timed out waiting for file '{}'", path.display()))
+}
+
+async fn wait_for_line_count(
+    path: &Path,
+    expected_lines: usize,
+    timeout: Duration,
+) -> Result<String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if path.exists() {
+            let content = tokio::fs::read_to_string(path).await?;
+            if content.lines().count() >= expected_lines {
+                return Ok(content);
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    Err(anyhow!(
+        "Timed out waiting for file '{}' to reach {} lines",
+        path.display(),
+        expected_lines
+    ))
+}
+
+async fn setup_drasi_for_mode(
+    output_dir: &str,
+    write_mode: WriteMode,
+    filename_template: &str,
+    default_template: Option<QueryConfig>,
+) -> Result<(DrasiLib, drasi_source_application::ApplicationSourceHandle)> {
+    let (app_source, app_handle) = ApplicationSource::new(
+        "test-source",
+        ApplicationSourceConfig {
+            properties: HashMap::new(),
+        },
+    )?;
+
+    let mut builder = FileReaction::builder("file-reaction")
+        .with_query("test-query")
+        .with_output_path(output_dir)
+        .with_write_mode(write_mode)
+        .with_filename_template(filename_template);
+
+    if let Some(template) = default_template {
+        builder = builder.with_default_template(template);
+    }
+
+    let file_reaction = builder.build()?;
+
+    let query = Query::cypher("test-query")
+        .query("MATCH (n:Item) RETURN n.id AS id, n.name AS name")
+        .from_source("test-source")
+        .auto_start(true)
+        .enable_bootstrap(false)
+        .build();
+
+    let drasi = DrasiLib::builder()
+        .with_id("file-reaction-integration")
+        .with_source(app_source)
+        .with_query(query)
+        .with_reaction(file_reaction)
+        .build()
+        .await?;
+
+    Ok((drasi, app_handle))
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_file_reaction_append_insert_update_delete() -> Result<()> {
+    let temp = TempDir::new()?;
+    let output_dir = temp.path().to_string_lossy().to_string();
+
+    let default_template = QueryConfig {
+        added: Some(TemplateSpec::new(
+            r#"{"op":"add","id":"{{after.id}}","name":"{{after.name}}"}"#,
+        )),
+        updated: Some(TemplateSpec::new(
+            r#"{"op":"update","before":"{{before.name}}","after":"{{after.name}}"}"#,
+        )),
+        deleted: Some(TemplateSpec::new(
+            r#"{"op":"delete","id":"{{before.id}}","name":"{{before.name}}"}"#,
+        )),
+    };
+
+    let (drasi, app_handle) = setup_drasi_for_mode(
+        &output_dir,
+        WriteMode::Append,
+        "{{query_name}}.ndjson",
+        Some(default_template),
+    )
+    .await?;
+
+    drasi.start().await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    app_handle
+        .send_node_insert(
+            "item-1",
+            vec!["Item"],
+            PropertyMapBuilder::new()
+                .with_string("id", "item-1")
+                .with_string("name", "Widget")
+                .build(),
+        )
+        .await?;
+
+    app_handle
+        .send_node_update(
+            "item-1",
+            vec!["Item"],
+            PropertyMapBuilder::new()
+                .with_string("id", "item-1")
+                .with_string("name", "Widget Pro")
+                .build(),
+        )
+        .await?;
+
+    app_handle.send_delete("item-1", vec!["Item"]).await?;
+
+    let output_file = temp.path().join("test-query.ndjson");
+    let content = wait_for_line_count(&output_file, 3, Duration::from_secs(10)).await?;
+    let lines: Vec<&str> = content.lines().collect();
+    assert!(lines.iter().any(|l| l.contains(r#""op":"add""#)));
+    assert!(lines.iter().any(|l| l.contains(r#""op":"update""#)));
+    assert!(lines.iter().any(|l| l.contains(r#""op":"delete""#)));
+
+    drasi.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_file_reaction_overwrite_mode_keeps_latest() -> Result<()> {
+    let temp = TempDir::new()?;
+    let output_dir = temp.path().to_string_lossy().to_string();
+
+    let default_template = QueryConfig {
+        added: Some(TemplateSpec::new(r#"{"op":"add","name":"{{after.name}}"}"#)),
+        updated: Some(TemplateSpec::new(
+            r#"{"op":"update","name":"{{after.name}}"}"#,
+        )),
+        deleted: Some(TemplateSpec::new(
+            r#"{"op":"delete","name":"{{before.name}}"}"#,
+        )),
+    };
+
+    let (drasi, app_handle) = setup_drasi_for_mode(
+        &output_dir,
+        WriteMode::Overwrite,
+        "snapshot.json",
+        Some(default_template),
+    )
+    .await?;
+
+    drasi.start().await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    app_handle
+        .send_node_insert(
+            "item-2",
+            vec!["Item"],
+            PropertyMapBuilder::new()
+                .with_string("id", "item-2")
+                .with_string("name", "Start")
+                .build(),
+        )
+        .await?;
+
+    app_handle
+        .send_node_update(
+            "item-2",
+            vec!["Item"],
+            PropertyMapBuilder::new()
+                .with_string("id", "item-2")
+                .with_string("name", "Latest")
+                .build(),
+        )
+        .await?;
+
+    let output_file = temp.path().join("snapshot.json");
+    let content = wait_for_file(&output_file, Duration::from_secs(10)).await?;
+    assert!(content.contains(r#""name":"Latest""#));
+
+    drasi.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_file_reaction_per_change_and_payload_filename() -> Result<()> {
+    let temp = TempDir::new()?;
+    let output_dir = temp.path().to_string_lossy().to_string();
+
+    let default_template = QueryConfig {
+        added: Some(TemplateSpec::new(r#"{"id":"{{after.id}}"}"#)),
+        updated: None,
+        deleted: None,
+    };
+
+    let (drasi, app_handle) = setup_drasi_for_mode(
+        &output_dir,
+        WriteMode::PerChange,
+        "item_{{after.id}}_{{operation}}.json",
+        Some(default_template),
+    )
+    .await?;
+
+    drasi.start().await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    app_handle
+        .send_node_insert(
+            "item-3",
+            vec!["Item"],
+            PropertyMapBuilder::new()
+                .with_string("id", "a/b")
+                .with_string("name", "Slash Name")
+                .build(),
+        )
+        .await?;
+
+    let output_file = temp.path().join("item_a_b_ADD.json");
+    let content = wait_for_file(&output_file, Duration::from_secs(10)).await?;
+    assert!(content.contains(r#""id":"a/b""#));
+
+    drasi.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_file_reaction_fallback_raw_json() -> Result<()> {
+    let temp = TempDir::new()?;
+    let output_dir = temp.path().to_string_lossy().to_string();
+
+    let (drasi, app_handle) =
+        setup_drasi_for_mode(&output_dir, WriteMode::Append, "{{query_name}}.log", None).await?;
+
+    drasi.start().await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    app_handle
+        .send_node_insert(
+            "item-4",
+            vec!["Item"],
+            PropertyMapBuilder::new()
+                .with_string("id", "item-4")
+                .with_string("name", "Raw")
+                .build(),
+        )
+        .await?;
+
+    let output_file = temp.path().join("test-query.log");
+    let content = wait_for_file(&output_file, Duration::from_secs(10)).await?;
+    assert!(content.contains("\"ADD\"") && content.contains("\"id\""));
+
+    drasi.stop().await?;
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces a new file-based reaction plugin to the Drasi project, enabling the system to write query result diffs to the filesystem with flexible formatting and file management options. The main changes add the new plugin as a workspace member, define its dependencies, configuration, and documentation, and implement its core logic and descriptor for integration with Drasi.

**Addition of file reaction plugin:**

* Added `drasi-reaction-file` as a new workspace member in `Cargo.toml` and included it as a dependency for the main project. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R43) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R122)
* Created the plugin's crate manifest (`Cargo.toml`), specifying dependencies, build features, and metadata.
* Added a `Makefile` for building, testing, integration testing, and linting the new plugin.
* Provided a comprehensive `README.md` documenting usage, configuration, template options, and testing strategies for the file reaction plugin.

**Implementation of plugin logic and configuration:**

* Implemented configuration types and logic for file output modes, template routing, and filename templating in `config.rs`.
* Added the plugin descriptor (`descriptor.rs`) for Drasi integration, including OpenAPI schema generation, DTO mapping, and plugin instantiation logic.
* Created the main library file (`lib.rs`) to expose the plugin's interface and enable dynamic plugin export.