### PR TITLE
Sui DeepBook Source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "components/bootstrappers/application",
   "components/bootstrappers/noop",
   "components/bootstrappers/mssql",
+  "components/bootstrappers/sui-deepbook",
 
   # Source Plugins
   "components/sources/postgres",
@@ -29,6 +30,7 @@ members = [
   "components/sources/application",
   "components/sources/mock",
   "components/sources/mssql",
+  "components/sources/sui-deepbook",
 
   # Reaction Plugins
   "components/reactions/http",
@@ -111,9 +113,11 @@ drasi-index-garnet = { version = "0.1.8", path = "components/indexes/garnet" }
 # Component plugins
 drasi-source-mssql = { version = "0.1.3", path = "components/sources/mssql" }
 drasi-bootstrap-mssql = { version = "0.1.3", path = "components/bootstrappers/mssql" }
+drasi-bootstrap-sui-deepbook = { version = "0.1.0", path = "components/bootstrappers/sui-deepbook" }
 drasi-bootstrap-postgres = { version = "0.1.13", path = "components/bootstrappers/postgres" }
 drasi-reaction-application = { version = "0.2.10", path = "components/reactions/application" }
 drasi-source-postgres = { version = "0.1.13", path = "components/sources/postgres" }
+drasi-source-sui-deepbook = { version = "0.1.0", path = "components/sources/sui-deepbook" }
 drasi-source-application = { version = "0.1.12", path = "components/sources/application" }
 drasi-bootstrap-application = { version = "0.1.11", path = "components/bootstrappers/application" }
 drasi-reaction-http = { version = "0.1.12", path = "components/reactions/http" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,8 @@ drasi-host-sdk = { version = "0.8.1", path = "components/host-sdk" }
 
 # Common dependencies
 im = "15"
+# Pin roaring below 0.11.4 which requires rustc 1.90.0 (transitive via sui-sdk-types)
+roaring = ">=0.11.2, <0.11.4"
 utoipa = { version = "4", features = ["chrono"] }
 drasi-index-rocksdb = { version = "0.5.1", path = "components/indexes/rocksdb" }
 drasi-index-garnet = { version = "0.3.0", path = "components/indexes/garnet" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   "components/bootstrappers/mssql",
   "components/bootstrappers/dataverse",
   "components/bootstrappers/http",
+  "components/bootstrappers/sui-deepbook",
 
   # Source Plugins
   "components/sources/postgres",
@@ -36,6 +37,7 @@ members = [
   "components/sources/mssql",
   "components/sources/dataverse",
   "components/sources/hyperliquid",
+  "components/sources/sui-deepbook",
 
   # Reaction Plugins
   "components/reactions/http",
@@ -142,6 +144,8 @@ drasi-reaction-http = { version = "0.2.1", path = "components/reactions/http" }
 drasi-reaction-grpc = { version = "0.3.1", path = "components/reactions/grpc" }
 drasi-mssql-common = { version = "0.2.1", path = "components/mssql-common" }
 drasi-source-ris-live = { version = "0.1.0", path = "components/sources/ris-live" }
+drasi-bootstrap-sui-deepbook = { version = "0.1.0", path = "components/bootstrappers/sui-deepbook" }
+drasi-source-sui-deepbook = { version = "0.1.0", path = "components/sources/sui-deepbook" }
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/components/bootstrappers/README.md
+++ b/components/bootstrappers/README.md
@@ -44,6 +44,7 @@ Bootstrap providers are responsible for:
 | `drasi-bootstrap-postgres` | PostgreSQL snapshot using COPY | `postgres/` |
 | `drasi-bootstrap-application` | Replays in-memory insert events | `application/` |
 | `drasi-bootstrap-platform` | HTTP streaming from remote Drasi | `platform/` |
+| `drasi-bootstrap-sui-deepbook` | Loads historical DeepBook events from Sui JSON-RPC | `sui-deepbook/` |
 
 ## Architecture
 

--- a/components/bootstrappers/sui-deepbook/Cargo.toml
+++ b/components/bootstrappers/sui-deepbook/Cargo.toml
@@ -1,0 +1,47 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-bootstrap-sui-deepbook"
+version = "0.1.0"
+edition = "2021"
+authors = ["Drasi Project"]
+description = "Sui DeepBook bootstrap plugin for Drasi"
+license = "Apache-2.0"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi", "plugin", "bootstrap", "sui", "deepbook"]
+categories = ["network-programming"]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+drasi-lib.workspace = true
+drasi-core.workspace = true
+drasi-plugin-sdk = { workspace = true }
+utoipa = { workspace = true }
+drasi-source-sui-deepbook = { path = "../../sources/sui-deepbook", default-features = false }
+anyhow = "1.0"
+async-trait = "0.1"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+reqwest = { version = "0.12", default-features = false }
+
+[features]
+dynamic-plugin = []

--- a/components/bootstrappers/sui-deepbook/Makefile
+++ b/components/bootstrappers/sui-deepbook/Makefile
@@ -1,0 +1,11 @@
+build:
+	cargo build -p drasi-bootstrap-sui-deepbook
+
+test:
+	cargo test -p drasi-bootstrap-sui-deepbook
+
+integration-test:
+	@echo "No standalone integration test target for bootstrap crate"
+
+lint:
+	cargo clippy -p drasi-bootstrap-sui-deepbook --all-targets -- -D warnings

--- a/components/bootstrappers/sui-deepbook/README.md
+++ b/components/bootstrappers/sui-deepbook/README.md
@@ -1,0 +1,144 @@
+# Sui DeepBook Bootstrap Provider
+
+## Overview
+
+The Sui DeepBook Bootstrap Provider loads historical DeepBook V3 events from the Sui blockchain and feeds them into a Drasi query as an initial dataset before the streaming source takes over. It uses the same `suix_queryEvents` JSON-RPC endpoint as the source but iterates through pages of historical events rather than polling continuously.
+
+**Key Capabilities**:
+- Paginated historical event loading via Sui JSON-RPC
+- Shared filtering logic with the streaming source (package ID, event type, pool ID)
+- Configurable page limits to control bootstrap duration
+- Same start-position options as the source (beginning, now, timestamp)
+
+## When to Use
+
+Use the bootstrap provider when your query needs access to **historical** events that were emitted before the streaming source started. Common scenarios:
+
+- **Order book reconstruction** — load all historical `OrderPlaced` events to build a snapshot of open orders
+- **Analytics dashboards** — populate initial metrics from past events before switching to real-time updates
+- **Back-testing** — replay a window of historical events through a Drasi query
+
+If you only care about events going forward, you can skip the bootstrap entirely and set the source to `StartPosition::Now`.
+
+## Configuration
+
+### Builder Pattern
+
+```rust
+use drasi_bootstrap_sui_deepbook::SuiDeepBookBootstrapProvider;
+
+let bootstrap = SuiDeepBookBootstrapProvider::builder()
+    .with_rpc_endpoint("https://fullnode.mainnet.sui.io:443")
+    .with_deepbook_package_id("0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497")
+    .with_request_limit(100)
+    .with_max_pages(50)
+    .with_start_from_beginning()
+    .build()?;
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `rpc_endpoint` | `String` | `https://fullnode.mainnet.sui.io:443` | Sui JSON-RPC endpoint URL |
+| `deepbook_package_id` | `String` | Mainnet DeepBook V3 address | Package ID to filter events by |
+| `request_limit` | `u16` | `100` | Max events per RPC page (1–1000) |
+| `max_pages` | `u32` | `10` | Maximum number of RPC pages to fetch |
+| `event_filters` | `Vec<String>` | `[]` | Event type substrings to include (empty = all) |
+| `pools` | `Vec<String>` | `[]` | Pool IDs to include (empty = all) |
+| `start_position` | `StartPosition` | `Beginning` | Where to begin loading historical events |
+
+### Start Position
+
+| Variant | Behaviour |
+|---------|-----------|
+| `StartPosition::Beginning` | Load from the earliest available event on chain |
+| `StartPosition::Now` | Skip bootstrap entirely (returns 0 events) |
+| `StartPosition::Timestamp(ms)` | Load from the beginning but skip events with `timestamp_ms < ms` |
+
+> **Note**: The bootstrap defaults to `Beginning` while the streaming source defaults to `Now`. This is intentional — the bootstrap's purpose is to load history.
+
+## Usage Examples
+
+### 1. Full Historical Load + Live Streaming
+
+```rust
+use drasi_source_sui_deepbook::SuiDeepBookSource;
+use drasi_bootstrap_sui_deepbook::SuiDeepBookBootstrapProvider;
+
+let bootstrap = SuiDeepBookBootstrapProvider::builder()
+    .with_max_pages(100)
+    .with_start_from_beginning()
+    .build()?;
+
+let source = SuiDeepBookSource::builder("deepbook-source")
+    .with_bootstrap_provider(bootstrap)
+    .with_start_from_beginning()
+    .build()?;
+```
+
+### 2. Load Only Recent History (Last 24 Hours)
+
+```rust
+use chrono::Utc;
+
+let twenty_four_hours_ago = Utc::now().timestamp_millis() - 86_400_000;
+
+let bootstrap = SuiDeepBookBootstrapProvider::builder()
+    .with_max_pages(200)
+    .with_start_from_timestamp(twenty_four_hours_ago)
+    .build()?;
+```
+
+### 3. Bootstrap Specific Event Types for a Specific Pool
+
+```rust
+let bootstrap = SuiDeepBookBootstrapProvider::builder()
+    .with_event_filters(vec![
+        "OrderPlaced".into(),
+        "OrderFilled".into(),
+        "OrderCancelled".into(),
+    ])
+    .with_pools(vec!["0xpool_sui_usdc".into()])
+    .with_max_pages(50)
+    .build()?;
+```
+
+### 4. Skip Bootstrap Entirely
+
+If you don't need historical data, either omit the bootstrap provider or use `StartPosition::Now`:
+
+```rust
+let bootstrap = SuiDeepBookBootstrapProvider::builder()
+    .with_start_from_now()
+    .build()?;
+// bootstrap() will return Ok(0) immediately
+```
+
+## How It Works
+
+1. The bootstrap provider is called once per query subscription
+2. It pages through `suix_queryEvents` with ascending order (oldest first)
+3. Each event passes through the same filtering pipeline as the streaming source:
+   - Package ID check → Event type filter → Pool filter
+4. Matching events are mapped to `SourceChange::Insert` records (all bootstrap events are inserts)
+5. Events are sent to the query engine via the bootstrap channel
+6. The bootstrap completes and the streaming source begins normal polling
+
+## Controlling Bootstrap Size
+
+The `max_pages` setting bounds how many RPC pages the bootstrap will fetch. Each page contains up to `request_limit` events. The total upper bound is `max_pages × request_limit` raw events (before filtering).
+
+Since the source queries `{"All": []}` and filters client-side by `deepbook_package_id`, most pages will contain events from other packages. Plan for a higher `max_pages` than you might expect.
+
+| Scenario | Suggested `max_pages` |
+|----------|----------------------|
+| Quick smoke test | `5–10` |
+| Recent activity (hours) | `50–100` |
+| Full historical load | `500–1000` |
+
+## Testing
+
+```bash
+cargo test -p drasi-bootstrap-sui-deepbook
+```

--- a/components/bootstrappers/sui-deepbook/README.md
+++ b/components/bootstrappers/sui-deepbook/README.md
@@ -40,13 +40,13 @@ let bootstrap = SuiDeepBookBootstrapProvider::builder()
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `rpc_endpoint` | `String` | `https://fullnode.mainnet.sui.io:443` | Sui JSON-RPC endpoint URL |
-| `deepbook_package_id` | `String` | Mainnet DeepBook V3 address | Package ID to filter events by |
-| `request_limit` | `u16` | `100` | Max events per RPC page (1–1000) |
-| `max_pages` | `u32` | `10` | Maximum number of RPC pages to fetch |
-| `event_filters` | `Vec<String>` | `[]` | Event type substrings to include (empty = all) |
+| `rpcEndpoint` | `String` | `https://fullnode.mainnet.sui.io:443` | Sui JSON-RPC endpoint URL |
+| `deepbookPackageId` | `String` | Mainnet DeepBook V3 address | Package ID to filter events by |
+| `requestLimit` | `u16` | `100` | Max events per RPC page (1–1000) |
+| `maxPages` | `u32` | `10` | Maximum number of RPC pages to fetch |
+| `eventFilters` | `Vec<String>` | `[]` | Event type substrings to include (empty = all) |
 | `pools` | `Vec<String>` | `[]` | Pool IDs to include (empty = all) |
-| `start_position` | `StartPosition` | `Beginning` | Where to begin loading historical events |
+| `startPosition` | `StartPosition` | `Beginning` | Where to begin loading historical events |
 
 ### Start Position
 

--- a/components/bootstrappers/sui-deepbook/src/config.rs
+++ b/components/bootstrappers/sui-deepbook/src/config.rs
@@ -44,6 +44,12 @@ pub struct SuiDeepBookBootstrapConfig {
     pub pools: Vec<String>,
     #[serde(default)]
     pub start_position: StartPosition,
+    #[serde(default = "default_true")]
+    pub enable_pool_nodes: bool,
+    #[serde(default = "default_true")]
+    pub enable_trader_nodes: bool,
+    #[serde(default = "default_true")]
+    pub enable_order_nodes: bool,
 }
 
 impl Default for SuiDeepBookBootstrapConfig {
@@ -56,6 +62,9 @@ impl Default for SuiDeepBookBootstrapConfig {
             event_filters: Vec::new(),
             pools: Vec::new(),
             start_position: StartPosition::Beginning,
+            enable_pool_nodes: true,
+            enable_trader_nodes: true,
+            enable_order_nodes: true,
         }
     }
 }
@@ -113,4 +122,8 @@ fn default_request_limit() -> u16 {
 
 fn default_max_pages() -> u32 {
     10
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/components/bootstrappers/sui-deepbook/src/config.rs
+++ b/components/bootstrappers/sui-deepbook/src/config.rs
@@ -1,0 +1,116 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_SUI_MAINNET_RPC: &str = "https://fullnode.mainnet.sui.io:443";
+pub const DEFAULT_DEEPBOOK_PACKAGE_ID: &str =
+    "0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(tag = "mode", content = "value", rename_all = "snake_case")]
+pub enum StartPosition {
+    #[default]
+    Beginning,
+    Now,
+    Timestamp(i64),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SuiDeepBookBootstrapConfig {
+    #[serde(default = "default_rpc_endpoint")]
+    pub rpc_endpoint: String,
+    #[serde(default = "default_deepbook_package_id")]
+    pub deepbook_package_id: String,
+    #[serde(default = "default_request_limit")]
+    pub request_limit: u16,
+    #[serde(default = "default_max_pages")]
+    pub max_pages: u32,
+    #[serde(default)]
+    pub event_filters: Vec<String>,
+    #[serde(default)]
+    pub pools: Vec<String>,
+    #[serde(default)]
+    pub start_position: StartPosition,
+}
+
+impl Default for SuiDeepBookBootstrapConfig {
+    fn default() -> Self {
+        Self {
+            rpc_endpoint: default_rpc_endpoint(),
+            deepbook_package_id: default_deepbook_package_id(),
+            request_limit: default_request_limit(),
+            max_pages: default_max_pages(),
+            event_filters: Vec::new(),
+            pools: Vec::new(),
+            start_position: StartPosition::Beginning,
+        }
+    }
+}
+
+impl SuiDeepBookBootstrapConfig {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.rpc_endpoint.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "Validation error: rpc_endpoint cannot be empty"
+            ));
+        }
+        reqwest::Url::parse(&self.rpc_endpoint)
+            .map_err(|e| anyhow::anyhow!("Validation error: invalid rpc_endpoint: {e}"))?;
+
+        if self.deepbook_package_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "Validation error: deepbook_package_id cannot be empty"
+            ));
+        }
+        if !self.deepbook_package_id.starts_with("0x") {
+            return Err(anyhow::anyhow!(
+                "Validation error: deepbook_package_id must start with 0x"
+            ));
+        }
+        if self.request_limit == 0 {
+            return Err(anyhow::anyhow!(
+                "Validation error: request_limit must be greater than 0"
+            ));
+        }
+        if self.request_limit > 1_000 {
+            return Err(anyhow::anyhow!(
+                "Validation error: request_limit must be <= 1000"
+            ));
+        }
+        if self.max_pages == 0 {
+            return Err(anyhow::anyhow!(
+                "Validation error: max_pages must be greater than 0"
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn default_rpc_endpoint() -> String {
+    DEFAULT_SUI_MAINNET_RPC.to_string()
+}
+
+fn default_deepbook_package_id() -> String {
+    DEFAULT_DEEPBOOK_PACKAGE_ID.to_string()
+}
+
+fn default_request_limit() -> u16 {
+    100
+}
+
+fn default_max_pages() -> u32 {
+    10
+}

--- a/components/bootstrappers/sui-deepbook/src/descriptor.rs
+++ b/components/bootstrappers/sui-deepbook/src/descriptor.rs
@@ -1,0 +1,160 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{StartPosition, SuiDeepBookBootstrapProvider};
+use drasi_lib::bootstrap::BootstrapProvider;
+use drasi_plugin_sdk::prelude::*;
+use std::str::FromStr;
+use utoipa::OpenApi;
+
+fn default_rpc_endpoint() -> ConfigValue<String> {
+    ConfigValue::Static(crate::config::DEFAULT_SUI_MAINNET_RPC.to_string())
+}
+
+fn default_package_id() -> ConfigValue<String> {
+    ConfigValue::Static(crate::config::DEFAULT_DEEPBOOK_PACKAGE_ID.to_string())
+}
+
+fn default_request_limit() -> ConfigValue<u16> {
+    ConfigValue::Static(100)
+}
+
+fn default_max_pages() -> ConfigValue<u32> {
+    ConfigValue::Static(10)
+}
+
+fn default_start_position() -> ConfigValue<StartPositionDto> {
+    ConfigValue::Static(StartPositionDto::default())
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema, Default)]
+#[schema(as = bootstrap::sui_deepbook::StartPosition)]
+#[serde(rename_all = "snake_case")]
+pub enum StartPositionDto {
+    #[default]
+    Beginning,
+    Now,
+    Timestamp,
+}
+
+impl FromStr for StartPositionDto {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "beginning" => Ok(Self::Beginning),
+            "now" => Ok(Self::Now),
+            "timestamp" => Ok(Self::Timestamp),
+            _ => Err(format!("Invalid start position: {s}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[schema(as = bootstrap::sui_deepbook::SuiDeepBookBootstrapConfig)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SuiDeepBookBootstrapConfigDto {
+    #[serde(default = "default_rpc_endpoint")]
+    #[schema(value_type = ConfigValueString)]
+    pub rpc_endpoint: ConfigValue<String>,
+    #[serde(default = "default_package_id")]
+    #[schema(value_type = ConfigValueString)]
+    pub deepbook_package_id: ConfigValue<String>,
+    #[serde(default = "default_request_limit")]
+    #[schema(value_type = ConfigValueU16)]
+    pub request_limit: ConfigValue<u16>,
+    #[serde(default = "default_max_pages")]
+    #[schema(value_type = ConfigValueU32)]
+    pub max_pages: ConfigValue<u32>,
+    #[serde(default)]
+    pub event_filters: Vec<String>,
+    #[serde(default)]
+    pub pools: Vec<String>,
+    #[serde(default = "default_start_position")]
+    #[schema(value_type = ConfigValue<bootstrap::sui_deepbook::StartPosition>)]
+    pub start_position: ConfigValue<StartPositionDto>,
+    #[serde(default)]
+    #[schema(value_type = Option<ConfigValueString>)]
+    pub start_timestamp_ms: Option<ConfigValue<String>>,
+}
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(StartPositionDto, SuiDeepBookBootstrapConfigDto)))]
+struct SuiDeepBookBootstrapSchemas;
+
+pub struct SuiDeepBookBootstrapDescriptor;
+
+#[async_trait]
+impl BootstrapPluginDescriptor for SuiDeepBookBootstrapDescriptor {
+    fn kind(&self) -> &str {
+        "sui-deepbook"
+    }
+
+    fn config_version(&self) -> &str {
+        "1.0.0"
+    }
+
+    fn config_schema_name(&self) -> &str {
+        "bootstrap.sui_deepbook.SuiDeepBookBootstrapConfig"
+    }
+
+    fn config_schema_json(&self) -> String {
+        let api = SuiDeepBookBootstrapSchemas::openapi();
+        serde_json::to_string(
+            &api.components
+                .as_ref()
+                .expect("OpenAPI components missing")
+                .schemas,
+        )
+        .expect("Failed to serialize config schema")
+    }
+
+    async fn create_bootstrap_provider(
+        &self,
+        config_json: &serde_json::Value,
+        _source_config_json: &serde_json::Value,
+    ) -> anyhow::Result<Box<dyn BootstrapProvider>> {
+        let dto: SuiDeepBookBootstrapConfigDto = serde_json::from_value(config_json.clone())?;
+        let mapper = DtoMapper::new();
+
+        let start_position = match mapper.resolve_typed::<StartPositionDto>(&dto.start_position)? {
+            StartPositionDto::Beginning => StartPosition::Beginning,
+            StartPositionDto::Now => StartPosition::Now,
+            StartPositionDto::Timestamp => {
+                let ts_config = dto.start_timestamp_ms.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "startTimestampMs is required when startPosition is 'timestamp'"
+                    )
+                })?;
+                let timestamp = mapper
+                    .resolve_string(ts_config)?
+                    .parse::<i64>()
+                    .map_err(|e| anyhow::anyhow!("Invalid startTimestampMs: {e}"))?;
+                StartPosition::Timestamp(timestamp)
+            }
+        };
+
+        let provider = SuiDeepBookBootstrapProvider::builder()
+            .with_rpc_endpoint(mapper.resolve_string(&dto.rpc_endpoint)?)
+            .with_deepbook_package_id(mapper.resolve_string(&dto.deepbook_package_id)?)
+            .with_request_limit(mapper.resolve_typed(&dto.request_limit)?)
+            .with_max_pages(mapper.resolve_typed(&dto.max_pages)?)
+            .with_event_filters(dto.event_filters)
+            .with_pools(dto.pools)
+            .with_start_position(start_position)
+            .build()?;
+
+        Ok(Box::new(provider))
+    }
+}

--- a/components/bootstrappers/sui-deepbook/src/lib.rs
+++ b/components/bootstrappers/sui-deepbook/src/lib.rs
@@ -1,0 +1,286 @@
+#![allow(unexpected_cfgs)]
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sui DeepBook bootstrap provider for Drasi.
+//!
+//! This provider loads historical DeepBook events from Sui JSON-RPC using pagination
+//! and emits them as bootstrap events.
+
+pub mod config;
+pub mod descriptor;
+
+pub use config::{
+    StartPosition, SuiDeepBookBootstrapConfig, DEFAULT_DEEPBOOK_PACKAGE_ID, DEFAULT_SUI_MAINNET_RPC,
+};
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use drasi_core::models::SourceChange;
+use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::channels::{BootstrapEvent, BootstrapEventSender};
+use drasi_source_sui_deepbook::mapping::{map_event_to_insert_change, should_include_event};
+use drasi_source_sui_deepbook::rpc::SuiRpcClient;
+use log::info;
+use std::sync::Arc;
+
+pub struct SuiDeepBookBootstrapProvider {
+    config: SuiDeepBookBootstrapConfig,
+    source_id: String,
+}
+
+impl SuiDeepBookBootstrapProvider {
+    pub fn new(source_id: impl Into<String>, config: SuiDeepBookBootstrapConfig) -> Result<Self> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            source_id: source_id.into(),
+        })
+    }
+
+    pub fn builder() -> SuiDeepBookBootstrapProviderBuilder {
+        SuiDeepBookBootstrapProviderBuilder::new()
+    }
+}
+
+#[async_trait]
+impl BootstrapProvider for SuiDeepBookBootstrapProvider {
+    async fn bootstrap(
+        &self,
+        request: BootstrapRequest,
+        context: &BootstrapContext,
+        event_tx: BootstrapEventSender,
+        _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
+    ) -> Result<usize> {
+        let source_id = if context.source_id.is_empty() {
+            self.source_id.as_str()
+        } else {
+            context.source_id.as_str()
+        };
+        info!(
+            "Starting Sui DeepBook bootstrap for source '{}' and query '{}'",
+            source_id, request.query_id
+        );
+
+        if matches!(self.config.start_position, StartPosition::Now) {
+            info!("Bootstrap start_position=Now, skipping historical load");
+            return Ok(0);
+        }
+
+        let rpc_client = SuiRpcClient::new(self.config.rpc_endpoint.clone())?;
+        let query_filter = serde_json::json!({ "All": [] });
+
+        let timestamp_floor = match self.config.start_position {
+            StartPosition::Timestamp(value) => Some(value.max(0) as u64),
+            _ => None,
+        };
+
+        let mut cursor = None;
+        let mut page_count = 0u32;
+        let mut sent_events = 0usize;
+
+        while page_count < self.config.max_pages {
+            let page = rpc_client
+                .query_events(
+                    query_filter.clone(),
+                    cursor.as_ref(),
+                    self.config.request_limit,
+                    false,
+                )
+                .await?;
+            page_count += 1;
+
+            for event in page.data {
+                cursor = Some(event.id.clone());
+
+                if event.package_id != self.config.deepbook_package_id {
+                    continue;
+                }
+
+                if let Some(ts_floor) = timestamp_floor {
+                    if event
+                        .timestamp_ms
+                        .is_some_and(|timestamp| timestamp < ts_floor)
+                    {
+                        continue;
+                    }
+                }
+                if !should_include_event(&event, &self.config.event_filters, &self.config.pools) {
+                    continue;
+                }
+
+                let change = map_event_to_insert_change(source_id, &event);
+                event_tx
+                    .send(BootstrapEvent {
+                        source_id: source_id.to_string(),
+                        change,
+                        timestamp: chrono::Utc::now(),
+                        sequence: context.next_sequence(),
+                    })
+                    .await
+                    .map_err(|e| anyhow!("Failed to send Sui DeepBook bootstrap event: {e}"))?;
+                sent_events += 1;
+            }
+
+            // Always advance cursor from next_cursor when present, even if all
+            // events on this page were filtered out.
+            if let Some(next_cursor) = page.next_cursor {
+                cursor = Some(next_cursor);
+            }
+
+            if !page.has_next_page {
+                break;
+            }
+        }
+
+        info!(
+            "Completed Sui DeepBook bootstrap for source '{source_id}': sent {sent_events} records in {page_count} pages"
+        );
+        Ok(sent_events)
+    }
+}
+
+pub struct SuiDeepBookBootstrapProviderBuilder {
+    source_id: String,
+    config: SuiDeepBookBootstrapConfig,
+}
+
+impl SuiDeepBookBootstrapProviderBuilder {
+    pub fn new() -> Self {
+        Self {
+            source_id: "sui-deepbook-bootstrap".to_string(),
+            config: SuiDeepBookBootstrapConfig::default(),
+        }
+    }
+
+    pub fn with_source_id(mut self, source_id: impl Into<String>) -> Self {
+        self.source_id = source_id.into();
+        self
+    }
+
+    pub fn with_rpc_endpoint(mut self, rpc_endpoint: impl Into<String>) -> Self {
+        self.config.rpc_endpoint = rpc_endpoint.into();
+        self
+    }
+
+    pub fn with_deepbook_package_id(mut self, package_id: impl Into<String>) -> Self {
+        self.config.deepbook_package_id = package_id.into();
+        self
+    }
+
+    pub fn with_request_limit(mut self, request_limit: u16) -> Self {
+        self.config.request_limit = request_limit;
+        self
+    }
+
+    pub fn with_max_pages(mut self, max_pages: u32) -> Self {
+        self.config.max_pages = max_pages;
+        self
+    }
+
+    pub fn with_event_filters(mut self, event_filters: Vec<String>) -> Self {
+        self.config.event_filters = event_filters;
+        self
+    }
+
+    pub fn with_pools(mut self, pools: Vec<String>) -> Self {
+        self.config.pools = pools;
+        self
+    }
+
+    pub fn with_start_position(mut self, start_position: StartPosition) -> Self {
+        self.config.start_position = start_position;
+        self
+    }
+
+    pub fn with_start_from_beginning(mut self) -> Self {
+        self.config.start_position = StartPosition::Beginning;
+        self
+    }
+
+    pub fn with_start_from_now(mut self) -> Self {
+        self.config.start_position = StartPosition::Now;
+        self
+    }
+
+    pub fn with_start_from_timestamp(mut self, timestamp_ms: i64) -> Self {
+        self.config.start_position = StartPosition::Timestamp(timestamp_ms);
+        self
+    }
+
+    pub fn with_config(mut self, config: SuiDeepBookBootstrapConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn build(self) -> Result<SuiDeepBookBootstrapProvider> {
+        SuiDeepBookBootstrapProvider::new(self.source_id, self.config)
+    }
+}
+
+impl Default for SuiDeepBookBootstrapProviderBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builder_defaults() {
+        let provider = SuiDeepBookBootstrapProvider::builder().build().unwrap();
+        assert_eq!(provider.source_id, "sui-deepbook-bootstrap");
+        assert_eq!(provider.config.request_limit, 100);
+        assert!(matches!(
+            provider.config.start_position,
+            StartPosition::Beginning
+        ));
+    }
+
+    #[test]
+    fn test_builder_custom_values() {
+        let provider = SuiDeepBookBootstrapProvider::builder()
+            .with_source_id("source-a")
+            .with_rpc_endpoint("https://fullnode.testnet.sui.io:443")
+            .with_deepbook_package_id("0xabc")
+            .with_request_limit(25)
+            .with_max_pages(5)
+            .with_start_from_now()
+            .build()
+            .unwrap();
+
+        assert_eq!(provider.source_id, "source-a");
+        assert_eq!(
+            provider.config.rpc_endpoint,
+            "https://fullnode.testnet.sui.io:443"
+        );
+        assert_eq!(provider.config.deepbook_package_id, "0xabc");
+        assert_eq!(provider.config.request_limit, 25);
+        assert_eq!(provider.config.max_pages, 5);
+        assert!(matches!(provider.config.start_position, StartPosition::Now));
+    }
+}
+
+#[cfg(feature = "dynamic-plugin")]
+drasi_plugin_sdk::export_plugin!(
+    plugin_id = "sui-deepbook-bootstrap",
+    core_version = env!("CARGO_PKG_VERSION"),
+    lib_version = env!("CARGO_PKG_VERSION"),
+    plugin_version = env!("CARGO_PKG_VERSION"),
+    source_descriptors = [],
+    reaction_descriptors = [],
+    bootstrap_descriptors = [descriptor::SuiDeepBookBootstrapDescriptor],
+);

--- a/components/bootstrappers/sui-deepbook/src/lib.rs
+++ b/components/bootstrappers/sui-deepbook/src/lib.rs
@@ -30,9 +30,14 @@ use async_trait::async_trait;
 use drasi_core::models::SourceChange;
 use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
 use drasi_lib::channels::{BootstrapEvent, BootstrapEventSender};
-use drasi_source_sui_deepbook::mapping::{map_event_to_insert_change, should_include_event};
+use drasi_source_sui_deepbook::mapping::{
+    build_order_node, build_pool_node, build_relationship, build_trader_node, derive_entity_id_pub,
+    event_order_id, event_pool_id, map_event_to_insert_change, should_include_event,
+    EnrichmentConfig,
+};
 use drasi_source_sui_deepbook::rpc::SuiRpcClient;
 use log::info;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 pub struct SuiDeepBookBootstrapProvider {
@@ -86,6 +91,15 @@ impl BootstrapProvider for SuiDeepBookBootstrapProvider {
             _ => None,
         };
 
+        let enrichment = EnrichmentConfig {
+            enable_pool_nodes: self.config.enable_pool_nodes,
+            enable_trader_nodes: self.config.enable_trader_nodes,
+            enable_order_nodes: self.config.enable_order_nodes,
+        };
+        let mut seen_pools = HashSet::new();
+        let mut seen_traders = HashSet::new();
+        let mut seen_orders = HashSet::new();
+
         let mut cursor = None;
         let mut page_count = 0u32;
         let mut sent_events = 0usize;
@@ -120,6 +134,74 @@ impl BootstrapProvider for SuiDeepBookBootstrapProvider {
                     continue;
                 }
 
+                let effective_from = event
+                    .timestamp_ms
+                    .unwrap_or_else(|| chrono::Utc::now().timestamp_millis().max(0) as u64);
+                let event_entity_id = derive_entity_id_pub(&event);
+
+                // Emit enrichment nodes before the event
+                let mut enrichment_changes: Vec<SourceChange> = Vec::new();
+
+                if enrichment.enable_pool_nodes {
+                    if let Some(ref pool_id) = event_pool_id(&event) {
+                        if seen_pools.insert(pool_id.clone()) {
+                            let object_data = match rpc_client.get_object(pool_id).await {
+                                Ok(data) => Some(data),
+                                Err(err) => {
+                                    log::warn!("Failed to fetch pool object for {pool_id}: {err}");
+                                    None
+                                }
+                            };
+                            enrichment_changes.push(build_pool_node(
+                                source_id,
+                                pool_id,
+                                object_data.as_ref(),
+                                effective_from,
+                            ));
+                        }
+                    }
+                }
+
+                if enrichment.enable_trader_nodes
+                    && !event.sender.is_empty()
+                    && seen_traders.insert(event.sender.clone())
+                {
+                    enrichment_changes.push(build_trader_node(
+                        source_id,
+                        &event.sender,
+                        effective_from,
+                    ));
+                }
+
+                if enrichment.enable_order_nodes {
+                    if let Some(ref order_id) = event_order_id(&event) {
+                        if seen_orders.insert(order_id.clone()) {
+                            let pool_id = event_pool_id(&event);
+                            enrichment_changes.push(build_order_node(
+                                source_id,
+                                order_id,
+                                pool_id.as_deref(),
+                                effective_from,
+                            ));
+                        }
+                    }
+                }
+
+                // Send enrichment nodes first
+                for ec in enrichment_changes {
+                    event_tx
+                        .send(BootstrapEvent {
+                            source_id: source_id.to_string(),
+                            change: ec,
+                            timestamp: chrono::Utc::now(),
+                            sequence: context.next_sequence(),
+                        })
+                        .await
+                        .map_err(|e| anyhow!("Failed to send enrichment bootstrap event: {e}"))?;
+                    sent_events += 1;
+                }
+
+                // Send the event node
                 let change = map_event_to_insert_change(source_id, &event);
                 event_tx
                     .send(BootstrapEvent {
@@ -131,6 +213,74 @@ impl BootstrapProvider for SuiDeepBookBootstrapProvider {
                     .await
                     .map_err(|e| anyhow!("Failed to send Sui DeepBook bootstrap event: {e}"))?;
                 sent_events += 1;
+
+                // Send relationships after both nodes exist
+                if enrichment.enable_pool_nodes {
+                    if let Some(pool_id) = event_pool_id(&event) {
+                        let rel = build_relationship(
+                            source_id,
+                            "IN_POOL",
+                            &format!("rel:in_pool:{event_entity_id}"),
+                            &event_entity_id,
+                            &format!("pool_meta:{pool_id}"),
+                            effective_from,
+                        );
+                        event_tx
+                            .send(BootstrapEvent {
+                                source_id: source_id.to_string(),
+                                change: rel,
+                                timestamp: chrono::Utc::now(),
+                                sequence: context.next_sequence(),
+                            })
+                            .await
+                            .map_err(|e| anyhow!("Failed to send relationship event: {e}"))?;
+                        sent_events += 1;
+                    }
+                }
+
+                if enrichment.enable_trader_nodes && !event.sender.is_empty() {
+                    let rel = build_relationship(
+                        source_id,
+                        "SENT_BY",
+                        &format!("rel:sent_by:{event_entity_id}"),
+                        &event_entity_id,
+                        &format!("trader:{}", event.sender),
+                        effective_from,
+                    );
+                    event_tx
+                        .send(BootstrapEvent {
+                            source_id: source_id.to_string(),
+                            change: rel,
+                            timestamp: chrono::Utc::now(),
+                            sequence: context.next_sequence(),
+                        })
+                        .await
+                        .map_err(|e| anyhow!("Failed to send relationship event: {e}"))?;
+                    sent_events += 1;
+                }
+
+                if enrichment.enable_order_nodes {
+                    if let Some(order_id) = event_order_id(&event) {
+                        let rel = build_relationship(
+                            source_id,
+                            "FOR_ORDER",
+                            &format!("rel:for_order:{event_entity_id}"),
+                            &event_entity_id,
+                            &format!("order_meta:{order_id}"),
+                            effective_from,
+                        );
+                        event_tx
+                            .send(BootstrapEvent {
+                                source_id: source_id.to_string(),
+                                change: rel,
+                                timestamp: chrono::Utc::now(),
+                                sequence: context.next_sequence(),
+                            })
+                            .await
+                            .map_err(|e| anyhow!("Failed to send relationship event: {e}"))?;
+                        sent_events += 1;
+                    }
+                }
             }
 
             // Always advance cursor from next_cursor when present, even if all
@@ -221,6 +371,21 @@ impl SuiDeepBookBootstrapProviderBuilder {
 
     pub fn with_config(mut self, config: SuiDeepBookBootstrapConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    pub fn with_enable_pool_nodes(mut self, enable: bool) -> Self {
+        self.config.enable_pool_nodes = enable;
+        self
+    }
+
+    pub fn with_enable_trader_nodes(mut self, enable: bool) -> Self {
+        self.config.enable_trader_nodes = enable;
+        self
+    }
+
+    pub fn with_enable_order_nodes(mut self, enable: bool) -> Self {
+        self.config.enable_order_nodes = enable;
         self
     }
 

--- a/components/bootstrappers/sui-deepbook/src/lib.rs
+++ b/components/bootstrappers/sui-deepbook/src/lib.rs
@@ -28,7 +28,9 @@ pub use config::{
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use drasi_core::models::SourceChange;
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
 use drasi_lib::channels::{BootstrapEvent, BootstrapEventSender};
 use drasi_source_sui_deepbook::mapping::{
     build_order_node, build_pool_node, build_relationship, build_trader_node, derive_entity_id_pub,
@@ -67,7 +69,7 @@ impl BootstrapProvider for SuiDeepBookBootstrapProvider {
         context: &BootstrapContext,
         event_tx: BootstrapEventSender,
         _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         let source_id = if context.source_id.is_empty() {
             self.source_id.as_str()
         } else {
@@ -80,7 +82,7 @@ impl BootstrapProvider for SuiDeepBookBootstrapProvider {
 
         if matches!(self.config.start_position, StartPosition::Now) {
             info!("Bootstrap start_position=Now, skipping historical load");
-            return Ok(0);
+            return Ok(BootstrapResult::default());
         }
 
         let rpc_client = SuiRpcClient::new(self.config.rpc_endpoint.clone())?;
@@ -297,7 +299,10 @@ impl BootstrapProvider for SuiDeepBookBootstrapProvider {
         info!(
             "Completed Sui DeepBook bootstrap for source '{source_id}': sent {sent_events} records in {page_count} pages"
         );
-        Ok(sent_events)
+        Ok(BootstrapResult {
+            event_count: sent_events,
+            ..Default::default()
+        })
     }
 }
 

--- a/components/reactions/http/src/http.rs
+++ b/components/reactions/http/src/http.rs
@@ -501,7 +501,28 @@ impl Reaction for HttpReaction {
                                 }
                             }
                         }
-                        ResultDiff::Aggregation { .. } | ResultDiff::Noop => {}
+                        ResultDiff::Aggregation { .. } => {
+                            if let Some(spec) = query_config.updated.as_ref() {
+                                let data_to_process = serde_json::to_value(result)
+                                    .expect("ResultDiff serialization should succeed");
+                                if let Err(e) = Self::process_result(
+                                    &client,
+                                    &handlebars,
+                                    &base_url,
+                                    &token,
+                                    spec,
+                                    "UPDATE",
+                                    &data_to_process,
+                                    query_name,
+                                    &reaction_name,
+                                )
+                                .await
+                                {
+                                    error!("[{reaction_name}] Failed to process result: {e}");
+                                }
+                            }
+                        }
+                        ResultDiff::Noop => {}
                     }
                 }
             }

--- a/components/reactions/http/src/http.rs
+++ b/components/reactions/http/src/http.rs
@@ -477,14 +477,8 @@ impl Reaction for HttpReaction {
                                 }
                             }
                         }
-                        ResultDiff::Update { .. } | ResultDiff::Aggregation { .. } => {
+                        ResultDiff::Update { .. } => {
                             if let Some(spec) = query_config.updated.as_ref() {
-                                let operation = if matches!(result, ResultDiff::Aggregation { .. })
-                                {
-                                    "AGGREGATION"
-                                } else {
-                                    "UPDATE"
-                                };
                                 let data_to_process = serde_json::to_value(result)
                                     .expect("ResultDiff serialization should succeed");
                                 if let Err(e) = Self::process_result(
@@ -493,7 +487,7 @@ impl Reaction for HttpReaction {
                                     &base_url,
                                     &token,
                                     spec,
-                                    operation,
+                                    "UPDATE",
                                     &data_to_process,
                                     query_name,
                                     &reaction_name,

--- a/components/reactions/http/src/http.rs
+++ b/components/reactions/http/src/http.rs
@@ -504,6 +504,27 @@ impl Reaction for HttpReaction {
                                 }
                             }
                         }
+                        ResultDiff::Aggregation { .. } => {
+                            if let Some(spec) = query_config.updated.as_ref() {
+                                let data_to_process = serde_json::to_value(result)
+                                    .expect("ResultDiff serialization should succeed");
+                                if let Err(e) = Self::process_result(
+                                    &client,
+                                    &handlebars,
+                                    &base_url,
+                                    &token,
+                                    spec,
+                                    "UPDATE",
+                                    &data_to_process,
+                                    query_name,
+                                    &reaction_name,
+                                )
+                                .await
+                                {
+                                    error!("[{reaction_name}] Failed to process result: {e}");
+                                }
+                            }
+                        }
                         ResultDiff::Noop => {}
                     }
                 }

--- a/components/reactions/sse/src/sse.rs
+++ b/components/reactions/sse/src/sse.rs
@@ -339,9 +339,7 @@ impl Reaction for SseReaction {
                             ResultDiff::Add { .. } => (config.added.as_ref(), "ADD"),
                             ResultDiff::Update { .. } => (config.updated.as_ref(), "UPDATE"),
                             ResultDiff::Delete { .. } => (config.deleted.as_ref(), "DELETE"),
-                            ResultDiff::Aggregation { .. } => {
-                                (config.updated.as_ref(), "UPDATE")
-                            }
+                            ResultDiff::Aggregation { .. } => (config.updated.as_ref(), "UPDATE"),
                             ResultDiff::Noop => (None, "NOOP"),
                         };
 

--- a/components/reactions/sse/src/sse.rs
+++ b/components/reactions/sse/src/sse.rs
@@ -339,7 +339,10 @@ impl Reaction for SseReaction {
                             ResultDiff::Add { .. } => (config.added.as_ref(), "ADD"),
                             ResultDiff::Update { .. } => (config.updated.as_ref(), "UPDATE"),
                             ResultDiff::Delete { .. } => (config.deleted.as_ref(), "DELETE"),
-                            ResultDiff::Aggregation { .. } | ResultDiff::Noop => (None, "NOOP"),
+                            ResultDiff::Aggregation { .. } => {
+                                (config.updated.as_ref(), "UPDATE")
+                            }
+                            ResultDiff::Noop => (None, "NOOP"),
                         };
 
                         if let Some(spec) = template_spec {
@@ -357,7 +360,13 @@ impl Reaction for SseReaction {
                                 ResultDiff::Delete { data } => {
                                     context.insert("before".to_string(), data.clone());
                                 }
-                                ResultDiff::Aggregation { .. } | ResultDiff::Noop => {}
+                                ResultDiff::Aggregation { before, after } => {
+                                    if let Some(b) = before {
+                                        context.insert("before".to_string(), b.clone());
+                                    }
+                                    context.insert("after".to_string(), after.clone());
+                                }
+                                ResultDiff::Noop => {}
                             }
 
                             context.insert(

--- a/components/sources/README.md
+++ b/components/sources/README.md
@@ -37,6 +37,7 @@ Sources are responsible for:
 | `drasi-source-mock` | Test data generator for development | `mock/` |
 | `drasi-source-platform` | Redis Streams consumer for platform integration | `platform/` |
 | `drasi-source-postgres` | PostgreSQL WAL-based replication | `postgres/` |
+| `drasi-source-sui-deepbook` | Sui DeepBook V3 event polling source | `sui-deepbook/` |
 
 ## Architecture
 

--- a/components/sources/README.md
+++ b/components/sources/README.md
@@ -38,6 +38,7 @@ Sources are responsible for:
 | `drasi-source-platform` | Redis Streams consumer for platform integration | `platform/` |
 | `drasi-source-postgres` | PostgreSQL WAL-based replication | `postgres/` |
 | `drasi-source-hyperliquid` | Hyperliquid market data streaming | `hyperliquid/` |
+| `drasi-source-sui-deepbook` | Sui DeepBook V3 event polling source | `sui-deepbook/` |
 
 ## Architecture
 

--- a/components/sources/sui-deepbook/Cargo.toml
+++ b/components/sources/sui-deepbook/Cargo.toml
@@ -1,0 +1,54 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-source-sui-deepbook"
+version = "0.1.0"
+edition = "2021"
+authors = ["Drasi Project"]
+description = "Sui DeepBook V3 source plugin for Drasi"
+license = "Apache-2.0"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi", "plugin", "sui", "deepbook"]
+categories = ["network-programming"]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+drasi-lib.workspace = true
+drasi-core.workspace = true
+drasi-plugin-sdk = { workspace = true }
+utoipa = { workspace = true }
+anyhow = "1.0"
+async-trait = "0.1"
+log = "0.4"
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+reqwest = { version = "0.12", features = ["json"] }
+chrono = { version = "0.4", features = ["serde"] }
+ordered-float = "3.0"
+
+[dev-dependencies]
+axum = "0.7"
+drasi-reaction-application.workspace = true
+tokio-test = "0.4"
+env_logger = "0.11"
+
+[features]
+dynamic-plugin = []

--- a/components/sources/sui-deepbook/Cargo.toml
+++ b/components/sources/sui-deepbook/Cargo.toml
@@ -43,6 +43,12 @@ serde_json = "1.0"
 reqwest = { version = "0.12", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
 ordered-float = "3.0"
+sui-rpc = "0.1"
+sui-sdk-types = "0.1"
+tonic = { version = "0.14", default-features = false }
+hex = "0.4"
+bcs = "0.1"
+prost-types = "0.14"
 
 [dev-dependencies]
 axum = "0.7"

--- a/components/sources/sui-deepbook/Cargo.toml
+++ b/components/sources/sui-deepbook/Cargo.toml
@@ -45,6 +45,8 @@ chrono = { version = "0.4", features = ["serde"] }
 ordered-float = "3.0"
 sui-rpc = "0.1"
 sui-sdk-types = "0.1"
+# Pin roaring below 0.11.4 which requires rustc 1.90.0
+roaring = { workspace = true }
 tonic = { version = "0.14", default-features = false }
 hex = "0.4"
 bcs = "0.1"

--- a/components/sources/sui-deepbook/GRAPH_SCHEMA.md
+++ b/components/sources/sui-deepbook/GRAPH_SCHEMA.md
@@ -1,10 +1,18 @@
 # Sui DeepBook Source — Graph Schema Reference
 
-This document describes the graph structure produced by the `drasi-source-sui-deepbook` source. Every on-chain DeepBook V3 event becomes a **node** in the Drasi graph. There are no relationship edges — entities are linked by shared keys (`order_id`, `pool_id`, `sender`).
+This document describes the graph structure produced by the `drasi-source-sui-deepbook` source. Every on-chain DeepBook V3 event becomes a **node** in the Drasi graph. When enrichment is enabled (the default), the source also emits **Pool**, **Trader**, and **Order** nodes linked to events via relationships.
 
 ---
 
-## Node Overview
+## Graph Overview
+
+```
+(:DeepBookEvent:OrderPlaced)-[:IN_POOL]->(:Pool)
+(:DeepBookEvent:OrderPlaced)-[:SENT_BY]->(:Trader)
+(:DeepBookEvent:OrderPlaced)-[:FOR_ORDER]->(:Order)
+```
+
+### Event Nodes
 
 ```
 (:DeepBookEvent:OrderPlaced   { entity_id, event_name, module, … })
@@ -77,6 +85,71 @@ For example, if the on-chain event contains:
 You access these as `e.payload.order_id`, `e.payload.price`, `e.payload.size`, etc.
 
 > **Note**: Numeric strings from Sui (e.g. `"2340"`) remain strings. Use Cypher's `toInteger()` or `toFloat()` for numeric comparisons.
+
+---
+
+## Enrichment Nodes
+
+When enrichment is enabled (the default), the source emits additional graph nodes for pools, traders, and orders, linked to event nodes via relationships. Each enrichment node is created once per unique identifier and cached in-memory.
+
+### Pool Node (`:Pool`)
+
+Created via `sui_getObject` RPC call on first encounter of a `pool_id`.
+
+| Property | Type | Description | Example |
+|----------|------|-------------|---------|
+| `pool_id` | `String` | Full pool object address | `"0xabc…"` |
+| `pool_id_short` | `String` | Truncated pool address | `"0xabc1…ef23"` |
+| `base_asset` | `String` | Base asset Move type (from type params) | `"0x2::sui::SUI"` |
+| `quote_asset` | `String` | Quote asset Move type (from type params) | `"0xabc::usdc::USDC"` |
+| `tick_size` | `String` | Minimum price increment (raw units) | `"1000000"` |
+| `lot_size` | `String` | Minimum order quantity (raw units) | `"100000000"` |
+| `min_size` | `String` | Minimum trade size (raw units) | `"500000000"` |
+
+**Entity ID**: `pool_meta:{pool_id}`
+
+### Trader Node (`:Trader`)
+
+Derived from `event.sender` — no additional RPC calls.
+
+| Property | Type | Description | Example |
+|----------|------|-------------|---------|
+| `address` | `String` | Full sender address | `"0x1a2b…"` |
+| `address_short` | `String` | Truncated address | `"0x1a2b…3c4d"` |
+
+**Entity ID**: `trader:{address}`
+
+### Order Node (`:Order`)
+
+Derived from `order_id` in event payload — no additional RPC calls.
+
+| Property | Type | Description | Example |
+|----------|------|-------------|---------|
+| `order_id` | `String` | Order identifier | `"42"` |
+| `order_id_short` | `String` | Truncated order ID | `"42"` |
+| `pool_id` | `String` | Pool where order was placed (if available) | `"0xabc…"` |
+
+**Entity ID**: `order_meta:{order_id}`
+
+### Relationships
+
+| Relationship | Direction | Present When |
+|-------------|-----------|-------------|
+| `IN_POOL` | `(:DeepBookEvent)-[:IN_POOL]->(:Pool)` | Event has a `pool_id` |
+| `SENT_BY` | `(:DeepBookEvent)-[:SENT_BY]->(:Trader)` | Always (every event has a sender) |
+| `FOR_ORDER` | `(:DeepBookEvent)-[:FOR_ORDER]->(:Order)` | Event has an `order_id` |
+
+**Relationship Entity IDs**: `rel:in_pool:{event_entity_id}`, `rel:sent_by:{event_entity_id}`, `rel:for_order:{event_entity_id}`
+
+### Enrichment Configuration
+
+Enrichment is controlled by three boolean config flags (all default to `true`):
+
+| Config Field | Controls | Default |
+|-------------|----------|---------|
+| `enable_pool_nodes` | `:Pool` nodes + `IN_POOL` relationships | `true` |
+| `enable_trader_nodes` | `:Trader` nodes + `SENT_BY` relationships | `true` |
+| `enable_order_nodes` | `:Order` nodes + `FOR_ORDER` relationships | `true` |
 
 ---
 
@@ -224,6 +297,52 @@ RETURN order.order_id, order.payload.price AS order_price, price.payload.price A
 MATCH (e:DeepBookEvent)
 WHERE e.pool_id IS NOT NULL
 RETURN e.pool_id_short, e.event_name, count(e) AS event_count
+```
+
+### 9. Graph Traversal: Events for a Trading Pair (enrichment)
+
+```cypher
+MATCH (e:OrderPlaced)-[:IN_POOL]->(p:Pool)
+WHERE p.base_asset CONTAINS 'SUI' AND p.quote_asset CONTAINS 'USDC'
+RETURN e.payload.price, e.payload.size, p.tick_size
+```
+
+### 10. All Events by a Specific Trader (enrichment)
+
+```cypher
+MATCH (e:DeepBookEvent)-[:SENT_BY]->(t:Trader)
+WHERE t.address = '0x1a2b3c…full_address…'
+RETURN e.event_name, e.entity_id, e.timestamp_ms
+```
+
+### 11. Full Order Lifecycle via Graph Traversal (enrichment)
+
+```cypher
+MATCH (e:DeepBookEvent)-[:FOR_ORDER]->(o:Order)
+WHERE o.order_id = '42'
+RETURN e.event_name, e.change_type, e.timestamp_ms
+```
+
+### 12. Aggregate Events per Pool with Metadata (enrichment)
+
+```cypher
+MATCH (e:DeepBookEvent)-[:IN_POOL]->(p:Pool)
+RETURN p.base_asset, p.quote_asset, count(e) AS events
+```
+
+### 13. Cross-Entity: Orders in a Specific Market (enrichment)
+
+```cypher
+MATCH (e:DeepBookEvent)-[:IN_POOL]->(p:Pool), (e)-[:FOR_ORDER]->(o:Order)
+WHERE p.base_asset CONTAINS 'SUI'
+RETURN o.order_id, e.event_name, e.payload.price
+```
+
+### 14. Pool Metadata Lookup (enrichment)
+
+```cypher
+MATCH (p:Pool)
+RETURN p.pool_id_short, p.base_asset, p.quote_asset, p.tick_size, p.lot_size
 ```
 
 ---

--- a/components/sources/sui-deepbook/GRAPH_SCHEMA.md
+++ b/components/sources/sui-deepbook/GRAPH_SCHEMA.md
@@ -1,0 +1,271 @@
+# Sui DeepBook Source — Graph Schema Reference
+
+This document describes the graph structure produced by the `drasi-source-sui-deepbook` source. Every on-chain DeepBook V3 event becomes a **node** in the Drasi graph. There are no relationship edges — entities are linked by shared keys (`order_id`, `pool_id`, `sender`).
+
+---
+
+## Node Overview
+
+```
+(:DeepBookEvent:OrderPlaced   { entity_id, event_name, module, … })
+(:DeepBookEvent:OrderFilled   { entity_id, event_name, module, … })
+(:DeepBookEvent:OrderCancelled{ entity_id, event_name, module, … })
+(:DeepBookEvent:PriceAdded    { entity_id, event_name, module, … })
+(:DeepBookEvent:BalanceEvent  { entity_id, event_name, module, … })
+(:DeepBookEvent:FlashLoanBorrowed { … })
+   …and any other event type emitted by the DeepBook package
+```
+
+Every node carries **two labels**:
+
+| Label | Meaning |
+|-------|---------|
+| `DeepBookEvent` | Constant on every node — use this for broad queries |
+| _secondary_ | The short event name (e.g. `OrderPlaced`, `BalanceEvent`) — use this for targeted queries |
+
+---
+
+## Properties
+
+### Fixed Properties (present on every node)
+
+| Property | Type | Description | Example |
+|----------|------|-------------|---------|
+| `entity_id` | `String` | Unique entity identifier (see [Entity ID Rules](#entity-id-rules)) | `order:42` |
+| `tx_digest` | `String` | Sui transaction digest that emitted the event | `"7fa2b3c…"` |
+| `event_seq` | `String` | Sequence number of the event within its transaction | `"0"` |
+| `package_id` | `String` | Move package address that emitted the event | `"0x337f4f…"` |
+| `transaction_module` | `String` | Move module from the transaction context | `"pool"` |
+| `sender` | `String` | Full address of the transaction sender | `"0x1a2b3c…"` |
+| `sender_short` | `String` | Truncated sender for display (`0xABCD…WXYZ`) | `"0x1a2b…3c4d"` |
+| `event_type` | `String` | Full qualified Move type path | `"0x337f…::events::OrderPlaced"` |
+| `event_name` | `String` | Short name extracted from the type path | `"OrderPlaced"` |
+| `module` | `String` | Move module that emitted the event | `"events"` |
+| `change_type` | `String` | Operation classification: `insert`, `update`, or `delete` | `"insert"` |
+| `timestamp_ms` | `Integer` | On-chain timestamp in milliseconds since epoch | `1772923888171` |
+| `payload` | `Object` | The full `parsedJson` from the event as a nested object | `{size: "1000", …}` |
+
+### Conditional Properties (present when the event payload contains the relevant field)
+
+| Property | Type | Present When | Description |
+|----------|------|-------------|-------------|
+| `order_id` | `String` | Payload has `order_id` or `orderId` | Order identifier |
+| `pool_id` | `String` | Payload has `pool_id`, `poolId`, or `pool` | Full pool address |
+| `pool_id_short` | `String` | Same as `pool_id` | Truncated pool address for display |
+
+### Accessing Payload Fields
+
+The full event payload is stored as a nested `payload` object. Use Cypher dot-notation to access individual fields:
+
+```cypher
+-- Access nested payload fields directly
+RETURN e.payload.price, e.payload.size, e.payload.is_bid
+```
+
+For example, if the on-chain event contains:
+
+```json
+{
+  "order_id": "42",
+  "price": "2340",
+  "size": "1000",
+  "is_bid": true,
+  "pool_id": "0xabc…"
+}
+```
+
+You access these as `e.payload.order_id`, `e.payload.price`, `e.payload.size`, etc.
+
+> **Note**: Numeric strings from Sui (e.g. `"2340"`) remain strings. Use Cypher's `toInteger()` or `toFloat()` for numeric comparisons.
+
+---
+
+## Entity ID Rules
+
+The `entity_id` determines how nodes are identified and how updates/deletes correlate with prior inserts. The derivation follows a priority chain:
+
+| Priority | Condition | Entity ID Format | Example |
+|----------|-----------|------------------|---------|
+| 1 (highest) | Payload has `order_id` or `orderId` | `order:{order_id}` | `order:42` |
+| 2 | Payload has `pool_id`, `poolId`, or `pool` | `pool:{pool_id}` | `pool:0xabc…` |
+| 3 (fallback) | Neither field present | `event:{tx_digest}:{event_seq}` | `event:0x7fa…:0` |
+
+**Implications for queries:**
+- Order-related events (`OrderPlaced`, `OrderFilled`, `OrderCancelled`) sharing the same `order_id` will target the same graph node, enabling the Drasi query engine to track the order lifecycle as ADD → UPDATE → DELETE.
+- Pool-level events without an `order_id` are grouped by pool address.
+- Events with neither field get a unique per-transaction ID and are never updated or deleted.
+
+---
+
+## Operation Classification
+
+The `change_type` property and the `SourceChange` variant (Insert/Update/Delete) are determined by keyword matching on the event's full type name:
+
+| Keywords in Event Type | Operation | SourceChange | `change_type` |
+|------------------------|-----------|--------------|---------------|
+| `cancel`, `delete`, `remove` | Delete | `SourceChange::Delete` | `"delete"` |
+| `fill`, `update`, `modify`, `amend` | Update | `SourceChange::Update` | `"update"` |
+| _(everything else)_ | Insert | `SourceChange::Insert` | `"insert"` |
+
+Matching is **case-insensitive** and uses **substring contains**.
+
+---
+
+## Known DeepBook V3 Event Types
+
+These are the event types observed on Sui mainnet from the DeepBook V3 package:
+
+### Order Events (module: `events`)
+
+| Event Type | Operation | Entity ID | Description |
+|------------|-----------|-----------|-------------|
+| `OrderPlaced` | Insert | `order:{order_id}` | A new limit or market order was submitted to the book |
+| `OrderFilled` | Update | `order:{order_id}` | An order was partially or fully matched |
+| `OrderCancelled` | Delete | `order:{order_id}` | An order was cancelled by the user or by the system (IOC/FOK) |
+| `OrderModified` | Update | `order:{order_id}` | An existing order was amended (price or size change) |
+
+**Typical payload fields**: `order_id`, `pool_id`, `price`, `size`, `is_bid`, `quantity`, `maker_fee`, `taker_fee`, `expire_timestamp`, `side`
+
+### Price Events (module: `deep_price`)
+
+| Event Type | Operation | Entity ID | Description |
+|------------|-----------|-----------|-------------|
+| `PriceAdded` | Insert | `pool:{pool_id}` | A new reference price was recorded for a pool |
+
+**Typical payload fields**: `pool_id`, `price`, `size`
+
+### Balance Events (module: `balance_manager`)
+
+| Event Type | Operation | Entity ID | Description |
+|------------|-----------|-----------|-------------|
+| `BalanceEvent` | Insert | `event:{tx}:{seq}` | A balance change occurred in a user's BalanceManager |
+| `DeepBookReferralSetEvent` | Insert | `event:{tx}:{seq}` | A referral was set for a balance manager |
+
+**Typical payload fields**: `amount`, `balance`, `fee`
+
+### Flash Loan Events (module: `vault`)
+
+| Event Type | Operation | Entity ID | Description |
+|------------|-----------|-----------|-------------|
+| `FlashLoanBorrowed` | Insert | `event:{tx}:{seq}` | A flash loan was initiated from a pool's vault |
+
+**Typical payload fields**: `amount`, `pool_id`
+
+> **Note**: DeepBook may emit additional event types not listed here. All events from the configured `deepbook_package_id` are captured regardless of type.
+
+---
+
+## Query Examples
+
+### 1. All Events (broad)
+
+```cypher
+MATCH (e:DeepBookEvent)
+RETURN e.event_name, e.entity_id, e.change_type, e.timestamp_ms
+```
+
+### 2. Order Lifecycle Tracking
+
+```cypher
+MATCH (e:DeepBookEvent)
+WHERE e.order_id IS NOT NULL
+RETURN e.order_id, e.event_name, e.change_type, e.timestamp_ms
+```
+
+As an order progresses, the Drasi continuous query emits:
+```
+ADD    order:42  OrderPlaced   (change_type = "insert")
+UPDATE order:42  OrderFilled   (change_type = "update")
+DELETE order:42  OrderCancelled (change_type = "delete")
+```
+
+### 3. Specific Event Type by Label
+
+```cypher
+MATCH (e:OrderPlaced)
+RETURN e.entity_id, e.pool_id, e.payload.price, e.payload.size, e.payload.is_bid
+```
+
+### 4. Filter by Pool
+
+```cypher
+MATCH (e:DeepBookEvent)
+WHERE e.pool_id = '0xabc123…'
+RETURN e.event_name, e.entity_id, e.sender_short, e.timestamp_ms
+```
+
+### 5. Large Orders (using payload fields)
+
+```cypher
+MATCH (e:OrderPlaced)
+WHERE toInteger(e.payload.size) > 1000000
+RETURN e.order_id, e.pool_id_short, e.payload.price, e.payload.size, e.sender_short
+```
+
+### 6. Balance Changes by Sender
+
+```cypher
+MATCH (e:BalanceEvent)
+WHERE e.sender = '0x1a2b3c…full_address…'
+RETURN e.entity_id, e.payload.amount, e.payload.balance, e.timestamp_ms
+```
+
+### 7. Cross-Event Join on Pool ID
+
+```cypher
+MATCH (order:OrderPlaced), (price:PriceAdded)
+WHERE order.pool_id = price.pool_id
+RETURN order.order_id, order.payload.price AS order_price, price.payload.price AS ref_price
+```
+
+### 8. Aggregate Events per Pool
+
+```cypher
+MATCH (e:DeepBookEvent)
+WHERE e.pool_id IS NOT NULL
+RETURN e.pool_id_short, e.event_name, count(e) AS event_count
+```
+
+---
+
+## Filtering Pipeline
+
+Events pass through three filter stages before becoming graph nodes:
+
+```
+Sui JSON-RPC → ① Package ID → ② Event Type → ③ Pool ID → Graph Node
+```
+
+| Stage | Config Field | Behaviour |
+|-------|-------------|-----------|
+| ① Package ID | `deepbook_package_id` | Only events from this package are kept. Always active. |
+| ② Event Type | `event_filters` | If non-empty, event type must contain or end with one of the filter strings (case-insensitive). |
+| ③ Pool ID | `pools` | If non-empty, the event must have a `pool_id`/`poolId`/`pool` field matching one of the listed IDs. |
+
+Events that fail any stage are silently dropped and do not appear in the graph.
+
+---
+
+## Type Mapping (Sui → Drasi)
+
+| Sui JSON Type | Drasi `ElementValue` | Notes |
+|---------------|---------------------|-------|
+| JSON string | `String` | Most Sui numeric values arrive as strings |
+| JSON number (integer) | `Integer` (i64) | |
+| JSON number (float) | `Float` (f64) | |
+| JSON boolean | `Bool` | |
+| JSON null | `Null` | |
+| JSON array | `List` | Recursively mapped |
+| JSON object | `Object` | Recursively mapped into `ElementPropertyMap` |
+
+---
+
+## Bootstrap vs. Streaming Behaviour
+
+| Aspect | Bootstrap Provider | Streaming Source |
+|--------|-------------------|-----------------|
+| Operation | Always `Insert` | Classified by event name |
+| `change_type` | Always `"insert"` | `"insert"`, `"update"`, or `"delete"` |
+| Use case | Loading historical events | Real-time change detection |
+
+The bootstrap treats every historical event as an insert because the Drasi query engine needs a baseline graph before it can compute diffs.

--- a/components/sources/sui-deepbook/GRAPH_SCHEMA.md
+++ b/components/sources/sui-deepbook/GRAPH_SCHEMA.md
@@ -66,7 +66,7 @@ Every node carries **two labels**:
 The full event payload is stored as a nested `payload` object. Use Cypher dot-notation to access individual fields:
 
 ```cypher
--- Access nested payload fields directly
+// Access nested payload fields directly
 RETURN e.payload.price, e.payload.size, e.payload.is_bid
 ```
 

--- a/components/sources/sui-deepbook/Makefile
+++ b/components/sources/sui-deepbook/Makefile
@@ -1,0 +1,11 @@
+build:
+	cargo build -p drasi-source-sui-deepbook
+
+test:
+	cargo test -p drasi-source-sui-deepbook
+
+integration-test:
+	cargo test -p drasi-source-sui-deepbook --test integration_test -- --ignored --nocapture
+
+lint:
+	cargo clippy -p drasi-source-sui-deepbook --all-targets -- -D warnings

--- a/components/sources/sui-deepbook/README.md
+++ b/components/sources/sui-deepbook/README.md
@@ -1,0 +1,253 @@
+# Sui DeepBook V3 Source
+
+## Overview
+
+The Sui DeepBook Source is a Change Data Capture (CDC) plugin for Drasi that streams events from [DeepBook V3](https://deepbook.tech/) — the native central-limit order book (CLOB) on the [Sui blockchain](https://sui.io/). It polls the Sui JSON-RPC endpoint (`suix_queryEvents`) for on-chain events emitted by the DeepBook package and transforms them into Drasi `SourceChange` events for continuous query processing.
+
+**Key Capabilities**:
+- Real-time event streaming via Sui JSON-RPC polling
+- Automatic cursor persistence and resume via `StateStoreProvider`
+- Client-side filtering by event type and pool ID
+- Configurable start position (beginning of chain, current tip, or specific timestamp)
+- Automatic retry with configurable back-off on transient RPC errors
+- Full event payload projection into queryable properties
+
+**Use Cases**:
+- Real-time order book monitoring (new orders, fills, cancellations)
+- Liquidity analytics across DeepBook pools
+- Trading signal generation from on-chain activity
+- DeFi dashboards tracking pool health and volume
+- Alerting on large trades or unusual order patterns
+- Historical event replay for back-testing strategies
+
+## Architecture
+
+### Components
+
+The source consists of four modules:
+
+1. **Config** (`config.rs`): Builder-pattern configuration with validation — RPC endpoint, package ID, poll interval, request limits, filters, and start position
+2. **RPC** (`rpc.rs`): HTTP JSON-RPC client wrapping `suix_queryEvents` with cursor-based pagination, timeout, and error handling
+3. **Mapping** (`mapping.rs`): Transforms raw Sui events into Drasi `SourceChange` records with entity ID derivation, operation classification, label assignment, and property projection
+4. **Descriptor** (`descriptor.rs`): Plugin descriptor for dynamic plugin loading via the Drasi plugin SDK
+
+**Note**: Bootstrap functionality is provided by the separate `drasi-bootstrap-sui-deepbook` crate via the pluggable bootstrap provider pattern.
+
+### Data Flow
+
+```
+Sui JSON-RPC  →  SuiRpcClient  →  Package-ID Filter  →  Event/Pool Filter  →  Mapping  →  SourceChange
+(suix_queryEvents)    ↓                                                                         ↓
+                  Cursor Mgmt                                                             Dispatcher → Queries
+                      ↓
+                  StateStore
+```
+
+### How Events Become Graph Nodes
+
+> **📖 Full schema reference**: See [GRAPH_SCHEMA.md](GRAPH_SCHEMA.md) for the complete graph schema including all properties, entity ID rules, operation classification, known event types, type mappings, and query examples.
+
+Each DeepBook event becomes a `Node` element in the Drasi graph with:
+
+| Property | Source | Example |
+|----------|--------|---------|
+| `entity_id` | Derived from `order_id`, `pool_id`, or `tx:seq` | `order:42`, `pool:0xabc` |
+| `event_type` | Full Move type path | `0x337…::events::OrderPlaced` |
+| `event_name` | Short name from the type path | `OrderPlaced` |
+| `module` | Move module that emitted the event | `deep_price`, `balance_manager` |
+| `change_type` | Classified from event name | `insert`, `update`, `delete` |
+| `tx_digest` | Transaction that emitted the event | `0x7fa2…` |
+| `event_seq` | Sequence within the transaction | `0` |
+| `package_id` | Originating package address | `0x337f…` |
+| `sender` | Transaction sender address (full) | `0x1a2b3c…` |
+| `sender_short` | Truncated sender for display | `0x1a2b…3c4d` |
+| `timestamp_ms` | On-chain timestamp (milliseconds) | `1772923888171` |
+| `order_id` | Extracted when present | `42` |
+| `pool_id` | Pool address (full, when present) | `0xabc123…` |
+| `pool_id_short` | Truncated pool address for display | `0xabc1…2345` |
+| `payload` | Full `parsedJson` as nested object | `{size: "1000", …}` |
+| `payload` | Nested object with all event fields | `e.payload.size`, `e.payload.price` |
+
+Every node receives two labels:
+- `DeepBookEvent` (constant, useful for broad queries)
+- A secondary label derived from the event name, e.g. `OrderPlaced`, `BalanceEvent`
+
+### Operation Classification
+
+Events are classified based on keywords in their type name:
+
+| Keyword(s) | Operation | SourceChange |
+|------------|-----------|--------------|
+| `cancel`, `delete`, `remove` | Delete | `SourceChange::Delete` |
+| `fill`, `update`, `modify`, `amend` | Update | `SourceChange::Update` |
+| Everything else | Insert | `SourceChange::Insert` |
+
+## Prerequisites
+
+- **Sui RPC Access**: A Sui full-node JSON-RPC endpoint. The default Sui mainnet endpoint (`https://fullnode.mainnet.sui.io:443`) works but may have rate limits. For production use, consider a dedicated provider (Shinami, BlastAPI, etc.).
+- **Network Connectivity**: Outbound HTTPS to the RPC endpoint.
+- **DeepBook Package ID**: The address of the DeepBook V3 package. The default targets Sui mainnet.
+
+## Configuration
+
+### Builder Pattern (Recommended)
+
+```rust
+use drasi_source_sui_deepbook::SuiDeepBookSource;
+
+let source = SuiDeepBookSource::builder("deepbook-source")
+    .with_rpc_endpoint("https://fullnode.mainnet.sui.io:443")
+    .with_deepbook_package_id("0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497")
+    .with_poll_interval_ms(2_000)
+    .with_request_limit(50)
+    .with_start_from_now()
+    .build()?;
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `rpc_endpoint` | `String` | `https://fullnode.mainnet.sui.io:443` | Sui JSON-RPC endpoint URL |
+| `deepbook_package_id` | `String` | Mainnet DeepBook V3 address | Package ID to filter events by |
+| `poll_interval_ms` | `u64` | `2000` | Milliseconds between poll cycles |
+| `request_limit` | `u16` | `100` | Max events per RPC page (1–1000) |
+| `event_filters` | `Vec<String>` | `[]` | Event type substrings to include (empty = all) |
+| `pools` | `Vec<String>` | `[]` | Pool IDs to include (empty = all) |
+| `start_position` | `StartPosition` | `Now` | Where to begin consuming events |
+
+### Start Position
+
+| Variant | Behaviour |
+|---------|-----------|
+| `StartPosition::Now` | Fetch the latest cursor and only process new events going forward |
+| `StartPosition::Beginning` | Start from the earliest available event on chain |
+| `StartPosition::Timestamp(ms)` | Start from the beginning but skip events with `timestamp_ms < ms` |
+
+## Query Examples
+
+### 1. Stream All DeepBook Events
+
+```cypher
+MATCH (e:DeepBookEvent)
+RETURN e.entity_id, e.event_type, e.change_type, e.timestamp_ms
+```
+
+### 2. Monitor a Specific Pool
+
+```cypher
+MATCH (e:DeepBookEvent)
+WHERE e.pool_id = '0xabc123…'
+RETURN e.entity_id, e.event_type, e.payload.size, e.payload.price
+```
+
+### 3. Track Order Lifecycle
+
+```cypher
+MATCH (e:DeepBookEvent)
+WHERE e.order_id IS NOT NULL
+RETURN e.order_id, e.change_type, e.event_type, e.timestamp_ms
+```
+
+This query surfaces `insert` → `update` → `delete` transitions as orders are placed, filled, and cancelled.
+
+### 4. Large-Trade Alert
+
+```cypher
+MATCH (e:OrderPlaced)
+WHERE e.payload.size IS NOT NULL
+RETURN e.entity_id, e.pool_id, e.payload.size, e.payload.price, e.sender
+```
+
+Pair with a reaction (e.g. webhook, Slack) to alert when new orders appear.
+
+### 5. Filter to Specific Event Types (Builder-Side)
+
+If you only care about order placement and cancellation, configure the source to filter before the query:
+
+```rust
+let source = SuiDeepBookSource::builder("deepbook-orders")
+    .with_event_filters(vec![
+        "OrderPlaced".into(),
+        "OrderCancelled".into(),
+    ])
+    .with_start_from_beginning()
+    .build()?;
+```
+
+Then query:
+
+```cypher
+MATCH (e:DeepBookEvent)
+RETURN e.entity_id, e.event_type, e.change_type
+```
+
+### 6. Multi-Pool Monitoring
+
+```rust
+let source = SuiDeepBookSource::builder("multi-pool")
+    .with_pools(vec![
+        "0xpool_sui_usdc".into(),
+        "0xpool_deep_sui".into(),
+    ])
+    .build()?;
+```
+
+```cypher
+MATCH (e:DeepBookEvent)
+RETURN e.pool_id, e.event_type, count(e) AS event_count
+```
+
+### 7. Using Bootstrap for Historical Replay
+
+Load the last 50 pages of historical events before switching to live streaming:
+
+```rust
+use drasi_bootstrap_sui_deepbook::SuiDeepBookBootstrapProvider;
+
+let bootstrap = SuiDeepBookBootstrapProvider::builder()
+    .with_max_pages(50)
+    .with_start_from_beginning()
+    .build()?;
+
+let source = SuiDeepBookSource::builder("deepbook-with-history")
+    .with_bootstrap_provider(bootstrap)
+    .with_start_from_beginning()
+    .build()?;
+```
+
+## State Management
+
+When a `StateStoreProvider` is injected (automatically by `DrasiLib`), the source persists the Sui event cursor under the key `cursor` in its state partition. On restart, polling resumes exactly where it left off — no events are lost or duplicated.
+
+Without a state store, the source falls back to the configured `start_position` on each startup.
+
+## Event Filtering Pipeline
+
+Filtering happens in three stages — broadest first:
+
+1. **Package ID** — only events from the configured `deepbook_package_id` are kept
+2. **Event type** — if `event_filters` is non-empty, the event's type name must contain or end with one of the filter strings (case-insensitive)
+3. **Pool ID** — if `pools` is non-empty, the event must contain a `pool_id`/`poolId`/`pool` field matching one of the configured IDs
+
+## Error Handling
+
+- Transient RPC failures are retried with the configured `poll_interval_ms` as back-off
+- After 10 consecutive failures the source transitions to `Error` status
+- Corrupted persisted cursors are automatically cleared and the source restarts from the configured `start_position`
+
+## Testing
+
+```bash
+# Unit tests
+cargo test -p drasi-source-sui-deepbook
+
+# Integration test (mock RPC, verifies INSERT/UPDATE/DELETE + package-ID filtering)
+cargo test -p drasi-source-sui-deepbook --test integration_test -- --ignored --nocapture
+```
+
+## Limitations
+
+- **Polling, not push**: The Sui JSON-RPC does not support server-push subscriptions for `suix_queryEvents`. The source polls at the configured interval.
+- **All-events query**: Sui full-nodes do not support the `{"Package": "0x…"}` event query filter. The source queries `{"All": []}` and filters client-side by package ID. This is bandwidth-inefficient on very busy networks; using a dedicated RPC provider helps.
+- **No relationship edges**: All events are modelled as independent nodes. If you need edges, use a query-time join on shared keys like `order_id` or `pool_id`.

--- a/components/sources/sui-deepbook/README.md
+++ b/components/sources/sui-deepbook/README.md
@@ -11,6 +11,7 @@ The Sui DeepBook Source is a Change Data Capture (CDC) plugin for Drasi that str
 - Configurable start position (beginning of chain, current tip, or specific timestamp)
 - Automatic retry with configurable back-off on transient RPC errors
 - Full event payload projection into queryable properties
+- **Graph enrichment**: Pool, Trader, and Order nodes linked to events via relationships
 
 **Use Cases**:
 - Real-time order book monitoring (new orders, fills, cancellations)
@@ -115,6 +116,9 @@ let source = SuiDeepBookSource::builder("deepbook-source")
 | `event_filters` | `Vec<String>` | `[]` | Event type substrings to include (empty = all) |
 | `pools` | `Vec<String>` | `[]` | Pool IDs to include (empty = all) |
 | `start_position` | `StartPosition` | `Now` | Where to begin consuming events |
+| `enable_pool_nodes` | `bool` | `true` | Emit `:Pool` nodes with metadata from `sui_getObject` |
+| `enable_trader_nodes` | `bool` | `true` | Emit `:Trader` nodes from event senders |
+| `enable_order_nodes` | `bool` | `true` | Emit `:Order` nodes from event order_ids |
 
 ### Start Position
 
@@ -198,7 +202,31 @@ MATCH (e:DeepBookEvent)
 RETURN e.pool_id, e.event_type, count(e) AS event_count
 ```
 
-### 7. Using Bootstrap for Historical Replay
+### 7. Graph Traversal: Orders for a Trading Pair (enrichment)
+
+```cypher
+MATCH (e:OrderPlaced)-[:IN_POOL]->(p:Pool)
+WHERE p.base_asset CONTAINS 'SUI' AND p.quote_asset CONTAINS 'USDC'
+RETURN e.payload.price, e.payload.size, p.tick_size
+```
+
+### 8. Events by Trader (enrichment)
+
+```cypher
+MATCH (e:DeepBookEvent)-[:SENT_BY]->(t:Trader)
+WHERE t.address = '0x1a2b3c…full_address…'
+RETURN e.event_name, e.entity_id, e.timestamp_ms
+```
+
+### 9. Order Lifecycle via Graph Traversal (enrichment)
+
+```cypher
+MATCH (e:DeepBookEvent)-[:FOR_ORDER]->(o:Order)
+WHERE o.order_id = '42'
+RETURN e.event_name, e.change_type, e.timestamp_ms
+```
+
+### 10. Using Bootstrap for Historical Replay
 
 Load the last 50 pages of historical events before switching to live streaming:
 
@@ -250,4 +278,4 @@ cargo test -p drasi-source-sui-deepbook --test integration_test -- --ignored --n
 
 - **Polling, not push**: The Sui JSON-RPC does not support server-push subscriptions for `suix_queryEvents`. The source polls at the configured interval.
 - **All-events query**: Sui full-nodes do not support the `{"Package": "0x…"}` event query filter. The source queries `{"All": []}` and filters client-side by package ID. This is bandwidth-inefficient on very busy networks; using a dedicated RPC provider helps.
-- **No relationship edges**: All events are modelled as independent nodes. If you need edges, use a query-time join on shared keys like `order_id` or `pool_id`.
+- **Pool metadata via RPC**: When `enable_pool_nodes` is true, the source calls `sui_getObject` once per unique pool_id to fetch metadata (base_asset, quote_asset, etc.). This adds ~20-50 RPC calls on startup for DeepBook's active pools, then results are cached.

--- a/components/sources/sui-deepbook/README.md
+++ b/components/sources/sui-deepbook/README.md
@@ -2,14 +2,21 @@
 
 ## Overview
 
-The Sui DeepBook Source is a Change Data Capture (CDC) plugin for Drasi that streams events from [DeepBook V3](https://deepbook.tech/) — the native central-limit order book (CLOB) on the [Sui blockchain](https://sui.io/). It polls the Sui JSON-RPC endpoint (`suix_queryEvents`) for on-chain events emitted by the DeepBook package and transforms them into Drasi `SourceChange` events for continuous query processing.
+The Sui DeepBook Source is a Change Data Capture (CDC) plugin for Drasi that streams events from [DeepBook V3](https://deepbook.tech/) — the native central-limit order book (CLOB) on the [Sui blockchain](https://sui.io/). It supports two transport modes:
+
+- **gRPC checkpoint streaming** (default, recommended): Push-based real-time streaming via the Sui gRPC API with sub-second latency
+- **JSON-RPC polling** (legacy fallback): Pull-based polling via `suix_queryEvents` — **deprecated**, scheduled for deactivation July 2026
+
+Events are transformed into Drasi `SourceChange` events for continuous query processing.
 
 **Key Capabilities**:
-- Real-time event streaming via Sui JSON-RPC polling
+- Real-time event streaming via gRPC checkpoint streaming (push-based, ~300ms latency)
+- Legacy JSON-RPC polling fallback with configurable interval
+- BCS deserialization of known DeepBook V3 event types (PriceAdded, OrderFilled, FlashLoanBorrowed, etc.)
 - Automatic cursor persistence and resume via `StateStoreProvider`
 - Client-side filtering by event type and pool ID
 - Configurable start position (beginning of chain, current tip, or specific timestamp)
-- Automatic retry with configurable back-off on transient RPC errors
+- Automatic reconnection with exponential backoff on transport errors
 - Full event payload projection into queryable properties
 - **Graph enrichment**: Pool, Trader, and Order nodes linked to events via relationships
 
@@ -25,17 +32,29 @@ The Sui DeepBook Source is a Change Data Capture (CDC) plugin for Drasi that str
 
 ### Components
 
-The source consists of four modules:
+The source consists of five modules:
 
-1. **Config** (`config.rs`): Builder-pattern configuration with validation — RPC endpoint, package ID, poll interval, request limits, filters, and start position
-2. **RPC** (`rpc.rs`): HTTP JSON-RPC client wrapping `suix_queryEvents` with cursor-based pagination, timeout, and error handling
-3. **Mapping** (`mapping.rs`): Transforms raw Sui events into Drasi `SourceChange` records with entity ID derivation, operation classification, label assignment, and property projection
-4. **Descriptor** (`descriptor.rs`): Plugin descriptor for dynamic plugin loading via the Drasi plugin SDK
+1. **Config** (`config.rs`): Builder-pattern configuration with validation — transport mode, RPC endpoint, package ID, poll interval, request limits, filters, and start position
+2. **gRPC** (`grpc.rs`): gRPC client wrapping `sui-rpc::Client` for checkpoint streaming, BCS deserialization of known DeepBook event types, and checkpoint-to-events extraction
+3. **RPC** (`rpc.rs`): HTTP JSON-RPC client wrapping `suix_queryEvents` with cursor-based pagination, timeout, and error handling (legacy transport)
+4. **Mapping** (`mapping.rs`): Transforms raw Sui events into Drasi `SourceChange` records with entity ID derivation, operation classification, label assignment, and property projection
+5. **Descriptor** (`descriptor.rs`): Plugin descriptor for dynamic plugin loading via the Drasi plugin SDK
 
 **Note**: Bootstrap functionality is provided by the separate `drasi-bootstrap-sui-deepbook` crate via the pluggable bootstrap provider pattern.
 
 ### Data Flow
 
+**gRPC Transport (default)**:
+```
+Sui gRPC API  →  SuiGrpcClient  →  Package-ID Filter  →  BCS Deserialize  →  Event/Pool Filter  →  Mapping  →  SourceChange
+(subscribe_checkpoints)  ↓                                                                                           ↓
+                     Cursor Mgmt                                                                                Dispatcher → Queries
+                     (checkpoint seq)                                                                                ↓
+                         ↓                                                                                     Enrichment Nodes
+                     StateStore                                                                              (Pool, Trader, Order)
+```
+
+**JSON-RPC Transport (legacy)**:
 ```
 Sui JSON-RPC  →  SuiRpcClient  →  Package-ID Filter  →  Event/Pool Filter  →  Mapping  →  SourceChange
 (suix_queryEvents)    ↓                                                                         ↓
@@ -85,8 +104,8 @@ Events are classified based on keywords in their type name:
 
 ## Prerequisites
 
-- **Sui RPC Access**: A Sui full-node JSON-RPC endpoint. The default Sui mainnet endpoint (`https://fullnode.mainnet.sui.io:443`) works but may have rate limits. For production use, consider a dedicated provider (Shinami, BlastAPI, etc.).
-- **Network Connectivity**: Outbound HTTPS to the RPC endpoint.
+- **Sui RPC Access**: A Sui full-node endpoint with gRPC support (for default transport) or JSON-RPC (for legacy transport). The default Sui mainnet endpoint (`https://fullnode.mainnet.sui.io:443`) supports both protocols but may have rate limits. For production use, consider a dedicated provider (Shinami, BlastAPI, etc.).
+- **Network Connectivity**: Outbound HTTPS/gRPC to the endpoint (port 443).
 - **DeepBook Package ID**: The address of the DeepBook V3 package. The default targets Sui mainnet.
 
 ## Configuration
@@ -94,11 +113,18 @@ Events are classified based on keywords in their type name:
 ### Builder Pattern (Recommended)
 
 ```rust
-use drasi_source_sui_deepbook::SuiDeepBookSource;
+use drasi_source_sui_deepbook::{SuiDeepBookSource, Transport};
 
+// gRPC transport (default, recommended)
 let source = SuiDeepBookSource::builder("deepbook-source")
     .with_rpc_endpoint("https://fullnode.mainnet.sui.io:443")
     .with_deepbook_package_id("0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497")
+    .with_start_from_now()
+    .build()?;
+
+// JSON-RPC transport (legacy fallback)
+let source = SuiDeepBookSource::builder("deepbook-source")
+    .with_transport(Transport::JsonRpc)
     .with_poll_interval_ms(2_000)
     .with_request_limit(50)
     .with_start_from_now()
@@ -109,16 +135,19 @@ let source = SuiDeepBookSource::builder("deepbook-source")
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `rpc_endpoint` | `String` | `https://fullnode.mainnet.sui.io:443` | Sui JSON-RPC endpoint URL |
+| `transport` | `Transport` | `Grpc` | Transport mode: `Grpc` (recommended) or `JsonRpc` (legacy) |
+| `rpc_endpoint` | `String` | `https://fullnode.mainnet.sui.io:443` | Sui endpoint URL (used for both gRPC and JSON-RPC) |
+| `grpc_endpoint` | `Option<String>` | `None` | Override gRPC endpoint (falls back to `rpc_endpoint`) |
 | `deepbook_package_id` | `String` | Mainnet DeepBook V3 address | Package ID to filter events by |
-| `poll_interval_ms` | `u64` | `2000` | Milliseconds between poll cycles |
-| `request_limit` | `u16` | `100` | Max events per RPC page (1–1000) |
+| `poll_interval_ms` | `u64` | `2000` | Milliseconds between poll cycles (JSON-RPC only) |
+| `request_limit` | `u16` | `100` | Max events per RPC page, 1–1000 (JSON-RPC only) |
 | `event_filters` | `Vec<String>` | `[]` | Event type substrings to include (empty = all) |
 | `pools` | `Vec<String>` | `[]` | Pool IDs to include (empty = all) |
 | `start_position` | `StartPosition` | `Now` | Where to begin consuming events |
 | `enable_pool_nodes` | `bool` | `true` | Emit `:Pool` nodes with metadata from `sui_getObject` |
 | `enable_trader_nodes` | `bool` | `true` | Emit `:Trader` nodes from event senders |
 | `enable_order_nodes` | `bool` | `true` | Emit `:Order` nodes from event order_ids |
+| `lookback_events` | `u16` | `0` | Recent historical events to fetch on startup (JSON-RPC only) |
 
 ### Start Position
 
@@ -246,9 +275,11 @@ let source = SuiDeepBookSource::builder("deepbook-with-history")
 
 ## State Management
 
-When a `StateStoreProvider` is injected (automatically by `DrasiLib`), the source persists the Sui event cursor under the key `cursor` in its state partition. On restart, polling resumes exactly where it left off — no events are lost or duplicated.
+When a `StateStoreProvider` is injected (automatically by `DrasiLib`), the source persists its cursor:
+- **gRPC transport**: Persists the checkpoint sequence number under key `grpc_checkpoint_seq`
+- **JSON-RPC transport**: Persists the Sui event cursor under key `cursor`
 
-Without a state store, the source falls back to the configured `start_position` on each startup.
+On restart, the source resumes exactly where it left off — no events are lost or duplicated. Without a state store, the source falls back to the configured `start_position` on each startup.
 
 ## Event Filtering Pipeline
 
@@ -260,22 +291,25 @@ Filtering happens in three stages — broadest first:
 
 ## Error Handling
 
-- Transient RPC failures are retried with the configured `poll_interval_ms` as back-off
-- After 10 consecutive failures the source transitions to `Error` status
-- Corrupted persisted cursors are automatically cleared and the source restarts from the configured `start_position`
+- **gRPC transport**: On stream disconnection or errors, reconnects with exponential backoff (1s → 2s → 4s → … up to 30s). After 20 consecutive failures, transitions to `Error` status.
+- **JSON-RPC transport**: Transient RPC failures are retried with the configured `poll_interval_ms` as back-off. After 10 consecutive failures, transitions to `Error` status.
+- Corrupted persisted cursors are automatically cleared and the source restarts from the configured `start_position`.
 
 ## Testing
 
 ```bash
-# Unit tests
+# Unit tests (22 tests including gRPC event extraction)
 cargo test -p drasi-source-sui-deepbook
 
-# Integration test (mock RPC, verifies INSERT/UPDATE/DELETE + package-ID filtering)
-cargo test -p drasi-source-sui-deepbook --test integration_test -- --ignored --nocapture
+# Integration test — JSON-RPC transport (requires mainnet connectivity)
+cargo test -p drasi-source-sui-deepbook --test integration_test -- --ignored --nocapture test_sui_deepbook_change_detection_end_to_end
+
+# Integration test — gRPC transport (requires mainnet connectivity)
+cargo test -p drasi-source-sui-deepbook --test integration_test -- --ignored --nocapture test_grpc_transport_receives_events
 ```
 
 ## Limitations
 
-- **Polling, not push**: The Sui JSON-RPC does not support server-push subscriptions for `suix_queryEvents`. The source polls at the configured interval.
-- **All-events query**: Sui full-nodes do not support the `{"Package": "0x…"}` event query filter. The source queries `{"All": []}` and filters client-side by package ID. This is bandwidth-inefficient on very busy networks; using a dedicated RPC provider helps.
-- **Pool metadata via RPC**: When `enable_pool_nodes` is true, the source calls `sui_getObject` once per unique pool_id to fetch metadata (base_asset, quote_asset, etc.). This adds ~20-50 RPC calls on startup for DeepBook's active pools, then results are cached.
+- **BCS deserialization**: The gRPC transport uses BCS-encoded event data. Known DeepBook V3 event types (PriceAdded, OrderFilled, FlashLoanBorrowed, ReferralClaimed, OrderPlaced/Canceled/Modified, PoolCreated) are fully deserialized. Unknown event types are emitted with metadata but an empty payload.
+- **JSON-RPC deprecation**: The Sui JSON-RPC API is scheduled for deactivation in July 2026. The `JsonRpc` transport is provided as a legacy fallback only.
+- **Pool metadata via RPC**: When `enable_pool_nodes` is true, the source calls `sui_getObject` via JSON-RPC once per unique pool_id to fetch metadata (base_asset, quote_asset, etc.). This adds ~20-50 RPC calls on startup for DeepBook's active pools, then results are cached.

--- a/components/sources/sui-deepbook/README.md
+++ b/components/sources/sui-deepbook/README.md
@@ -136,18 +136,18 @@ let source = SuiDeepBookSource::builder("deepbook-source")
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `transport` | `Transport` | `Grpc` | Transport mode: `Grpc` (recommended) or `JsonRpc` (legacy) |
-| `rpc_endpoint` | `String` | `https://fullnode.mainnet.sui.io:443` | Sui endpoint URL (used for both gRPC and JSON-RPC) |
-| `grpc_endpoint` | `Option<String>` | `None` | Override gRPC endpoint (falls back to `rpc_endpoint`) |
-| `deepbook_package_id` | `String` | Mainnet DeepBook V3 address | Package ID to filter events by |
-| `poll_interval_ms` | `u64` | `2000` | Milliseconds between poll cycles (JSON-RPC only) |
-| `request_limit` | `u16` | `100` | Max events per RPC page, 1–1000 (JSON-RPC only) |
-| `event_filters` | `Vec<String>` | `[]` | Event type substrings to include (empty = all) |
+| `rpcEndpoint` | `String` | `https://fullnode.mainnet.sui.io:443` | Sui endpoint URL (used for both gRPC and JSON-RPC) |
+| `grpcEndpoint` | `Option<String>` | `None` | Override gRPC endpoint (falls back to `rpcEndpoint`) |
+| `deepbookPackageId` | `String` | Mainnet DeepBook V3 address | Package ID to filter events by |
+| `pollIntervalMs` | `u64` | `2000` | Milliseconds between poll cycles (JSON-RPC only) |
+| `requestLimit` | `u16` | `100` | Max events per RPC page, 1–1000 (JSON-RPC only) |
+| `eventFilters` | `Vec<String>` | `[]` | Event type substrings to include (empty = all) |
 | `pools` | `Vec<String>` | `[]` | Pool IDs to include (empty = all) |
-| `start_position` | `StartPosition` | `Now` | Where to begin consuming events |
-| `enable_pool_nodes` | `bool` | `true` | Emit `:Pool` nodes with metadata from `sui_getObject` |
-| `enable_trader_nodes` | `bool` | `true` | Emit `:Trader` nodes from event senders |
-| `enable_order_nodes` | `bool` | `true` | Emit `:Order` nodes from event order_ids |
-| `lookback_events` | `u16` | `0` | Recent historical events to fetch on startup (JSON-RPC only) |
+| `startPosition` | `StartPosition` | `Now` | Where to begin consuming events |
+| `enablePoolNodes` | `bool` | `true` | Emit `:Pool` nodes with metadata from `sui_getObject` |
+| `enableTraderNodes` | `bool` | `true` | Emit `:Trader` nodes from event senders |
+| `enableOrderNodes` | `bool` | `true` | Emit `:Order` nodes from event order_ids |
+| `lookbackEvents` | `u16` | `0` | Recent historical events to fetch on startup (JSON-RPC only) |
 
 ### Start Position
 

--- a/components/sources/sui-deepbook/README.md
+++ b/components/sources/sui-deepbook/README.md
@@ -85,8 +85,7 @@ Each DeepBook event becomes a `Node` element in the Drasi graph with:
 | `order_id` | Extracted when present | `42` |
 | `pool_id` | Pool address (full, when present) | `0xabc123…` |
 | `pool_id_short` | Truncated pool address for display | `0xabc1…2345` |
-| `payload` | Full `parsedJson` as nested object | `{size: "1000", …}` |
-| `payload` | Nested object with all event fields | `e.payload.size`, `e.payload.price` |
+| `payload` | Full `parsedJson` as nested object — access fields via dot notation (e.g. `e.payload.size`, `e.payload.price`) | `{size: "1000", …}` |
 
 Every node receives two labels:
 - `DeepBookEvent` (constant, useful for broad queries)

--- a/components/sources/sui-deepbook/src/config.rs
+++ b/components/sources/sui-deepbook/src/config.rs
@@ -44,6 +44,12 @@ pub struct SuiDeepBookSourceConfig {
     pub pools: Vec<String>,
     #[serde(default)]
     pub start_position: StartPosition,
+    #[serde(default = "default_true")]
+    pub enable_pool_nodes: bool,
+    #[serde(default = "default_true")]
+    pub enable_trader_nodes: bool,
+    #[serde(default = "default_true")]
+    pub enable_order_nodes: bool,
 }
 
 impl Default for SuiDeepBookSourceConfig {
@@ -56,6 +62,9 @@ impl Default for SuiDeepBookSourceConfig {
             event_filters: Vec::new(),
             pools: Vec::new(),
             start_position: StartPosition::Now,
+            enable_pool_nodes: true,
+            enable_trader_nodes: true,
+            enable_order_nodes: true,
         }
     }
 }
@@ -114,4 +123,8 @@ fn default_poll_interval_ms() -> u64 {
 
 fn default_request_limit() -> u16 {
     100
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/components/sources/sui-deepbook/src/config.rs
+++ b/components/sources/sui-deepbook/src/config.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_SUI_MAINNET_RPC: &str = "https://fullnode.mainnet.sui.io:443";
+pub const DEFAULT_DEEPBOOK_PACKAGE_ID: &str =
+    "0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(tag = "mode", content = "value", rename_all = "snake_case")]
+pub enum StartPosition {
+    Beginning,
+    #[default]
+    Now,
+    Timestamp(i64),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SuiDeepBookSourceConfig {
+    #[serde(default = "default_rpc_endpoint")]
+    pub rpc_endpoint: String,
+    #[serde(default = "default_deepbook_package_id")]
+    pub deepbook_package_id: String,
+    #[serde(default = "default_poll_interval_ms")]
+    pub poll_interval_ms: u64,
+    #[serde(default = "default_request_limit")]
+    pub request_limit: u16,
+    #[serde(default)]
+    pub event_filters: Vec<String>,
+    #[serde(default)]
+    pub pools: Vec<String>,
+    #[serde(default)]
+    pub start_position: StartPosition,
+}
+
+impl Default for SuiDeepBookSourceConfig {
+    fn default() -> Self {
+        Self {
+            rpc_endpoint: default_rpc_endpoint(),
+            deepbook_package_id: default_deepbook_package_id(),
+            poll_interval_ms: default_poll_interval_ms(),
+            request_limit: default_request_limit(),
+            event_filters: Vec::new(),
+            pools: Vec::new(),
+            start_position: StartPosition::Now,
+        }
+    }
+}
+
+impl SuiDeepBookSourceConfig {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.rpc_endpoint.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "Validation error: rpc_endpoint cannot be empty"
+            ));
+        }
+        reqwest::Url::parse(&self.rpc_endpoint)
+            .map_err(|e| anyhow::anyhow!("Validation error: invalid rpc_endpoint: {e}"))?;
+
+        if self.deepbook_package_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "Validation error: deepbook_package_id cannot be empty"
+            ));
+        }
+        if !self.deepbook_package_id.starts_with("0x") {
+            return Err(anyhow::anyhow!(
+                "Validation error: deepbook_package_id must start with 0x"
+            ));
+        }
+        if self.poll_interval_ms == 0 {
+            return Err(anyhow::anyhow!(
+                "Validation error: poll_interval_ms must be greater than 0"
+            ));
+        }
+        if self.request_limit == 0 {
+            return Err(anyhow::anyhow!(
+                "Validation error: request_limit must be greater than 0"
+            ));
+        }
+        if self.request_limit > 1_000 {
+            return Err(anyhow::anyhow!(
+                "Validation error: request_limit must be <= 1000"
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+fn default_rpc_endpoint() -> String {
+    DEFAULT_SUI_MAINNET_RPC.to_string()
+}
+
+fn default_deepbook_package_id() -> String {
+    DEFAULT_DEEPBOOK_PACKAGE_ID.to_string()
+}
+
+fn default_poll_interval_ms() -> u64 {
+    2_000
+}
+
+fn default_request_limit() -> u16 {
+    100
+}

--- a/components/sources/sui-deepbook/src/config.rs
+++ b/components/sources/sui-deepbook/src/config.rs
@@ -50,6 +50,11 @@ pub struct SuiDeepBookSourceConfig {
     pub enable_trader_nodes: bool,
     #[serde(default = "default_true")]
     pub enable_order_nodes: bool,
+    /// Number of recent historical events to fetch on startup (descending).
+    /// When > 0, the source fetches the most recent N events before entering
+    /// the forward-polling loop, giving dashboards immediate data.
+    #[serde(default)]
+    pub lookback_events: u16,
 }
 
 impl Default for SuiDeepBookSourceConfig {
@@ -65,6 +70,7 @@ impl Default for SuiDeepBookSourceConfig {
             enable_pool_nodes: true,
             enable_trader_nodes: true,
             enable_order_nodes: true,
+            lookback_events: 0,
         }
     }
 }

--- a/components/sources/sui-deepbook/src/config.rs
+++ b/components/sources/sui-deepbook/src/config.rs
@@ -15,8 +15,22 @@
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_SUI_MAINNET_RPC: &str = "https://fullnode.mainnet.sui.io:443";
+pub const DEFAULT_SUI_MAINNET_GRPC: &str = "https://fullnode.mainnet.sui.io";
 pub const DEFAULT_DEEPBOOK_PACKAGE_ID: &str =
     "0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497";
+
+/// Transport mechanism for receiving events from the Sui blockchain.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Transport {
+    /// gRPC checkpoint streaming (recommended). Push-based, low latency (~300ms).
+    /// Requires a Sui fullnode with gRPC support.
+    #[default]
+    Grpc,
+    /// JSON-RPC polling (legacy). Pull-based, configurable poll interval.
+    /// **Deprecated**: JSON-RPC will be deactivated July 2026.
+    JsonRpc,
+}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(tag = "mode", content = "value", rename_all = "snake_case")]
@@ -30,8 +44,14 @@ pub enum StartPosition {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiDeepBookSourceConfig {
+    /// Transport to use for event streaming. Default: gRPC.
+    #[serde(default)]
+    pub transport: Transport,
     #[serde(default = "default_rpc_endpoint")]
     pub rpc_endpoint: String,
+    /// gRPC endpoint. Defaults to the same as rpc_endpoint.
+    /// Only used when transport is Grpc.
+    pub grpc_endpoint: Option<String>,
     #[serde(default = "default_deepbook_package_id")]
     pub deepbook_package_id: String,
     #[serde(default = "default_poll_interval_ms")]
@@ -60,7 +80,9 @@ pub struct SuiDeepBookSourceConfig {
 impl Default for SuiDeepBookSourceConfig {
     fn default() -> Self {
         Self {
+            transport: Transport::default(),
             rpc_endpoint: default_rpc_endpoint(),
+            grpc_endpoint: None,
             deepbook_package_id: default_deepbook_package_id(),
             poll_interval_ms: default_poll_interval_ms(),
             request_limit: default_request_limit(),
@@ -76,6 +98,16 @@ impl Default for SuiDeepBookSourceConfig {
 }
 
 impl SuiDeepBookSourceConfig {
+    /// Returns the effective gRPC endpoint.
+    /// If `grpc_endpoint` is set, uses that; otherwise falls back to the default
+    /// gRPC endpoint (without explicit `:443` port, which is required for proper
+    /// HTTP/2 `:authority` header handling with the Sui load balancer).
+    pub fn effective_grpc_endpoint(&self) -> &str {
+        self.grpc_endpoint
+            .as_deref()
+            .unwrap_or(DEFAULT_SUI_MAINNET_GRPC)
+    }
+
     pub fn validate(&self) -> anyhow::Result<()> {
         if self.rpc_endpoint.trim().is_empty() {
             return Err(anyhow::anyhow!(
@@ -95,20 +127,22 @@ impl SuiDeepBookSourceConfig {
                 "Validation error: deepbook_package_id must start with 0x"
             ));
         }
-        if self.poll_interval_ms == 0 {
-            return Err(anyhow::anyhow!(
-                "Validation error: poll_interval_ms must be greater than 0"
-            ));
-        }
-        if self.request_limit == 0 {
-            return Err(anyhow::anyhow!(
-                "Validation error: request_limit must be greater than 0"
-            ));
-        }
-        if self.request_limit > 1_000 {
-            return Err(anyhow::anyhow!(
-                "Validation error: request_limit must be <= 1000"
-            ));
+        if self.transport == Transport::JsonRpc {
+            if self.poll_interval_ms == 0 {
+                return Err(anyhow::anyhow!(
+                    "Validation error: poll_interval_ms must be greater than 0"
+                ));
+            }
+            if self.request_limit == 0 {
+                return Err(anyhow::anyhow!(
+                    "Validation error: request_limit must be greater than 0"
+                ));
+            }
+            if self.request_limit > 1_000 {
+                return Err(anyhow::anyhow!(
+                    "Validation error: request_limit must be <= 1000"
+                ));
+            }
         }
 
         Ok(())

--- a/components/sources/sui-deepbook/src/config.rs
+++ b/components/sources/sui-deepbook/src/config.rs
@@ -32,12 +32,16 @@ pub enum Transport {
     JsonRpc,
 }
 
+/// Where to start consuming events from the Sui blockchain.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(tag = "mode", content = "value", rename_all = "snake_case")]
 pub enum StartPosition {
+    /// Start from the earliest available event on chain.
     Beginning,
+    /// Start from the current chain tip; only process new events going forward.
     #[default]
     Now,
+    /// Start from the beginning but skip events with `timestamp_ms` earlier than the given value (milliseconds since epoch).
     Timestamp(i64),
 }
 
@@ -47,27 +51,37 @@ pub struct SuiDeepBookSourceConfig {
     /// Transport to use for event streaming. Default: gRPC.
     #[serde(default)]
     pub transport: Transport,
+    /// Sui JSON-RPC endpoint URL. Used for JSON-RPC transport and pool-metadata lookups.
     #[serde(default = "default_rpc_endpoint")]
     pub rpc_endpoint: String,
-    /// gRPC endpoint. Defaults to the same as rpc_endpoint.
+    /// gRPC endpoint for checkpoint streaming. Defaults to Sui mainnet gRPC.
     /// Only used when transport is Grpc.
     pub grpc_endpoint: Option<String>,
+    /// The DeepBook V3 package address on-chain (must start with `0x`).
     #[serde(default = "default_deepbook_package_id")]
     pub deepbook_package_id: String,
+    /// Polling interval in milliseconds for JSON-RPC transport.
     #[serde(default = "default_poll_interval_ms")]
     pub poll_interval_ms: u64,
+    /// Maximum number of events to request per JSON-RPC page (1–1000).
     #[serde(default = "default_request_limit")]
     pub request_limit: u16,
+    /// Event type filters. When non-empty, only events whose type suffix or substring matches are included.
     #[serde(default)]
     pub event_filters: Vec<String>,
+    /// Pool address filters. When non-empty, only events from these pools are included.
     #[serde(default)]
     pub pools: Vec<String>,
+    /// Where to start consuming events from the Sui blockchain.
     #[serde(default)]
     pub start_position: StartPosition,
+    /// Whether to emit enrichment nodes for pools (pool metadata lookup).
     #[serde(default = "default_true")]
     pub enable_pool_nodes: bool,
+    /// Whether to emit enrichment nodes for traders (sender address).
     #[serde(default = "default_true")]
     pub enable_trader_nodes: bool,
+    /// Whether to emit enrichment nodes for orders (order_id extraction).
     #[serde(default = "default_true")]
     pub enable_order_nodes: bool,
     /// Number of recent historical events to fetch on startup (descending).
@@ -167,4 +181,99 @@ fn default_request_limit() -> u16 {
 
 fn default_true() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_config() -> SuiDeepBookSourceConfig {
+        SuiDeepBookSourceConfig::default()
+    }
+
+    #[test]
+    fn test_validate_default_config_passes() {
+        assert!(valid_config().validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_empty_rpc_endpoint() {
+        let mut config = valid_config();
+        config.rpc_endpoint = "".to_string();
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("rpc_endpoint cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_invalid_rpc_endpoint_url() {
+        let mut config = valid_config();
+        config.rpc_endpoint = "not a url".to_string();
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("invalid rpc_endpoint"));
+    }
+
+    #[test]
+    fn test_validate_empty_package_id() {
+        let mut config = valid_config();
+        config.deepbook_package_id = "".to_string();
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("deepbook_package_id cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_package_id_missing_0x() {
+        let mut config = valid_config();
+        config.deepbook_package_id = "abc123".to_string();
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("must start with 0x"));
+    }
+
+    #[test]
+    fn test_validate_json_rpc_zero_poll_interval() {
+        let mut config = valid_config();
+        config.transport = Transport::JsonRpc;
+        config.poll_interval_ms = 0;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("poll_interval_ms must be greater than 0"));
+    }
+
+    #[test]
+    fn test_validate_json_rpc_zero_request_limit() {
+        let mut config = valid_config();
+        config.transport = Transport::JsonRpc;
+        config.request_limit = 0;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("request_limit must be greater than 0"));
+    }
+
+    #[test]
+    fn test_validate_json_rpc_request_limit_too_high() {
+        let mut config = valid_config();
+        config.transport = Transport::JsonRpc;
+        config.request_limit = 1001;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("request_limit must be <= 1000"));
+    }
+
+    #[test]
+    fn test_validate_grpc_skips_json_rpc_checks() {
+        let mut config = valid_config();
+        config.transport = Transport::Grpc;
+        config.poll_interval_ms = 0; // would fail for JsonRpc
+        config.request_limit = 5000; // would fail for JsonRpc
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_effective_grpc_endpoint_default() {
+        let config = valid_config();
+        assert_eq!(config.effective_grpc_endpoint(), DEFAULT_SUI_MAINNET_GRPC);
+    }
+
+    #[test]
+    fn test_effective_grpc_endpoint_custom() {
+        let mut config = valid_config();
+        config.grpc_endpoint = Some("https://custom.node.io".to_string());
+        assert_eq!(config.effective_grpc_endpoint(), "https://custom.node.io");
+    }
 }

--- a/components/sources/sui-deepbook/src/descriptor.rs
+++ b/components/sources/sui-deepbook/src/descriptor.rs
@@ -1,0 +1,161 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{StartPosition, SuiDeepBookSourceBuilder};
+use drasi_plugin_sdk::prelude::*;
+use std::str::FromStr;
+use utoipa::OpenApi;
+
+fn default_rpc_endpoint() -> ConfigValue<String> {
+    ConfigValue::Static(crate::config::DEFAULT_SUI_MAINNET_RPC.to_string())
+}
+
+fn default_package_id() -> ConfigValue<String> {
+    ConfigValue::Static(crate::config::DEFAULT_DEEPBOOK_PACKAGE_ID.to_string())
+}
+
+fn default_poll_interval() -> ConfigValue<u64> {
+    ConfigValue::Static(2_000)
+}
+
+fn default_request_limit() -> ConfigValue<u16> {
+    ConfigValue::Static(100)
+}
+
+fn default_start_position() -> ConfigValue<StartPositionDto> {
+    ConfigValue::Static(StartPositionDto::default())
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema, Default)]
+#[schema(as = source::sui_deepbook::StartPosition)]
+#[serde(rename_all = "snake_case")]
+pub enum StartPositionDto {
+    Beginning,
+    #[default]
+    Now,
+    Timestamp,
+}
+
+impl FromStr for StartPositionDto {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "beginning" => Ok(Self::Beginning),
+            "now" => Ok(Self::Now),
+            "timestamp" => Ok(Self::Timestamp),
+            _ => Err(format!("Invalid start position: {s}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[schema(as = source::sui_deepbook::SuiDeepBookSourceConfig)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SuiDeepBookSourceConfigDto {
+    #[serde(default = "default_rpc_endpoint")]
+    #[schema(value_type = ConfigValueString)]
+    pub rpc_endpoint: ConfigValue<String>,
+    #[serde(default = "default_package_id")]
+    #[schema(value_type = ConfigValueString)]
+    pub deepbook_package_id: ConfigValue<String>,
+    #[serde(default = "default_poll_interval")]
+    #[schema(value_type = ConfigValueU64)]
+    pub poll_interval_ms: ConfigValue<u64>,
+    #[serde(default = "default_request_limit")]
+    #[schema(value_type = ConfigValueU16)]
+    pub request_limit: ConfigValue<u16>,
+    #[serde(default)]
+    pub event_filters: Vec<String>,
+    #[serde(default)]
+    pub pools: Vec<String>,
+    #[serde(default = "default_start_position")]
+    #[schema(value_type = ConfigValue<source::sui_deepbook::StartPosition>)]
+    pub start_position: ConfigValue<StartPositionDto>,
+    #[serde(default)]
+    #[schema(value_type = Option<ConfigValueString>)]
+    pub start_timestamp_ms: Option<ConfigValue<String>>,
+}
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(StartPositionDto, SuiDeepBookSourceConfigDto)))]
+struct SuiDeepBookSourceSchemas;
+
+pub struct SuiDeepBookSourceDescriptor;
+
+#[async_trait]
+impl SourcePluginDescriptor for SuiDeepBookSourceDescriptor {
+    fn kind(&self) -> &str {
+        "sui-deepbook"
+    }
+
+    fn config_version(&self) -> &str {
+        "1.0.0"
+    }
+
+    fn config_schema_name(&self) -> &str {
+        "source.sui_deepbook.SuiDeepBookSourceConfig"
+    }
+
+    fn config_schema_json(&self) -> String {
+        let api = SuiDeepBookSourceSchemas::openapi();
+        serde_json::to_string(
+            &api.components
+                .as_ref()
+                .expect("OpenAPI components missing")
+                .schemas,
+        )
+        .expect("Failed to serialize config schema")
+    }
+
+    async fn create_source(
+        &self,
+        id: &str,
+        config_json: &serde_json::Value,
+        auto_start: bool,
+    ) -> anyhow::Result<Box<dyn drasi_lib::sources::Source>> {
+        let dto: SuiDeepBookSourceConfigDto = serde_json::from_value(config_json.clone())?;
+        let mapper = DtoMapper::new();
+
+        let start_position = match mapper.resolve_typed::<StartPositionDto>(&dto.start_position)? {
+            StartPositionDto::Beginning => StartPosition::Beginning,
+            StartPositionDto::Now => StartPosition::Now,
+            StartPositionDto::Timestamp => {
+                let ts_config = dto.start_timestamp_ms.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "startTimestampMs is required when startPosition is 'timestamp'"
+                    )
+                })?;
+                let timestamp = mapper
+                    .resolve_string(ts_config)?
+                    .parse::<i64>()
+                    .map_err(|e| anyhow::anyhow!("Invalid startTimestampMs: {e}"))?;
+                StartPosition::Timestamp(timestamp)
+            }
+        };
+
+        let source = SuiDeepBookSourceBuilder::new(id)
+            .with_rpc_endpoint(mapper.resolve_string(&dto.rpc_endpoint)?)
+            .with_deepbook_package_id(mapper.resolve_string(&dto.deepbook_package_id)?)
+            .with_poll_interval_ms(mapper.resolve_typed(&dto.poll_interval_ms)?)
+            .with_request_limit(mapper.resolve_typed(&dto.request_limit)?)
+            .with_event_filters(dto.event_filters.clone())
+            .with_pools(dto.pools.clone())
+            .with_start_position(start_position)
+            .with_auto_start(auto_start)
+            .build()?;
+
+        Ok(Box::new(source))
+    }
+}

--- a/components/sources/sui-deepbook/src/grpc.rs
+++ b/components/sources/sui-deepbook/src/grpc.rs
@@ -1,0 +1,433 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{Context, Result};
+use log::{debug, warn};
+use serde::Deserialize;
+use sui_rpc::field::FieldMask;
+use sui_rpc::proto::sui::rpc::v2::{
+    self as proto, SubscribeCheckpointsRequest, SubscribeCheckpointsResponse,
+};
+use sui_sdk_types::bcs::FromBcs;
+use tonic::Streaming;
+
+use crate::rpc::SuiEvent;
+
+const MAX_DECODING_MESSAGE_SIZE: usize = 8 * 1024 * 1024;
+
+/// gRPC client for Sui full node checkpoint streaming.
+pub struct SuiGrpcClient {
+    client: sui_rpc::Client,
+}
+
+impl SuiGrpcClient {
+    pub fn new(endpoint: &str) -> Result<Self> {
+        let client = sui_rpc::Client::new(endpoint)
+            .map_err(|e| anyhow::anyhow!("Failed to create gRPC client: {e}"))?
+            .with_max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
+        Ok(Self { client })
+    }
+
+    /// Subscribe to the live checkpoint stream.
+    /// Returns a streaming response that yields checkpoints in order.
+    pub async fn subscribe_checkpoints(
+        &mut self,
+    ) -> Result<Streaming<SubscribeCheckpointsResponse>> {
+        let mut sub_client = self.client.subscription_client();
+        let mut request = SubscribeCheckpointsRequest::default();
+        request.read_mask = Some(FieldMask {
+            paths: vec![
+                "sequence_number".to_owned(),
+                "transactions.digest".to_owned(),
+                "transactions.events".to_owned(),
+                "transactions.timestamp".to_owned(),
+            ],
+        });
+
+        let response = sub_client
+            .subscribe_checkpoints(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to subscribe to checkpoints: {e}"))?;
+
+        Ok(response.into_inner())
+    }
+
+    /// Fetch a specific checkpoint by sequence number (for backfilling gaps).
+    pub async fn get_checkpoint(&mut self, sequence_number: u64) -> Result<proto::Checkpoint> {
+        let mut ledger_client = self.client.ledger_client();
+        let mut request = proto::GetCheckpointRequest::default();
+        request.read_mask = Some(FieldMask {
+            paths: vec![
+                "sequence_number".to_owned(),
+                "transactions.digest".to_owned(),
+                "transactions.events".to_owned(),
+                "transactions.timestamp".to_owned(),
+            ],
+        });
+        request.checkpoint_id = Some(proto::get_checkpoint_request::CheckpointId::SequenceNumber(
+            sequence_number,
+        ));
+
+        let response = ledger_client
+            .get_checkpoint(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get checkpoint {sequence_number}: {e}"))?
+            .into_inner();
+
+        response.checkpoint.context(format!(
+            "No checkpoint in response for seq {sequence_number}"
+        ))
+    }
+}
+
+/// Extract DeepBook events from a gRPC checkpoint, filtering by package ID.
+/// Converts gRPC proto events to our existing `SuiEvent` struct for compatibility
+/// with the existing mapping pipeline.
+pub fn extract_deepbook_events(
+    checkpoint: &proto::Checkpoint,
+    deepbook_package_id: &str,
+) -> Vec<SuiEvent> {
+    let mut events = Vec::new();
+    let checkpoint_seq = checkpoint.sequence_number.unwrap_or(0);
+
+    for tx in &checkpoint.transactions {
+        let tx_digest = tx.digest.as_deref().unwrap_or("unknown");
+        let timestamp_ms = tx
+            .timestamp
+            .as_ref()
+            .map(|t| (t.seconds as u64) * 1000 + (t.nanos as u64) / 1_000_000);
+
+        if let Some(ref events_container) = tx.events {
+            for (event_seq, event) in events_container.events.iter().enumerate() {
+                let pkg = event.package_id.as_deref().unwrap_or("");
+                if pkg != deepbook_package_id {
+                    continue;
+                }
+
+                let event_type = event.event_type.as_deref().unwrap_or("").to_string();
+                let sender = event.sender.as_deref().unwrap_or("").to_string();
+                let module = event.module.as_deref().unwrap_or("").to_string();
+
+                // Deserialize BCS event contents to JSON
+                let parsed_json = deserialize_event_bcs(
+                    &event_type,
+                    event.contents.as_ref().and_then(|c| c.value.as_deref()),
+                );
+
+                let sui_event = SuiEvent {
+                    id: crate::rpc::EventCursor {
+                        tx_digest: tx_digest.to_string(),
+                        event_seq: event_seq.to_string(),
+                    },
+                    package_id: pkg.to_string(),
+                    transaction_module: module,
+                    sender,
+                    event_type,
+                    parsed_json,
+                    timestamp_ms,
+                };
+
+                events.push(sui_event);
+            }
+        }
+    }
+
+    if !events.is_empty() {
+        debug!(
+            "Extracted {} DeepBook events from checkpoint {}",
+            events.len(),
+            checkpoint_seq
+        );
+    }
+
+    events
+}
+
+// ── BCS Deserialization for Known DeepBook V3 Event Types ──
+
+/// Deserialize BCS event contents based on the event type string.
+/// Returns a serde_json::Value for the existing mapping pipeline.
+fn deserialize_event_bcs(event_type: &str, bcs_bytes: Option<&[u8]>) -> serde_json::Value {
+    let Some(bytes) = bcs_bytes else {
+        return serde_json::Value::Object(Default::default());
+    };
+
+    // Extract the short event name from the full type path
+    // e.g., "0x2c8d...::deep_price::PriceAdded" -> "PriceAdded"
+    let short_name = event_type.rsplit("::").next().unwrap_or("");
+
+    let result =
+        match short_name {
+            "PriceAdded" => {
+                PriceAdded::from_bcs(bytes).map(|e| serde_json::to_value(e).unwrap_or_default())
+            }
+            "FlashLoanBorrowed" => FlashLoanBorrowed::from_bcs(bytes)
+                .map(|e| serde_json::to_value(e).unwrap_or_default()),
+            "OrderFilled" => {
+                OrderFilled::from_bcs(bytes).map(|e| serde_json::to_value(e).unwrap_or_default())
+            }
+            "ReferralClaimed" => ReferralClaimed::from_bcs(bytes)
+                .map(|e| serde_json::to_value(e).unwrap_or_default()),
+            "OrderPlaced" | "OrderCanceled" | "OrderModified" => {
+                OrderEvent::from_bcs(bytes).map(|e| serde_json::to_value(e).unwrap_or_default())
+            }
+            "PoolCreated" => {
+                PoolCreated::from_bcs(bytes).map(|e| serde_json::to_value(e).unwrap_or_default())
+            }
+            _ => {
+                debug!("Unknown DeepBook event type for BCS deserialization: {short_name}");
+                Ok(serde_json::Value::Object(Default::default()))
+            }
+        };
+
+    match result {
+        Ok(val) => val,
+        Err(e) => {
+            warn!("Failed to BCS-deserialize event type '{short_name}': {e}. Using empty payload.");
+            serde_json::Value::Object(Default::default())
+        }
+    }
+}
+
+// ── DeepBook V3 Event Structs ──
+// These are BCS-serialized by the Move runtime. Field order must match the Move struct definition.
+// Values are BCS-encoded: u64 as little-endian 8 bytes, bool as single byte,
+// Address as 32 bytes, String as length-prefixed bytes.
+
+/// PriceAdded event from deep_price module
+#[derive(Debug, Deserialize, serde::Serialize)]
+pub struct PriceAdded {
+    pub conversion_rate: u64,
+    pub timestamp: u64,
+    pub is_base_conversion: bool,
+    #[serde(with = "address_as_hex")]
+    pub reference_pool: [u8; 32],
+    #[serde(with = "address_as_hex")]
+    pub target_pool: [u8; 32],
+}
+
+/// FlashLoanBorrowed event from pool module
+#[derive(Debug, Deserialize, serde::Serialize)]
+pub struct FlashLoanBorrowed {
+    #[serde(with = "address_as_hex")]
+    pub pool_id: [u8; 32],
+    pub borrow_quantity: u64,
+    pub type_name: TypeName,
+}
+
+/// TypeName struct used in FlashLoanBorrowed
+#[derive(Debug, Deserialize, serde::Serialize)]
+pub struct TypeName {
+    pub name: String,
+}
+
+/// OrderFilled event from order_info module
+#[derive(Debug, Deserialize, serde::Serialize)]
+pub struct OrderFilled {
+    #[serde(with = "address_as_hex")]
+    pub pool_id: [u8; 32],
+    pub maker_order_id: u128,
+    pub taker_order_id: u128,
+    pub maker_client_order_id: u64,
+    pub taker_client_order_id: u64,
+    pub price: u64,
+    pub taker_is_bid: bool,
+    pub taker_fee: u64,
+    pub taker_fee_is_deep: bool,
+    pub maker_fee: u64,
+    pub maker_fee_is_deep: bool,
+    pub base_quantity: u64,
+    pub quote_quantity: u64,
+    #[serde(with = "address_as_hex")]
+    pub maker_balance_manager_id: [u8; 32],
+    #[serde(with = "address_as_hex")]
+    pub taker_balance_manager_id: [u8; 32],
+    pub timestamp: u64,
+}
+
+/// ReferralClaimed event
+#[derive(Debug, Deserialize, serde::Serialize)]
+pub struct ReferralClaimed {
+    #[serde(with = "address_as_hex")]
+    pub pool_id: [u8; 32],
+    #[serde(with = "address_as_hex")]
+    pub referral_id: [u8; 32],
+    #[serde(with = "address_as_hex")]
+    pub owner: [u8; 32],
+    pub base_amount: u64,
+    pub quote_amount: u64,
+    pub deep_amount: u64,
+}
+
+/// Generic order event (OrderPlaced, OrderCanceled, OrderModified)
+#[derive(Debug, Deserialize, serde::Serialize)]
+pub struct OrderEvent {
+    #[serde(with = "address_as_hex")]
+    pub pool_id: [u8; 32],
+    pub order_id: u128,
+    pub client_order_id: u64,
+    pub price: u64,
+    pub is_bid: bool,
+    #[serde(with = "address_as_hex")]
+    pub balance_manager_id: [u8; 32],
+    pub quantity: u64,
+    pub timestamp: u64,
+}
+
+/// PoolCreated event
+#[derive(Debug, Deserialize, serde::Serialize)]
+pub struct PoolCreated {
+    #[serde(with = "address_as_hex")]
+    pub pool_id: [u8; 32],
+    pub taker_fee: u64,
+    pub maker_fee: u64,
+    pub tick_size: u64,
+    pub lot_size: u64,
+    pub min_size: u64,
+}
+
+/// Serde helper to serialize/deserialize [u8; 32] as "0x"-prefixed hex string.
+mod address_as_hex {
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(bytes: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex = format!("0x{}", hex::encode(bytes));
+        serializer.serialize_str(&hex)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // BCS deserializes addresses as raw 32 bytes, not hex strings
+        <[u8; 32]>::deserialize(deserializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_deepbook_events_filters_by_package() {
+        let deepbook_pkg = "0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497";
+        let other_pkg = "0x0000000000000000000000000000000000000000000000000000000000000002";
+
+        let mut deepbook_event = proto::Event::default();
+        deepbook_event.package_id = Some(deepbook_pkg.to_string());
+        deepbook_event.module = Some("pool".to_string());
+        deepbook_event.sender = Some("0xsender1".to_string());
+        deepbook_event.event_type = Some(format!(
+            "{}::deep_price::PriceAdded",
+            "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809"
+        ));
+
+        let mut other_event = proto::Event::default();
+        other_event.package_id = Some(other_pkg.to_string());
+        other_event.module = Some("coin".to_string());
+        other_event.sender = Some("0xsender2".to_string());
+        other_event.event_type = Some("0x2::coin::CoinEvent".to_string());
+
+        let mut events_container = proto::TransactionEvents::default();
+        events_container.events = vec![deepbook_event, other_event];
+
+        let mut tx = proto::ExecutedTransaction::default();
+        tx.digest = Some("test_tx".to_string());
+        tx.timestamp = Some(prost_types::Timestamp {
+            seconds: 1700000000,
+            nanos: 500_000_000,
+        });
+        tx.events = Some(events_container);
+
+        let mut checkpoint = proto::Checkpoint::default();
+        checkpoint.sequence_number = Some(100);
+        checkpoint.transactions = vec![tx];
+
+        let events = extract_deepbook_events(&checkpoint, deepbook_pkg);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].package_id, deepbook_pkg);
+        assert!(events[0].event_type.contains("PriceAdded"));
+        assert_eq!(events[0].sender, "0xsender1");
+        assert_eq!(events[0].timestamp_ms, Some(1700000000500));
+    }
+
+    #[test]
+    fn test_extract_empty_checkpoint() {
+        let checkpoint = proto::Checkpoint::default();
+        let events = extract_deepbook_events(&checkpoint, "0xsomepkg");
+        assert!(events.is_empty());
+    }
+
+    /// Diagnostic test: connect to mainnet gRPC and verify messages are received.
+    #[tokio::test]
+    #[ignore]
+    async fn test_grpc_stream_delivers_messages() {
+        use sui_rpc::field::FieldMask;
+
+        let mut client =
+            SuiGrpcClient::new("https://fullnode.mainnet.sui.io").expect("Failed to create client");
+
+        let mut stream = client
+            .subscribe_checkpoints()
+            .await
+            .expect("Failed to subscribe");
+
+        let deepbook_pkg = "0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497";
+
+        let mut total_checkpoints = 0u32;
+        let mut total_deepbook = 0u32;
+
+        for i in 0..20 {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), stream.message()).await {
+                Ok(Ok(Some(resp))) => {
+                    total_checkpoints += 1;
+                    let seq = resp.cursor.unwrap_or(0);
+                    if let Some(cp) = &resp.checkpoint {
+                        let events = extract_deepbook_events(cp, deepbook_pkg);
+                        if !events.is_empty() {
+                            total_deepbook += events.len() as u32;
+                            println!("CP#{i}: seq={seq}, deepbook_events={}", events.len());
+                        }
+                    } else {
+                        println!("CP#{i}: seq={seq}, checkpoint=None");
+                    }
+                    if total_deepbook >= 3 {
+                        break;
+                    }
+                }
+                Ok(Ok(None)) => {
+                    println!("Stream ended at checkpoint #{i}");
+                    break;
+                }
+                Ok(Err(e)) => {
+                    println!("Stream error at checkpoint #{i}: {e}");
+                    break;
+                }
+                Err(_) => {
+                    println!("Timeout at checkpoint #{i}");
+                    break;
+                }
+            }
+        }
+
+        println!("Total: {total_checkpoints} checkpoints, {total_deepbook} deepbook events");
+        assert!(
+            total_checkpoints > 0,
+            "Should receive at least 1 checkpoint"
+        );
+    }
+}

--- a/components/sources/sui-deepbook/src/grpc.rs
+++ b/components/sources/sui-deepbook/src/grpc.rs
@@ -163,9 +163,11 @@ fn deserialize_event_bcs(event_type: &str, bcs_bytes: Option<&[u8]>) -> serde_js
         return serde_json::Value::Object(Default::default());
     };
 
-    // Extract the short event name from the full type path
-    // e.g., "0x2c8d...::deep_price::PriceAdded" -> "PriceAdded"
-    let short_name = event_type.rsplit("::").next().unwrap_or("");
+    // Extract the short event name from the full type path.
+    // First strip generic type parameters (e.g. `<0x2::sui::SUI, ...::USDC>`)
+    // so that rsplit("::") finds the event name, not a type parameter.
+    let base_type = event_type.split('<').next().unwrap_or(event_type);
+    let short_name = base_type.rsplit("::").next().unwrap_or("");
 
     let result =
         match short_name {
@@ -429,5 +431,34 @@ mod tests {
             total_checkpoints > 0,
             "Should receive at least 1 checkpoint"
         );
+    }
+
+    #[test]
+    fn test_deserialize_event_bcs_strips_generics() {
+        // Event types with generic parameters should still match the short name.
+        // e.g. "0x2c8d...::deep_price::PriceAdded<0x2::sui::SUI, 0xdba3...::usdc::USDC>"
+        let event_type_with_generics =
+            "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809::deep_price::PriceAdded<0x2::sui::SUI, 0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC>";
+
+        // Without valid BCS bytes it will fail to deserialize, but it should NOT
+        // fall through to the "unknown" arm.  We verify by passing None (which
+        // returns an empty object for all branches).  The real test is that the
+        // name extraction works — covered by the extraction logic.
+        let base_type = event_type_with_generics
+            .split('<')
+            .next()
+            .unwrap_or(event_type_with_generics);
+        let short_name = base_type.rsplit("::").next().unwrap_or("");
+        assert_eq!(short_name, "PriceAdded");
+
+        // Without generics
+        let event_type_simple =
+            "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809::deep_price::PriceAdded";
+        let base2 = event_type_simple
+            .split('<')
+            .next()
+            .unwrap_or(event_type_simple);
+        let short2 = base2.rsplit("::").next().unwrap_or("");
+        assert_eq!(short2, "PriceAdded");
     }
 }

--- a/components/sources/sui-deepbook/src/grpc.rs
+++ b/components/sources/sui-deepbook/src/grpc.rs
@@ -106,7 +106,7 @@ pub fn extract_deepbook_events(
         let timestamp_ms = tx
             .timestamp
             .as_ref()
-            .map(|t| (t.seconds as u64) * 1000 + (t.nanos as u64) / 1_000_000);
+            .map(|t| (t.seconds.max(0) as u64) * 1000 + (t.nanos.max(0) as u64) / 1_000_000);
 
         if let Some(ref events_container) = tx.events {
             for (event_seq, event) in events_container.events.iter().enumerate() {

--- a/components/sources/sui-deepbook/src/lib.rs
+++ b/components/sources/sui-deepbook/src/lib.rs
@@ -34,13 +34,16 @@ use drasi_lib::sources::base::{SourceBase, SourceBaseParams};
 use drasi_lib::sources::Source;
 use drasi_lib::state_store::StateStoreProvider;
 use log::{debug, error, info, warn};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::watch;
 use tokio::sync::RwLock;
 
-use crate::mapping::{map_event_to_change, should_include_event};
+use crate::mapping::{
+    build_order_node, build_pool_node, build_relationship, build_trader_node, event_order_id,
+    event_pool_id, map_event_to_change, should_include_event, EnrichmentConfig,
+};
 use crate::rpc::{EventCursor, SuiRpcClient};
 
 const CURSOR_STATE_KEY: &str = "cursor";
@@ -251,6 +254,17 @@ async fn run_poll_loop(
         _ => None,
     };
 
+    let enrichment = EnrichmentConfig {
+        enable_pool_nodes: config.enable_pool_nodes,
+        enable_trader_nodes: config.enable_trader_nodes,
+        enable_order_nodes: config.enable_order_nodes,
+    };
+    let mut enrichment_state = EnrichmentState {
+        seen_pools: HashSet::new(),
+        seen_traders: HashSet::new(),
+        seen_orders: HashSet::new(),
+    };
+
     let mut consecutive_failures = 0usize;
     loop {
         if *shutdown_rx.borrow() {
@@ -305,8 +319,37 @@ async fn run_poll_loop(
                 continue;
             }
 
+            let effective_from = event
+                .timestamp_ms
+                .unwrap_or_else(|| chrono::Utc::now().timestamp_millis().max(0) as u64);
+
+            // Emit enrichment nodes before the event node
+            emit_enrichment_nodes(
+                source_id,
+                &event,
+                &enrichment,
+                &rpc_client,
+                &mut enrichment_state,
+                effective_from,
+                base,
+            )
+            .await?;
+
+            // Emit the event node itself
+            let event_entity_id = crate::mapping::derive_entity_id_pub(&event);
             let change = map_event_to_change(source_id, &event);
             base.dispatch_source_change(change).await?;
+
+            // Emit relationships after both nodes exist
+            emit_enrichment_relationships(
+                source_id,
+                &event,
+                &enrichment,
+                &event_entity_id,
+                effective_from,
+                base,
+            )
+            .await?;
         }
 
         // Always advance cursor from next_cursor when present, even if all
@@ -329,6 +372,123 @@ async fn run_poll_loop(
 
         if wait_for_poll_or_shutdown(shutdown_rx, config.poll_interval_ms).await {
             break;
+        }
+    }
+
+    Ok(())
+}
+
+/// Mutable state for the enrichment caches within a polling session.
+struct EnrichmentState {
+    seen_pools: HashSet<String>,
+    seen_traders: HashSet<String>,
+    seen_orders: HashSet<String>,
+}
+
+/// Emit Pool, Trader, and Order nodes if not already seen.
+async fn emit_enrichment_nodes(
+    source_id: &str,
+    event: &crate::rpc::SuiEvent,
+    enrichment: &EnrichmentConfig,
+    rpc_client: &SuiRpcClient,
+    state: &mut EnrichmentState,
+    effective_from: u64,
+    base: &SourceBase,
+) -> Result<()> {
+    // Pool node
+    if enrichment.enable_pool_nodes {
+        if let Some(pool_id) = event_pool_id(event) {
+            if state.seen_pools.insert(pool_id.clone()) {
+                let object_data = match rpc_client.get_object(&pool_id).await {
+                    Ok(data) => {
+                        debug!("Fetched pool metadata for {pool_id}");
+                        Some(data)
+                    }
+                    Err(err) => {
+                        warn!("Failed to fetch pool object for {pool_id}: {err}");
+                        None
+                    }
+                };
+                let pool_change =
+                    build_pool_node(source_id, &pool_id, object_data.as_ref(), effective_from);
+                base.dispatch_source_change(pool_change).await?;
+            }
+        }
+    }
+
+    // Trader node
+    if enrichment.enable_trader_nodes
+        && !event.sender.is_empty()
+        && state.seen_traders.insert(event.sender.clone())
+    {
+        let trader_change = build_trader_node(source_id, &event.sender, effective_from);
+        base.dispatch_source_change(trader_change).await?;
+    }
+
+    // Order node
+    if enrichment.enable_order_nodes {
+        if let Some(order_id) = event_order_id(event) {
+            if state.seen_orders.insert(order_id.clone()) {
+                let pool_id = event_pool_id(event);
+                let order_change =
+                    build_order_node(source_id, &order_id, pool_id.as_deref(), effective_from);
+                base.dispatch_source_change(order_change).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Emit IN_POOL, SENT_BY, FOR_ORDER relationships after both nodes exist.
+async fn emit_enrichment_relationships(
+    source_id: &str,
+    event: &crate::rpc::SuiEvent,
+    enrichment: &EnrichmentConfig,
+    event_entity_id: &str,
+    effective_from: u64,
+    base: &SourceBase,
+) -> Result<()> {
+    // IN_POOL relationship
+    if enrichment.enable_pool_nodes {
+        if let Some(pool_id) = event_pool_id(event) {
+            let rel = build_relationship(
+                source_id,
+                "IN_POOL",
+                &format!("rel:in_pool:{event_entity_id}"),
+                event_entity_id,
+                &format!("pool_meta:{pool_id}"),
+                effective_from,
+            );
+            base.dispatch_source_change(rel).await?;
+        }
+    }
+
+    // SENT_BY relationship
+    if enrichment.enable_trader_nodes && !event.sender.is_empty() {
+        let rel = build_relationship(
+            source_id,
+            "SENT_BY",
+            &format!("rel:sent_by:{event_entity_id}"),
+            event_entity_id,
+            &format!("trader:{}", event.sender),
+            effective_from,
+        );
+        base.dispatch_source_change(rel).await?;
+    }
+
+    // FOR_ORDER relationship
+    if enrichment.enable_order_nodes {
+        if let Some(order_id) = event_order_id(event) {
+            let rel = build_relationship(
+                source_id,
+                "FOR_ORDER",
+                &format!("rel:for_order:{event_entity_id}"),
+                event_entity_id,
+                &format!("order_meta:{order_id}"),
+                effective_from,
+            );
+            base.dispatch_source_change(rel).await?;
         }
     }
 
@@ -503,6 +663,21 @@ impl SuiDeepBookSourceBuilder {
 
     pub fn with_config(mut self, config: SuiDeepBookSourceConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    pub fn with_enable_pool_nodes(mut self, enable: bool) -> Self {
+        self.config.enable_pool_nodes = enable;
+        self
+    }
+
+    pub fn with_enable_trader_nodes(mut self, enable: bool) -> Self {
+        self.config.enable_trader_nodes = enable;
+        self
+    }
+
+    pub fn with_enable_order_nodes(mut self, enable: bool) -> Self {
+        self.config.enable_order_nodes = enable;
         self
     }
 

--- a/components/sources/sui-deepbook/src/lib.rs
+++ b/components/sources/sui-deepbook/src/lib.rs
@@ -1,0 +1,590 @@
+#![allow(unexpected_cfgs)]
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sui DeepBook source plugin for Drasi.
+//!
+//! This source polls the Sui JSON-RPC API (`suix_queryEvents`) for DeepBook package events
+//! and emits them as Drasi source changes.
+
+pub mod config;
+pub mod descriptor;
+pub mod mapping;
+pub mod rpc;
+
+pub use config::{
+    StartPosition, SuiDeepBookSourceConfig, DEFAULT_DEEPBOOK_PACKAGE_ID, DEFAULT_SUI_MAINNET_RPC,
+};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use drasi_lib::channels::{ComponentStatus, DispatchMode, SubscriptionResponse};
+use drasi_lib::sources::base::{SourceBase, SourceBaseParams};
+use drasi_lib::sources::Source;
+use drasi_lib::state_store::StateStoreProvider;
+use log::{debug, error, info, warn};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch;
+use tokio::sync::RwLock;
+
+use crate::mapping::{map_event_to_change, should_include_event};
+use crate::rpc::{EventCursor, SuiRpcClient};
+
+const CURSOR_STATE_KEY: &str = "cursor";
+
+pub struct SuiDeepBookSource {
+    base: SourceBase,
+    config: SuiDeepBookSourceConfig,
+    state_store: Arc<RwLock<Option<Arc<dyn StateStoreProvider>>>>,
+    task_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
+    shutdown_tx: watch::Sender<bool>,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+impl SuiDeepBookSource {
+    pub fn new(id: impl Into<String>, config: SuiDeepBookSourceConfig) -> Result<Self> {
+        config.validate()?;
+        let id = id.into();
+        let params = SourceBaseParams::new(&id);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        Ok(Self {
+            base: SourceBase::new(params)?,
+            config,
+            state_store: Arc::new(RwLock::new(None)),
+            task_handle: Arc::new(RwLock::new(None)),
+            shutdown_tx,
+            shutdown_rx,
+        })
+    }
+
+    pub fn builder(id: impl Into<String>) -> SuiDeepBookSourceBuilder {
+        SuiDeepBookSourceBuilder::new(id)
+    }
+}
+
+#[async_trait]
+impl Source for SuiDeepBookSource {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "sui-deepbook"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        let mut props = HashMap::new();
+        props.insert(
+            "rpc_endpoint".to_string(),
+            serde_json::Value::String(self.config.rpc_endpoint.clone()),
+        );
+        props.insert(
+            "deepbook_package_id".to_string(),
+            serde_json::Value::String(self.config.deepbook_package_id.clone()),
+        );
+        props.insert(
+            "poll_interval_ms".to_string(),
+            serde_json::Value::Number(self.config.poll_interval_ms.into()),
+        );
+        props.insert(
+            "request_limit".to_string(),
+            serde_json::Value::Number(self.config.request_limit.into()),
+        );
+        props.insert(
+            "event_filters".to_string(),
+            serde_json::Value::Array(
+                self.config
+                    .event_filters
+                    .iter()
+                    .cloned()
+                    .map(serde_json::Value::String)
+                    .collect(),
+            ),
+        );
+        props.insert(
+            "pools".to_string(),
+            serde_json::Value::Array(
+                self.config
+                    .pools
+                    .iter()
+                    .cloned()
+                    .map(serde_json::Value::String)
+                    .collect(),
+            ),
+        );
+        props.insert(
+            "start_position".to_string(),
+            serde_json::to_value(self.config.start_position).unwrap_or(serde_json::Value::Null),
+        );
+        props
+    }
+
+    fn auto_start(&self) -> bool {
+        self.base.get_auto_start()
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn start(&self) -> Result<()> {
+        if self.base.get_status().await == ComponentStatus::Running {
+            return Ok(());
+        }
+
+        self.base.set_status(ComponentStatus::Starting).await;
+        info!("Starting Sui DeepBook source '{}'", self.base.id);
+
+        let source_id = self.base.id.clone();
+        let config = self.config.clone();
+        let base = self.base.clone_shared();
+        let state_store = self.state_store.read().await.clone();
+        let mut shutdown_rx = self.shutdown_rx.clone();
+
+        let task_handle = tokio::spawn(async move {
+            if let Err(err) =
+                run_poll_loop(&source_id, config, &base, state_store, &mut shutdown_rx).await
+            {
+                error!("Sui DeepBook polling task failed for '{source_id}': {err}");
+                let _ = base
+                    .set_status_with_event(ComponentStatus::Error, Some(err.to_string()))
+                    .await;
+            }
+        });
+
+        *self.task_handle.write().await = Some(task_handle);
+        self.base.set_status(ComponentStatus::Running).await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        info!("Stopping Sui DeepBook source '{}'", self.base.id);
+        self.base.set_status(ComponentStatus::Stopping).await;
+
+        if let Err(err) = self.shutdown_tx.send(true) {
+            warn!(
+                "Failed sending shutdown signal for Sui DeepBook source '{}': {err}",
+                self.base.id
+            );
+        }
+
+        if let Some(handle) = self.task_handle.write().await.take() {
+            match tokio::time::timeout(Duration::from_secs(5), handle).await {
+                Ok(Ok(())) => debug!("Sui DeepBook polling task stopped gracefully"),
+                Ok(Err(err)) => warn!("Sui DeepBook polling task panicked: {err}"),
+                Err(_) => warn!("Sui DeepBook polling task did not stop within timeout"),
+            }
+        }
+
+        self.base.set_status(ComponentStatus::Stopped).await;
+        Ok(())
+    }
+
+    async fn subscribe(
+        &self,
+        settings: drasi_lib::config::SourceSubscriptionSettings,
+    ) -> Result<SubscriptionResponse> {
+        self.base
+            .subscribe_with_bootstrap(&settings, "Sui DeepBook")
+            .await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn initialize(&self, context: drasi_lib::context::SourceRuntimeContext) {
+        self.base.initialize(context.clone()).await;
+        if let Some(state_store) = context.state_store {
+            *self.state_store.write().await = Some(state_store);
+            debug!(
+                "State store injected into Sui DeepBook source '{}'",
+                self.base.id
+            );
+        }
+    }
+
+    async fn set_bootstrap_provider(
+        &self,
+        provider: Box<dyn drasi_lib::bootstrap::BootstrapProvider + 'static>,
+    ) {
+        self.base.set_bootstrap_provider(provider).await;
+    }
+}
+
+async fn run_poll_loop(
+    source_id: &str,
+    config: SuiDeepBookSourceConfig,
+    base: &SourceBase,
+    state_store: Option<Arc<dyn StateStoreProvider>>,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> Result<()> {
+    let rpc_client = SuiRpcClient::new(config.rpc_endpoint.clone())?;
+    let query_filter = serde_json::json!({ "All": [] });
+
+    let mut cursor = load_cursor(source_id, &state_store).await?;
+
+    if cursor.is_none() && matches!(config.start_position, StartPosition::Now) {
+        cursor =
+            initialize_cursor_for_now(&rpc_client, &query_filter, config.request_limit).await?;
+        if let Some(cursor_ref) = cursor.as_ref() {
+            save_cursor(source_id, cursor_ref, &state_store).await?;
+        }
+    }
+
+    let timestamp_floor = match config.start_position {
+        StartPosition::Timestamp(value) => Some(value.max(0) as u64),
+        _ => None,
+    };
+
+    let mut consecutive_failures = 0usize;
+    loop {
+        if *shutdown_rx.borrow() {
+            info!("Received shutdown signal for Sui DeepBook source '{source_id}'");
+            break;
+        }
+
+        let query_result = match rpc_client
+            .query_events(
+                query_filter.clone(),
+                cursor.as_ref(),
+                config.request_limit,
+                false,
+            )
+            .await
+        {
+            Ok(result) => {
+                consecutive_failures = 0;
+                result
+            }
+            Err(err) => {
+                consecutive_failures += 1;
+                error!("Failed querying DeepBook events (attempt {consecutive_failures}): {err}");
+                if consecutive_failures >= 10 {
+                    return Err(err);
+                }
+                if wait_for_poll_or_shutdown(shutdown_rx, config.poll_interval_ms).await {
+                    break;
+                }
+                continue;
+            }
+        };
+
+        let mut latest_cursor = cursor.clone();
+        for event in query_result.data {
+            latest_cursor = Some(event.id.clone());
+
+            if event.package_id != config.deepbook_package_id {
+                continue;
+            }
+
+            if let Some(ts_floor) = timestamp_floor {
+                if event
+                    .timestamp_ms
+                    .is_some_and(|timestamp| timestamp < ts_floor)
+                {
+                    continue;
+                }
+            }
+
+            if !should_include_event(&event, &config.event_filters, &config.pools) {
+                continue;
+            }
+
+            let change = map_event_to_change(source_id, &event);
+            base.dispatch_source_change(change).await?;
+        }
+
+        // Always advance cursor from next_cursor when present, even if all
+        // events on this page were filtered out.  Without this, the source
+        // would re-fetch the same page forever when no events match.
+        if let Some(next_cursor) = query_result.next_cursor {
+            latest_cursor = Some(next_cursor);
+        }
+
+        if latest_cursor != cursor {
+            cursor = latest_cursor;
+            if let Some(cursor_ref) = cursor.as_ref() {
+                save_cursor(source_id, cursor_ref, &state_store).await?;
+            }
+        }
+
+        if query_result.has_next_page {
+            continue;
+        }
+
+        if wait_for_poll_or_shutdown(shutdown_rx, config.poll_interval_ms).await {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+async fn initialize_cursor_for_now(
+    rpc_client: &SuiRpcClient,
+    query_filter: &serde_json::Value,
+    request_limit: u16,
+) -> Result<Option<EventCursor>> {
+    let result = rpc_client
+        .query_events(query_filter.clone(), None, request_limit.min(10), true)
+        .await?;
+
+    if let Some(first) = result.data.first() {
+        return Ok(Some(first.id.clone()));
+    }
+    Ok(result.next_cursor)
+}
+
+async fn load_cursor(
+    source_id: &str,
+    state_store: &Option<Arc<dyn StateStoreProvider>>,
+) -> Result<Option<EventCursor>> {
+    let Some(store) = state_store else {
+        return Ok(None);
+    };
+
+    let Some(bytes) = store.get(source_id, CURSOR_STATE_KEY).await? else {
+        return Ok(None);
+    };
+
+    match serde_json::from_slice::<EventCursor>(&bytes) {
+        Ok(cursor) => Ok(Some(cursor)),
+        Err(err) => {
+            warn!(
+                "Failed to parse persisted DeepBook cursor for source '{source_id}': {err}. Clearing state."
+            );
+            let _ = store.delete(source_id, CURSOR_STATE_KEY).await;
+            Ok(None)
+        }
+    }
+}
+
+async fn save_cursor(
+    source_id: &str,
+    cursor: &EventCursor,
+    state_store: &Option<Arc<dyn StateStoreProvider>>,
+) -> Result<()> {
+    let Some(store) = state_store else {
+        return Ok(());
+    };
+
+    let bytes = serde_json::to_vec(cursor)?;
+    store.set(source_id, CURSOR_STATE_KEY, bytes).await?;
+    Ok(())
+}
+
+async fn wait_for_poll_or_shutdown(
+    shutdown_rx: &mut watch::Receiver<bool>,
+    poll_interval_ms: u64,
+) -> bool {
+    tokio::select! {
+        _ = tokio::time::sleep(Duration::from_millis(poll_interval_ms)) => false,
+        changed = shutdown_rx.changed() => {
+            changed.is_ok() && *shutdown_rx.borrow()
+        }
+    }
+}
+
+pub struct SuiDeepBookSourceBuilder {
+    id: String,
+    config: SuiDeepBookSourceConfig,
+    dispatch_mode: Option<DispatchMode>,
+    dispatch_buffer_capacity: Option<usize>,
+    bootstrap_provider: Option<Box<dyn drasi_lib::bootstrap::BootstrapProvider + 'static>>,
+    state_store: Option<Arc<dyn StateStoreProvider>>,
+    auto_start: bool,
+}
+
+impl SuiDeepBookSourceBuilder {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            config: SuiDeepBookSourceConfig::default(),
+            dispatch_mode: None,
+            dispatch_buffer_capacity: None,
+            bootstrap_provider: None,
+            state_store: None,
+            auto_start: true,
+        }
+    }
+
+    pub fn with_rpc_endpoint(mut self, rpc_endpoint: impl Into<String>) -> Self {
+        self.config.rpc_endpoint = rpc_endpoint.into();
+        self
+    }
+
+    pub fn with_deepbook_package_id(mut self, package_id: impl Into<String>) -> Self {
+        self.config.deepbook_package_id = package_id.into();
+        self
+    }
+
+    pub fn with_poll_interval_ms(mut self, poll_interval_ms: u64) -> Self {
+        self.config.poll_interval_ms = poll_interval_ms;
+        self
+    }
+
+    pub fn with_request_limit(mut self, request_limit: u16) -> Self {
+        self.config.request_limit = request_limit;
+        self
+    }
+
+    pub fn with_event_filters(mut self, event_filters: Vec<String>) -> Self {
+        self.config.event_filters = event_filters;
+        self
+    }
+
+    pub fn with_pools(mut self, pools: Vec<String>) -> Self {
+        self.config.pools = pools;
+        self
+    }
+
+    pub fn with_start_position(mut self, start_position: StartPosition) -> Self {
+        self.config.start_position = start_position;
+        self
+    }
+
+    pub fn with_start_from_beginning(mut self) -> Self {
+        self.config.start_position = StartPosition::Beginning;
+        self
+    }
+
+    pub fn with_start_from_now(mut self) -> Self {
+        self.config.start_position = StartPosition::Now;
+        self
+    }
+
+    pub fn with_start_from_timestamp(mut self, timestamp_ms: i64) -> Self {
+        self.config.start_position = StartPosition::Timestamp(timestamp_ms);
+        self
+    }
+
+    pub fn with_dispatch_mode(mut self, mode: DispatchMode) -> Self {
+        self.dispatch_mode = Some(mode);
+        self
+    }
+
+    pub fn with_dispatch_buffer_capacity(mut self, capacity: usize) -> Self {
+        self.dispatch_buffer_capacity = Some(capacity);
+        self
+    }
+
+    pub fn with_bootstrap_provider(
+        mut self,
+        provider: impl drasi_lib::bootstrap::BootstrapProvider + 'static,
+    ) -> Self {
+        self.bootstrap_provider = Some(Box::new(provider));
+        self
+    }
+
+    pub fn with_state_store(mut self, state_store: Arc<dyn StateStoreProvider>) -> Self {
+        self.state_store = Some(state_store);
+        self
+    }
+
+    pub fn with_auto_start(mut self, auto_start: bool) -> Self {
+        self.auto_start = auto_start;
+        self
+    }
+
+    pub fn with_config(mut self, config: SuiDeepBookSourceConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn build(self) -> Result<SuiDeepBookSource> {
+        self.config.validate()?;
+
+        let mut params = SourceBaseParams::new(&self.id).with_auto_start(self.auto_start);
+        if let Some(mode) = self.dispatch_mode {
+            params = params.with_dispatch_mode(mode);
+        }
+        if let Some(capacity) = self.dispatch_buffer_capacity {
+            params = params.with_dispatch_buffer_capacity(capacity);
+        }
+        if let Some(provider) = self.bootstrap_provider {
+            params = params.with_bootstrap_provider(provider);
+        }
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        Ok(SuiDeepBookSource {
+            base: SourceBase::new(params)?,
+            config: self.config,
+            state_store: Arc::new(RwLock::new(self.state_store)),
+            task_handle: Arc::new(RwLock::new(None)),
+            shutdown_tx,
+            shutdown_rx,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builder_defaults() {
+        let source = SuiDeepBookSource::builder("source-1").build().unwrap();
+        assert_eq!(source.id(), "source-1");
+        assert_eq!(source.type_name(), "sui-deepbook");
+        assert_eq!(source.config.poll_interval_ms, 2_000);
+    }
+
+    #[test]
+    fn test_builder_with_custom_values() {
+        let source = SuiDeepBookSource::builder("source-1")
+            .with_rpc_endpoint("https://fullnode.testnet.sui.io:443")
+            .with_deepbook_package_id("0xabc")
+            .with_poll_interval_ms(500)
+            .with_request_limit(25)
+            .with_start_from_beginning()
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            source.config.rpc_endpoint,
+            "https://fullnode.testnet.sui.io:443"
+        );
+        assert_eq!(source.config.deepbook_package_id, "0xabc");
+        assert_eq!(source.config.poll_interval_ms, 500);
+        assert_eq!(source.config.request_limit, 25);
+        assert!(matches!(
+            source.config.start_position,
+            StartPosition::Beginning
+        ));
+    }
+
+    #[test]
+    fn test_builder_rejects_invalid_config() {
+        let result = SuiDeepBookSource::builder("source-1")
+            .with_rpc_endpoint("")
+            .build();
+        assert!(result.is_err());
+    }
+}
+
+#[cfg(feature = "dynamic-plugin")]
+drasi_plugin_sdk::export_plugin!(
+    plugin_id = "sui-deepbook-source",
+    core_version = env!("CARGO_PKG_VERSION"),
+    lib_version = env!("CARGO_PKG_VERSION"),
+    plugin_version = env!("CARGO_PKG_VERSION"),
+    source_descriptors = [descriptor::SuiDeepBookSourceDescriptor],
+    reaction_descriptors = [],
+    bootstrap_descriptors = [],
+);

--- a/components/sources/sui-deepbook/src/lib.rs
+++ b/components/sources/sui-deepbook/src/lib.rs
@@ -15,16 +15,19 @@
 
 //! Sui DeepBook source plugin for Drasi.
 //!
-//! This source polls the Sui JSON-RPC API (`suix_queryEvents`) for DeepBook package events
+//! This source monitors the Sui blockchain for DeepBook package events using either
+//! gRPC checkpoint streaming (recommended) or JSON-RPC polling (legacy fallback),
 //! and emits them as Drasi source changes.
 
 pub mod config;
 pub mod descriptor;
+pub mod grpc;
 pub mod mapping;
 pub mod rpc;
 
 pub use config::{
-    StartPosition, SuiDeepBookSourceConfig, DEFAULT_DEEPBOOK_PACKAGE_ID, DEFAULT_SUI_MAINNET_RPC,
+    StartPosition, SuiDeepBookSourceConfig, Transport, DEFAULT_DEEPBOOK_PACKAGE_ID,
+    DEFAULT_SUI_MAINNET_GRPC, DEFAULT_SUI_MAINNET_RPC,
 };
 
 use anyhow::Result;
@@ -47,6 +50,7 @@ use crate::mapping::{
 use crate::rpc::{EventCursor, SuiRpcClient};
 
 const CURSOR_STATE_KEY: &str = "cursor";
+const GRPC_CURSOR_STATE_KEY: &str = "grpc_checkpoint_seq";
 
 pub struct SuiDeepBookSource {
     base: SourceBase,
@@ -159,10 +163,16 @@ impl Source for SuiDeepBookSource {
         let mut shutdown_rx = self.shutdown_rx.clone();
 
         let task_handle = tokio::spawn(async move {
-            if let Err(err) =
-                run_poll_loop(&source_id, config, &base, state_store, &mut shutdown_rx).await
-            {
-                error!("Sui DeepBook polling task failed for '{source_id}': {err}");
+            let result = match config.transport {
+                Transport::Grpc => {
+                    run_grpc_stream(&source_id, config, &base, state_store, &mut shutdown_rx).await
+                }
+                Transport::JsonRpc => {
+                    run_poll_loop(&source_id, config, &base, state_store, &mut shutdown_rx).await
+                }
+            };
+            if let Err(err) = result {
+                error!("Sui DeepBook task failed for '{source_id}': {err}");
                 let _ = base
                     .set_status_with_event(ComponentStatus::Error, Some(err.to_string()))
                     .await;
@@ -228,6 +238,238 @@ impl Source for SuiDeepBookSource {
         self.base.set_bootstrap_provider(provider).await;
     }
 }
+
+// ── gRPC Checkpoint Streaming ──
+
+async fn run_grpc_stream(
+    source_id: &str,
+    config: SuiDeepBookSourceConfig,
+    base: &SourceBase,
+    state_store: Option<Arc<dyn StateStoreProvider>>,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> Result<()> {
+    let grpc_endpoint = config.effective_grpc_endpoint().to_owned();
+    info!("Starting gRPC checkpoint stream for '{source_id}' from {grpc_endpoint}");
+
+    // We still need the JSON-RPC client for pool metadata enrichment (get_object)
+    let rpc_client = SuiRpcClient::new(config.rpc_endpoint.clone())?;
+
+    let enrichment = EnrichmentConfig {
+        enable_pool_nodes: config.enable_pool_nodes,
+        enable_trader_nodes: config.enable_trader_nodes,
+        enable_order_nodes: config.enable_order_nodes,
+    };
+    let mut enrichment_state = EnrichmentState {
+        seen_pools: HashSet::new(),
+        seen_traders: HashSet::new(),
+        seen_orders: HashSet::new(),
+    };
+
+    let last_checkpoint_seq = load_grpc_cursor(source_id, &state_store).await?;
+    if let Some(seq) = last_checkpoint_seq {
+        info!("Resuming gRPC stream from checkpoint sequence {seq}");
+    }
+
+    let mut consecutive_failures = 0u32;
+    let max_retries = 20u32;
+
+    loop {
+        if *shutdown_rx.borrow() {
+            info!("Received shutdown signal for gRPC stream '{source_id}'");
+            break;
+        }
+
+        // Connect / reconnect (connect_lazy — doesn't actually connect yet)
+        let mut grpc_client = match crate::grpc::SuiGrpcClient::new(&grpc_endpoint) {
+            Ok(c) => c,
+            Err(err) => {
+                consecutive_failures += 1;
+                error!("Failed to create gRPC client (attempt {consecutive_failures}): {err}");
+                if consecutive_failures >= max_retries {
+                    return Err(err);
+                }
+                let backoff_ms = backoff_delay_ms(consecutive_failures);
+                if wait_for_poll_or_shutdown(shutdown_rx, backoff_ms).await {
+                    break;
+                }
+                continue;
+            }
+        };
+
+        let mut stream = match grpc_client.subscribe_checkpoints().await {
+            Ok(s) => {
+                info!("gRPC checkpoint stream established for '{source_id}'");
+                s
+            }
+            Err(err) => {
+                consecutive_failures += 1;
+                error!(
+                    "Failed to subscribe to checkpoints (attempt {consecutive_failures}): {err}"
+                );
+                if consecutive_failures >= max_retries {
+                    return Err(err);
+                }
+                let backoff_ms = backoff_delay_ms(consecutive_failures);
+                if wait_for_poll_or_shutdown(shutdown_rx, backoff_ms).await {
+                    break;
+                }
+                continue;
+            }
+        };
+
+        // Stream processing loop
+        loop {
+            if *shutdown_rx.borrow() {
+                break;
+            }
+
+            let msg = tokio::select! {
+                msg = stream.message() => msg,
+                _ = shutdown_rx.changed() => {
+                    break;
+                }
+            };
+
+            match msg {
+                Ok(Some(response)) => {
+                    consecutive_failures = 0;
+                    let seq = response.cursor.unwrap_or(0);
+
+                    // Skip checkpoints we've already processed
+                    if let Some(last_seq) = last_checkpoint_seq {
+                        if seq <= last_seq {
+                            continue;
+                        }
+                    }
+
+                    if let Some(checkpoint) = response.checkpoint {
+                        let events = crate::grpc::extract_deepbook_events(
+                            &checkpoint,
+                            &config.deepbook_package_id,
+                        );
+
+                        if !events.is_empty() {
+                            info!(
+                                "Checkpoint {seq}: extracted {} DeepBook event(s)",
+                                events.len()
+                            );
+                        }
+
+                        for event in &events {
+                            if !should_include_event(event, &config.event_filters, &config.pools) {
+                                debug!("Skipping event (filtered): {}", event.event_type);
+                                continue;
+                            }
+
+                            let effective_from = event.timestamp_ms.unwrap_or_else(|| {
+                                chrono::Utc::now().timestamp_millis().max(0) as u64
+                            });
+
+                            emit_enrichment_nodes(
+                                source_id,
+                                event,
+                                &enrichment,
+                                &rpc_client,
+                                &mut enrichment_state,
+                                effective_from,
+                                base,
+                            )
+                            .await?;
+
+                            let event_entity_id = crate::mapping::derive_entity_id_pub(event);
+                            let change = map_event_to_change(source_id, event);
+                            debug!(
+                                "Dispatching gRPC event: entity_id={event_entity_id}, type={}",
+                                event.event_type
+                            );
+                            base.dispatch_source_change(change).await?;
+
+                            emit_enrichment_relationships(
+                                source_id,
+                                event,
+                                &enrichment,
+                                &event_entity_id,
+                                effective_from,
+                                base,
+                            )
+                            .await?;
+                        }
+                    } else {
+                        debug!("Checkpoint {seq}: no checkpoint data in response");
+                    }
+
+                    save_grpc_cursor(source_id, seq, &state_store).await?;
+                }
+                Ok(None) => {
+                    warn!("gRPC checkpoint stream ended for '{source_id}', reconnecting...");
+                    break;
+                }
+                Err(err) => {
+                    consecutive_failures += 1;
+                    error!("gRPC stream error (attempt {consecutive_failures}): {err}");
+                    break;
+                }
+            }
+        }
+
+        if *shutdown_rx.borrow() {
+            break;
+        }
+
+        let backoff_ms = backoff_delay_ms(consecutive_failures);
+        warn!("Reconnecting gRPC stream in {backoff_ms}ms...");
+        if wait_for_poll_or_shutdown(shutdown_rx, backoff_ms).await {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn backoff_delay_ms(failures: u32) -> u64 {
+    let base_ms = 1000u64;
+    let max_ms = 30_000u64;
+    let delay = base_ms * 2u64.saturating_pow(failures.min(15));
+    delay.min(max_ms)
+}
+
+async fn load_grpc_cursor(
+    source_id: &str,
+    state_store: &Option<Arc<dyn StateStoreProvider>>,
+) -> Result<Option<u64>> {
+    let Some(store) = state_store else {
+        return Ok(None);
+    };
+
+    let Some(bytes) = store.get(source_id, GRPC_CURSOR_STATE_KEY).await? else {
+        return Ok(None);
+    };
+
+    match serde_json::from_slice::<u64>(&bytes) {
+        Ok(seq) => Ok(Some(seq)),
+        Err(err) => {
+            warn!("Failed to parse gRPC cursor for source '{source_id}': {err}. Clearing state.");
+            let _ = store.delete(source_id, GRPC_CURSOR_STATE_KEY).await;
+            Ok(None)
+        }
+    }
+}
+
+async fn save_grpc_cursor(
+    source_id: &str,
+    seq: u64,
+    state_store: &Option<Arc<dyn StateStoreProvider>>,
+) -> Result<()> {
+    let Some(store) = state_store else {
+        return Ok(());
+    };
+
+    let bytes = serde_json::to_vec(&seq)?;
+    store.set(source_id, GRPC_CURSOR_STATE_KEY, bytes).await?;
+    Ok(())
+}
+
+// ── JSON-RPC Polling (Legacy) ──
 
 async fn run_poll_loop(
     source_id: &str,
@@ -703,6 +945,16 @@ impl SuiDeepBookSourceBuilder {
 
     pub fn with_rpc_endpoint(mut self, rpc_endpoint: impl Into<String>) -> Self {
         self.config.rpc_endpoint = rpc_endpoint.into();
+        self
+    }
+
+    pub fn with_grpc_endpoint(mut self, grpc_endpoint: impl Into<String>) -> Self {
+        self.config.grpc_endpoint = Some(grpc_endpoint.into());
+        self
+    }
+
+    pub fn with_transport(mut self, transport: Transport) -> Self {
+        self.config.transport = transport;
         self
     }
 

--- a/components/sources/sui-deepbook/src/lib.rs
+++ b/components/sources/sui-deepbook/src/lib.rs
@@ -237,7 +237,14 @@ async fn run_poll_loop(
     shutdown_rx: &mut watch::Receiver<bool>,
 ) -> Result<()> {
     let rpc_client = SuiRpcClient::new(config.rpc_endpoint.clone())?;
-    let query_filter = serde_json::json!({ "All": [] });
+    // Use MoveModule filter to only fetch events from the DeepBook package.
+    // This is orders of magnitude faster than {"All":[]} on Sui mainnet.
+    let query_filter = serde_json::json!({
+        "MoveModule": {
+            "package": config.deepbook_package_id,
+            "module": "pool"
+        }
+    });
 
     let mut cursor = load_cursor(source_id, &state_store).await?;
 
@@ -264,6 +271,30 @@ async fn run_poll_loop(
         seen_traders: HashSet::new(),
         seen_orders: HashSet::new(),
     };
+
+    // ── Lookback phase ──
+    // Fetch recent historical events in descending order so the dashboard
+    // has data immediately on startup.
+    if config.lookback_events > 0 && cursor.is_some() {
+        info!(
+            "Fetching up to {} recent events for lookback",
+            config.lookback_events
+        );
+        match fetch_lookback_events(
+            source_id,
+            &config,
+            &rpc_client,
+            &query_filter,
+            &enrichment,
+            &mut enrichment_state,
+            base,
+        )
+        .await
+        {
+            Ok(count) => info!("Lookback phase complete: processed {count} events"),
+            Err(err) => warn!("Lookback phase failed (non-fatal, continuing): {err}"),
+        }
+    }
 
     let mut consecutive_failures = 0usize;
     loop {
@@ -510,6 +541,93 @@ async fn initialize_cursor_for_now(
     Ok(result.next_cursor)
 }
 
+/// Fetch the most recent `lookback_events` events in descending order,
+/// reverse them into chronological order, and process them as inserts.
+/// This lets the dashboard display data immediately on startup.
+async fn fetch_lookback_events(
+    source_id: &str,
+    config: &SuiDeepBookSourceConfig,
+    rpc_client: &SuiRpcClient,
+    query_filter: &serde_json::Value,
+    enrichment: &EnrichmentConfig,
+    enrichment_state: &mut EnrichmentState,
+    base: &SourceBase,
+) -> Result<usize> {
+    let mut all_events = Vec::new();
+    let mut page_cursor: Option<EventCursor> = None;
+    let remaining = config.lookback_events as usize;
+    let page_size = config.request_limit.min(50);
+
+    // Fetch pages in descending (most recent first) order
+    loop {
+        let result = rpc_client
+            .query_events(
+                query_filter.clone(),
+                page_cursor.as_ref(),
+                page_size,
+                true, // descending
+            )
+            .await?;
+
+        for event in result.data {
+            if event.package_id != config.deepbook_package_id {
+                continue;
+            }
+            if !should_include_event(&event, &config.event_filters, &config.pools) {
+                continue;
+            }
+            all_events.push(event);
+            if all_events.len() >= remaining {
+                break;
+            }
+        }
+
+        if all_events.len() >= remaining || !result.has_next_page {
+            break;
+        }
+        page_cursor = result.next_cursor;
+    }
+
+    // Reverse to chronological order (oldest first)
+    all_events.reverse();
+
+    let count = all_events.len();
+    debug!("Lookback: processing {count} events in chronological order");
+
+    for event in &all_events {
+        let effective_from = event
+            .timestamp_ms
+            .unwrap_or_else(|| chrono::Utc::now().timestamp_millis().max(0) as u64);
+
+        emit_enrichment_nodes(
+            source_id,
+            event,
+            enrichment,
+            rpc_client,
+            enrichment_state,
+            effective_from,
+            base,
+        )
+        .await?;
+
+        let event_entity_id = crate::mapping::derive_entity_id_pub(event);
+        let change = map_event_to_change(source_id, event);
+        base.dispatch_source_change(change).await?;
+
+        emit_enrichment_relationships(
+            source_id,
+            event,
+            enrichment,
+            &event_entity_id,
+            effective_from,
+            base,
+        )
+        .await?;
+    }
+
+    Ok(count)
+}
+
 async fn load_cursor(
     source_id: &str,
     state_store: &Option<Arc<dyn StateStoreProvider>>,
@@ -630,6 +748,14 @@ impl SuiDeepBookSourceBuilder {
 
     pub fn with_start_from_timestamp(mut self, timestamp_ms: i64) -> Self {
         self.config.start_position = StartPosition::Timestamp(timestamp_ms);
+        self
+    }
+
+    /// Fetch up to `count` recent historical events on startup before
+    /// entering the forward-polling loop.  Useful for populating dashboards
+    /// with recent data immediately.
+    pub fn with_lookback_events(mut self, count: u16) -> Self {
+        self.config.lookback_events = count;
         self
     }
 

--- a/components/sources/sui-deepbook/src/lib.rs
+++ b/components/sources/sui-deepbook/src/lib.rs
@@ -153,7 +153,7 @@ impl Source for SuiDeepBookSource {
             return Ok(());
         }
 
-        self.base.set_status(ComponentStatus::Starting).await;
+        self.base.set_status(ComponentStatus::Starting, None).await;
         info!("Starting Sui DeepBook source '{}'", self.base.id);
 
         let source_id = self.base.id.clone();
@@ -173,20 +173,19 @@ impl Source for SuiDeepBookSource {
             };
             if let Err(err) = result {
                 error!("Sui DeepBook task failed for '{source_id}': {err}");
-                let _ = base
-                    .set_status_with_event(ComponentStatus::Error, Some(err.to_string()))
+                base.set_status(ComponentStatus::Error, Some(err.to_string()))
                     .await;
             }
         });
 
         *self.task_handle.write().await = Some(task_handle);
-        self.base.set_status(ComponentStatus::Running).await;
+        self.base.set_status(ComponentStatus::Running, None).await;
         Ok(())
     }
 
     async fn stop(&self) -> Result<()> {
         info!("Stopping Sui DeepBook source '{}'", self.base.id);
-        self.base.set_status(ComponentStatus::Stopping).await;
+        self.base.set_status(ComponentStatus::Stopping, None).await;
 
         if let Err(err) = self.shutdown_tx.send(true) {
             warn!(
@@ -203,7 +202,7 @@ impl Source for SuiDeepBookSource {
             }
         }
 
-        self.base.set_status(ComponentStatus::Stopped).await;
+        self.base.set_status(ComponentStatus::Stopped, None).await;
         Ok(())
     }
 

--- a/components/sources/sui-deepbook/src/lib.rs
+++ b/components/sources/sui-deepbook/src/lib.rs
@@ -264,7 +264,7 @@ async fn run_grpc_stream(
         seen_orders: HashSet::new(),
     };
 
-    let last_checkpoint_seq = load_grpc_cursor(source_id, &state_store).await?;
+    let mut last_checkpoint_seq = load_grpc_cursor(source_id, &state_store).await?;
     if let Some(seq) = last_checkpoint_seq {
         info!("Resuming gRPC stream from checkpoint sequence {seq}");
     }
@@ -398,6 +398,7 @@ async fn run_grpc_stream(
                     }
 
                     save_grpc_cursor(source_id, seq, &state_store).await?;
+                    last_checkpoint_seq = Some(seq);
                 }
                 Ok(None) => {
                     warn!("gRPC checkpoint stream ended for '{source_id}', reconnecting...");

--- a/components/sources/sui-deepbook/src/mapping.rs
+++ b/components/sources/sui-deepbook/src/mapping.rs
@@ -310,12 +310,12 @@ fn build_common_properties(event: &SuiEvent, entity_id: &str) -> ElementProperty
         ElementValue::String(Arc::from(event.event_type.as_str())),
     );
     // Short human-readable name extracted from the Move type path
-    // e.g. "0x337…::deep_price::PriceAdded" → "PriceAdded"
-    let event_name = event.event_type.split("::").last().unwrap_or("Event");
+    // e.g. "0x337…::deep_price::PriceAdded<0x2::sui::SUI>" → "PriceAdded"
+    let base_type = strip_type_params(&event.event_type);
+    let event_name = base_type.split("::").last().unwrap_or("Event");
     properties.insert("event_name", ElementValue::String(Arc::from(event_name)));
     // Module that emitted the event, e.g. "deep_price", "balance_manager"
-    let module_name = event
-        .event_type
+    let module_name = base_type
         .split("::")
         .nth(1)
         .unwrap_or(&event.transaction_module);
@@ -345,6 +345,12 @@ fn build_common_properties(event: &SuiEvent, entity_id: &str) -> ElementProperty
     }
 
     properties
+}
+
+/// Strips Move generic type parameters from an event type string.
+/// e.g. `"0xdee9::clob_v2::OrderPlaced<0x2::sui::SUI, ...>"` → `"0xdee9::clob_v2::OrderPlaced"`
+fn strip_type_params(event_type: &str) -> &str {
+    event_type.split('<').next().unwrap_or(event_type)
 }
 
 fn classify_operation(event_type: &str) -> EventOperation {
@@ -381,8 +387,8 @@ fn derive_entity_id(event: &SuiEvent) -> String {
 }
 
 fn derive_secondary_label(event: &SuiEvent) -> String {
-    let name = event
-        .event_type
+    let base_type = strip_type_params(&event.event_type);
+    let name = base_type
         .split("::")
         .last()
         .unwrap_or("Event")
@@ -404,7 +410,7 @@ fn derive_secondary_label(event: &SuiEvent) -> String {
 }
 
 fn extract_pool_id(parsed_json: &serde_json::Value) -> Option<String> {
-    extract_string_field(parsed_json, &["pool_id", "poolId", "pool"])
+    extract_string_field(parsed_json, &["pool_id", "poolId", "pool", "reference_pool", "target_pool"])
 }
 
 fn extract_string_field(parsed_json: &serde_json::Value, keys: &[&str]) -> Option<String> {
@@ -717,5 +723,39 @@ mod tests {
         );
         assert_eq!(event_pool_id(&event_no_ids), None);
         assert_eq!(event_order_id(&event_no_ids), None);
+    }
+
+    #[test]
+    fn test_generic_event_type_parsing() {
+        // Real DeepBook event types include Move generic parameters
+        let event = event_with_type(
+            "0xdee9::clob_v2::OrderPlaced<0x2::sui::SUI, 0x5d4b::coin::COIN>",
+            serde_json::json!({"order_id": "99", "pool_id": "0xpool", "price": "1.5"}),
+        );
+        let change = map_event_to_change("src", &event);
+        match change {
+            SourceChange::Insert {
+                element: Element::Node { properties, .. },
+            } => {
+                // event_name must be "OrderPlaced", NOT "COIN>"
+                assert_eq!(
+                    properties["event_name"],
+                    ElementValue::String(Arc::from("OrderPlaced"))
+                );
+                // module must be "clob_v2", NOT something from generics
+                assert_eq!(
+                    properties["module"],
+                    ElementValue::String(Arc::from("clob_v2"))
+                );
+            }
+            _ => panic!("expected insert node"),
+        }
+    }
+
+    #[test]
+    fn test_strip_type_params() {
+        assert_eq!(strip_type_params("0x1::mod::Foo<0x2::bar::BAZ>"), "0x1::mod::Foo");
+        assert_eq!(strip_type_params("0x1::mod::Foo"), "0x1::mod::Foo");
+        assert_eq!(strip_type_params("Foo<A, B>"), "Foo");
     }
 }

--- a/components/sources/sui-deepbook/src/mapping.rs
+++ b/components/sources/sui-deepbook/src/mapping.rs
@@ -1,0 +1,387 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use drasi_core::models::{
+    Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
+};
+use ordered_float::OrderedFloat;
+use std::sync::Arc;
+
+use crate::rpc::SuiEvent;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EventOperation {
+    Insert,
+    Update,
+    Delete,
+}
+
+pub fn should_include_event(event: &SuiEvent, event_filters: &[String], pools: &[String]) -> bool {
+    if !event_filters.is_empty() {
+        let event_type_lower = event.event_type.to_ascii_lowercase();
+        let has_match = event_filters.iter().any(|filter| {
+            let filter_lower = filter.to_ascii_lowercase();
+            event_type_lower.ends_with(&format!("::{filter_lower}"))
+                || event_type_lower.contains(&filter_lower)
+        });
+        if !has_match {
+            return false;
+        }
+    }
+
+    if pools.is_empty() {
+        return true;
+    }
+
+    let Some(pool_id) = extract_pool_id(&event.parsed_json) else {
+        return false;
+    };
+
+    pools.iter().any(|p| p == &pool_id)
+}
+
+/// Maps a Sui event to a SourceChange using operation classification (insert/update/delete).
+/// Used by the streaming source.
+pub fn map_event_to_change(source_id: &str, event: &SuiEvent) -> SourceChange {
+    let effective_from = event
+        .timestamp_ms
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis().max(0) as u64);
+
+    let entity_id = derive_entity_id(event);
+    let operation = classify_operation(&event.event_type);
+    let label = derive_secondary_label(event);
+
+    let mut properties = build_common_properties(event, &entity_id);
+    properties.insert(
+        "change_type",
+        ElementValue::String(Arc::from(match operation {
+            EventOperation::Insert => "insert",
+            EventOperation::Update => "update",
+            EventOperation::Delete => "delete",
+        })),
+    );
+
+    let labels: Arc<[Arc<str>]> =
+        vec![Arc::from("DeepBookEvent"), Arc::from(label.as_str())].into();
+
+    let metadata = ElementMetadata {
+        reference: ElementReference::new(source_id, &entity_id),
+        labels,
+        effective_from,
+    };
+
+    match operation {
+        EventOperation::Insert => SourceChange::Insert {
+            element: Element::Node {
+                metadata,
+                properties,
+            },
+        },
+        EventOperation::Update => SourceChange::Update {
+            element: Element::Node {
+                metadata,
+                properties,
+            },
+        },
+        EventOperation::Delete => SourceChange::Delete { metadata },
+    }
+}
+
+/// Maps a Sui event to an Insert-only SourceChange.  Used by the bootstrap
+/// provider where every historical event is treated as an insert.
+pub fn map_event_to_insert_change(source_id: &str, event: &SuiEvent) -> SourceChange {
+    let effective_from = event
+        .timestamp_ms
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis().max(0) as u64);
+
+    let entity_id = derive_entity_id(event);
+    let label = derive_secondary_label(event);
+
+    let mut properties = build_common_properties(event, &entity_id);
+    properties.insert("change_type", ElementValue::String(Arc::from("insert")));
+
+    let labels: Arc<[Arc<str>]> =
+        vec![Arc::from("DeepBookEvent"), Arc::from(label.as_str())].into();
+
+    SourceChange::Insert {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(source_id, &entity_id),
+                labels,
+                effective_from,
+            },
+            properties,
+        },
+    }
+}
+
+fn build_common_properties(event: &SuiEvent, entity_id: &str) -> ElementPropertyMap {
+    let mut properties = ElementPropertyMap::new();
+    properties.insert("entity_id", ElementValue::String(Arc::from(entity_id)));
+    properties.insert(
+        "tx_digest",
+        ElementValue::String(Arc::from(event.id.tx_digest.as_str())),
+    );
+    properties.insert(
+        "event_seq",
+        ElementValue::String(Arc::from(event.id.event_seq.as_str())),
+    );
+    properties.insert(
+        "package_id",
+        ElementValue::String(Arc::from(event.package_id.as_str())),
+    );
+    properties.insert(
+        "transaction_module",
+        ElementValue::String(Arc::from(event.transaction_module.as_str())),
+    );
+    properties.insert(
+        "sender",
+        ElementValue::String(Arc::from(event.sender.as_str())),
+    );
+    properties.insert(
+        "event_type",
+        ElementValue::String(Arc::from(event.event_type.as_str())),
+    );
+    // Short human-readable name extracted from the Move type path
+    // e.g. "0x337…::deep_price::PriceAdded" → "PriceAdded"
+    let event_name = event.event_type.split("::").last().unwrap_or("Event");
+    properties.insert("event_name", ElementValue::String(Arc::from(event_name)));
+    // Module that emitted the event, e.g. "deep_price", "balance_manager"
+    let module_name = event
+        .event_type
+        .split("::")
+        .nth(1)
+        .unwrap_or(&event.transaction_module);
+    properties.insert("module", ElementValue::String(Arc::from(module_name)));
+    properties.insert(
+        "sender_short",
+        ElementValue::String(Arc::from(truncate_hex(&event.sender))),
+    );
+    properties.insert(
+        "timestamp_ms",
+        ElementValue::Integer(event.timestamp_ms.unwrap_or_default() as i64),
+    );
+    properties.insert("payload", json_value_to_element_value(&event.parsed_json));
+
+    if let Some(order_id) = extract_string_field(&event.parsed_json, &["order_id", "orderId"]) {
+        properties.insert(
+            "order_id",
+            ElementValue::String(Arc::from(order_id.as_str())),
+        );
+    }
+    if let Some(pool_id) = extract_pool_id(&event.parsed_json) {
+        properties.insert("pool_id", ElementValue::String(Arc::from(pool_id.as_str())));
+        properties.insert(
+            "pool_id_short",
+            ElementValue::String(Arc::from(truncate_hex(&pool_id))),
+        );
+    }
+
+    properties
+}
+
+fn classify_operation(event_type: &str) -> EventOperation {
+    let event_type = event_type.to_ascii_lowercase();
+    if event_type.contains("cancel")
+        || event_type.contains("delete")
+        || event_type.contains("remove")
+    {
+        return EventOperation::Delete;
+    }
+    if event_type.contains("fill")
+        || event_type.contains("update")
+        || event_type.contains("modify")
+        || event_type.contains("amend")
+    {
+        return EventOperation::Update;
+    }
+    EventOperation::Insert
+}
+
+fn derive_entity_id(event: &SuiEvent) -> String {
+    if let Some(order_id) = extract_string_field(&event.parsed_json, &["order_id", "orderId"]) {
+        return format!("order:{order_id}");
+    }
+    if let Some(pool_id) = extract_pool_id(&event.parsed_json) {
+        return format!("pool:{pool_id}");
+    }
+    format!("event:{}:{}", event.id.tx_digest, event.id.event_seq)
+}
+
+fn derive_secondary_label(event: &SuiEvent) -> String {
+    let name = event
+        .event_type
+        .split("::")
+        .last()
+        .unwrap_or("Event")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+
+    if name.is_empty() {
+        "Event".to_string()
+    } else {
+        name
+    }
+}
+
+fn extract_pool_id(parsed_json: &serde_json::Value) -> Option<String> {
+    extract_string_field(parsed_json, &["pool_id", "poolId", "pool"])
+}
+
+fn extract_string_field(parsed_json: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    let serde_json::Value::Object(map) = parsed_json else {
+        return None;
+    };
+    for key in keys {
+        let Some(value) = map.get(*key) else {
+            continue;
+        };
+        let converted = match value {
+            serde_json::Value::String(text) => Some(text.clone()),
+            serde_json::Value::Number(num) => Some(num.to_string()),
+            serde_json::Value::Bool(value) => Some(value.to_string()),
+            _ => None,
+        };
+        if converted.is_some() {
+            return converted;
+        }
+    }
+    None
+}
+
+fn json_value_to_element_value(value: &serde_json::Value) -> ElementValue {
+    match value {
+        serde_json::Value::Null => ElementValue::Null,
+        serde_json::Value::Bool(v) => ElementValue::Bool(*v),
+        serde_json::Value::Number(v) => {
+            if let Some(i) = v.as_i64() {
+                ElementValue::Integer(i)
+            } else if let Some(f) = v.as_f64() {
+                ElementValue::Float(OrderedFloat(f))
+            } else {
+                ElementValue::String(Arc::from(v.to_string()))
+            }
+        }
+        serde_json::Value::String(v) => ElementValue::String(Arc::from(v.as_str())),
+        serde_json::Value::Array(items) => ElementValue::List(
+            items
+                .iter()
+                .map(json_value_to_element_value)
+                .collect::<Vec<_>>(),
+        ),
+        serde_json::Value::Object(map) => {
+            let mut props = ElementPropertyMap::new();
+            for (key, value) in map {
+                props.insert(key, json_value_to_element_value(value));
+            }
+            ElementValue::Object(props)
+        }
+    }
+}
+
+/// Truncate a hex address to `0x1234…abcd` form for readable output.
+fn truncate_hex(hex: &str) -> String {
+    if hex.len() <= 12 {
+        return hex.to_string();
+    }
+    let prefix = &hex[..6]; // "0x" + 4 chars
+    let suffix = &hex[hex.len() - 4..];
+    format!("{prefix}…{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::{EventCursor, SuiEvent};
+
+    fn event_with_type(event_type: &str, parsed_json: serde_json::Value) -> SuiEvent {
+        SuiEvent {
+            id: EventCursor {
+                tx_digest: "0xtx".to_string(),
+                event_seq: "1".to_string(),
+            },
+            package_id: "0xpackage".to_string(),
+            transaction_module: "pool".to_string(),
+            sender: "0xsender".to_string(),
+            event_type: event_type.to_string(),
+            parsed_json,
+            timestamp_ms: Some(1_772_923_888_171),
+        }
+    }
+
+    #[test]
+    fn test_classifies_delete_events() {
+        let event = event_with_type(
+            "0x1::events::OrderCancelled",
+            serde_json::json!({"order_id": "42"}),
+        );
+        let change = map_event_to_change("source-a", &event);
+        assert!(matches!(change, SourceChange::Delete { .. }));
+    }
+
+    #[test]
+    fn test_maps_insert_order_event() {
+        let event = event_with_type(
+            "0x1::events::OrderPlaced",
+            serde_json::json!({"order_id": "42", "price": "12.34"}),
+        );
+        let change = map_event_to_change("source-a", &event);
+        match change {
+            SourceChange::Insert {
+                element:
+                    Element::Node {
+                        metadata,
+                        properties,
+                    },
+            } => {
+                assert_eq!(metadata.reference.element_id.as_ref(), "order:42");
+                assert_eq!(
+                    properties["change_type"],
+                    ElementValue::String(Arc::from("insert"))
+                );
+            }
+            _ => panic!("expected insert node"),
+        }
+    }
+
+    #[test]
+    fn test_filter_by_event_type_and_pool() {
+        let event = event_with_type(
+            "0x1::events::OrderPlaced",
+            serde_json::json!({"order_id": "42", "pool_id": "pool-a"}),
+        );
+        assert!(should_include_event(
+            &event,
+            &[String::from("OrderPlaced")],
+            &[String::from("pool-a")]
+        ));
+        assert!(!should_include_event(
+            &event,
+            &[String::from("OrderFilled")],
+            &[String::from("pool-a")]
+        ));
+        assert!(!should_include_event(
+            &event,
+            &[String::from("OrderPlaced")],
+            &[String::from("pool-b")]
+        ));
+    }
+}

--- a/components/sources/sui-deepbook/src/mapping.rs
+++ b/components/sources/sui-deepbook/src/mapping.rs
@@ -18,7 +18,16 @@ use drasi_core::models::{
 use ordered_float::OrderedFloat;
 use std::sync::Arc;
 
-use crate::rpc::SuiEvent;
+use crate::rpc::{SuiEvent, SuiObjectData};
+
+/// Enrichment configuration flags controlling which graph nodes and
+/// relationships are emitted alongside the core event nodes.
+#[derive(Debug, Clone, Copy)]
+pub struct EnrichmentConfig {
+    pub enable_pool_nodes: bool,
+    pub enable_trader_nodes: bool,
+    pub enable_order_nodes: bool,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EventOperation {
@@ -126,6 +135,153 @@ pub fn map_event_to_insert_change(source_id: &str, event: &SuiEvent) -> SourceCh
     }
 }
 
+// ---------------------------------------------------------------------------
+// Enrichment node & relationship builders
+// ---------------------------------------------------------------------------
+
+/// Build a `:Pool` node from `sui_getObject` data.
+pub fn build_pool_node(
+    source_id: &str,
+    pool_id: &str,
+    object_data: Option<&SuiObjectData>,
+    effective_from: u64,
+) -> SourceChange {
+    let entity_id = format!("pool_meta:{pool_id}");
+    let mut properties = ElementPropertyMap::new();
+    properties.insert("pool_id", ElementValue::String(Arc::from(pool_id)));
+    properties.insert(
+        "pool_id_short",
+        ElementValue::String(Arc::from(truncate_hex(pool_id))),
+    );
+
+    if let Some(data) = object_data {
+        let type_params = data.type_params();
+        if let Some(base) = type_params.first() {
+            properties.insert("base_asset", ElementValue::String(Arc::from(base.as_str())));
+        }
+        if let Some(quote) = type_params.get(1) {
+            properties.insert(
+                "quote_asset",
+                ElementValue::String(Arc::from(quote.as_str())),
+            );
+        }
+        if let Some(tick_size) = data.field_str("tick_size") {
+            properties.insert(
+                "tick_size",
+                ElementValue::String(Arc::from(tick_size.as_str())),
+            );
+        }
+        if let Some(lot_size) = data.field_str("lot_size") {
+            properties.insert(
+                "lot_size",
+                ElementValue::String(Arc::from(lot_size.as_str())),
+            );
+        }
+        if let Some(min_size) = data.field_str("min_size") {
+            properties.insert(
+                "min_size",
+                ElementValue::String(Arc::from(min_size.as_str())),
+            );
+        }
+    }
+
+    SourceChange::Insert {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(source_id, &entity_id),
+                labels: Arc::new([Arc::from("Pool")]),
+                effective_from,
+            },
+            properties,
+        },
+    }
+}
+
+/// Build a `:Trader` node from a sender address.
+pub fn build_trader_node(source_id: &str, address: &str, effective_from: u64) -> SourceChange {
+    let entity_id = format!("trader:{address}");
+    let mut properties = ElementPropertyMap::new();
+    properties.insert("address", ElementValue::String(Arc::from(address)));
+    properties.insert(
+        "address_short",
+        ElementValue::String(Arc::from(truncate_hex(address))),
+    );
+
+    SourceChange::Insert {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(source_id, &entity_id),
+                labels: Arc::new([Arc::from("Trader")]),
+                effective_from,
+            },
+            properties,
+        },
+    }
+}
+
+/// Build an `:Order` node from an order_id.
+pub fn build_order_node(
+    source_id: &str,
+    order_id: &str,
+    pool_id: Option<&str>,
+    effective_from: u64,
+) -> SourceChange {
+    let entity_id = format!("order_meta:{order_id}");
+    let mut properties = ElementPropertyMap::new();
+    properties.insert("order_id", ElementValue::String(Arc::from(order_id)));
+    properties.insert(
+        "order_id_short",
+        ElementValue::String(Arc::from(truncate_hex(order_id))),
+    );
+    if let Some(pool) = pool_id {
+        properties.insert("pool_id", ElementValue::String(Arc::from(pool)));
+    }
+
+    SourceChange::Insert {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(source_id, &entity_id),
+                labels: Arc::new([Arc::from("Order")]),
+                effective_from,
+            },
+            properties,
+        },
+    }
+}
+
+/// Build a relationship edge between two nodes.
+pub fn build_relationship(
+    source_id: &str,
+    label: &str,
+    rel_entity_id: &str,
+    in_node_id: &str,
+    out_node_id: &str,
+    effective_from: u64,
+) -> SourceChange {
+    SourceChange::Insert {
+        element: Element::Relation {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(source_id, rel_entity_id),
+                labels: Arc::new([Arc::from(label)]),
+                effective_from,
+            },
+            properties: ElementPropertyMap::new(),
+            in_node: ElementReference::new(source_id, in_node_id),
+            out_node: ElementReference::new(source_id, out_node_id),
+        },
+    }
+}
+
+/// Helper to extract `pool_id` from an event (public for use by enrichment logic).
+pub fn event_pool_id(event: &SuiEvent) -> Option<String> {
+    extract_pool_id(&event.parsed_json)
+}
+
+/// Helper to extract `order_id` from an event (public for use by enrichment logic).
+pub fn event_order_id(event: &SuiEvent) -> Option<String> {
+    extract_string_field(&event.parsed_json, &["order_id", "orderId"])
+}
+
 fn build_common_properties(event: &SuiEvent, entity_id: &str) -> ElementPropertyMap {
     let mut properties = ElementPropertyMap::new();
     properties.insert("entity_id", ElementValue::String(Arc::from(entity_id)));
@@ -207,6 +363,11 @@ fn classify_operation(event_type: &str) -> EventOperation {
         return EventOperation::Update;
     }
     EventOperation::Insert
+}
+
+/// Public accessor for the entity ID derivation logic.
+pub fn derive_entity_id_pub(event: &SuiEvent) -> String {
+    derive_entity_id(event)
 }
 
 fn derive_entity_id(event: &SuiEvent) -> String {
@@ -383,5 +544,178 @@ mod tests {
             &[String::from("OrderPlaced")],
             &[String::from("pool-b")]
         ));
+    }
+
+    #[test]
+    fn test_build_pool_node_with_object_data() {
+        use crate::rpc::{SuiObjectContent, SuiObjectData};
+
+        let object_data = SuiObjectData {
+            object_id: "0xpool_abc".to_string(),
+            object_type: Some("0xdee9::pool::Pool<0x2::sui::SUI, 0xabc::usdc::USDC>".to_string()),
+            content: Some(SuiObjectContent {
+                data_type: "moveObject".to_string(),
+                fields: Some(serde_json::json!({
+                    "tick_size": "1000000",
+                    "lot_size": "100000000",
+                    "min_size": "500000000"
+                })),
+            }),
+        };
+
+        let change = build_pool_node("src-1", "0xpool_abc", Some(&object_data), 100);
+        match change {
+            SourceChange::Insert {
+                element:
+                    Element::Node {
+                        metadata,
+                        properties,
+                    },
+            } => {
+                assert_eq!(
+                    metadata.reference.element_id.as_ref(),
+                    "pool_meta:0xpool_abc"
+                );
+                assert_eq!(metadata.labels[0].as_ref(), "Pool");
+                assert_eq!(
+                    properties["base_asset"],
+                    ElementValue::String(Arc::from("0x2::sui::SUI"))
+                );
+                assert_eq!(
+                    properties["quote_asset"],
+                    ElementValue::String(Arc::from("0xabc::usdc::USDC"))
+                );
+                assert_eq!(
+                    properties["tick_size"],
+                    ElementValue::String(Arc::from("1000000"))
+                );
+            }
+            _ => panic!("expected insert node"),
+        }
+    }
+
+    #[test]
+    fn test_build_pool_node_without_object_data() {
+        let change = build_pool_node("src-1", "0xpool_abc", None, 100);
+        match change {
+            SourceChange::Insert {
+                element:
+                    Element::Node {
+                        metadata,
+                        properties,
+                    },
+            } => {
+                assert_eq!(
+                    metadata.reference.element_id.as_ref(),
+                    "pool_meta:0xpool_abc"
+                );
+                assert_eq!(
+                    properties["pool_id"],
+                    ElementValue::String(Arc::from("0xpool_abc"))
+                );
+                assert!(properties.get("base_asset").is_none());
+            }
+            _ => panic!("expected insert node"),
+        }
+    }
+
+    #[test]
+    fn test_build_trader_node() {
+        let change = build_trader_node("src-1", "0xtrader_123456789abcdef", 200);
+        match change {
+            SourceChange::Insert {
+                element:
+                    Element::Node {
+                        metadata,
+                        properties,
+                    },
+            } => {
+                assert_eq!(
+                    metadata.reference.element_id.as_ref(),
+                    "trader:0xtrader_123456789abcdef"
+                );
+                assert_eq!(metadata.labels[0].as_ref(), "Trader");
+                assert_eq!(
+                    properties["address"],
+                    ElementValue::String(Arc::from("0xtrader_123456789abcdef"))
+                );
+            }
+            _ => panic!("expected insert node"),
+        }
+    }
+
+    #[test]
+    fn test_build_order_node() {
+        let change = build_order_node("src-1", "42", Some("0xpool_abc"), 300);
+        match change {
+            SourceChange::Insert {
+                element:
+                    Element::Node {
+                        metadata,
+                        properties,
+                    },
+            } => {
+                assert_eq!(metadata.reference.element_id.as_ref(), "order_meta:42");
+                assert_eq!(metadata.labels[0].as_ref(), "Order");
+                assert_eq!(
+                    properties["order_id"],
+                    ElementValue::String(Arc::from("42"))
+                );
+                assert_eq!(
+                    properties["pool_id"],
+                    ElementValue::String(Arc::from("0xpool_abc"))
+                );
+            }
+            _ => panic!("expected insert node"),
+        }
+    }
+
+    #[test]
+    fn test_build_relationship() {
+        let change = build_relationship(
+            "src-1",
+            "IN_POOL",
+            "rel:in_pool:order:42",
+            "order:42",
+            "pool_meta:0xpool_abc",
+            100,
+        );
+        match change {
+            SourceChange::Insert {
+                element:
+                    Element::Relation {
+                        metadata,
+                        in_node,
+                        out_node,
+                        ..
+                    },
+            } => {
+                assert_eq!(
+                    metadata.reference.element_id.as_ref(),
+                    "rel:in_pool:order:42"
+                );
+                assert_eq!(metadata.labels[0].as_ref(), "IN_POOL");
+                assert_eq!(in_node.element_id.as_ref(), "order:42");
+                assert_eq!(out_node.element_id.as_ref(), "pool_meta:0xpool_abc");
+            }
+            _ => panic!("expected insert relation"),
+        }
+    }
+
+    #[test]
+    fn test_event_pool_id_and_order_id() {
+        let event = event_with_type(
+            "0x1::events::OrderPlaced",
+            serde_json::json!({"order_id": "42", "pool_id": "0xpool_abc"}),
+        );
+        assert_eq!(event_pool_id(&event), Some("0xpool_abc".to_string()));
+        assert_eq!(event_order_id(&event), Some("42".to_string()));
+
+        let event_no_ids = event_with_type(
+            "0x1::events::BalanceEvent",
+            serde_json::json!({"amount": "100"}),
+        );
+        assert_eq!(event_pool_id(&event_no_ids), None);
+        assert_eq!(event_order_id(&event_no_ids), None);
     }
 }

--- a/components/sources/sui-deepbook/src/mapping.rs
+++ b/components/sources/sui-deepbook/src/mapping.rs
@@ -410,7 +410,10 @@ fn derive_secondary_label(event: &SuiEvent) -> String {
 }
 
 fn extract_pool_id(parsed_json: &serde_json::Value) -> Option<String> {
-    extract_string_field(parsed_json, &["pool_id", "poolId", "pool", "reference_pool", "target_pool"])
+    extract_string_field(
+        parsed_json,
+        &["pool_id", "poolId", "pool", "reference_pool", "target_pool"],
+    )
 }
 
 fn extract_string_field(parsed_json: &serde_json::Value, keys: &[&str]) -> Option<String> {
@@ -754,7 +757,10 @@ mod tests {
 
     #[test]
     fn test_strip_type_params() {
-        assert_eq!(strip_type_params("0x1::mod::Foo<0x2::bar::BAZ>"), "0x1::mod::Foo");
+        assert_eq!(
+            strip_type_params("0x1::mod::Foo<0x2::bar::BAZ>"),
+            "0x1::mod::Foo"
+        );
         assert_eq!(strip_type_params("0x1::mod::Foo"), "0x1::mod::Foo");
         assert_eq!(strip_type_params("Foo<A, B>"), "Foo");
     }

--- a/components/sources/sui-deepbook/src/mapping.rs
+++ b/components/sources/sui-deepbook/src/mapping.rs
@@ -764,4 +764,109 @@ mod tests {
         assert_eq!(strip_type_params("0x1::mod::Foo"), "0x1::mod::Foo");
         assert_eq!(strip_type_params("Foo<A, B>"), "Foo");
     }
+
+    #[test]
+    fn test_classifies_update_events() {
+        assert_eq!(
+            classify_operation("0x1::events::OrderFilled"),
+            EventOperation::Update
+        );
+        assert_eq!(
+            classify_operation("0x1::events::OrderModify"),
+            EventOperation::Update
+        );
+        assert_eq!(
+            classify_operation("0x1::events::PositionUpdate"),
+            EventOperation::Update
+        );
+        assert_eq!(
+            classify_operation("0x1::events::OrderAmend"),
+            EventOperation::Update
+        );
+    }
+
+    #[test]
+    fn test_classifies_delete_keywords() {
+        assert_eq!(
+            classify_operation("0x1::events::OrderCancelled"),
+            EventOperation::Delete
+        );
+        assert_eq!(
+            classify_operation("0x1::events::PositionDeleted"),
+            EventOperation::Delete
+        );
+        assert_eq!(
+            classify_operation("0x1::events::TradeRemoved"),
+            EventOperation::Delete
+        );
+    }
+
+    #[test]
+    fn test_classifies_insert_by_default() {
+        assert_eq!(
+            classify_operation("0x1::events::OrderPlaced"),
+            EventOperation::Insert
+        );
+        assert_eq!(
+            classify_operation("0x1::events::BalanceEvent"),
+            EventOperation::Insert
+        );
+        assert_eq!(
+            classify_operation("0x1::events::Unknown"),
+            EventOperation::Insert
+        );
+    }
+
+    #[test]
+    fn test_classify_operation_case_insensitive() {
+        assert_eq!(
+            classify_operation("0x1::events::ORDERCANCELLED"),
+            EventOperation::Delete
+        );
+        assert_eq!(
+            classify_operation("0x1::events::OrderFILLED"),
+            EventOperation::Update
+        );
+    }
+
+    #[test]
+    fn test_should_include_event_empty_filters_pass_all() {
+        let event = event_with_type(
+            "0x1::events::OrderPlaced",
+            serde_json::json!({"order_id": "42"}),
+        );
+        assert!(should_include_event(&event, &[], &[]));
+    }
+
+    #[test]
+    fn test_should_include_event_no_pool_id_excluded_by_pool_filter() {
+        let event = event_with_type(
+            "0x1::events::OrderPlaced",
+            serde_json::json!({"order_id": "42"}), // no pool_id
+        );
+        assert!(!should_include_event(
+            &event,
+            &[],
+            &[String::from("pool-a")]
+        ));
+    }
+
+    #[test]
+    fn test_should_include_event_substring_match() {
+        let event = event_with_type(
+            "0x1::events::OrderPlaced",
+            serde_json::json!({"order_id": "42"}),
+        );
+        // "Order" is a substring of "OrderPlaced"
+        assert!(should_include_event(&event, &[String::from("Order")], &[]));
+    }
+
+    #[test]
+    fn test_should_include_event_no_match() {
+        let event = event_with_type(
+            "0x1::events::OrderPlaced",
+            serde_json::json!({"order_id": "42"}),
+        );
+        assert!(!should_include_event(&event, &[String::from("Trade")], &[]));
+    }
 }

--- a/components/sources/sui-deepbook/src/rpc.rs
+++ b/components/sources/sui-deepbook/src/rpc.rs
@@ -63,6 +63,85 @@ struct RpcError {
     message: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct SuiGetObjectResult {
+    data: Option<SuiObjectData>,
+}
+
+/// Top-level object data returned by `sui_getObject`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SuiObjectData {
+    pub object_id: String,
+    /// Full Move type path including type parameters,
+    /// e.g. `"0x…::pool::Pool<0x2::sui::SUI, 0x…::usdc::USDC>"`.
+    #[serde(rename = "type")]
+    pub object_type: Option<String>,
+    pub content: Option<SuiObjectContent>,
+}
+
+/// Parsed Move object content.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SuiObjectContent {
+    pub data_type: String,
+    pub fields: Option<Value>,
+}
+
+impl SuiObjectData {
+    /// Extract type parameters from the Move type path.
+    ///
+    /// For a type like `0x…::pool::Pool<0x2::sui::SUI, 0x…::usdc::USDC>`
+    /// this returns `["0x2::sui::SUI", "0x…::usdc::USDC"]`.
+    pub fn type_params(&self) -> Vec<String> {
+        let Some(ref type_str) = self.object_type else {
+            return Vec::new();
+        };
+        let Some(start) = type_str.find('<') else {
+            return Vec::new();
+        };
+        let Some(end) = type_str.rfind('>') else {
+            return Vec::new();
+        };
+        if start >= end {
+            return Vec::new();
+        }
+        let inner = &type_str[start + 1..end];
+        // Split on ", " while respecting nested generics
+        let mut params = Vec::new();
+        let mut depth = 0usize;
+        let mut current_start = 0;
+        for (i, ch) in inner.char_indices() {
+            match ch {
+                '<' => depth += 1,
+                '>' => {
+                    depth = depth.saturating_sub(1);
+                }
+                ',' if depth == 0 => {
+                    params.push(inner[current_start..i].trim().to_string());
+                    current_start = i + 1;
+                }
+                _ => {}
+            }
+        }
+        let last = inner[current_start..].trim();
+        if !last.is_empty() {
+            params.push(last.to_string());
+        }
+        params
+    }
+
+    /// Extract a string field from the object's content fields.
+    pub fn field_str(&self, key: &str) -> Option<String> {
+        let fields = self.content.as_ref()?.fields.as_ref()?;
+        match fields.get(key)? {
+            Value::String(s) => Some(s.clone()),
+            Value::Number(n) => Some(n.to_string()),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SuiRpcClient {
     endpoint: String,
@@ -79,6 +158,49 @@ impl SuiRpcClient {
             .build()
             .context("Failed to build HTTP client for Sui RPC")?;
         Ok(Self { endpoint, client })
+    }
+
+    /// Fetch a Sui object by ID using `sui_getObject`.
+    ///
+    /// Returns the parsed content fields so callers can extract pool metadata
+    /// such as `base_asset`, `quote_asset`, `tick_size`, `lot_size`, etc.
+    pub async fn get_object(&self, object_id: &str) -> Result<SuiObjectData> {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "sui_getObject",
+            "params": [object_id, { "showContent": true, "showType": true }],
+        });
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to send sui_getObject request")?;
+
+        let status = response.status();
+        let body: RpcEnvelope<SuiGetObjectResult> = response
+            .json()
+            .await
+            .with_context(|| format!("Failed to parse sui_getObject response (status {status})"))?;
+
+        if let Some(error) = body.error {
+            return Err(anyhow!(
+                "Sui RPC error {} from sui_getObject: {}",
+                error.code,
+                error.message
+            ));
+        }
+
+        let result = body
+            .result
+            .ok_or_else(|| anyhow!("Sui RPC response missing result for sui_getObject"))?;
+
+        result
+            .data
+            .ok_or_else(|| anyhow!("sui_getObject returned no data for '{object_id}'"))
     }
 
     pub async fn query_events(
@@ -190,5 +312,65 @@ mod tests {
         });
         let event: SuiEvent = serde_json::from_value(raw).unwrap();
         assert_eq!(event.timestamp_ms, Some(1_772_923_888_171));
+    }
+
+    #[test]
+    fn test_deserializes_object_response() {
+        let raw = serde_json::json!({
+            "objectId": "0xpool123",
+            "type": "0xdee9::pool::Pool<0x2::sui::SUI, 0xabc::usdc::USDC>",
+            "content": {
+                "dataType": "moveObject",
+                "fields": {
+                    "tick_size": "1000000",
+                    "lot_size": "100000000",
+                    "min_size": "500000000"
+                }
+            }
+        });
+        let data: SuiObjectData = serde_json::from_value(raw).unwrap();
+        assert_eq!(data.object_id, "0xpool123");
+        assert_eq!(data.field_str("tick_size"), Some("1000000".to_string()));
+        assert_eq!(data.field_str("lot_size"), Some("100000000".to_string()));
+        assert_eq!(data.field_str("min_size"), Some("500000000".to_string()));
+        assert_eq!(data.field_str("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_type_params_extraction() {
+        let data = SuiObjectData {
+            object_id: "0xpool".to_string(),
+            object_type: Some("0xdee9::pool::Pool<0x2::sui::SUI, 0xabc::usdc::USDC>".to_string()),
+            content: None,
+        };
+        let params = data.type_params();
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0], "0x2::sui::SUI");
+        assert_eq!(params[1], "0xabc::usdc::USDC");
+    }
+
+    #[test]
+    fn test_type_params_no_generics() {
+        let data = SuiObjectData {
+            object_id: "0x1".to_string(),
+            object_type: Some("0x2::coin::Coin".to_string()),
+            content: None,
+        };
+        assert!(data.type_params().is_empty());
+    }
+
+    #[test]
+    fn test_type_params_nested_generics() {
+        let data = SuiObjectData {
+            object_id: "0x1".to_string(),
+            object_type: Some(
+                "0xdee9::pool::Pool<0x2::coin::Coin<0x3::foo::Bar>, 0x4::usdc::USDC>".to_string(),
+            ),
+            content: None,
+        };
+        let params = data.type_params();
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0], "0x2::coin::Coin<0x3::foo::Bar>");
+        assert_eq!(params[1], "0x4::usdc::USDC");
     }
 }

--- a/components/sources/sui-deepbook/src/rpc.rs
+++ b/components/sources/sui-deepbook/src/rpc.rs
@@ -1,0 +1,194 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{anyhow, Context, Result};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use serde_json::{json, Value};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EventCursor {
+    #[serde(rename = "txDigest")]
+    pub tx_digest: String,
+    #[serde(
+        rename = "eventSeq",
+        deserialize_with = "deserialize_string_or_number_as_string"
+    )]
+    pub event_seq: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SuiEvent {
+    pub id: EventCursor,
+    pub package_id: String,
+    pub transaction_module: String,
+    pub sender: String,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub parsed_json: Value,
+    #[serde(default, deserialize_with = "deserialize_optional_u64")]
+    pub timestamp_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryEventsResult {
+    pub data: Vec<SuiEvent>,
+    pub next_cursor: Option<EventCursor>,
+    pub has_next_page: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcEnvelope<T> {
+    result: Option<T>,
+    error: Option<RpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SuiRpcClient {
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+impl SuiRpcClient {
+    pub fn new(endpoint: impl Into<String>) -> Result<Self> {
+        let endpoint = endpoint.into();
+        reqwest::Url::parse(&endpoint)
+            .map_err(|e| anyhow!("Invalid Sui RPC endpoint '{endpoint}': {e}"))?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("Failed to build HTTP client for Sui RPC")?;
+        Ok(Self { endpoint, client })
+    }
+
+    pub async fn query_events(
+        &self,
+        query_filter: Value,
+        cursor: Option<&EventCursor>,
+        limit: u16,
+        descending_order: bool,
+    ) -> Result<QueryEventsResult> {
+        let cursor_value = match cursor {
+            Some(c) => serde_json::to_value(c)?,
+            None => Value::Null,
+        };
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "suix_queryEvents",
+            "params": [query_filter, cursor_value, limit, descending_order],
+        });
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to send suix_queryEvents request")?;
+
+        let status = response.status();
+        let body: RpcEnvelope<QueryEventsResult> = response.json().await.with_context(|| {
+            format!("Failed to parse suix_queryEvents response (status {status})")
+        })?;
+
+        if let Some(error) = body.error {
+            return Err(anyhow!(
+                "Sui RPC error {} from suix_queryEvents: {}",
+                error.code,
+                error.message
+            ));
+        }
+
+        body.result
+            .ok_or_else(|| anyhow!("Sui RPC response missing result for suix_queryEvents"))
+    }
+}
+
+fn deserialize_optional_u64<'de, D>(deserializer: D) -> std::result::Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    match value {
+        Value::Null => Ok(None),
+        Value::Number(num) => num
+            .as_u64()
+            .ok_or_else(|| D::Error::custom("timestampMs number is not a valid u64"))
+            .map(Some),
+        Value::String(text) => text
+            .parse::<u64>()
+            .map(Some)
+            .map_err(|e| D::Error::custom(format!("invalid timestampMs '{text}': {e}"))),
+        _ => Err(D::Error::custom(
+            "timestampMs must be a string, number, or null",
+        )),
+    }
+}
+
+fn deserialize_string_or_number_as_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    match value {
+        Value::String(text) => Ok(text),
+        Value::Number(num) => Ok(num.to_string()),
+        _ => Err(D::Error::custom(
+            "Expected string or number for value conversion",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserializes_event_seq_number() {
+        let raw = serde_json::json!({
+            "txDigest": "abc",
+            "eventSeq": 12
+        });
+        let cursor: EventCursor = serde_json::from_value(raw).unwrap();
+        assert_eq!(cursor.event_seq, "12");
+    }
+
+    #[test]
+    fn test_deserializes_timestamp_string() {
+        let raw = serde_json::json!({
+            "id": {"txDigest": "tx", "eventSeq": "1"},
+            "packageId": "0x1",
+            "transactionModule": "pool",
+            "sender": "0x2",
+            "type": "0x1::events::OrderPlaced",
+            "parsedJson": {"order_id": "1"},
+            "timestampMs": "1772923888171"
+        });
+        let event: SuiEvent = serde_json::from_value(raw).unwrap();
+        assert_eq!(event.timestamp_ms, Some(1_772_923_888_171));
+    }
+}

--- a/components/sources/sui-deepbook/tests/integration_test.rs
+++ b/components/sources/sui-deepbook/tests/integration_test.rs
@@ -18,7 +18,7 @@ use drasi_lib::channels::ResultDiff;
 use drasi_lib::{DrasiLib, Query};
 use drasi_reaction_application::subscription::{Subscription, SubscriptionOptions};
 use drasi_reaction_application::ApplicationReaction;
-use drasi_source_sui_deepbook::SuiDeepBookSource;
+use drasi_source_sui_deepbook::{SuiDeepBookSource, Transport};
 use serde_json::Value;
 use std::sync::Arc;
 use std::time::Duration;
@@ -232,6 +232,7 @@ async fn test_sui_deepbook_change_detection_end_to_end() -> Result<()> {
     });
 
     let source = SuiDeepBookSource::builder(SOURCE_ID)
+        .with_transport(Transport::JsonRpc)
         .with_rpc_endpoint(format!("http://{address}"))
         .with_deepbook_package_id("0xdeepbook")
         .with_poll_interval_ms(150)
@@ -312,5 +313,102 @@ async fn test_sui_deepbook_change_detection_end_to_end() -> Result<()> {
 
     drasi.stop().await.context("Failed to stop DrasiLib")?;
     server_handle.abort();
+    Ok(())
+}
+
+/// Test that the gRPC transport successfully receives DeepBook events from Sui mainnet.
+/// This test requires internet connectivity and connects to the public Sui fullnode.
+#[tokio::test]
+#[ignore]
+async fn test_grpc_transport_receives_events() -> Result<()> {
+    use drasi_reaction_application::subscription::SubscriptionOptions;
+
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let source = SuiDeepBookSource::builder(SOURCE_ID)
+        .with_transport(Transport::Grpc)
+        .with_start_from_now()
+        .with_enable_pool_nodes(true)
+        .with_enable_trader_nodes(true)
+        .with_enable_order_nodes(false)
+        .build()
+        .context("Failed to build gRPC source")?;
+
+    let query = Query::cypher(QUERY_ID)
+        .query(
+            r#"
+            MATCH (e:DeepBookEvent)
+            RETURN
+              e.entity_id    AS entity_id,
+              e.event_type   AS event_type,
+              e.sender       AS sender,
+              e.timestamp_ms AS timestamp_ms
+            "#,
+        )
+        .from_source(SOURCE_ID)
+        .auto_start(true)
+        .build();
+
+    let (reaction, handle) = ApplicationReaction::builder("grpc-test-reaction")
+        .with_query(QUERY_ID)
+        .build();
+
+    let mut drasi = DrasiLib::builder()
+        .with_id("sui-deepbook-grpc-test")
+        .with_source(source)
+        .with_query(query)
+        .with_reaction(reaction)
+        .build()
+        .await
+        .context("Failed to build DrasiLib")?;
+
+    drasi.start().await.context("Failed to start DrasiLib")?;
+
+    let mut subscription = handle
+        .subscribe_with_options(SubscriptionOptions::default().with_timeout(Duration::from_secs(3)))
+        .await
+        .context("Failed to subscribe")?;
+
+    let mut event_count = 0usize;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+
+    while tokio::time::Instant::now() < deadline {
+        match subscription.recv().await {
+            Some(result) => {
+                for diff in &result.results {
+                    match diff {
+                        ResultDiff::Add { data } | ResultDiff::Update { data, .. } => {
+                            if let Some(entity_id) = data.get("entity_id") {
+                                log::info!(
+                                    "gRPC event #{}: entity_id={entity_id}",
+                                    event_count + 1
+                                );
+                                event_count += 1;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                if event_count >= 3 {
+                    break;
+                }
+            }
+            None => {
+                // Timeout, continue waiting
+                continue;
+            }
+        }
+    }
+
+    assert!(
+        event_count >= 1,
+        "Expected at least 1 DeepBook event via gRPC within 30s, got {event_count}"
+    );
+    log::info!("gRPC transport test passed with {event_count} events");
+
+    drasi.stop().await.context("Failed to stop DrasiLib")?;
     Ok(())
 }

--- a/components/sources/sui-deepbook/tests/integration_test.rs
+++ b/components/sources/sui-deepbook/tests/integration_test.rs
@@ -1,0 +1,284 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{Context, Result};
+use axum::{extract::State, routing::post, Json, Router};
+use drasi_lib::channels::ResultDiff;
+use drasi_lib::{DrasiLib, Query};
+use drasi_reaction_application::subscription::{Subscription, SubscriptionOptions};
+use drasi_reaction_application::ApplicationReaction;
+use drasi_source_sui_deepbook::SuiDeepBookSource;
+use serde_json::Value;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+const SOURCE_ID: &str = "deepbook-source";
+const QUERY_ID: &str = "deepbook-query";
+
+fn diff_matches(diff: &ResultDiff, expected_kind: &str, expected_id: &str) -> bool {
+    match (expected_kind, diff) {
+        ("ADD", ResultDiff::Add { data }) => data
+            .get("entity_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|v| v == expected_id),
+        ("DELETE", ResultDiff::Delete { data }) => data
+            .get("entity_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|v| v == expected_id),
+        _ => false,
+    }
+}
+
+fn update_matches(diff: &ResultDiff, expected_id: &str) -> bool {
+    match diff {
+        ResultDiff::Update { before, after, .. } => {
+            before
+                .get("entity_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| v == expected_id)
+                && after
+                    .get("entity_id")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|v| v == expected_id)
+        }
+        _ => false,
+    }
+}
+
+/// Waits for a matching diff, collecting all observed entity_ids into `seen_ids`.
+async fn wait_for_change<F>(
+    subscription: &mut Subscription,
+    attempts: usize,
+    seen_ids: &mut Vec<String>,
+    mut matcher: F,
+) -> Result<ResultDiff>
+where
+    F: FnMut(&ResultDiff) -> bool,
+{
+    for _ in 0..attempts {
+        if let Some(result) = subscription.recv().await {
+            for entry in &result.results {
+                if let Some(id) = extract_entity_id(entry) {
+                    seen_ids.push(id);
+                }
+                if matcher(entry) {
+                    return Ok(entry.clone());
+                }
+            }
+        }
+    }
+    anyhow::bail!("Timed out waiting for expected query diff")
+}
+
+fn extract_entity_id(diff: &ResultDiff) -> Option<String> {
+    let data = match diff {
+        ResultDiff::Add { data } => Some(data),
+        ResultDiff::Delete { data } => Some(data),
+        ResultDiff::Update { after, .. } => Some(after),
+        _ => None,
+    };
+    data.and_then(|d| d.get("entity_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+#[derive(Clone)]
+struct MockState {
+    call_count: Arc<Mutex<u32>>,
+}
+
+async fn mock_sui_rpc(State(state): State<MockState>, Json(request): Json<Value>) -> Json<Value> {
+    let mut call_count = state.call_count.lock().await;
+    let response_id = request
+        .get("id")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!(1));
+
+    let payload = match *call_count {
+        0 => serde_json::json!({
+            "data": [
+                mock_event_with_pkg("0", "0xother-pkg", "TokenTransfer", serde_json::json!({
+                    "amount": "500"
+                })),
+                mock_event_with_pkg("1", "0xdeepbook", "OrderPlaced", serde_json::json!({
+                    "order_id": "42",
+                    "pool_id": "pool-alpha",
+                    "size": "1000",
+                    "price": "2.34"
+                }))
+            ],
+            "nextCursor": {"txDigest": "0xtx1", "eventSeq": "1"},
+            "hasNextPage": false
+        }),
+        1 => serde_json::json!({
+            "data": [
+                mock_event_with_pkg("2", "0xother-pkg", "SomethingElse", serde_json::json!({
+                    "foo": "bar"
+                })),
+                mock_event_with_pkg("3", "0xdeepbook", "OrderUpdated", serde_json::json!({
+                    "order_id": "42",
+                    "pool_id": "pool-alpha",
+                    "size": "1200",
+                    "price": "2.35"
+                }))
+            ],
+            "nextCursor": {"txDigest": "0xtx3", "eventSeq": "3"},
+            "hasNextPage": false
+        }),
+        2 => serde_json::json!({
+            "data": [mock_event_with_pkg("4", "0xdeepbook", "OrderCancelled", serde_json::json!({
+                "order_id": "42",
+                "pool_id": "pool-alpha"
+            }))],
+            "nextCursor": {"txDigest": "0xtx4", "eventSeq": "4"},
+            "hasNextPage": false
+        }),
+        _ => serde_json::json!({
+            "data": [],
+            "nextCursor": null,
+            "hasNextPage": false
+        }),
+    };
+
+    *call_count += 1;
+
+    Json(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": response_id,
+        "result": payload
+    }))
+}
+
+fn mock_event_with_pkg(
+    event_seq: &str,
+    package_id: &str,
+    event_suffix: &str,
+    parsed_json: Value,
+) -> Value {
+    serde_json::json!({
+        "id": {
+            "txDigest": format!("0xtx{event_seq}"),
+            "eventSeq": event_seq,
+        },
+        "packageId": package_id,
+        "transactionModule": "pool",
+        "sender": "0xsender",
+        "type": format!("{package_id}::events::{event_suffix}"),
+        "parsedJson": parsed_json,
+        "timestampMs": "1772923888171",
+    })
+}
+
+#[tokio::test]
+#[ignore] // Run with: cargo test -p drasi-source-sui-deepbook --test integration_test -- --ignored --nocapture
+async fn test_sui_deepbook_change_detection_end_to_end() -> Result<()> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("Failed to bind mock Sui RPC listener")?;
+    let address = listener.local_addr()?;
+
+    let mock_state = MockState {
+        call_count: Arc::new(Mutex::new(0)),
+    };
+    let app = Router::new()
+        .route("/", post(mock_sui_rpc))
+        .with_state(mock_state.clone());
+
+    let server_handle = tokio::spawn(async move {
+        if let Err(err) = axum::serve(listener, app).await {
+            eprintln!("Mock Sui RPC server failed: {err}");
+        }
+    });
+
+    let source = SuiDeepBookSource::builder(SOURCE_ID)
+        .with_rpc_endpoint(format!("http://{address}"))
+        .with_deepbook_package_id("0xdeepbook")
+        .with_poll_interval_ms(150)
+        .with_request_limit(25)
+        .with_start_from_beginning()
+        .build()
+        .context("Failed to build Sui DeepBook source")?;
+
+    let query = Query::cypher(QUERY_ID)
+        .query(
+            r#"
+            MATCH (e:DeepBookEvent)
+            RETURN e.entity_id AS entity_id, e.change_type AS change_type, e.event_type AS event_type
+        "#,
+        )
+        .from_source(SOURCE_ID)
+        .auto_start(true)
+        .build();
+
+    let (reaction, handle) = ApplicationReaction::builder("app-reaction")
+        .with_query(QUERY_ID)
+        .build();
+
+    let drasi = DrasiLib::builder()
+        .with_id("sui-deepbook-integration")
+        .with_source(source)
+        .with_query(query)
+        .with_reaction(reaction)
+        .build()
+        .await
+        .context("Failed to build DrasiLib")?;
+
+    drasi.start().await.context("Failed to start DrasiLib")?;
+
+    let mut subscription = handle
+        .subscribe_with_options(SubscriptionOptions::default().with_timeout(Duration::from_secs(2)))
+        .await
+        .context("Failed to subscribe to application reaction output")?;
+
+    let mut seen_ids: Vec<String> = Vec::new();
+
+    wait_for_change(&mut subscription, 20, &mut seen_ids, |entry| {
+        diff_matches(entry, "ADD", "order:42")
+    })
+    .await
+    .context("Did not observe INSERT/ADD change")?;
+
+    wait_for_change(&mut subscription, 20, &mut seen_ids, |entry| {
+        update_matches(entry, "order:42")
+    })
+    .await
+    .context("Did not observe UPDATE change")?;
+
+    wait_for_change(&mut subscription, 20, &mut seen_ids, |entry| {
+        diff_matches(entry, "DELETE", "order:42")
+    })
+    .await
+    .context("Did not observe DELETE change")?;
+
+    // Verify that events from "0xother-pkg" were filtered out —
+    // no entity_id should reference the non-DeepBook package events.
+    let leaked: Vec<&String> = seen_ids
+        .iter()
+        .filter(|id| !id.starts_with("order:42") && !id.starts_with("pool:"))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "Package-ID filtering is broken: non-DeepBook entity_ids leaked through: {leaked:?}"
+    );
+
+    drasi.stop().await.context("Failed to stop DrasiLib")?;
+    server_handle.abort();
+    Ok(())
+}

--- a/components/sources/sui-deepbook/tests/integration_test.rs
+++ b/components/sources/sui-deepbook/tests/integration_test.rs
@@ -101,64 +101,88 @@ struct MockState {
 }
 
 async fn mock_sui_rpc(State(state): State<MockState>, Json(request): Json<Value>) -> Json<Value> {
-    let mut call_count = state.call_count.lock().await;
     let response_id = request
         .get("id")
         .cloned()
         .unwrap_or_else(|| serde_json::json!(1));
 
-    let payload = match *call_count {
-        0 => serde_json::json!({
-            "data": [
-                mock_event_with_pkg("0", "0xother-pkg", "TokenTransfer", serde_json::json!({
-                    "amount": "500"
-                })),
-                mock_event_with_pkg("1", "0xdeepbook", "OrderPlaced", serde_json::json!({
-                    "order_id": "42",
-                    "pool_id": "pool-alpha",
-                    "size": "1000",
-                    "price": "2.34"
-                }))
-            ],
-            "nextCursor": {"txDigest": "0xtx1", "eventSeq": "1"},
-            "hasNextPage": false
-        }),
-        1 => serde_json::json!({
-            "data": [
-                mock_event_with_pkg("2", "0xother-pkg", "SomethingElse", serde_json::json!({
-                    "foo": "bar"
-                })),
-                mock_event_with_pkg("3", "0xdeepbook", "OrderUpdated", serde_json::json!({
-                    "order_id": "42",
-                    "pool_id": "pool-alpha",
-                    "size": "1200",
-                    "price": "2.35"
-                }))
-            ],
-            "nextCursor": {"txDigest": "0xtx3", "eventSeq": "3"},
-            "hasNextPage": false
-        }),
-        2 => serde_json::json!({
-            "data": [mock_event_with_pkg("4", "0xdeepbook", "OrderCancelled", serde_json::json!({
-                "order_id": "42",
-                "pool_id": "pool-alpha"
-            }))],
-            "nextCursor": {"txDigest": "0xtx4", "eventSeq": "4"},
-            "hasNextPage": false
-        }),
-        _ => serde_json::json!({
-            "data": [],
-            "nextCursor": null,
-            "hasNextPage": false
-        }),
-    };
+    let method = request.get("method").and_then(|m| m.as_str()).unwrap_or("");
 
-    *call_count += 1;
+    let result = match method {
+        "sui_getObject" => {
+            // Return mock pool metadata for any object ID
+            serde_json::json!({
+                "data": {
+                    "objectId": "pool-alpha",
+                    "type": "0xdee9::pool::Pool<0x2::sui::SUI, 0xabc::usdc::USDC>",
+                    "content": {
+                        "dataType": "moveObject",
+                        "fields": {
+                            "tick_size": "1000000",
+                            "lot_size": "100000000",
+                            "min_size": "500000000"
+                        }
+                    }
+                }
+            })
+        }
+        _ => {
+            // suix_queryEvents
+            let mut call_count = state.call_count.lock().await;
+            let payload = match *call_count {
+                0 => serde_json::json!({
+                    "data": [
+                        mock_event_with_pkg("0", "0xother-pkg", "TokenTransfer", serde_json::json!({
+                            "amount": "500"
+                        })),
+                        mock_event_with_pkg("1", "0xdeepbook", "OrderPlaced", serde_json::json!({
+                            "order_id": "42",
+                            "pool_id": "pool-alpha",
+                            "size": "1000",
+                            "price": "2.34"
+                        }))
+                    ],
+                    "nextCursor": {"txDigest": "0xtx1", "eventSeq": "1"},
+                    "hasNextPage": false
+                }),
+                1 => serde_json::json!({
+                    "data": [
+                        mock_event_with_pkg("2", "0xother-pkg", "SomethingElse", serde_json::json!({
+                            "foo": "bar"
+                        })),
+                        mock_event_with_pkg("3", "0xdeepbook", "OrderUpdated", serde_json::json!({
+                            "order_id": "42",
+                            "pool_id": "pool-alpha",
+                            "size": "1200",
+                            "price": "2.35"
+                        }))
+                    ],
+                    "nextCursor": {"txDigest": "0xtx3", "eventSeq": "3"},
+                    "hasNextPage": false
+                }),
+                2 => serde_json::json!({
+                    "data": [mock_event_with_pkg("4", "0xdeepbook", "OrderCancelled", serde_json::json!({
+                        "order_id": "42",
+                        "pool_id": "pool-alpha"
+                    }))],
+                    "nextCursor": {"txDigest": "0xtx4", "eventSeq": "4"},
+                    "hasNextPage": false
+                }),
+                _ => serde_json::json!({
+                    "data": [],
+                    "nextCursor": null,
+                    "hasNextPage": false
+                }),
+            };
+            *call_count += 1;
+            payload
+        }
+    };
 
     Json(serde_json::json!({
         "jsonrpc": "2.0",
         "id": response_id,
-        "result": payload
+        "result": result
     }))
 }
 
@@ -269,9 +293,17 @@ async fn test_sui_deepbook_change_detection_end_to_end() -> Result<()> {
 
     // Verify that events from "0xother-pkg" were filtered out —
     // no entity_id should reference the non-DeepBook package events.
+    // Enrichment entity_ids (pool_meta:, trader:, order_meta:, rel:) are allowed.
     let leaked: Vec<&String> = seen_ids
         .iter()
-        .filter(|id| !id.starts_with("order:42") && !id.starts_with("pool:"))
+        .filter(|id| {
+            !id.starts_with("order:42")
+                && !id.starts_with("pool:")
+                && !id.starts_with("pool_meta:")
+                && !id.starts_with("trader:")
+                && !id.starts_with("order_meta:")
+                && !id.starts_with("rel:")
+        })
         .collect();
     assert!(
         leaked.is_empty(),

--- a/components/sources/sui-deepbook/tests/integration_test.rs
+++ b/components/sources/sui-deepbook/tests/integration_test.rs
@@ -30,11 +30,11 @@ const QUERY_ID: &str = "deepbook-query";
 
 fn diff_matches(diff: &ResultDiff, expected_kind: &str, expected_id: &str) -> bool {
     match (expected_kind, diff) {
-        ("ADD", ResultDiff::Add { data }) => data
+        ("ADD", ResultDiff::Add { data, .. }) => data
             .get("entity_id")
             .and_then(|v| v.as_str())
             .is_some_and(|v| v == expected_id),
-        ("DELETE", ResultDiff::Delete { data }) => data
+        ("DELETE", ResultDiff::Delete { data, .. }) => data
             .get("entity_id")
             .and_then(|v| v.as_str())
             .is_some_and(|v| v == expected_id),
@@ -85,8 +85,8 @@ where
 
 fn extract_entity_id(diff: &ResultDiff) -> Option<String> {
     let data = match diff {
-        ResultDiff::Add { data } => Some(data),
-        ResultDiff::Delete { data } => Some(data),
+        ResultDiff::Add { data, .. } => Some(data),
+        ResultDiff::Delete { data, .. } => Some(data),
         ResultDiff::Update { after, .. } => Some(after),
         _ => None,
     };
@@ -380,7 +380,7 @@ async fn test_grpc_transport_receives_events() -> Result<()> {
             Some(result) => {
                 for diff in &result.results {
                     match diff {
-                        ResultDiff::Add { data } | ResultDiff::Update { data, .. } => {
+                        ResultDiff::Add { data, .. } | ResultDiff::Update { data, .. } => {
                             if let Some(entity_id) = data.get("entity_id") {
                                 log::info!(
                                     "gRPC event #{}: entity_id={entity_id}",

--- a/examples/lib/sui-deepbook-getting-started/Cargo.toml
+++ b/examples/lib/sui-deepbook-getting-started/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sui-deepbook-getting-started"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "DrasiLib getting-started example for Sui DeepBook source"
+
+[workspace]
+
+[dependencies]
+drasi-lib = { path = "../../../lib" }
+drasi-source-sui-deepbook = { path = "../../../components/sources/sui-deepbook" }
+drasi-reaction-application = { path = "../../../components/reactions/application" }
+tokio = { version = "1.6", features = ["full"] }
+anyhow = "1.0"
+env_logger = "0.11"
+chrono = "0.4"
+serde_json = "1.0"
+
+[[bin]]
+name = "sui-deepbook-getting-started"
+path = "main.rs"

--- a/examples/lib/sui-deepbook-getting-started/Cargo.toml
+++ b/examples/lib/sui-deepbook-getting-started/Cargo.toml
@@ -10,12 +10,12 @@ description = "DrasiLib getting-started example for Sui DeepBook source"
 [dependencies]
 drasi-lib = { path = "../../../lib" }
 drasi-source-sui-deepbook = { path = "../../../components/sources/sui-deepbook" }
-drasi-reaction-application = { path = "../../../components/reactions/application" }
+drasi-reaction-sse = { path = "../../../components/reactions/sse" }
 tokio = { version = "1.6", features = ["full"] }
 anyhow = "1.0"
 env_logger = "0.11"
-chrono = "0.4"
-serde_json = "1.0"
+axum = "0.7"
+log = "0.4"
 
 [[bin]]
 name = "sui-deepbook-getting-started"

--- a/examples/lib/sui-deepbook-getting-started/README.md
+++ b/examples/lib/sui-deepbook-getting-started/README.md
@@ -1,12 +1,12 @@
 # Sui DeepBook Getting Started
 
-This example connects to the Sui mainnet JSON-RPC and streams live DeepBook V3 events through a Drasi continuous query. Every event is logged to the console via a `LogReaction` showing the entity ID, event type, and operation.
+This example connects to the Sui mainnet JSON-RPC and streams live DeepBook V3 events through a Drasi continuous query. Every event is displayed in a color-coded terminal UI via an `ApplicationReaction` with custom formatting.
 
 ## Prerequisites
 
 - Rust toolchain (workspace default)
 - Internet access to a Sui RPC endpoint
-- `curl` and `jq` (for helper scripts)
+- `curl` (for helper scripts)
 
 ## Quick Start
 
@@ -155,16 +155,10 @@ RETURN e.order_id, e.event_name, e.change_type, e.sender_short
 
 Output:
 ```
---- Chain Info ---
-{"jsonrpc":"2.0","result":"35834a8a"}
---- Scanning events (up to 100 pages) ---
-  Page 1: 50 events returned
-  Page 2: 50 events returned
-  ...
-  Page 47: 50 events returned — FOUND 3 matching events!
-    Type: 0x337…::deep_price::PriceAdded
-    Type: 0x337…::balance_manager::BalanceEvent
-    Type: 0x337…::balance_manager::BalanceEvent
+Scanned 12 page(s), 600 event(s); found 3 match(es).
+- 0x337…::deep_price::PriceAdded @ 2024-01-15T12:34:56Z (tx=ABCDEFG123, seq=456789)
+- 0x337…::balance_manager::BalanceEvent @ 2024-01-15T12:35:10Z (tx=HIJKLMN456, seq=456790)
+- 0x337…::balance_manager::BalanceEvent @ 2024-01-15T12:36:03Z (tx=OPQRSTU789, seq=456791)
 ```
 
 ## How It Works
@@ -173,7 +167,7 @@ Output:
 2. Raw events are filtered to only those from the DeepBook package
 3. Each matching event becomes a `DeepBookEvent` node in the Drasi graph
 4. The Cypher query runs continuously and emits diffs (ADD/UPDATE/DELETE)
-5. The `LogReaction` formats each diff using Handlebars templates and prints to stdout
+5. The `ApplicationReaction` receives each diff and renders it as a color-coded event card in the terminal
 
 ## Troubleshooting
 

--- a/examples/lib/sui-deepbook-getting-started/README.md
+++ b/examples/lib/sui-deepbook-getting-started/README.md
@@ -1,11 +1,30 @@
 # Sui DeepBook Getting Started
 
-This example connects to the Sui mainnet JSON-RPC and streams live DeepBook V3 events through a Drasi continuous query. Every event is displayed in a color-coded terminal UI via an `ApplicationReaction` with custom formatting.
+This example runs a real-time **DeFi dashboard** for Sui DeepBook V3, powered by Drasi continuous queries and delivered to the browser via Server-Sent Events (SSE).
+
+Three categories of Drasi queries feed the dashboard:
+
+**Core queries** — simple projections:
+
+| Query | Purpose |
+|-------|---------|
+| `event-feed` | Every DeepBook event with full payload |
+| `pool-tracker` | Enrichment `Pool` nodes with base/quote assets |
+| `trader-tracker` | Enrichment `Trader` nodes from event senders |
+
+**Aggregation queries** — server-side continuous aggregations:
+
+| Query | Purpose | Drasi features used |
+|-------|---------|---------------------|
+| `event-breakdown` | Event count by type | `count()` aggregation with grouping |
+| `bid-ask-ratio` | Bids vs asks per pool | `CASE WHEN` + `sum()` |
+| `fill-tracker` | Fill count per pool | Filtered `count()` with `WHERE` |
 
 ## Prerequisites
 
 - Rust toolchain (workspace default)
 - Internet access to a Sui RPC endpoint
+- A modern web browser
 - `curl` (for helper scripts)
 
 ## Quick Start
@@ -25,79 +44,61 @@ Or step-by-step:
 cargo run
 ```
 
+Then open **http://localhost:3000** in your browser.
+
 ## What You'll See
 
-Once running, the console shows a styled live feed of DeepBook events with colour-coded actions and extracted trading data:
+The terminal shows the server endpoints:
 
 ```
 ╔══════════════════════════════════════════════════════════════╗
-║  Sui DeepBook Live Event Monitor                             ║
+║  DeepBook DeFi Dashboard                                   ║
 ╠══════════════════════════════════════════════════════════════╣
-║  RPC:     https://fullnode.mainnet.sui.io:443
-║  Package: 0x337f4f…ef497
-║  Mode:    Live streaming (start from now)
+║  RPC:       https://fullnode.mainnet.sui.io:443
+║  Package:   0x337f4f…ef497
+║  SSE:       http://localhost:8080/events
+║  Dashboard: http://localhost:3000
+║  Enrichment: Pool + Trader + Order nodes enabled
 ╠══════════════════════════════════════════════════════════════╣
-║  Waiting for DeepBook events… (Ctrl+C to stop)
+║  Open the dashboard URL in your browser.                   ║
+║  Press Ctrl+C to stop.                                     ║
 ╚══════════════════════════════════════════════════════════════╝
-
-  ▶ ADD  PriceAdded (deep_price)
-        entity: pool:0xab…abcd  sender: 0x1a…2b3c  time: 14:32:08
-        pool: 0xab…abcd  price=2850000000  size=1500000
-
-  ▶ ADD  BalanceEvent (balance_manager)
-        entity: event:0x7fa…:0  sender: 0x9d…ef01  time: 14:32:08
-        amount=500000000  balance=12000000000
-
-  ▶ ADD  OrderPlaced (events)
-        entity: order:42  sender: 0x1a…2b3c  time: 14:32:09
-        pool: 0xab…abcd  price=2340  size=1000  side=BID
-
-  ⟳ UPD  OrderFilled (events)
-        entity: order:42  sender: 0x1a…2b3c  time: 14:32:11
-        pool: 0xab…abcd  price=2340  size=800  fee=120
-        transition: insert → update
-
-  ✕ DEL  OrderCancelled (events)
-        entity: order:42  sender: 0x1a…2b3c  time: 14:32:15
 ```
 
-### Reading the Output
+The browser dashboard shows:
 
-**Action icons** indicate what happened:
+- **Stats bar** — total events, active pools, unique traders, total fills, throughput
+- **Price ticker** — scrolling tape of latest fill prices per pool
+- **Live Event Feed** — scrolling table of every DeepBook event with type, side (BID/ASK), pool, sender, price, and quantity
+- **Pool Overview** — cards showing base/quote pair, event count, fill count, last fill price, and bid/ask ratio bar
+- **Event Distribution** — donut chart breaking down events by type, powered by a server-side `count()` aggregation query
+- **Top Traders** — leaderboard of most active traders by event count
+- **Whale Alerts** — highlighted large trades above the quantity threshold
 
-| Icon | Colour | Meaning |
-|------|--------|---------|
-| `▶ ADD` | Green | New event appeared (order placed, price update, balance change) |
-| `⟳ UPD` | Yellow | An existing entity was modified (order filled, amended) |
-| `✕ DEL` | Red | An entity was removed (order cancelled, position closed) |
+All data updates in real time via SSE — no page reloads needed.
 
-**Event details** are broken into lines:
+## Architecture
 
-| Line | Content |
-|------|---------|
-| 1st | **Event name** and Move module (e.g. `PriceAdded (deep_price)`) |
-| 2nd | Entity ID, sender (truncated), and on-chain timestamp |
-| 3rd | Pool (truncated) + payload highlights (price, size, amount, side, fees) |
+```
+Sui RPC ──► DeepBook Source ──► Drasi Queries ──► SSE Reaction ──► Browser Dashboard
+              (poll 2s)          (continuous)       (port 8080)      (port 3000)
+```
 
-**Payload highlights** are automatically extracted from common DeepBook fields:
-
-| Field | Display | Example |
-|-------|---------|---------|
-| `price` | `price=…` | `price=2340` |
-| `size` / `quantity` | `size=…` / `qty=…` | `size=1000` |
-| `amount` / `balance` | `amount=…` / `balance=…` | `amount=500000000` |
-| `fee` / `maker_fee` / `taker_fee` | `fee=…` | `fee=120` |
-| `is_bid` / `side` | `side=BID` or `side=ASK` | `side=BID` |
+1. **Source** polls `suix_queryEvents` every 2 seconds and emits graph nodes
+2. **Enrichment** adds `Pool`, `Trader`, and `Order` nodes linked to events
+3. **Three Cypher queries** run continuously, emitting diffs (ADD/UPDATE/DELETE)
+4. **SSE Reaction** streams query results to connected browsers at `/events`
+5. **Dashboard server** serves the HTML dashboard at port 3000
+6. **Browser JS** connects to SSE, dispatches by `queryId`, updates the UI
 
 ## Configuration
-
-Environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SUI_RPC_URL` | `https://fullnode.mainnet.sui.io:443` | Sui JSON-RPC endpoint |
 | `DEEPBOOK_PACKAGE_ID` | Mainnet DeepBook V3 address | Package ID for filtering |
-| `MAX_PAGES` | `100` | Pages to scan in `diagnose.sh` / `test-updates.sh` |
+| `SSE_PORT` | `8080` | Port for the SSE event stream |
+| `DASHBOARD_PORT` | `3000` | Port for the HTML dashboard |
 
 ### Using a Different Network
 
@@ -108,34 +109,71 @@ DEEPBOOK_PACKAGE_ID=0x<testnet-package-id> \
 cargo run
 
 # Custom provider (higher rate limits)
-SUI_RPC_URL=https://sui-mainnet.rpc.example.com \
-cargo run
+SUI_RPC_URL=https://sui-mainnet.rpc.example.com cargo run
 ```
 
-## The Cypher Query
+## The Cypher Queries
 
-The example runs this continuous query:
+### Event Feed — all events in real time
 
 ```cypher
 MATCH (e:DeepBookEvent)
 RETURN
-  e.entity_id     AS entity_id,
-  e.event_name    AS event_name,
-  e.module        AS module,
-  e.change_type   AS change_type,
-  e.pool_id_short AS pool,
-  e.sender_short  AS sender,
-  e.timestamp_ms  AS timestamp_ms,
-  e.order_id      AS order_id,
-  e.payload       AS payload
+  e.entity_id    AS id,
+  e.event_name   AS event_name,
+  e.pool_id      AS pool_id,
+  e.timestamp_ms AS timestamp,
+  e.sender       AS sender,
+  e.payload      AS payload
 ```
 
-The example uses `ApplicationReaction` with a custom formatting loop (not `LogReaction`) to render structured, colour-coded output. You can modify `main.rs` to try more targeted queries. For example, to only track orders in a specific pool:
+### Pool Tracker — discovered pools with asset info
+
+```cypher
+MATCH (p:Pool)
+RETURN
+  p.pool_id     AS pool_id,
+  p.base_asset  AS base_asset,
+  p.quote_asset AS quote_asset
+```
+
+### Trader Tracker — unique trader addresses
+
+```cypher
+MATCH (t:Trader)
+RETURN t.address AS address
+```
+
+### Event Breakdown — server-side count by event type
 
 ```cypher
 MATCH (e:DeepBookEvent)
-WHERE e.pool_id = '0xabc123…' AND e.order_id IS NOT NULL
-RETURN e.order_id, e.event_name, e.change_type, e.sender_short
+RETURN e.event_name AS event_name, count(e) AS cnt
+```
+
+This aggregation query groups events by type and emits real-time count updates.
+Each time a new event arrives, the count for that type increments and the dashboard
+donut chart updates automatically.
+
+### Bid/Ask Ratio — CASE WHEN aggregation per pool
+
+```cypher
+MATCH (e:DeepBookEvent)
+WHERE e.payload.is_bid IS NOT NULL
+RETURN e.pool_id AS pool_id,
+  sum(CASE WHEN e.payload.is_bid = true THEN 1 ELSE 0 END) AS bids,
+  sum(CASE WHEN e.payload.is_bid = false THEN 1 ELSE 0 END) AS asks
+```
+
+Showcases Drasi's support for `CASE WHEN` expressions inside aggregations.
+The dashboard renders this as a bid/ask ratio bar on each pool card.
+
+### Fill Tracker — filtered fill count per pool
+
+```cypher
+MATCH (e:DeepBookEvent)
+WHERE e.event_name = 'OrderFilled'
+RETURN e.pool_id AS pool_id, count(e) AS fill_count
 ```
 
 ## Helper Scripts
@@ -144,46 +182,26 @@ RETURN e.order_id, e.event_name, e.change_type, e.sender_short
 |--------|---------|
 | `setup.sh` | Validates RPC endpoint health with a 60-second timeout |
 | `quickstart.sh` | Runs setup → build → start in one command |
-| `diagnose.sh` | Prints chain ID and scans recent events paginated by package ID |
-| `test-updates.sh` | Scans recent events and prints matching DeepBook events as JSON |
-
-### Diagnosing Connectivity
-
-```bash
-./diagnose.sh
-```
-
-Output:
-```
-Scanned 12 page(s), 600 event(s); found 3 match(es).
-- 0x337…::deep_price::PriceAdded @ 2024-01-15T12:34:56Z (tx=ABCDEFG123, seq=456789)
-- 0x337…::balance_manager::BalanceEvent @ 2024-01-15T12:35:10Z (tx=HIJKLMN456, seq=456790)
-- 0x337…::balance_manager::BalanceEvent @ 2024-01-15T12:36:03Z (tx=OPQRSTU789, seq=456791)
-```
-
-## How It Works
-
-1. **Source** polls `suix_queryEvents` every 2 seconds
-2. Raw events are filtered to only those from the DeepBook package
-3. Each matching event becomes a `DeepBookEvent` node in the Drasi graph
-4. The Cypher query runs continuously and emits diffs (ADD/UPDATE/DELETE)
-5. The `ApplicationReaction` receives each diff and renders it as a color-coded event card in the terminal
+| `diagnose.sh` | Prints chain ID and scans recent events by package ID |
+| `test-updates.sh` | Scans recent events and prints matching DeepBook events |
 
 ## Troubleshooting
 
-### No output / "No events found"
+### Dashboard shows "Connecting…" / "Reconnecting…"
 
-DeepBook events are relatively infrequent. The `StartPosition::Now` setting (default in this example) means the source only captures events emitted **after** it starts. Wait a few minutes, or switch to `StartPosition::Beginning` to replay historical events:
+- Verify the Rust process is running and printed the SSE endpoint URL
+- Check that port 8080 is not blocked or in use
+- Try opening `http://localhost:8080/events` directly — you should see SSE heartbeats
 
-```rust
-.with_start_from_beginning()
-```
+### No events appearing
+
+DeepBook events are relatively infrequent. With `StartPosition::Now` (default), only events emitted **after** startup are captured. Wait a few minutes for market activity, or switch to `StartPosition::Beginning` in the code to replay history.
 
 ### RPC errors / timeouts
 
-- Verify the endpoint is reachable: `curl -s https://fullnode.mainnet.sui.io:443 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"sui_getChainIdentifier","id":1,"params":[]}'`
-- The public mainnet endpoint has rate limits. Switch to a dedicated provider via `SUI_RPC_URL`.
-- Run `./diagnose.sh` for a full connectivity check.
+- Verify: `curl -s https://fullnode.mainnet.sui.io:443 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"sui_getChainIdentifier","id":1,"params":[]}'`
+- The public endpoint has rate limits — use a dedicated provider via `SUI_RPC_URL`
+- Run `./diagnose.sh` for full diagnostics
 
 ### "DeepBook package changed"
 

--- a/examples/lib/sui-deepbook-getting-started/README.md
+++ b/examples/lib/sui-deepbook-getting-started/README.md
@@ -1,0 +1,196 @@
+# Sui DeepBook Getting Started
+
+This example connects to the Sui mainnet JSON-RPC and streams live DeepBook V3 events through a Drasi continuous query. Every event is logged to the console via a `LogReaction` showing the entity ID, event type, and operation.
+
+## Prerequisites
+
+- Rust toolchain (workspace default)
+- Internet access to a Sui RPC endpoint
+- `curl` and `jq` (for helper scripts)
+
+## Quick Start
+
+```bash
+cd examples/lib/sui-deepbook-getting-started
+./quickstart.sh
+```
+
+Or step-by-step:
+
+```bash
+# 1. Check RPC connectivity
+./setup.sh
+
+# 2. Build and run
+cargo run
+```
+
+## What You'll See
+
+Once running, the console shows a styled live feed of DeepBook events with colour-coded actions and extracted trading data:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  Sui DeepBook Live Event Monitor                             ║
+╠══════════════════════════════════════════════════════════════╣
+║  RPC:     https://fullnode.mainnet.sui.io:443
+║  Package: 0x337f4f…ef497
+║  Mode:    Live streaming (start from now)
+╠══════════════════════════════════════════════════════════════╣
+║  Waiting for DeepBook events… (Ctrl+C to stop)
+╚══════════════════════════════════════════════════════════════╝
+
+  ▶ ADD  PriceAdded (deep_price)
+        entity: pool:0xab…abcd  sender: 0x1a…2b3c  time: 14:32:08
+        pool: 0xab…abcd  price=2850000000  size=1500000
+
+  ▶ ADD  BalanceEvent (balance_manager)
+        entity: event:0x7fa…:0  sender: 0x9d…ef01  time: 14:32:08
+        amount=500000000  balance=12000000000
+
+  ▶ ADD  OrderPlaced (events)
+        entity: order:42  sender: 0x1a…2b3c  time: 14:32:09
+        pool: 0xab…abcd  price=2340  size=1000  side=BID
+
+  ⟳ UPD  OrderFilled (events)
+        entity: order:42  sender: 0x1a…2b3c  time: 14:32:11
+        pool: 0xab…abcd  price=2340  size=800  fee=120
+        transition: insert → update
+
+  ✕ DEL  OrderCancelled (events)
+        entity: order:42  sender: 0x1a…2b3c  time: 14:32:15
+```
+
+### Reading the Output
+
+**Action icons** indicate what happened:
+
+| Icon | Colour | Meaning |
+|------|--------|---------|
+| `▶ ADD` | Green | New event appeared (order placed, price update, balance change) |
+| `⟳ UPD` | Yellow | An existing entity was modified (order filled, amended) |
+| `✕ DEL` | Red | An entity was removed (order cancelled, position closed) |
+
+**Event details** are broken into lines:
+
+| Line | Content |
+|------|---------|
+| 1st | **Event name** and Move module (e.g. `PriceAdded (deep_price)`) |
+| 2nd | Entity ID, sender (truncated), and on-chain timestamp |
+| 3rd | Pool (truncated) + payload highlights (price, size, amount, side, fees) |
+
+**Payload highlights** are automatically extracted from common DeepBook fields:
+
+| Field | Display | Example |
+|-------|---------|---------|
+| `price` | `price=…` | `price=2340` |
+| `size` / `quantity` | `size=…` / `qty=…` | `size=1000` |
+| `amount` / `balance` | `amount=…` / `balance=…` | `amount=500000000` |
+| `fee` / `maker_fee` / `taker_fee` | `fee=…` | `fee=120` |
+| `is_bid` / `side` | `side=BID` or `side=ASK` | `side=BID` |
+
+## Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SUI_RPC_URL` | `https://fullnode.mainnet.sui.io:443` | Sui JSON-RPC endpoint |
+| `DEEPBOOK_PACKAGE_ID` | Mainnet DeepBook V3 address | Package ID for filtering |
+| `MAX_PAGES` | `100` | Pages to scan in `diagnose.sh` / `test-updates.sh` |
+
+### Using a Different Network
+
+```bash
+# Testnet
+SUI_RPC_URL=https://fullnode.testnet.sui.io:443 \
+DEEPBOOK_PACKAGE_ID=0x<testnet-package-id> \
+cargo run
+
+# Custom provider (higher rate limits)
+SUI_RPC_URL=https://sui-mainnet.rpc.example.com \
+cargo run
+```
+
+## The Cypher Query
+
+The example runs this continuous query:
+
+```cypher
+MATCH (e:DeepBookEvent)
+RETURN
+  e.entity_id     AS entity_id,
+  e.event_name    AS event_name,
+  e.module        AS module,
+  e.change_type   AS change_type,
+  e.pool_id_short AS pool,
+  e.sender_short  AS sender,
+  e.timestamp_ms  AS timestamp_ms,
+  e.order_id      AS order_id,
+  e.payload       AS payload
+```
+
+The example uses `ApplicationReaction` with a custom formatting loop (not `LogReaction`) to render structured, colour-coded output. You can modify `main.rs` to try more targeted queries. For example, to only track orders in a specific pool:
+
+```cypher
+MATCH (e:DeepBookEvent)
+WHERE e.pool_id = '0xabc123…' AND e.order_id IS NOT NULL
+RETURN e.order_id, e.event_name, e.change_type, e.sender_short
+```
+
+## Helper Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `setup.sh` | Validates RPC endpoint health with a 60-second timeout |
+| `quickstart.sh` | Runs setup → build → start in one command |
+| `diagnose.sh` | Prints chain ID and scans recent events paginated by package ID |
+| `test-updates.sh` | Scans recent events and prints matching DeepBook events as JSON |
+
+### Diagnosing Connectivity
+
+```bash
+./diagnose.sh
+```
+
+Output:
+```
+--- Chain Info ---
+{"jsonrpc":"2.0","result":"35834a8a"}
+--- Scanning events (up to 100 pages) ---
+  Page 1: 50 events returned
+  Page 2: 50 events returned
+  ...
+  Page 47: 50 events returned — FOUND 3 matching events!
+    Type: 0x337…::deep_price::PriceAdded
+    Type: 0x337…::balance_manager::BalanceEvent
+    Type: 0x337…::balance_manager::BalanceEvent
+```
+
+## How It Works
+
+1. **Source** polls `suix_queryEvents` every 2 seconds
+2. Raw events are filtered to only those from the DeepBook package
+3. Each matching event becomes a `DeepBookEvent` node in the Drasi graph
+4. The Cypher query runs continuously and emits diffs (ADD/UPDATE/DELETE)
+5. The `LogReaction` formats each diff using Handlebars templates and prints to stdout
+
+## Troubleshooting
+
+### No output / "No events found"
+
+DeepBook events are relatively infrequent. The `StartPosition::Now` setting (default in this example) means the source only captures events emitted **after** it starts. Wait a few minutes, or switch to `StartPosition::Beginning` to replay historical events:
+
+```rust
+.with_start_from_beginning()
+```
+
+### RPC errors / timeouts
+
+- Verify the endpoint is reachable: `curl -s https://fullnode.mainnet.sui.io:443 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"sui_getChainIdentifier","id":1,"params":[]}'`
+- The public mainnet endpoint has rate limits. Switch to a dedicated provider via `SUI_RPC_URL`.
+- Run `./diagnose.sh` for a full connectivity check.
+
+### "DeepBook package changed"
+
+If Mysten Labs deploys a new DeepBook package, override `DEEPBOOK_PACKAGE_ID` with the updated address.

--- a/examples/lib/sui-deepbook-getting-started/dashboard.html
+++ b/examples/lib/sui-deepbook-getting-started/dashboard.html
@@ -1,0 +1,612 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DeepBook DeFi Dashboard — Drasi</title>
+  <style>
+    :root {
+      --bg: #0c0f1a;
+      --bg-card: #131726;
+      --bg-alt: #171c30;
+      --bg-hover: #1a2040;
+      --border: #232946;
+      --glow: #00e5a033;
+      --text: #e2e8f0;
+      --text2: #94a3b8;
+      --muted: #64748b;
+      --accent: #00e5a0;
+      --accent-d: #00e5a044;
+      --blue: #3b82f6;
+      --yellow: #f59e0b;
+      --red: #ef4444;
+      --purple: #a78bfa;
+      --orange: #fb923c;
+      --mono: 'JetBrains Mono','Fira Code','SF Mono',Consolas,monospace;
+      --sans: 'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+    }
+    *{margin:0;padding:0;box-sizing:border-box}
+    body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100vh;overflow-x:hidden}
+    .dash{max-width:1480px;margin:0 auto;padding:20px 24px}
+
+    /* Header */
+    .hdr{display:flex;align-items:center;justify-content:space-between;padding:14px 0 18px;border-bottom:1px solid var(--border);margin-bottom:18px}
+    .hdr-left{display:flex;align-items:center;gap:14px}
+    .logo{width:36px;height:36px;background:linear-gradient(135deg,var(--accent),var(--blue));border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;color:var(--bg)}
+    .hdr-title{font-size:22px;font-weight:700;letter-spacing:-.5px}
+    .hdr-sub{font-size:12px;color:var(--muted);margin-top:2px}
+    .badge{display:flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;font-size:12px;font-weight:600;border:1px solid var(--border);background:var(--bg-card)}
+    .dot{width:8px;height:8px;border-radius:50%;background:var(--muted);transition:background .3s}
+    .badge.on .dot{background:var(--accent);box-shadow:0 0 8px var(--accent)}
+    .badge.on{border-color:var(--accent-d);color:var(--accent)}
+    .badge.off .dot{background:var(--red);box-shadow:0 0 8px var(--red)}
+    .badge.off{border-color:#ef444444;color:var(--red)}
+
+    /* Stats */
+    .stats{display:grid;grid-template-columns:repeat(5,1fr);gap:14px;margin-bottom:16px}
+    .stat{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:14px 18px;transition:border-color .3s}
+    .stat:hover{border-color:var(--glow)}
+    .stat-lbl{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--muted);margin-bottom:6px}
+    .stat-val{font-family:var(--mono);font-size:24px;font-weight:700;line-height:1}
+    .stat-val .u{font-size:12px;font-weight:400;color:var(--text2);margin-left:3px}
+    .stat-ico{float:right;font-family:var(--mono);font-size:18px;color:var(--accent);opacity:.5;margin-top:-2px}
+
+    /* Ticker */
+    .ticker-wrap{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden;margin-bottom:16px;height:38px;position:relative}
+    .ticker-label{position:absolute;left:0;top:0;bottom:0;width:96px;background:var(--bg-card);z-index:2;display:flex;align-items:center;padding-left:14px;font-size:11px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.5px}
+    .ticker{display:flex;align-items:center;height:100%;gap:28px;padding-left:96px;white-space:nowrap}
+    .ticker.scrolling{animation:scroll 40s linear infinite}
+    .ticker.scrolling:hover{animation-play-state:paused}
+    .tick-item{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:13px}
+    .tick-pair{font-weight:600;color:var(--text)}
+    .tick-price{color:var(--accent)}
+    .tick-time{color:var(--muted);font-size:11px}
+    @keyframes scroll{from{transform:translateX(0)}to{transform:translateX(-50%)}}
+
+    /* Main grid */
+    .grid{display:grid;grid-template-columns:1fr 360px;gap:18px;min-height:520px}
+
+    /* Panels */
+    .panel{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;overflow:hidden;display:flex;flex-direction:column}
+    .panel-hdr{display:flex;align-items:center;justify-content:space-between;padding:12px 18px;border-bottom:1px solid var(--border);font-size:13px;font-weight:600}
+    .panel-hdr .tag{font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:6px;background:var(--accent-d);color:var(--accent)}
+
+    /* Event feed table */
+    .feed{overflow:hidden;height:100%}
+    .feed-wrap{flex:1;overflow-y:auto}
+    .etbl{width:100%;border-collapse:collapse;font-size:12px}
+    .etbl thead th{position:sticky;top:0;background:var(--bg-card);padding:8px 10px;text-align:left;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.6px;color:var(--muted);border-bottom:1px solid var(--border);z-index:1}
+    .etbl tbody tr{border-bottom:1px solid var(--border);transition:background .15s}
+    .etbl tbody tr:hover{background:var(--bg-hover)}
+    .etbl td{padding:8px 10px;white-space:nowrap;vertical-align:middle}
+    .addr{font-family:var(--mono);font-size:11px;color:var(--text2)}
+    .time{font-family:var(--mono);font-size:11px;color:var(--muted)}
+    .evbadge{display:inline-block;padding:2px 7px;border-radius:4px;font-size:10px;font-weight:700;letter-spacing:.2px}
+    .ev-placed{background:#3b82f620;color:var(--blue)}
+    .ev-filled{background:#00e5a020;color:var(--accent)}
+    .ev-cancel{background:#ef444420;color:var(--red)}
+    .ev-modify{background:#f59e0b20;color:var(--yellow)}
+    .ev-other{background:#a78bfa20;color:var(--purple)}
+    .side-bid{font-size:10px;font-weight:700;color:var(--accent)}
+    .side-ask{font-size:10px;font-weight:700;color:var(--red)}
+    @keyframes flash{from{background:var(--accent-d)}to{background:transparent}}
+    .etbl tbody tr.flash{animation:flash 1s ease-out}
+
+    /* Empty / spinner */
+    .empty{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:50px 20px;color:var(--muted);font-size:13px;gap:8px}
+    .spin{width:22px;height:22px;border:2px solid var(--border);border-top-color:var(--accent);border-radius:50%;animation:sp 1s linear infinite}
+    @keyframes sp{to{transform:rotate(360deg)}}
+
+    /* Sidebar */
+    .side{display:flex;flex-direction:column;gap:16px}
+
+    /* Pool cards */
+    .pool-list{padding:10px;flex:1;overflow-y:auto}
+    .pcard{background:var(--bg-alt);border:1px solid var(--border);border-radius:8px;padding:12px 14px;margin-bottom:10px;transition:border-color .3s,transform .1s}
+    .pcard:hover{border-color:var(--glow);transform:translateY(-1px)}
+    .pcard-row{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px}
+    .ppair{font-size:14px;font-weight:700;letter-spacing:-.3px}
+    .ppair .q{color:var(--text2);font-weight:400}
+    .pcard-stats{display:flex;gap:12px;margin-bottom:8px;font-family:var(--mono);font-size:11px}
+    .pcard-stats span{color:var(--text2)}
+    .pcard-stats .val{color:var(--text);font-weight:600}
+    .pcard-stats .price-val{color:var(--accent);font-weight:700}
+    .pid{font-family:var(--mono);font-size:10px;color:var(--muted)}
+    /* Loan badge in pool cards */
+    .pcard-loan{font-size:10px;font-weight:700;color:var(--blue);font-family:var(--mono)}
+
+    /* Donut chart */
+    .donut-wrap{padding:16px;display:flex;align-items:center;gap:20px}
+    .donut{width:100px;height:100px;border-radius:50%;position:relative;flex-shrink:0}
+    .donut-hole{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:60px;height:60px;border-radius:50%;background:var(--bg-card);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:16px;font-weight:700}
+    .donut-legend{flex:1;font-size:12px}
+    .leg-item{display:flex;align-items:center;gap:6px;margin-bottom:5px}
+    .leg-dot{width:8px;height:8px;border-radius:2px;flex-shrink:0}
+    .leg-name{flex:1;color:var(--text2)}
+    .leg-val{font-family:var(--mono);font-weight:600}
+
+    /* Trader list */
+    .trader-list{padding:10px;flex:1;overflow-y:auto}
+    .trow{display:flex;align-items:center;justify-content:space-between;padding:8px 12px;border-radius:6px;margin-bottom:4px;transition:background .2s}
+    .trow:hover{background:var(--bg-alt)}
+    .trank{font-family:var(--mono);font-size:11px;font-weight:700;color:var(--muted);width:26px}
+    .trank.top{color:var(--accent)}
+    .taddr{font-family:var(--mono);font-size:11px;color:var(--text2);flex:1}
+    .tcnt{font-family:var(--mono);font-size:11px;font-weight:600}
+
+    /* Flash Loan cards */
+    .fl-list{padding:10px;flex:1;overflow-y:auto;max-height:200px}
+    .fl-item{background:var(--bg-alt);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:6px;padding:10px 12px;margin-bottom:8px;font-size:12px}
+    .fl-item .fl-top{display:flex;justify-content:space-between;margin-bottom:4px}
+    .fl-item .fl-asset{font-weight:700;color:var(--accent)}
+    .fl-item .fl-time{font-family:var(--mono);font-size:11px;color:var(--muted)}
+    .fl-item .fl-detail{font-family:var(--mono);font-size:11px;color:var(--text2)}
+    @keyframes flIn{from{opacity:0;transform:translateX(-10px)}to{opacity:1;transform:translateX(0)}}
+    .fl-item.new{animation:flIn .4s ease-out}
+
+    /* Price Oracle items */
+    .po-list{padding:10px;flex:1;overflow-y:auto;max-height:200px}
+    .po-item{background:var(--bg-alt);border:1px solid var(--border);border-left:3px solid var(--blue);border-radius:6px;padding:10px 12px;margin-bottom:8px;font-size:12px}
+    .po-item .po-top{display:flex;justify-content:space-between;margin-bottom:4px}
+    .po-item .po-pair{font-weight:700;color:var(--blue)}
+    .po-item .po-time{font-family:var(--mono);font-size:11px;color:var(--muted)}
+    .po-item .po-detail{font-family:var(--mono);font-size:11px;color:var(--text2)}
+    .po-item .po-rate{color:var(--accent);font-weight:700;font-family:var(--mono)}
+    .po-dir{font-size:10px;font-weight:700;padding:1px 5px;border-radius:3px;background:#3b82f620;color:var(--blue)}
+
+    /* Scrollbar */
+    ::-webkit-scrollbar{width:5px}
+    ::-webkit-scrollbar-track{background:transparent}
+    ::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}
+    ::-webkit-scrollbar-thumb:hover{background:var(--muted)}
+
+    @media(max-width:960px){
+      .grid{grid-template-columns:1fr}
+      .stats{grid-template-columns:repeat(3,1fr)}
+    }
+  </style>
+</head>
+<body>
+<div class="dash">
+
+  <!-- Header -->
+  <header class="hdr">
+    <div class="hdr-left">
+      <div class="logo">D</div>
+      <div>
+        <div class="hdr-title">DeepBook DeFi Dashboard</div>
+        <div class="hdr-sub">Powered by Drasi Continuous Queries &middot; Sui Blockchain</div>
+      </div>
+    </div>
+    <div id="status" class="badge">
+      <span class="dot"></span>
+      <span id="statusTxt">Connecting…</span>
+    </div>
+  </header>
+
+  <!-- Stats -->
+  <div class="stats">
+    <div class="stat"><div class="stat-ico">#</div><div class="stat-lbl">Total Events</div><div class="stat-val" id="sEvents">0</div></div>
+    <div class="stat"><div class="stat-ico">~</div><div class="stat-lbl">Active Pools</div><div class="stat-val" id="sPools">0</div></div>
+    <div class="stat"><div class="stat-ico">@</div><div class="stat-lbl">Unique Traders</div><div class="stat-val" id="sTraders">0</div></div>
+    <div class="stat"><div class="stat-ico">^</div><div class="stat-lbl">Flash Loans</div><div class="stat-val" id="sFlash">0</div></div>
+    <div class="stat"><div class="stat-ico">&gt;</div><div class="stat-lbl">Throughput</div><div class="stat-val" id="sRate">0<span class="u">/min</span></div></div>
+  </div>
+
+  <!-- Price Ticker -->
+  <div class="ticker-wrap">
+    <div class="ticker-label">PRICES</div>
+    <div class="ticker" id="ticker">
+      <span class="tick-item" style="color:var(--muted)">Waiting for price updates…</span>
+    </div>
+  </div>
+
+  <!-- Main Grid -->
+  <div class="grid">
+
+    <!-- Primary: Analytical Panels -->
+    <div class="side">
+
+      <!-- Pool Overview -->
+      <div class="panel" style="flex:1.2">
+        <div class="panel-hdr"><span>Pool Overview</span><span class="tag" id="poolTag">0</span></div>
+        <div class="pool-list" id="poolList">
+          <div class="empty" id="poolEmpty" style="padding:30px 20px"><div class="spin"></div><span>Discovering pools…</span></div>
+        </div>
+      </div>
+
+      <!-- Event Distribution + Top Traders row -->
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+
+        <!-- Event Distribution -->
+        <div class="panel">
+          <div class="panel-hdr"><span>Event Distribution</span></div>
+          <div class="donut-wrap" id="donutWrap">
+            <div class="empty" id="donutEmpty" style="padding:20px"><div class="spin"></div><span>Collecting data…</span></div>
+          </div>
+        </div>
+
+        <!-- Top Traders -->
+        <div class="panel">
+          <div class="panel-hdr"><span>Top Traders</span><span class="tag" id="traderTag">0</span></div>
+          <div class="trader-list" id="traderList">
+            <div class="empty" id="traderEmpty" style="padding:30px 20px"><div class="spin"></div><span>Discovering traders…</span></div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Live Order Book + Whale Alerts row -->
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+
+        <!-- Flash Loan Activity -->
+        <div class="panel" style="max-height:340px">
+          <div class="panel-hdr"><span>Flash Loan Activity</span><span class="tag" id="flTag">0</span></div>
+          <div class="fl-list" id="flList">
+            <div class="empty" id="flEmpty" style="padding:30px 20px"><span>No flash loans yet</span></div>
+          </div>
+        </div>
+
+        <!-- Price Oracle -->
+        <div class="panel" style="max-height:340px">
+          <div class="panel-hdr"><span>Price Oracle</span><span class="tag" id="poTag">0</span></div>
+          <div class="po-list" id="poList">
+            <div class="empty" id="poEmpty" style="padding:20px"><span>No price updates yet</span></div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Secondary: Event Feed (compact sidebar) -->
+    <div class="panel feed">
+      <div class="panel-hdr"><span>Live Event Feed</span><span class="tag" id="feedTag">0</span></div>
+      <div class="feed-wrap" id="feedWrap">
+        <div class="empty" id="feedEmpty"><div class="spin"></div><span>Waiting for events…</span></div>
+        <table class="etbl" id="feedTbl" style="display:none">
+          <thead><tr><th>Time</th><th>Event</th><th>Pool</th><th>Sender</th></tr></thead>
+          <tbody id="feedBody"></tbody>
+        </table>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+(function(){
+  'use strict';
+
+  const params = new URLSearchParams(location.search);
+  const SSE = params.get('sse') || `http://${location.hostname}:8080/events`;
+  const MAX_ROWS = 200;
+
+  // ── State ──
+  const S = {
+    total: 0,
+    pools: {},          // pool_id -> {base,quote,events,loans}
+    traders: {},        // addr -> count
+    breakdown: {},      // event_name -> count
+    flashLoans: 0,
+    flashLoanList: [],  // recent flash loan items
+    priceUpdates: [],   // recent price oracle items
+    ticks: [],          // [{pair,rate,time}]
+    rateTs: [],
+  };
+
+  // ── DOM ──
+  const $ = id => document.getElementById(id);
+  const D = {
+    status:$('status'), statusTxt:$('statusTxt'),
+    sEvents:$('sEvents'), sPools:$('sPools'), sTraders:$('sTraders'), sFlash:$('sFlash'), sRate:$('sRate'),
+    ticker:$('ticker'),
+    feedTbl:$('feedTbl'), feedBody:$('feedBody'), feedEmpty:$('feedEmpty'), feedTag:$('feedTag'),
+    poolList:$('poolList'), poolEmpty:$('poolEmpty'), poolTag:$('poolTag'),
+    donutWrap:$('donutWrap'), donutEmpty:$('donutEmpty'),
+    traderList:$('traderList'), traderEmpty:$('traderEmpty'), traderTag:$('traderTag'),
+    flList:$('flList'), flEmpty:$('flEmpty'), flTag:$('flTag'),
+    poList:$('poList'), poEmpty:$('poEmpty'), poTag:$('poTag'),
+  };
+
+  // ── SSE ──
+  let es = null, reconn = null;
+  function connect(){
+    if(es) es.close();
+    es = new EventSource(SSE);
+    es.onopen = () => { D.status.className='badge on'; D.statusTxt.textContent='Live'; if(reconn){clearTimeout(reconn);reconn=null} };
+    es.onmessage = e => { try{ const d=JSON.parse(e.data); if(d.type==='heartbeat') return; dispatch(d) }catch(x){} };
+    es.onerror = () => { D.status.className='badge off'; D.statusTxt.textContent='Reconnecting…'; es.close(); reconn=setTimeout(connect,3000) };
+  }
+
+  // ── Dispatch ──
+  function dispatch(d){
+    const q=d.queryId, rs=d.results||[];
+    for(const r of rs){
+      const t=r.type, p=r.data||r.after||{};
+      switch(q){
+        case 'event-feed':        onEvent(t,r); break;
+        case 'pool-tracker':      onPool(t,p); break;
+        case 'trader-tracker':    onTrader(t,p); break;
+        case 'event-breakdown':   onBreakdown(t,r); break;
+        case 'flash-loan-tracker':onFlashLoan(t,r); break;
+        case 'price-oracle':      onPriceOracle(t,r); break;
+      }
+    }
+  }
+
+  // ── Event Feed ──
+  function onEvent(t,r){
+    if(t!=='ADD') return;
+    const ev = r.data||{};
+    const pl = ev.payload||{};
+    S.total++;
+    trackRate();
+
+    const eName = ev.event_name||'';
+
+    // Update pool event count; auto-discover pool from events if pool-tracker was missed
+    if(ev.pool_id){
+      if(!S.pools[ev.pool_id]) S.pools[ev.pool_id]={base:'',quote:'',events:0,loans:0};
+      S.pools[ev.pool_id].events++;
+    }
+
+    // Update trader count (client-side)
+    if(ev.sender){ S.traders[ev.sender] = (S.traders[ev.sender]||0)+1 }
+
+    // Track flash loans from event feed
+    if(eName === 'FlashLoanBorrowed'){
+      S.flashLoans++;
+      if(ev.pool_id && S.pools[ev.pool_id]) S.pools[ev.pool_id].loans++;
+    }
+
+    // Price ticker (for PriceAdded events)
+    if(eName === 'PriceAdded' && pl.conversion_rate && ev.pool_id){
+      const rate = (Number(pl.conversion_rate) / 1e9).toFixed(4);
+      addTick(ev.pool_id, rate, ev.timestamp_ms || ev.timestamp);
+    }
+
+    // Table row
+    addFeedRow(ev, eName);
+    renderPools(); updateStats();
+  }
+
+  function addFeedRow(ev, eName){
+    D.feedTbl.style.display='';
+    D.feedEmpty.style.display='none';
+    const tr = document.createElement('tr');
+    tr.className='flash';
+    const badge = evClass(eName);
+    const short = eName.replace('Event','');
+    tr.innerHTML =
+      '<td class="time">'+fmtTime(ev.timestamp)+'</td>'+
+      '<td><span class="evbadge '+badge+'">'+esc(short)+'</span></td>'+
+      '<td class="addr">'+trunc(ev.pool_id)+'</td>'+
+      '<td class="addr">'+trunc(ev.sender)+'</td>';
+    D.feedBody.insertBefore(tr, D.feedBody.firstChild);
+    while(D.feedBody.children.length > MAX_ROWS) D.feedBody.removeChild(D.feedBody.lastChild);
+    D.feedTag.textContent = S.total;
+  }
+
+  // ── Pool Tracker ──
+  function onPool(t,p){
+    if(t==='ADD'){
+      const id=p.pool_id; if(!id) return;
+      if(!S.pools[id]) S.pools[id]={base:assetName(p.base_asset),quote:assetName(p.quote_asset),events:0,loans:0};
+    } else if(t==='DELETE'){
+      delete S.pools[p.pool_id];
+    }
+    renderPools(); updateStats();
+  }
+
+  // ── Trader Tracker ──
+  function onTrader(t,p){
+    if(t==='ADD'){ const a=p.address; if(a && !(a in S.traders)) S.traders[a]=0 }
+    else if(t==='DELETE'){ delete S.traders[p.address] }
+    renderTraders(); updateStats();
+  }
+
+  // ── Event Breakdown (aggregation) ──
+  function onBreakdown(t,r){
+    const d = r.data||r.after||{};
+    const name = d.event_name;
+    const cnt  = toNum(d.cnt);
+    if(!name) return;
+    if(t==='ADD'||t==='UPDATE') S.breakdown[name]=cnt;
+    else if(t==='DELETE') delete S.breakdown[name];
+    // Also handle aggregation type
+    if(t==='aggregation'){ const a=r.after||{}; if(a.event_name) S.breakdown[a.event_name]=toNum(a.cnt) }
+    renderDonut();
+  }
+
+  // ── Flash Loan Tracker (from flash-loan-tracker query) ──
+  function onFlashLoan(t,r){
+    if(t!=='ADD') return;
+    const d = r.data||{};
+    const pl = d.payload||{};
+    S.flashLoans++;
+    if(d.pool_id && S.pools[d.pool_id]) S.pools[d.pool_id].loans++;
+
+    const typeName = (pl.type_name && pl.type_name.name) || '';
+    const isSui = typeName.includes('sui::SUI');
+    const decimals = isSui ? 9 : 6;
+    const rawQty = Number(pl.borrow_quantity) || 0;
+    const qty = (rawQty / Math.pow(10, decimals)).toLocaleString(undefined, {maximumFractionDigits:2});
+    const assetShort = typeName ? typeName.split('::').pop() : '?';
+    const pool = S.pools[d.pool_id];
+    const poolName = pool && pool.base ? pool.base+'/'+pool.quote : trunc(d.pool_id);
+
+    S.flashLoanList.unshift({asset:assetShort, qty, poolName, sender:d.sender, time:fmtTime(d.timestamp)});
+    if(S.flashLoanList.length > 20) S.flashLoanList.pop();
+
+    D.flEmpty.style.display='none';
+    D.flTag.textContent = S.flashLoans;
+
+    const div = document.createElement('div');
+    div.className='fl-item new';
+    div.innerHTML =
+      '<div class="fl-top"><span class="fl-asset">⚡ '+esc(qty)+' '+esc(assetShort)+'</span><span class="fl-time">'+esc(S.flashLoanList[0].time)+'</span></div>'+
+      '<div class="fl-detail">Pool: '+esc(poolName)+' — '+trunc(d.sender)+'</div>';
+    D.flList.insertBefore(div, D.flList.querySelector('.fl-item'));
+    while(D.flList.querySelectorAll('.fl-item').length > 10){
+      const last = D.flList.querySelector('.fl-item:last-of-type');
+      if(last) last.remove();
+    }
+    updateStats();
+  }
+
+  // ── Price Oracle (from price-oracle query) ──
+  function onPriceOracle(t,r){
+    if(t!=='ADD') return;
+    const d = r.data||{};
+    const pl = d.payload||{};
+    const rate = (Number(pl.conversion_rate) / 1e9).toFixed(4);
+    const isBase = pl.is_base_conversion === true || pl.is_base_conversion === 'true';
+    const refPool = pl.reference_pool || '';
+    const tgtPool = pl.target_pool || '';
+    const refName = S.pools[refPool] ? S.pools[refPool].base+'/'+S.pools[refPool].quote : trunc(refPool);
+    const tgtName = S.pools[tgtPool] ? S.pools[tgtPool].base+'/'+S.pools[tgtPool].quote : trunc(tgtPool);
+
+    S.priceUpdates.unshift({refName, tgtName, rate, isBase, time:fmtTime(d.timestamp)});
+    if(S.priceUpdates.length > 30) S.priceUpdates.pop();
+
+    D.poEmpty.style.display='none';
+    D.poTag.textContent = S.priceUpdates.length;
+
+    const div = document.createElement('div');
+    div.className='po-item new';
+    div.innerHTML =
+      '<div class="po-top"><span class="po-pair">'+esc(refName)+' → '+esc(tgtName)+'</span><span class="po-time">'+esc(S.priceUpdates[0].time)+'</span></div>'+
+      '<div class="po-detail">Rate: <span class="po-rate">'+esc(rate)+'</span> <span class="po-dir">'+(isBase?'Base':'Quote')+'</span></div>';
+    D.poList.insertBefore(div, D.poList.querySelector('.po-item'));
+    while(D.poList.querySelectorAll('.po-item').length > 10){
+      const last = D.poList.querySelector('.po-item:last-of-type');
+      if(last) last.remove();
+    }
+
+    // Also feed price ticker
+    addTick(refPool, rate, d.timestamp);
+  }
+
+  // ── Price Ticker ──
+  function addTick(poolId, rate, ts){
+    const pool = S.pools[poolId];
+    const pair = pool && pool.base ? pool.base+'/'+pool.quote : trunc(poolId);
+    S.ticks.push({pair, rate, time:fmtTime(ts)});
+    if(S.ticks.length>60) S.ticks.shift();
+    renderTicker();
+  }
+
+  function renderTicker(){
+    if(!S.ticks.length) return;
+    D.ticker.classList.add('scrolling');
+    const items = [...S.ticks, ...S.ticks];
+    D.ticker.innerHTML = items.map(t =>
+      '<span class="tick-item"><span class="tick-pair">'+esc(t.pair)+'</span><span class="tick-price">'+esc(t.rate)+'</span><span class="tick-time">'+esc(t.time)+'</span></span>'
+    ).join('');
+  }
+
+  // ── Pool Cards ──
+  function renderPools(){
+    const ids = Object.keys(S.pools);
+    D.poolEmpty.style.display = ids.length?'none':'';
+    D.poolTag.textContent = ids.length;
+    ids.sort((a,b) => S.pools[b].events - S.pools[a].events);
+
+    const frag = document.createDocumentFragment();
+    for(const id of ids){
+      const p = S.pools[id];
+
+      const card = document.createElement('div');
+      card.className='pcard';
+      card.innerHTML =
+        '<div class="pcard-row"><span class="ppair">'+esc(p.base)+' <span class="q">/ '+esc(p.quote)+'</span></span></div>'+
+        '<div class="pcard-stats">'+
+          '<span>Events: <span class="val">'+p.events+'</span></span>'+
+          '<span>Loans: <span class="val pcard-loan">'+p.loans+'</span></span>'+
+        '</div>'+
+        '<div class="pid" style="margin-top:4px">'+trunc(id)+'</div>';
+      frag.appendChild(card);
+    }
+    const old = D.poolList.querySelectorAll('.pcard');
+    old.forEach(el=>el.remove());
+    D.poolList.appendChild(frag);
+  }
+
+  // ── Donut Chart ──
+  const DONUT_COLORS = ['#3b82f6','#00e5a0','#ef4444','#f59e0b','#a78bfa','#fb923c','#06b6d4','#ec4899'];
+  function renderDonut(){
+    const names = Object.keys(S.breakdown);
+    if(!names.length) return;
+    D.donutEmpty.style.display='none';
+
+    const total = names.reduce((s,n)=>s+S.breakdown[n],0);
+    names.sort((a,b)=>S.breakdown[b]-S.breakdown[a]);
+
+    // Conic gradient
+    let grad='', pct=0;
+    const legendHtml=[];
+    for(let i=0;i<names.length;i++){
+      const n=names[i], c=DONUT_COLORS[i%DONUT_COLORS.length];
+      const slice = total?S.breakdown[n]/total*100:0;
+      grad += (i?',':'') + c+' '+pct+'% '+(pct+slice)+'%';
+      pct+=slice;
+      legendHtml.push(
+        '<div class="leg-item"><div class="leg-dot" style="background:'+c+'"></div>'+
+        '<span class="leg-name">'+esc(n.replace('Event',''))+'</span>'+
+        '<span class="leg-val">'+S.breakdown[n]+'</span></div>'
+      );
+    }
+
+    D.donutWrap.innerHTML =
+      '<div class="donut" style="background:conic-gradient('+grad+')"><div class="donut-hole">'+total+'</div></div>'+
+      '<div class="donut-legend">'+legendHtml.join('')+'</div>';
+  }
+
+  // ── Trader Leaderboard ──
+  function renderTraders(){
+    const addrs = Object.keys(S.traders);
+    D.traderEmpty.style.display = addrs.length?'none':'';
+    D.traderTag.textContent = addrs.length;
+    addrs.sort((a,b)=>S.traders[b]-S.traders[a]);
+    const top = addrs.slice(0,15);
+
+    const frag = document.createDocumentFragment();
+    for(let i=0;i<top.length;i++){
+      const a=top[i], c=S.traders[a];
+      const row = document.createElement('div');
+      row.className='trow';
+      row.innerHTML='<span class="trank '+(i<3?'top':'')+'">'+(i+1)+'.</span><span class="taddr">'+trunc(a)+'</span><span class="tcnt">'+c+'</span>';
+      frag.appendChild(row);
+    }
+    const old = D.traderList.querySelectorAll('.trow');
+    old.forEach(el=>el.remove());
+    D.traderList.appendChild(frag);
+  }
+
+  // ── Stats ──
+  function updateStats(){
+    D.sEvents.textContent = S.total.toLocaleString();
+    D.sPools.textContent = Object.keys(S.pools).length;
+    D.sTraders.textContent = Object.keys(S.traders).length;
+    D.sFlash.textContent = S.flashLoans.toLocaleString();
+  }
+
+  function trackRate(){ const now=Date.now(); S.rateTs.push(now); while(S.rateTs.length&&S.rateTs[0]<now-60000) S.rateTs.shift() }
+  setInterval(()=>{
+    const now=Date.now(); while(S.rateTs.length&&S.rateTs[0]<now-60000) S.rateTs.shift();
+    D.sRate.innerHTML=S.rateTs.length+'<span class="u">/min</span>';
+  },1000);
+
+  // ── Helpers ──
+  function fmtTime(ts){ if(!ts) return '—'; const n=typeof ts==='string'?parseInt(ts,10):ts; if(isNaN(n)) return '—'; return new Date(n).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'}) }
+  function trunc(s){ if(!s) return '—'; if(s.length<=14) return s; return s.slice(0,8)+'…'+s.slice(-6) }
+  function assetName(t){ if(!t) return '?'; const p=t.split('::'); return p.length>=3?p[p.length-1]:t }
+  function toNum(v){ const n=Number(v); return isNaN(n)?0:n }
+  function esc(s){ if(!s) return ''; const el=document.createElement('span'); el.textContent=s; return el.innerHTML }
+  function evClass(n){ if(!n) return 'ev-other'; if(n==='PriceAdded') return 'ev-placed'; if(n==='FlashLoanBorrowed') return 'ev-filled'; if(n==='ReferralClaimed') return 'ev-modify'; return 'ev-other' }
+
+  connect();
+})();
+</script>
+</body>
+</html>

--- a/examples/lib/sui-deepbook-getting-started/dashboard.html
+++ b/examples/lib/sui-deepbook-getting-started/dashboard.html
@@ -263,16 +263,16 @@
   function dispatch(d){
     const q = d.queryId, rs = d.results || [];
     for(const r of rs){
-      const t = r.type, p = r.data || r.after || {};
+      const t = r.type;
       if(q === 'event-feed') onEvent(t, r);
-      else if(q === 'pool-tracker') onPool(t, p);
+      else if(q === 'pool-tracker') onPool(t, r);
     }
   }
 
   // ── Event Handler ──
   function onEvent(t, r){
-    if(t !== 'ADD') return;
-    const ev = r.data || {};
+    if(t === 'DELETE') return;
+    const ev = (t === 'UPDATE') ? (r.after || {}) : (r.data || {});
     const pl = safePl(ev.payload);
     const eName = ev.event_name || '';
     S.total++;
@@ -317,15 +317,17 @@
   }
 
   // ── Pool Tracker ──
-  function onPool(t, p){
-    if(t === 'ADD'){
-      const id = p.pool_id; if(!id) return;
-      S.pools[id] = { base: assetName(p.base_asset), quote: assetName(p.quote_asset) };
-      renderPoolSelect();
-    } else if(t === 'DELETE'){
+  function onPool(t, r){
+    if(t === 'DELETE'){
+      const p = r.data || r.before || {};
       delete S.pools[p.pool_id];
       renderPoolSelect();
+      return;
     }
+    const p = (t === 'UPDATE') ? (r.after || {}) : (r.data || {});
+    const id = p.pool_id; if(!id) return;
+    S.pools[id] = { base: assetName(p.base_asset), quote: assetName(p.quote_asset) };
+    renderPoolSelect();
   }
 
   // ── Render Order Book ──

--- a/examples/lib/sui-deepbook-getting-started/dashboard.html
+++ b/examples/lib/sui-deepbook-getting-started/dashboard.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DeepBook DeFi Dashboard — Drasi</title>
+  <title>DeepBook Order Book — Drasi</title>
   <style>
     :root {
       --bg: #0c0f1a;
@@ -20,145 +20,110 @@
       --blue: #3b82f6;
       --yellow: #f59e0b;
       --red: #ef4444;
+      --red-d: #ef444433;
       --purple: #a78bfa;
-      --orange: #fb923c;
       --mono: 'JetBrains Mono','Fira Code','SF Mono',Consolas,monospace;
       --sans: 'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
     }
     *{margin:0;padding:0;box-sizing:border-box}
     body{font-family:var(--sans);background:var(--bg);color:var(--text);min-height:100vh;overflow-x:hidden}
-    .dash{max-width:1480px;margin:0 auto;padding:20px 24px}
+    .dash{max-width:1480px;margin:0 auto;padding:16px 24px}
 
     /* Header */
-    .hdr{display:flex;align-items:center;justify-content:space-between;padding:14px 0 18px;border-bottom:1px solid var(--border);margin-bottom:18px}
+    .hdr{display:flex;align-items:center;justify-content:space-between;padding:12px 0 14px;border-bottom:1px solid var(--border);margin-bottom:14px}
     .hdr-left{display:flex;align-items:center;gap:14px}
-    .logo{width:36px;height:36px;background:linear-gradient(135deg,var(--accent),var(--blue));border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:700;color:var(--bg)}
-    .hdr-title{font-size:22px;font-weight:700;letter-spacing:-.5px}
-    .hdr-sub{font-size:12px;color:var(--muted);margin-top:2px}
-    .badge{display:flex;align-items:center;gap:6px;padding:6px 14px;border-radius:20px;font-size:12px;font-weight:600;border:1px solid var(--border);background:var(--bg-card)}
-    .dot{width:8px;height:8px;border-radius:50%;background:var(--muted);transition:background .3s}
+    .logo{width:34px;height:34px;background:linear-gradient(135deg,var(--accent),var(--blue));border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:17px;font-weight:700;color:var(--bg)}
+    .hdr-title{font-size:20px;font-weight:700;letter-spacing:-.5px}
+    .hdr-sub{font-size:11px;color:var(--muted);margin-top:1px}
+    .hdr-right{display:flex;align-items:center;gap:12px}
+    .pool-select{background:var(--bg-card);border:1px solid var(--border);color:var(--text);padding:6px 12px;border-radius:8px;font-size:13px;font-family:var(--sans);cursor:pointer;min-width:180px;outline:none;transition:border-color .2s}
+    .pool-select:hover,.pool-select:focus{border-color:var(--accent)}
+    .pool-select option{background:var(--bg-card);color:var(--text)}
+    .badge{display:flex;align-items:center;gap:6px;padding:5px 12px;border-radius:20px;font-size:11px;font-weight:600;border:1px solid var(--border);background:var(--bg-card)}
+    .dot{width:7px;height:7px;border-radius:50%;background:var(--muted);transition:background .3s}
     .badge.on .dot{background:var(--accent);box-shadow:0 0 8px var(--accent)}
     .badge.on{border-color:var(--accent-d);color:var(--accent)}
-    .badge.off .dot{background:var(--red);box-shadow:0 0 8px var(--red)}
-    .badge.off{border-color:#ef444444;color:var(--red)}
 
     /* Stats */
-    .stats{display:grid;grid-template-columns:repeat(5,1fr);gap:14px;margin-bottom:16px}
-    .stat{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:14px 18px;transition:border-color .3s}
-    .stat:hover{border-color:var(--glow)}
-    .stat-lbl{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--muted);margin-bottom:6px}
-    .stat-val{font-family:var(--mono);font-size:24px;font-weight:700;line-height:1}
-    .stat-val .u{font-size:12px;font-weight:400;color:var(--text2);margin-left:3px}
-    .stat-ico{float:right;font-family:var(--mono);font-size:18px;color:var(--accent);opacity:.5;margin-top:-2px}
-
-    /* Ticker */
-    .ticker-wrap{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;overflow:hidden;margin-bottom:16px;height:38px;position:relative}
-    .ticker-label{position:absolute;left:0;top:0;bottom:0;width:96px;background:var(--bg-card);z-index:2;display:flex;align-items:center;padding-left:14px;font-size:11px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.5px}
-    .ticker{display:flex;align-items:center;height:100%;gap:28px;padding-left:96px;white-space:nowrap}
-    .ticker.scrolling{animation:scroll 40s linear infinite}
-    .ticker.scrolling:hover{animation-play-state:paused}
-    .tick-item{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:13px}
-    .tick-pair{font-weight:600;color:var(--text)}
-    .tick-price{color:var(--accent)}
-    .tick-time{color:var(--muted);font-size:11px}
-    @keyframes scroll{from{transform:translateX(0)}to{transform:translateX(-50%)}}
+    .stats{display:grid;grid-template-columns:repeat(6,1fr);gap:10px;margin-bottom:14px}
+    .stat{background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:10px 14px}
+    .stat-lbl{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.7px;color:var(--muted);margin-bottom:4px}
+    .stat-val{font-family:var(--mono);font-size:18px;font-weight:700;line-height:1}
+    .stat-val.bid{color:var(--accent)}
+    .stat-val.ask{color:var(--red)}
+    .stat-val .u{font-size:11px;font-weight:400;color:var(--text2);margin-left:2px}
 
     /* Main grid */
-    .grid{display:grid;grid-template-columns:1fr 360px;gap:18px;min-height:520px}
+    .grid{display:grid;grid-template-columns:1fr 340px;gap:14px;min-height:600px}
 
     /* Panels */
     .panel{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;overflow:hidden;display:flex;flex-direction:column}
-    .panel-hdr{display:flex;align-items:center;justify-content:space-between;padding:12px 18px;border-bottom:1px solid var(--border);font-size:13px;font-weight:600}
+    .panel-hdr{display:flex;align-items:center;justify-content:space-between;padding:10px 16px;border-bottom:1px solid var(--border);font-size:13px;font-weight:600}
     .panel-hdr .tag{font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:6px;background:var(--accent-d);color:var(--accent)}
 
-    /* Event feed table */
-    .feed{overflow:hidden;height:100%}
+    /* Order Book */
+    .book-content{flex:1;display:flex;flex-direction:column;overflow:hidden}
+    .book-header{display:grid;grid-template-columns:1fr 1fr 1fr;padding:6px 16px;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.6px;color:var(--muted);border-bottom:1px solid var(--border)}
+    .book-header span:last-child{text-align:right}
+    .book-asks{flex:1;display:flex;flex-direction:column;justify-content:flex-end;overflow:hidden;min-height:0}
+    .book-spread{padding:8px 16px;text-align:center;font-family:var(--mono);font-size:13px;font-weight:700;color:var(--yellow);border-top:1px solid var(--border);border-bottom:1px solid var(--border);background:var(--bg-alt)}
+    .book-bids{flex:1;overflow:hidden;min-height:0}
+    .book-row{display:grid;grid-template-columns:1fr 1fr 1fr;padding:3px 16px;font-family:var(--mono);font-size:12px;position:relative;transition:background .15s;cursor:default}
+    .book-row:hover{background:var(--bg-hover)}
+    .book-row span{position:relative;z-index:1}
+    .book-row span:last-child{text-align:right}
+    .book-row::before{content:'';position:absolute;top:0;bottom:0;width:var(--depth,0%);z-index:0;opacity:.15;transition:width .3s ease}
+    .book-row.bid{color:var(--accent)}
+    .book-row.bid::before{right:0;background:var(--accent)}
+    .book-row.ask{color:var(--red)}
+    .book-row.ask::before{right:0;background:var(--red)}
+    .book-row.bid .r-price{color:var(--accent)}
+    .book-row.ask .r-price{color:var(--red)}
+    .book-row .r-size{color:var(--text)}
+    .book-row .r-total{color:var(--text2)}
+    @keyframes bookFlash{from{background:rgba(255,255,255,.06)}to{background:transparent}}
+    .book-row.flash{animation:bookFlash .6s ease-out}
+
+    /* Empty / spinner */
+    .empty{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:40px 20px;color:var(--muted);font-size:12px;gap:8px;flex:1}
+    .spin{width:20px;height:20px;border:2px solid var(--border);border-top-color:var(--accent);border-radius:50%;animation:sp .8s linear infinite}
+    @keyframes sp{to{transform:rotate(360deg)}}
+
+    /* Sidebar */
+    .side{display:flex;flex-direction:column;gap:14px}
+
+    /* Recent Trades */
+    .trades-wrap{flex:1;overflow-y:auto}
+    .ttbl{width:100%;border-collapse:collapse;font-size:11px}
+    .ttbl thead th{position:sticky;top:0;background:var(--bg-card);padding:6px 10px;text-align:left;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;color:var(--muted);border-bottom:1px solid var(--border);z-index:1}
+    .ttbl thead th:last-child{text-align:right}
+    .ttbl tbody tr{border-bottom:1px solid #1a1f35}
+    .ttbl td{padding:5px 10px;font-family:var(--mono);white-space:nowrap}
+    .ttbl td:last-child{text-align:right;color:var(--muted);font-size:10px}
+    .ttbl .t-buy{color:var(--accent)}
+    .ttbl .t-sell{color:var(--red)}
+    @keyframes tradeFlash{from{background:rgba(255,255,255,.04)}to{background:transparent}}
+    .ttbl tbody tr.flash{animation:tradeFlash .5s ease-out}
+
+    /* Event Feed */
     .feed-wrap{flex:1;overflow-y:auto}
-    .etbl{width:100%;border-collapse:collapse;font-size:12px}
-    .etbl thead th{position:sticky;top:0;background:var(--bg-card);padding:8px 10px;text-align:left;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.6px;color:var(--muted);border-bottom:1px solid var(--border);z-index:1}
-    .etbl tbody tr{border-bottom:1px solid var(--border);transition:background .15s}
-    .etbl tbody tr:hover{background:var(--bg-hover)}
-    .etbl td{padding:8px 10px;white-space:nowrap;vertical-align:middle}
-    .addr{font-family:var(--mono);font-size:11px;color:var(--text2)}
-    .time{font-family:var(--mono);font-size:11px;color:var(--muted)}
-    .evbadge{display:inline-block;padding:2px 7px;border-radius:4px;font-size:10px;font-weight:700;letter-spacing:.2px}
+    .etbl{width:100%;border-collapse:collapse;font-size:11px}
+    .etbl thead th{position:sticky;top:0;background:var(--bg-card);padding:6px 10px;text-align:left;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;color:var(--muted);border-bottom:1px solid var(--border);z-index:1}
+    .etbl tbody tr{border-bottom:1px solid #1a1f35}
+    .etbl td{padding:4px 10px;font-size:11px;white-space:nowrap}
+    .evbadge{display:inline-block;padding:1px 6px;border-radius:3px;font-size:9px;font-weight:700;letter-spacing:.2px}
     .ev-placed{background:#3b82f620;color:var(--blue)}
     .ev-filled{background:#00e5a020;color:var(--accent)}
     .ev-cancel{background:#ef444420;color:var(--red)}
     .ev-modify{background:#f59e0b20;color:var(--yellow)}
     .ev-other{background:#a78bfa20;color:var(--purple)}
-    .side-bid{font-size:10px;font-weight:700;color:var(--accent)}
-    .side-ask{font-size:10px;font-weight:700;color:var(--red)}
-    @keyframes flash{from{background:var(--accent-d)}to{background:transparent}}
-    .etbl tbody tr.flash{animation:flash 1s ease-out}
-
-    /* Empty / spinner */
-    .empty{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:50px 20px;color:var(--muted);font-size:13px;gap:8px}
-    .spin{width:22px;height:22px;border:2px solid var(--border);border-top-color:var(--accent);border-radius:50%;animation:sp 1s linear infinite}
-    @keyframes sp{to{transform:rotate(360deg)}}
-
-    /* Sidebar */
-    .side{display:flex;flex-direction:column;gap:16px}
-
-    /* Pool cards */
-    .pool-list{padding:10px;flex:1;overflow-y:auto}
-    .pcard{background:var(--bg-alt);border:1px solid var(--border);border-radius:8px;padding:12px 14px;margin-bottom:10px;transition:border-color .3s,transform .1s}
-    .pcard:hover{border-color:var(--glow);transform:translateY(-1px)}
-    .pcard-row{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px}
-    .ppair{font-size:14px;font-weight:700;letter-spacing:-.3px}
-    .ppair .q{color:var(--text2);font-weight:400}
-    .pcard-stats{display:flex;gap:12px;margin-bottom:8px;font-family:var(--mono);font-size:11px}
-    .pcard-stats span{color:var(--text2)}
-    .pcard-stats .val{color:var(--text);font-weight:600}
-    .pcard-stats .price-val{color:var(--accent);font-weight:700}
-    .pid{font-family:var(--mono);font-size:10px;color:var(--muted)}
-    /* Loan badge in pool cards */
-    .pcard-loan{font-size:10px;font-weight:700;color:var(--blue);font-family:var(--mono)}
-
-    /* Donut chart */
-    .donut-wrap{padding:16px;display:flex;align-items:center;gap:20px}
-    .donut{width:100px;height:100px;border-radius:50%;position:relative;flex-shrink:0}
-    .donut-hole{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:60px;height:60px;border-radius:50%;background:var(--bg-card);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:16px;font-weight:700}
-    .donut-legend{flex:1;font-size:12px}
-    .leg-item{display:flex;align-items:center;gap:6px;margin-bottom:5px}
-    .leg-dot{width:8px;height:8px;border-radius:2px;flex-shrink:0}
-    .leg-name{flex:1;color:var(--text2)}
-    .leg-val{font-family:var(--mono);font-weight:600}
-
-    /* Trader list */
-    .trader-list{padding:10px;flex:1;overflow-y:auto}
-    .trow{display:flex;align-items:center;justify-content:space-between;padding:8px 12px;border-radius:6px;margin-bottom:4px;transition:background .2s}
-    .trow:hover{background:var(--bg-alt)}
-    .trank{font-family:var(--mono);font-size:11px;font-weight:700;color:var(--muted);width:26px}
-    .trank.top{color:var(--accent)}
-    .taddr{font-family:var(--mono);font-size:11px;color:var(--text2);flex:1}
-    .tcnt{font-family:var(--mono);font-size:11px;font-weight:600}
-
-    /* Flash Loan cards */
-    .fl-list{padding:10px;flex:1;overflow-y:auto;max-height:200px}
-    .fl-item{background:var(--bg-alt);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:6px;padding:10px 12px;margin-bottom:8px;font-size:12px}
-    .fl-item .fl-top{display:flex;justify-content:space-between;margin-bottom:4px}
-    .fl-item .fl-asset{font-weight:700;color:var(--accent)}
-    .fl-item .fl-time{font-family:var(--mono);font-size:11px;color:var(--muted)}
-    .fl-item .fl-detail{font-family:var(--mono);font-size:11px;color:var(--text2)}
-    @keyframes flIn{from{opacity:0;transform:translateX(-10px)}to{opacity:1;transform:translateX(0)}}
-    .fl-item.new{animation:flIn .4s ease-out}
-
-    /* Price Oracle items */
-    .po-list{padding:10px;flex:1;overflow-y:auto;max-height:200px}
-    .po-item{background:var(--bg-alt);border:1px solid var(--border);border-left:3px solid var(--blue);border-radius:6px;padding:10px 12px;margin-bottom:8px;font-size:12px}
-    .po-item .po-top{display:flex;justify-content:space-between;margin-bottom:4px}
-    .po-item .po-pair{font-weight:700;color:var(--blue)}
-    .po-item .po-time{font-family:var(--mono);font-size:11px;color:var(--muted)}
-    .po-item .po-detail{font-family:var(--mono);font-size:11px;color:var(--text2)}
-    .po-item .po-rate{color:var(--accent);font-weight:700;font-family:var(--mono)}
-    .po-dir{font-size:10px;font-weight:700;padding:1px 5px;border-radius:3px;background:#3b82f620;color:var(--blue)}
+    .addr{font-family:var(--mono);font-size:10px;color:var(--text2)}
+    .time{font-family:var(--mono);font-size:10px;color:var(--muted)}
 
     /* Scrollbar */
-    ::-webkit-scrollbar{width:5px}
+    ::-webkit-scrollbar{width:4px}
     ::-webkit-scrollbar-track{background:transparent}
-    ::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}
-    ::-webkit-scrollbar-thumb:hover{background:var(--muted)}
+    ::-webkit-scrollbar-thumb{background:var(--border);border-radius:2px}
 
     @media(max-width:960px){
       .grid{grid-template-columns:1fr}
@@ -174,102 +139,77 @@
     <div class="hdr-left">
       <div class="logo">D</div>
       <div>
-        <div class="hdr-title">DeepBook DeFi Dashboard</div>
+        <div class="hdr-title">DeepBook Order Book</div>
         <div class="hdr-sub">Powered by Drasi Continuous Queries &middot; Sui Blockchain</div>
       </div>
     </div>
-    <div id="status" class="badge">
-      <span class="dot"></span>
-      <span id="statusTxt">Connecting…</span>
+    <div class="hdr-right">
+      <select id="poolSelect" class="pool-select">
+        <option value="">All Pools</option>
+      </select>
+      <div id="status" class="badge">
+        <span class="dot"></span>
+        <span id="statusTxt">Connecting&hellip;</span>
+      </div>
     </div>
   </header>
 
   <!-- Stats -->
   <div class="stats">
-    <div class="stat"><div class="stat-ico">#</div><div class="stat-lbl">Total Events</div><div class="stat-val" id="sEvents">0</div></div>
-    <div class="stat"><div class="stat-ico">~</div><div class="stat-lbl">Active Pools</div><div class="stat-val" id="sPools">0</div></div>
-    <div class="stat"><div class="stat-ico">@</div><div class="stat-lbl">Unique Traders</div><div class="stat-val" id="sTraders">0</div></div>
-    <div class="stat"><div class="stat-ico">^</div><div class="stat-lbl">Flash Loans</div><div class="stat-val" id="sFlash">0</div></div>
-    <div class="stat"><div class="stat-ico">&gt;</div><div class="stat-lbl">Throughput</div><div class="stat-val" id="sRate">0<span class="u">/min</span></div></div>
-  </div>
-
-  <!-- Price Ticker -->
-  <div class="ticker-wrap">
-    <div class="ticker-label">PRICES</div>
-    <div class="ticker" id="ticker">
-      <span class="tick-item" style="color:var(--muted)">Waiting for price updates…</span>
-    </div>
+    <div class="stat"><div class="stat-lbl">Events</div><div class="stat-val" id="sEvents">0</div></div>
+    <div class="stat"><div class="stat-lbl">Book Depth</div><div class="stat-val" id="sDepth">0<span class="u">levels</span></div></div>
+    <div class="stat"><div class="stat-lbl">Best Bid</div><div class="stat-val bid" id="sBid">&mdash;</div></div>
+    <div class="stat"><div class="stat-lbl">Spread</div><div class="stat-val" id="sSpread">&mdash;</div></div>
+    <div class="stat"><div class="stat-lbl">Best Ask</div><div class="stat-val ask" id="sAsk">&mdash;</div></div>
+    <div class="stat"><div class="stat-lbl">Trades</div><div class="stat-val" id="sTrades">0</div></div>
   </div>
 
   <!-- Main Grid -->
   <div class="grid">
 
-    <!-- Primary: Analytical Panels -->
+    <!-- Order Book -->
+    <div class="panel">
+      <div class="panel-hdr">
+        <span>Order Book</span>
+        <span class="tag" id="bookTag">0 orders</span>
+      </div>
+      <div class="book-content">
+        <div class="book-header"><span>Price</span><span>Size</span><span>Total</span></div>
+        <div class="book-asks" id="askSide"></div>
+        <div class="book-spread" id="spreadBar">Spread: &mdash;</div>
+        <div class="book-bids" id="bidSide"></div>
+        <div class="empty" id="bookEmpty"><div class="spin"></div><span>Building order book&hellip;</span></div>
+      </div>
+    </div>
+
+    <!-- Sidebar -->
     <div class="side">
 
-      <!-- Pool Overview -->
-      <div class="panel" style="flex:1.2">
-        <div class="panel-hdr"><span>Pool Overview</span><span class="tag" id="poolTag">0</span></div>
-        <div class="pool-list" id="poolList">
-          <div class="empty" id="poolEmpty" style="padding:30px 20px"><div class="spin"></div><span>Discovering pools…</span></div>
+      <!-- Recent Trades -->
+      <div class="panel" style="flex:1">
+        <div class="panel-hdr"><span>Recent Trades</span><span class="tag" id="tradeTag">0</span></div>
+        <div class="trades-wrap" id="tradesWrap">
+          <div class="empty" id="tradeEmpty"><span>Waiting for trades&hellip;</span></div>
+          <table class="ttbl" id="tradeTbl" style="display:none">
+            <thead><tr><th>Price</th><th>Size</th><th>Time</th></tr></thead>
+            <tbody id="tradeBody"></tbody>
+          </table>
         </div>
       </div>
 
-      <!-- Event Distribution + Top Traders row -->
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
-
-        <!-- Event Distribution -->
-        <div class="panel">
-          <div class="panel-hdr"><span>Event Distribution</span></div>
-          <div class="donut-wrap" id="donutWrap">
-            <div class="empty" id="donutEmpty" style="padding:20px"><div class="spin"></div><span>Collecting data…</span></div>
-          </div>
+      <!-- Event Feed -->
+      <div class="panel" style="flex:1">
+        <div class="panel-hdr"><span>Event Feed</span><span class="tag" id="feedTag">0</span></div>
+        <div class="feed-wrap" id="feedWrap">
+          <div class="empty" id="feedEmpty"><div class="spin"></div><span>Waiting for events&hellip;</span></div>
+          <table class="etbl" id="feedTbl" style="display:none">
+            <thead><tr><th>Time</th><th>Event</th><th>Pool</th></tr></thead>
+            <tbody id="feedBody"></tbody>
+          </table>
         </div>
-
-        <!-- Top Traders -->
-        <div class="panel">
-          <div class="panel-hdr"><span>Top Traders</span><span class="tag" id="traderTag">0</span></div>
-          <div class="trader-list" id="traderList">
-            <div class="empty" id="traderEmpty" style="padding:30px 20px"><div class="spin"></div><span>Discovering traders…</span></div>
-          </div>
-        </div>
-
       </div>
 
-      <!-- Live Order Book + Whale Alerts row -->
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
-
-        <!-- Flash Loan Activity -->
-        <div class="panel" style="max-height:340px">
-          <div class="panel-hdr"><span>Flash Loan Activity</span><span class="tag" id="flTag">0</span></div>
-          <div class="fl-list" id="flList">
-            <div class="empty" id="flEmpty" style="padding:30px 20px"><span>No flash loans yet</span></div>
-          </div>
-        </div>
-
-        <!-- Price Oracle -->
-        <div class="panel" style="max-height:340px">
-          <div class="panel-hdr"><span>Price Oracle</span><span class="tag" id="poTag">0</span></div>
-          <div class="po-list" id="poList">
-            <div class="empty" id="poEmpty" style="padding:20px"><span>No price updates yet</span></div>
-          </div>
-        </div>
-
-      </div>
     </div>
-
-    <!-- Secondary: Event Feed (compact sidebar) -->
-    <div class="panel feed">
-      <div class="panel-hdr"><span>Live Event Feed</span><span class="tag" id="feedTag">0</span></div>
-      <div class="feed-wrap" id="feedWrap">
-        <div class="empty" id="feedEmpty"><div class="spin"></div><span>Waiting for events…</span></div>
-        <table class="etbl" id="feedTbl" style="display:none">
-          <thead><tr><th>Time</th><th>Event</th><th>Pool</th><th>Sender</th></tr></thead>
-          <tbody id="feedBody"></tbody>
-        </table>
-      </div>
-    </div>
-
   </div>
 </div>
 
@@ -279,18 +219,20 @@
 
   const params = new URLSearchParams(location.search);
   const SSE = params.get('sse') || `http://${location.hostname}:8080/events`;
-  const MAX_ROWS = 200;
+  const MAX_ROWS = 100;
+  const MAX_LEVELS = 15;
+
+  // DeepBook V3 scaling factors
+  const PRICE_SCALE = 1e9;
+  const QTY_SCALE = 1e9;
 
   // ── State ──
   const S = {
     total: 0,
-    pools: {},          // pool_id -> {base,quote,events,loans}
-    traders: {},        // addr -> count
-    breakdown: {},      // event_name -> count
-    flashLoans: 0,
-    flashLoanList: [],  // recent flash loan items
-    priceUpdates: [],   // recent price oracle items
-    ticks: [],          // [{pair,rate,time}]
+    tradeCount: 0,
+    pools: {},           // pool_id -> {base, quote}
+    selectedPool: '',    // '' = all pools
+    orders: {},          // order_id_str -> {pool_id, price, quantity, is_bid}
     rateTs: [],
   };
 
@@ -298,15 +240,14 @@
   const $ = id => document.getElementById(id);
   const D = {
     status:$('status'), statusTxt:$('statusTxt'),
-    sEvents:$('sEvents'), sPools:$('sPools'), sTraders:$('sTraders'), sFlash:$('sFlash'), sRate:$('sRate'),
-    ticker:$('ticker'),
+    sEvents:$('sEvents'), sDepth:$('sDepth'), sBid:$('sBid'), sAsk:$('sAsk'), sSpread:$('sSpread'), sTrades:$('sTrades'),
+    poolSelect:$('poolSelect'),
+    askSide:$('askSide'), bidSide:$('bidSide'), spreadBar:$('spreadBar'), bookEmpty:$('bookEmpty'), bookTag:$('bookTag'),
+    tradeTbl:$('tradeTbl'), tradeBody:$('tradeBody'), tradeEmpty:$('tradeEmpty'), tradeTag:$('tradeTag'),
     feedTbl:$('feedTbl'), feedBody:$('feedBody'), feedEmpty:$('feedEmpty'), feedTag:$('feedTag'),
-    poolList:$('poolList'), poolEmpty:$('poolEmpty'), poolTag:$('poolTag'),
-    donutWrap:$('donutWrap'), donutEmpty:$('donutEmpty'),
-    traderList:$('traderList'), traderEmpty:$('traderEmpty'), traderTag:$('traderTag'),
-    flList:$('flList'), flEmpty:$('flEmpty'), flTag:$('flTag'),
-    poList:$('poList'), poEmpty:$('poEmpty'), poTag:$('poTag'),
   };
+
+  D.poolSelect.addEventListener('change', () => { S.selectedPool = D.poolSelect.value; renderBook() });
 
   // ── SSE ──
   let es = null, reconn = null;
@@ -315,295 +256,227 @@
     es = new EventSource(SSE);
     es.onopen = () => { D.status.className='badge on'; D.statusTxt.textContent='Live'; if(reconn){clearTimeout(reconn);reconn=null} };
     es.onmessage = e => { try{ const d=JSON.parse(e.data); if(d.type==='heartbeat') return; dispatch(d) }catch(x){} };
-    es.onerror = () => { D.status.className='badge off'; D.statusTxt.textContent='Reconnecting…'; es.close(); reconn=setTimeout(connect,3000) };
+    es.onerror = () => { D.status.className='badge'; D.statusTxt.textContent='Reconnecting…'; es.close(); reconn=setTimeout(connect,3000) };
   }
 
   // ── Dispatch ──
   function dispatch(d){
-    const q=d.queryId, rs=d.results||[];
+    const q = d.queryId, rs = d.results || [];
     for(const r of rs){
-      const t=r.type, p=r.data||r.after||{};
-      switch(q){
-        case 'event-feed':        onEvent(t,r); break;
-        case 'pool-tracker':      onPool(t,p); break;
-        case 'trader-tracker':    onTrader(t,p); break;
-        case 'event-breakdown':   onBreakdown(t,r); break;
-        case 'flash-loan-tracker':onFlashLoan(t,r); break;
-        case 'price-oracle':      onPriceOracle(t,r); break;
-      }
+      const t = r.type, p = r.data || r.after || {};
+      if(q === 'event-feed') onEvent(t, r);
+      else if(q === 'pool-tracker') onPool(t, p);
     }
   }
 
-  // ── Event Feed ──
-  function onEvent(t,r){
-    if(t!=='ADD') return;
-    const ev = r.data||{};
-    const pl = ev.payload||{};
+  // ── Event Handler ──
+  function onEvent(t, r){
+    if(t !== 'ADD') return;
+    const ev = r.data || {};
+    const pl = safePl(ev.payload);
+    const eName = ev.event_name || '';
     S.total++;
-    trackRate();
 
-    const eName = ev.event_name||'';
-
-    // Update pool event count; auto-discover pool from events if pool-tracker was missed
-    if(ev.pool_id){
-      if(!S.pools[ev.pool_id]) S.pools[ev.pool_id]={base:'',quote:'',events:0,loans:0};
-      S.pools[ev.pool_id].events++;
+    // Order book state management
+    if(eName === 'OrderPlaced'){
+      const oid = String(pl.order_id);
+      S.orders[oid] = {
+        pool_id: pl.pool_id || ev.pool_id,
+        price: Number(pl.price) || 0,
+        quantity: Number(pl.quantity) || 0,
+        is_bid: pl.is_bid === true || pl.is_bid === 'true',
+      };
+    } else if(eName === 'OrderCanceled'){
+      delete S.orders[String(pl.order_id)];
+    } else if(eName === 'OrderModified'){
+      const oid = String(pl.order_id);
+      if(S.orders[oid]){
+        S.orders[oid].price = Number(pl.price) || S.orders[oid].price;
+        S.orders[oid].quantity = Number(pl.quantity) || S.orders[oid].quantity;
+      } else {
+        S.orders[oid] = {
+          pool_id: pl.pool_id || ev.pool_id,
+          price: Number(pl.price) || 0,
+          quantity: Number(pl.quantity) || 0,
+          is_bid: pl.is_bid === true || pl.is_bid === 'true',
+        };
+      }
+    } else if(eName === 'OrderFilled'){
+      S.tradeCount++;
+      const moid = String(pl.maker_order_id);
+      if(S.orders[moid]){
+        S.orders[moid].quantity -= Number(pl.base_quantity) || 0;
+        if(S.orders[moid].quantity <= 0) delete S.orders[moid];
+      }
+      addTradeRow(ev, pl);
     }
 
-    // Update trader count (client-side)
-    if(ev.sender){ S.traders[ev.sender] = (S.traders[ev.sender]||0)+1 }
-
-    // Track flash loans from event feed
-    if(eName === 'FlashLoanBorrowed'){
-      S.flashLoans++;
-      if(ev.pool_id && S.pools[ev.pool_id]) S.pools[ev.pool_id].loans++;
-    }
-
-    // Price ticker (for PriceAdded events)
-    if(eName === 'PriceAdded' && pl.conversion_rate && ev.pool_id){
-      const rate = (Number(pl.conversion_rate) / 1e9).toFixed(4);
-      addTick(ev.pool_id, rate, ev.timestamp_ms || ev.timestamp);
-    }
-
-    // Table row
     addFeedRow(ev, eName);
-    renderPools(); updateStats();
-  }
-
-  function addFeedRow(ev, eName){
-    D.feedTbl.style.display='';
-    D.feedEmpty.style.display='none';
-    const tr = document.createElement('tr');
-    tr.className='flash';
-    const badge = evClass(eName);
-    const short = eName.replace('Event','');
-    tr.innerHTML =
-      '<td class="time">'+fmtTime(ev.timestamp)+'</td>'+
-      '<td><span class="evbadge '+badge+'">'+esc(short)+'</span></td>'+
-      '<td class="addr">'+trunc(ev.pool_id)+'</td>'+
-      '<td class="addr">'+trunc(ev.sender)+'</td>';
-    D.feedBody.insertBefore(tr, D.feedBody.firstChild);
-    while(D.feedBody.children.length > MAX_ROWS) D.feedBody.removeChild(D.feedBody.lastChild);
-    D.feedTag.textContent = S.total;
-  }
-
-  // ── Pool Tracker ──
-  function onPool(t,p){
-    if(t==='ADD'){
-      const id=p.pool_id; if(!id) return;
-      if(!S.pools[id]) S.pools[id]={base:assetName(p.base_asset),quote:assetName(p.quote_asset),events:0,loans:0};
-    } else if(t==='DELETE'){
-      delete S.pools[p.pool_id];
-    }
-    renderPools(); updateStats();
-  }
-
-  // ── Trader Tracker ──
-  function onTrader(t,p){
-    if(t==='ADD'){ const a=p.address; if(a && !(a in S.traders)) S.traders[a]=0 }
-    else if(t==='DELETE'){ delete S.traders[p.address] }
-    renderTraders(); updateStats();
-  }
-
-  // ── Event Breakdown (aggregation) ──
-  function onBreakdown(t,r){
-    const d = r.data||r.after||{};
-    const name = d.event_name;
-    const cnt  = toNum(d.cnt);
-    if(!name) return;
-    if(t==='ADD'||t==='UPDATE') S.breakdown[name]=cnt;
-    else if(t==='DELETE') delete S.breakdown[name];
-    // Also handle aggregation type
-    if(t==='aggregation'){ const a=r.after||{}; if(a.event_name) S.breakdown[a.event_name]=toNum(a.cnt) }
-    renderDonut();
-  }
-
-  // ── Flash Loan Tracker (from flash-loan-tracker query) ──
-  function onFlashLoan(t,r){
-    if(t!=='ADD') return;
-    const d = r.data||{};
-    const pl = d.payload||{};
-    S.flashLoans++;
-    if(d.pool_id && S.pools[d.pool_id]) S.pools[d.pool_id].loans++;
-
-    const typeName = (pl.type_name && pl.type_name.name) || '';
-    const isSui = typeName.includes('sui::SUI');
-    const decimals = isSui ? 9 : 6;
-    const rawQty = Number(pl.borrow_quantity) || 0;
-    const qty = (rawQty / Math.pow(10, decimals)).toLocaleString(undefined, {maximumFractionDigits:2});
-    const assetShort = typeName ? typeName.split('::').pop() : '?';
-    const pool = S.pools[d.pool_id];
-    const poolName = pool && pool.base ? pool.base+'/'+pool.quote : trunc(d.pool_id);
-
-    S.flashLoanList.unshift({asset:assetShort, qty, poolName, sender:d.sender, time:fmtTime(d.timestamp)});
-    if(S.flashLoanList.length > 20) S.flashLoanList.pop();
-
-    D.flEmpty.style.display='none';
-    D.flTag.textContent = S.flashLoans;
-
-    const div = document.createElement('div');
-    div.className='fl-item new';
-    div.innerHTML =
-      '<div class="fl-top"><span class="fl-asset">⚡ '+esc(qty)+' '+esc(assetShort)+'</span><span class="fl-time">'+esc(S.flashLoanList[0].time)+'</span></div>'+
-      '<div class="fl-detail">Pool: '+esc(poolName)+' — '+trunc(d.sender)+'</div>';
-    D.flList.insertBefore(div, D.flList.querySelector('.fl-item'));
-    while(D.flList.querySelectorAll('.fl-item').length > 10){
-      const last = D.flList.querySelector('.fl-item:last-of-type');
-      if(last) last.remove();
-    }
+    renderBook();
     updateStats();
   }
 
-  // ── Price Oracle (from price-oracle query) ──
-  function onPriceOracle(t,r){
-    if(t!=='ADD') return;
-    const d = r.data||{};
-    const pl = d.payload||{};
-    const rate = (Number(pl.conversion_rate) / 1e9).toFixed(4);
-    const isBase = pl.is_base_conversion === true || pl.is_base_conversion === 'true';
-    const refPool = pl.reference_pool || '';
-    const tgtPool = pl.target_pool || '';
-    const refName = S.pools[refPool] ? S.pools[refPool].base+'/'+S.pools[refPool].quote : trunc(refPool);
-    const tgtName = S.pools[tgtPool] ? S.pools[tgtPool].base+'/'+S.pools[tgtPool].quote : trunc(tgtPool);
+  // ── Pool Tracker ──
+  function onPool(t, p){
+    if(t === 'ADD'){
+      const id = p.pool_id; if(!id) return;
+      S.pools[id] = { base: assetName(p.base_asset), quote: assetName(p.quote_asset) };
+      renderPoolSelect();
+    } else if(t === 'DELETE'){
+      delete S.pools[p.pool_id];
+      renderPoolSelect();
+    }
+  }
 
-    S.priceUpdates.unshift({refName, tgtName, rate, isBase, time:fmtTime(d.timestamp)});
-    if(S.priceUpdates.length > 30) S.priceUpdates.pop();
+  // ── Render Order Book ──
+  function renderBook(){
+    const pool = S.selectedPool;
+    const bids = [], asks = [];
 
-    D.poEmpty.style.display='none';
-    D.poTag.textContent = S.priceUpdates.length;
-
-    const div = document.createElement('div');
-    div.className='po-item new';
-    div.innerHTML =
-      '<div class="po-top"><span class="po-pair">'+esc(refName)+' → '+esc(tgtName)+'</span><span class="po-time">'+esc(S.priceUpdates[0].time)+'</span></div>'+
-      '<div class="po-detail">Rate: <span class="po-rate">'+esc(rate)+'</span> <span class="po-dir">'+(isBase?'Base':'Quote')+'</span></div>';
-    D.poList.insertBefore(div, D.poList.querySelector('.po-item'));
-    while(D.poList.querySelectorAll('.po-item').length > 10){
-      const last = D.poList.querySelector('.po-item:last-of-type');
-      if(last) last.remove();
+    // Group orders by price level
+    const bidLevels = {}, askLevels = {};
+    for(const oid in S.orders){
+      const o = S.orders[oid];
+      if(pool && o.pool_id !== pool) continue;
+      const key = o.price;
+      if(o.is_bid){
+        if(!bidLevels[key]) bidLevels[key] = 0;
+        bidLevels[key] += o.quantity;
+      } else {
+        if(!askLevels[key]) askLevels[key] = 0;
+        askLevels[key] += o.quantity;
+      }
     }
 
-    // Also feed price ticker
-    addTick(refPool, rate, d.timestamp);
+    // Sort: bids high→low, asks low→high
+    const bidPrices = Object.keys(bidLevels).map(Number).sort((a,b) => b - a);
+    const askPrices = Object.keys(askLevels).map(Number).sort((a,b) => a - b);
+
+    // Slice to MAX_LEVELS nearest the spread
+    const topBids = bidPrices.slice(0, MAX_LEVELS);
+    const topAsks = askPrices.slice(0, MAX_LEVELS);
+
+    // Calculate cumulative totals
+    let bidTotal = 0, askTotal = 0;
+    for(const p of topBids) bids.push({ price: p, size: bidLevels[p], total: (bidTotal += bidLevels[p]) });
+    for(const p of topAsks) asks.push({ price: p, size: askLevels[p], total: (askTotal += askLevels[p]) });
+
+    const maxTotal = Math.max(bidTotal, askTotal, 1);
+    const hasData = bids.length > 0 || asks.length > 0;
+
+    D.bookEmpty.style.display = hasData ? 'none' : '';
+    D.askSide.style.display = hasData ? '' : 'none';
+    D.bidSide.style.display = hasData ? '' : 'none';
+
+    if(!hasData) return;
+
+    // Render asks (reversed so lowest ask is at bottom, near spread)
+    const askRows = asks.slice().reverse();
+    D.askSide.innerHTML = askRows.map(a => {
+      const depth = (a.total / maxTotal * 100).toFixed(1);
+      return '<div class="book-row ask" style="--depth:'+depth+'%"><span class="r-price">'+fmtPrice(a.price)+'</span><span class="r-size">'+fmtQty(a.size)+'</span><span class="r-total">'+fmtQty(a.total)+'</span></div>';
+    }).join('');
+
+    // Render bids (highest bid at top, near spread)
+    D.bidSide.innerHTML = bids.map(b => {
+      const depth = (b.total / maxTotal * 100).toFixed(1);
+      return '<div class="book-row bid" style="--depth:'+depth+'%"><span class="r-price">'+fmtPrice(b.price)+'</span><span class="r-size">'+fmtQty(b.size)+'</span><span class="r-total">'+fmtQty(b.total)+'</span></div>';
+    }).join('');
+
+    // Spread
+    const bestBid = topBids.length ? topBids[0] : 0;
+    const bestAsk = topAsks.length ? topAsks[0] : 0;
+    if(bestBid && bestAsk){
+      const spread = bestAsk - bestBid;
+      D.spreadBar.textContent = 'Spread: ' + fmtPrice(spread) + ' (' + (spread / bestAsk * 100).toFixed(2) + '%)';
+      D.sBid.textContent = fmtPrice(bestBid);
+      D.sAsk.textContent = fmtPrice(bestAsk);
+      D.sSpread.textContent = fmtPrice(spread);
+    } else {
+      D.spreadBar.textContent = 'Spread: —';
+      D.sBid.textContent = '—';
+      D.sAsk.textContent = '—';
+      D.sSpread.textContent = '—';
+    }
+
+    const totalOrders = Object.keys(S.orders).length;
+    D.bookTag.textContent = totalOrders + ' order' + (totalOrders !== 1 ? 's' : '');
+    D.sDepth.innerHTML = (topBids.length + topAsks.length) + '<span class="u">levels</span>';
   }
 
-  // ── Price Ticker ──
-  function addTick(poolId, rate, ts){
-    const pool = S.pools[poolId];
-    const pair = pool && pool.base ? pool.base+'/'+pool.quote : trunc(poolId);
-    S.ticks.push({pair, rate, time:fmtTime(ts)});
-    if(S.ticks.length>60) S.ticks.shift();
-    renderTicker();
+  // ── Trade Row ──
+  function addTradeRow(ev, pl){
+    D.tradeTbl.style.display = '';
+    D.tradeEmpty.style.display = 'none';
+    D.tradeTag.textContent = S.tradeCount;
+
+    const isBuy = pl.taker_is_bid === true || pl.taker_is_bid === 'true';
+    const tr = document.createElement('tr');
+    tr.className = 'flash';
+    const cls = isBuy ? 't-buy' : 't-sell';
+    tr.innerHTML =
+      '<td class="'+cls+'">'+fmtPrice(Number(pl.price)||0)+'</td>'+
+      '<td>'+fmtQty(Number(pl.base_quantity)||0)+'</td>'+
+      '<td>'+fmtTime(ev.timestamp)+'</td>';
+    D.tradeBody.insertBefore(tr, D.tradeBody.firstChild);
+    while(D.tradeBody.children.length > MAX_ROWS) D.tradeBody.removeChild(D.tradeBody.lastChild);
   }
 
-  function renderTicker(){
-    if(!S.ticks.length) return;
-    D.ticker.classList.add('scrolling');
-    const items = [...S.ticks, ...S.ticks];
-    D.ticker.innerHTML = items.map(t =>
-      '<span class="tick-item"><span class="tick-pair">'+esc(t.pair)+'</span><span class="tick-price">'+esc(t.rate)+'</span><span class="tick-time">'+esc(t.time)+'</span></span>'
-    ).join('');
+  // ── Event Feed Row ──
+  function addFeedRow(ev, eName){
+    D.feedTbl.style.display = '';
+    D.feedEmpty.style.display = 'none';
+    D.feedTag.textContent = S.total;
+
+    const tr = document.createElement('tr');
+    const badge = evClass(eName);
+    tr.innerHTML =
+      '<td class="time">'+fmtTime(ev.timestamp)+'</td>'+
+      '<td><span class="evbadge '+badge+'">'+esc(eName)+'</span></td>'+
+      '<td class="addr">'+trunc(ev.pool_id)+'</td>';
+    D.feedBody.insertBefore(tr, D.feedBody.firstChild);
+    while(D.feedBody.children.length > MAX_ROWS) D.feedBody.removeChild(D.feedBody.lastChild);
   }
 
-  // ── Pool Cards ──
-  function renderPools(){
+  // ── Pool Selector ──
+  function renderPoolSelect(){
+    const cur = D.poolSelect.value;
     const ids = Object.keys(S.pools);
-    D.poolEmpty.style.display = ids.length?'none':'';
-    D.poolTag.textContent = ids.length;
-    ids.sort((a,b) => S.pools[b].events - S.pools[a].events);
-
-    const frag = document.createDocumentFragment();
+    D.poolSelect.innerHTML = '<option value="">All Pools</option>';
     for(const id of ids){
       const p = S.pools[id];
-
-      const card = document.createElement('div');
-      card.className='pcard';
-      card.innerHTML =
-        '<div class="pcard-row"><span class="ppair">'+esc(p.base)+' <span class="q">/ '+esc(p.quote)+'</span></span></div>'+
-        '<div class="pcard-stats">'+
-          '<span>Events: <span class="val">'+p.events+'</span></span>'+
-          '<span>Loans: <span class="val pcard-loan">'+p.loans+'</span></span>'+
-        '</div>'+
-        '<div class="pid" style="margin-top:4px">'+trunc(id)+'</div>';
-      frag.appendChild(card);
+      const label = p.base && p.quote ? p.base + ' / ' + p.quote : trunc(id);
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = label;
+      if(id === cur) opt.selected = true;
+      D.poolSelect.appendChild(opt);
     }
-    const old = D.poolList.querySelectorAll('.pcard');
-    old.forEach(el=>el.remove());
-    D.poolList.appendChild(frag);
-  }
-
-  // ── Donut Chart ──
-  const DONUT_COLORS = ['#3b82f6','#00e5a0','#ef4444','#f59e0b','#a78bfa','#fb923c','#06b6d4','#ec4899'];
-  function renderDonut(){
-    const names = Object.keys(S.breakdown);
-    if(!names.length) return;
-    D.donutEmpty.style.display='none';
-
-    const total = names.reduce((s,n)=>s+S.breakdown[n],0);
-    names.sort((a,b)=>S.breakdown[b]-S.breakdown[a]);
-
-    // Conic gradient
-    let grad='', pct=0;
-    const legendHtml=[];
-    for(let i=0;i<names.length;i++){
-      const n=names[i], c=DONUT_COLORS[i%DONUT_COLORS.length];
-      const slice = total?S.breakdown[n]/total*100:0;
-      grad += (i?',':'') + c+' '+pct+'% '+(pct+slice)+'%';
-      pct+=slice;
-      legendHtml.push(
-        '<div class="leg-item"><div class="leg-dot" style="background:'+c+'"></div>'+
-        '<span class="leg-name">'+esc(n.replace('Event',''))+'</span>'+
-        '<span class="leg-val">'+S.breakdown[n]+'</span></div>'
-      );
-    }
-
-    D.donutWrap.innerHTML =
-      '<div class="donut" style="background:conic-gradient('+grad+')"><div class="donut-hole">'+total+'</div></div>'+
-      '<div class="donut-legend">'+legendHtml.join('')+'</div>';
-  }
-
-  // ── Trader Leaderboard ──
-  function renderTraders(){
-    const addrs = Object.keys(S.traders);
-    D.traderEmpty.style.display = addrs.length?'none':'';
-    D.traderTag.textContent = addrs.length;
-    addrs.sort((a,b)=>S.traders[b]-S.traders[a]);
-    const top = addrs.slice(0,15);
-
-    const frag = document.createDocumentFragment();
-    for(let i=0;i<top.length;i++){
-      const a=top[i], c=S.traders[a];
-      const row = document.createElement('div');
-      row.className='trow';
-      row.innerHTML='<span class="trank '+(i<3?'top':'')+'">'+(i+1)+'.</span><span class="taddr">'+trunc(a)+'</span><span class="tcnt">'+c+'</span>';
-      frag.appendChild(row);
-    }
-    const old = D.traderList.querySelectorAll('.trow');
-    old.forEach(el=>el.remove());
-    D.traderList.appendChild(frag);
+    // Keep "All Pools" as default so the book shows all orders
   }
 
   // ── Stats ──
   function updateStats(){
     D.sEvents.textContent = S.total.toLocaleString();
-    D.sPools.textContent = Object.keys(S.pools).length;
-    D.sTraders.textContent = Object.keys(S.traders).length;
-    D.sFlash.textContent = S.flashLoans.toLocaleString();
+    D.sTrades.textContent = S.tradeCount.toLocaleString();
   }
 
-  function trackRate(){ const now=Date.now(); S.rateTs.push(now); while(S.rateTs.length&&S.rateTs[0]<now-60000) S.rateTs.shift() }
-  setInterval(()=>{
-    const now=Date.now(); while(S.rateTs.length&&S.rateTs[0]<now-60000) S.rateTs.shift();
-    D.sRate.innerHTML=S.rateTs.length+'<span class="u">/min</span>';
-  },1000);
-
-  // ── Helpers ──
-  function fmtTime(ts){ if(!ts) return '—'; const n=typeof ts==='string'?parseInt(ts,10):ts; if(isNaN(n)) return '—'; return new Date(n).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'}) }
-  function trunc(s){ if(!s) return '—'; if(s.length<=14) return s; return s.slice(0,8)+'…'+s.slice(-6) }
-  function assetName(t){ if(!t) return '?'; const p=t.split('::'); return p.length>=3?p[p.length-1]:t }
-  function toNum(v){ const n=Number(v); return isNaN(n)?0:n }
-  function esc(s){ if(!s) return ''; const el=document.createElement('span'); el.textContent=s; return el.innerHTML }
-  function evClass(n){ if(!n) return 'ev-other'; if(n==='PriceAdded') return 'ev-placed'; if(n==='FlashLoanBorrowed') return 'ev-filled'; if(n==='ReferralClaimed') return 'ev-modify'; return 'ev-other' }
+  // ── Formatting ──
+  function fmtPrice(raw){ return (raw / PRICE_SCALE).toFixed(4) }
+  function fmtQty(raw){ const v = raw / QTY_SCALE; return v >= 1000 ? v.toFixed(0) : v >= 1 ? v.toFixed(2) : v.toFixed(4) }
+  function fmtTime(ts){ if(!ts) return '—'; const n = typeof ts==='string' ? parseInt(ts,10) : ts; if(isNaN(n)) return '—'; return new Date(n).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'}) }
+  function trunc(s){ if(!s) return '—'; if(s.length <= 14) return s; return s.slice(0,8)+'…'+s.slice(-4) }
+  function assetName(t){ if(!t) return '?'; const p = t.split('::'); return p.length >= 3 ? p[p.length-1] : t }
+  function esc(s){ if(!s) return ''; const el = document.createElement('span'); el.textContent = s; return el.innerHTML }
+  function safePl(p){ if(!p) return {}; if(typeof p === 'string'){ try{ return JSON.parse(p) }catch(e){ return {} } } return p }
+  function evClass(n){
+    if(!n) return 'ev-other';
+    if(n === 'OrderPlaced') return 'ev-placed';
+    if(n === 'OrderFilled') return 'ev-filled';
+    if(n === 'OrderCanceled') return 'ev-cancel';
+    if(n === 'OrderModified') return 'ev-modify';
+    return 'ev-other';
+  }
 
   connect();
 })();

--- a/examples/lib/sui-deepbook-getting-started/diagnose.sh
+++ b/examples/lib/sui-deepbook-getting-started/diagnose.sh
@@ -34,13 +34,7 @@ total_rows = 0
 matches = []
 
 for page in range(max_pages):
-    params = {
-        "query": {"All": []},
-        "limit": 50,
-        "descending_order": True,
-    }
-    if cursor is not None:
-        params["cursor"] = cursor
+    params = [{"All": []}, cursor, 50, True]
 
     payload = {
         "jsonrpc": "2.0",

--- a/examples/lib/sui-deepbook-getting-started/diagnose.sh
+++ b/examples/lib/sui-deepbook-getting-started/diagnose.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RPC_URL="${SUI_RPC_URL:-https://fullnode.mainnet.sui.io:443}"
+DEEPBOOK_PACKAGE_ID="${DEEPBOOK_PACKAGE_ID:-0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497}"
+MAX_PAGES="${MAX_PAGES:-100}"
+
+echo "=== Sui DeepBook diagnostics ==="
+echo "RPC endpoint: ${RPC_URL}"
+echo "DeepBook package: ${DEEPBOOK_PACKAGE_ID}"
+echo
+
+echo "1) Chain identifier:"
+curl -s -X POST "${RPC_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"sui_getChainIdentifier","params":[]}'
+echo
+echo
+
+echo "2) Recent DeepBook package events:"
+python3 - "${RPC_URL}" "${DEEPBOOK_PACKAGE_ID}" "${MAX_PAGES}" <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+
+rpc_url = sys.argv[1]
+package_id = sys.argv[2].lower()
+max_pages = max(int(sys.argv[3]), 1)
+
+cursor = None
+pages_scanned = 0
+total_rows = 0
+matches = []
+
+for page in range(max_pages):
+    params = {
+        "query": {"All": []},
+        "limit": 50,
+        "descending_order": True,
+    }
+    if cursor is not None:
+        params["cursor"] = cursor
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": page + 1,
+        "method": "suix_queryEvents",
+        "params": params,
+    }
+
+    request = urllib.request.Request(
+        rpc_url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            body = json.load(response)
+    except urllib.error.URLError as err:
+        print(f"RPC request failed: {err}")
+        sys.exit(1)
+    except json.JSONDecodeError as err:
+        print(f"Failed to parse RPC response as JSON: {err}")
+        sys.exit(1)
+
+    if "error" in body:
+        print(f"RPC error: {body['error']}")
+        sys.exit(1)
+
+    result = body.get("result", {})
+    rows = result.get("data", [])
+    pages_scanned += 1
+    total_rows += len(rows)
+
+    for event in rows:
+        if str(event.get("packageId", "")).lower() == package_id:
+            matches.append(event)
+            if len(matches) >= 5:
+                break
+
+    if len(matches) >= 5:
+        break
+
+    cursor = result.get("nextCursor")
+    if not result.get("hasNextPage") or cursor is None:
+        break
+
+print(f"Scanned {pages_scanned} page(s), {total_rows} event(s); found {len(matches)} match(es).")
+for event in matches:
+    event_type = event.get("type", "<unknown>")
+    timestamp = event.get("timestampMs", "<unknown>")
+    event_id = event.get("id", {})
+    tx = event_id.get("txDigest", "<unknown>")
+    seq = event_id.get("eventSeq", "<unknown>")
+    print(f"- {event_type} @ {timestamp} (tx={tx}, seq={seq})")
+PY
+
+echo
+
+echo "✓ Diagnostics complete"

--- a/examples/lib/sui-deepbook-getting-started/main.rs
+++ b/examples/lib/sui-deepbook-getting-started/main.rs
@@ -94,84 +94,19 @@ async fn main() -> Result<()> {
         .auto_start(true)
         .build();
 
-    // 3. Trader tracker – enrichment Trader nodes discovered from events
-    let trader_tracker = Query::cypher("trader-tracker")
-        .query(
-            r#"
-            MATCH (t:Trader)
-            RETURN t.address AS address
-            "#,
-        )
-        .from_source("deepbook-mainnet")
-        .auto_start(true)
-        .build();
-
-    // 4. Event type breakdown – aggregation by event name
-    let event_breakdown = Query::cypher("event-breakdown")
-        .query(
-            r#"
-            MATCH (e:DeepBookEvent)
-            RETURN e.event_name AS event_name, count(e) AS cnt
-            "#,
-        )
-        .from_source("deepbook-mainnet")
-        .auto_start(true)
-        .build();
-
-    // 5. Flash loan tracker – individual flash loan events
-    let flash_loan_tracker = Query::cypher("flash-loan-tracker")
-        .query(
-            r#"
-            MATCH (e:DeepBookEvent)
-            WHERE e.event_name = 'FlashLoanBorrowed'
-            RETURN e.entity_id AS id,
-              e.pool_id        AS pool_id,
-              e.sender         AS sender,
-              e.timestamp_ms   AS timestamp,
-              e.payload        AS payload
-            "#,
-        )
-        .from_source("deepbook-mainnet")
-        .auto_start(true)
-        .build();
-
-    // 6. Price oracle – conversion rate updates from PriceAdded events
-    let price_oracle = Query::cypher("price-oracle")
-        .query(
-            r#"
-            MATCH (e:DeepBookEvent)
-            WHERE e.event_name = 'PriceAdded'
-            RETURN e.entity_id AS id,
-              e.pool_id        AS pool_id,
-              e.timestamp_ms   AS timestamp,
-              e.payload        AS payload
-            "#,
-        )
-        .from_source("deepbook-mainnet")
-        .auto_start(true)
-        .build();
-
     // ── SSE Reaction ──
     let sse = SseReaction::builder("dashboard-sse")
         .with_port(sse_port)
         .with_query("event-feed")
         .with_query("pool-tracker")
-        .with_query("trader-tracker")
-        .with_query("event-breakdown")
-        .with_query("flash-loan-tracker")
-        .with_query("price-oracle")
         .build()?;
 
     // ── Drasi Core ──
     let core = DrasiLib::builder()
-        .with_id("sui-deepbook-dashboard")
+        .with_id("sui-deepbook-orderbook")
         .with_source(source)
         .with_query(event_feed)
         .with_query(pool_tracker)
-        .with_query(trader_tracker)
-        .with_query(event_breakdown)
-        .with_query(flash_loan_tracker)
-        .with_query(price_oracle)
         .with_reaction(sse)
         .build()
         .await?;
@@ -203,7 +138,7 @@ fn print_banner(rpc: &str, pkg: &str, sse_port: u16, dash_port: u16) {
     };
     println!();
     println!("╔══════════════════════════════════════════════════════════════╗");
-    println!("║  DeepBook DeFi Dashboard                                   ║");
+    println!("║  DeepBook Live Order Book                                  ║");
     println!("╠══════════════════════════════════════════════════════════════╣");
     println!("║  RPC:       {rpc}");
     println!("║  Package:   {pkg_short}");

--- a/examples/lib/sui-deepbook-getting-started/main.rs
+++ b/examples/lib/sui-deepbook-getting-started/main.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use axum::{response::Html, Router};
 use drasi_lib::{DrasiLib, Query};
 use drasi_reaction_sse::SseReaction;
-use drasi_source_sui_deepbook::{SuiDeepBookSource, DEFAULT_DEEPBOOK_PACKAGE_ID};
+use drasi_source_sui_deepbook::{SuiDeepBookSource, Transport, DEFAULT_DEEPBOOK_PACKAGE_ID};
 use log::info;
 
 const DASHBOARD_HTML: &str = include_str!("dashboard.html");
@@ -29,6 +29,14 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|_| "https://fullnode.mainnet.sui.io:443".to_string());
     let package_id = std::env::var("DEEPBOOK_PACKAGE_ID")
         .unwrap_or_else(|_| DEFAULT_DEEPBOOK_PACKAGE_ID.to_string());
+    let transport = match std::env::var("SUI_TRANSPORT")
+        .unwrap_or_else(|_| "grpc".to_string())
+        .to_lowercase()
+        .as_str()
+    {
+        "json-rpc" | "jsonrpc" | "json_rpc" => Transport::JsonRpc,
+        _ => Transport::Grpc,
+    };
     let sse_port: u16 = std::env::var("SSE_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -38,9 +46,11 @@ async fn main() -> Result<()> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(3000);
 
+    info!("Using transport: {:?}", transport);
+
     // ── Source ──
-    // MoveModule filter ensures fast event retrieval from Sui RPC
     let source = SuiDeepBookSource::builder("deepbook-mainnet")
+        .with_transport(transport)
         .with_rpc_endpoint(rpc_endpoint.clone())
         .with_deepbook_package_id(package_id.clone())
         .with_poll_interval_ms(2_000)

--- a/examples/lib/sui-deepbook-getting-started/main.rs
+++ b/examples/lib/sui-deepbook-getting-started/main.rs
@@ -225,7 +225,7 @@ fn extract_payload_highlights(data: &serde_json::Value) -> String {
         ("fee", "fee"),
         ("maker_fee", "maker_fee"),
         ("taker_fee", "taker_fee"),
-        ("is_bid", "side"),
+        ("is_bid", "is_bid"),
         ("side", "side"),
         ("expire_timestamp", "expires"),
     ];

--- a/examples/lib/sui-deepbook-getting-started/main.rs
+++ b/examples/lib/sui-deepbook-getting-started/main.rs
@@ -1,0 +1,281 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use chrono::{TimeZone, Utc};
+use drasi_lib::channels::ResultDiff;
+use drasi_lib::{DrasiLib, Query};
+use drasi_reaction_application::subscription::SubscriptionOptions;
+use drasi_reaction_application::ApplicationReaction;
+use drasi_source_sui_deepbook::{StartPosition, SuiDeepBookSource, DEFAULT_DEEPBOOK_PACKAGE_ID};
+use std::time::Duration;
+
+// ANSI colour helpers
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const RED: &str = "\x1b[31m";
+const CYAN: &str = "\x1b[36m";
+const MAGENTA: &str = "\x1b[35m";
+const WHITE: &str = "\x1b[37m";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let rpc_endpoint = std::env::var("SUI_RPC_URL")
+        .unwrap_or_else(|_| "https://fullnode.mainnet.sui.io:443".to_string());
+    let package_id = std::env::var("DEEPBOOK_PACKAGE_ID")
+        .unwrap_or_else(|_| DEFAULT_DEEPBOOK_PACKAGE_ID.to_string());
+
+    let source = SuiDeepBookSource::builder("deepbook-mainnet")
+        .with_rpc_endpoint(rpc_endpoint.clone())
+        .with_deepbook_package_id(package_id.clone())
+        .with_poll_interval_ms(2_000)
+        .with_start_position(StartPosition::Now)
+        .build()?;
+
+    let query = Query::cypher("deepbook-events")
+        .query(
+            r#"
+            MATCH (e:DeepBookEvent)
+            RETURN
+              e.entity_id     AS entity_id,
+              e.event_name    AS event_name,
+              e.module        AS module,
+              e.change_type   AS change_type,
+              e.pool_id_short AS pool,
+              e.sender_short  AS sender,
+              e.timestamp_ms  AS timestamp_ms,
+              e.order_id      AS order_id,
+              e.payload       AS payload
+        "#,
+        )
+        .from_source("deepbook-mainnet")
+        .auto_start(true)
+        .build();
+
+    let (reaction, handle) = ApplicationReaction::builder("deepbook-app")
+        .with_query("deepbook-events")
+        .build();
+
+    let core = DrasiLib::builder()
+        .with_id("sui-deepbook-example")
+        .with_source(source)
+        .with_query(query)
+        .with_reaction(reaction)
+        .build()
+        .await?;
+
+    core.start().await?;
+
+    print_banner(&rpc_endpoint, &package_id);
+
+    let mut subscription = handle
+        .subscribe_with_options(
+            SubscriptionOptions::default().with_timeout(Duration::from_secs(5)),
+        )
+        .await?;
+
+    let ctrl_c = tokio::signal::ctrl_c();
+    tokio::pin!(ctrl_c);
+
+    loop {
+        tokio::select! {
+            _ = &mut ctrl_c => {
+                println!("\n{DIM}Shutting down…{RESET}");
+                break;
+            }
+            result = subscription.recv() => {
+                if let Some(query_result) = result {
+                    for diff in &query_result.results {
+                        print_diff(diff);
+                    }
+                }
+            }
+        }
+    }
+
+    core.stop().await?;
+    Ok(())
+}
+
+fn print_banner(rpc_endpoint: &str, package_id: &str) {
+    let pkg_short = truncate_hex(package_id);
+    println!();
+    println!("{BOLD}{CYAN}╔══════════════════════════════════════════════════════════════╗{RESET}");
+    println!("{BOLD}{CYAN}║{RESET}  {BOLD}Sui DeepBook Live Event Monitor{RESET}                             {BOLD}{CYAN}║{RESET}");
+    println!("{BOLD}{CYAN}╠══════════════════════════════════════════════════════════════╣{RESET}");
+    println!("{BOLD}{CYAN}║{RESET}  RPC:     {WHITE}{rpc_endpoint}{RESET}");
+    println!("{BOLD}{CYAN}║{RESET}  Package: {WHITE}{pkg_short}{RESET}");
+    println!("{BOLD}{CYAN}║{RESET}  Mode:    {GREEN}Live streaming (start from now){RESET}");
+    println!("{BOLD}{CYAN}╠══════════════════════════════════════════════════════════════╣{RESET}");
+    println!("{BOLD}{CYAN}║{RESET}  {DIM}Waiting for DeepBook events… (Ctrl+C to stop){RESET}");
+    println!("{BOLD}{CYAN}╚══════════════════════════════════════════════════════════════╝{RESET}");
+    println!();
+}
+
+fn print_diff(diff: &ResultDiff) {
+    match diff {
+        ResultDiff::Add { data } => {
+            let (icon, color) = ("▶ ADD", GREEN);
+            print_event(icon, color, data);
+        }
+        ResultDiff::Update { before, after, .. } => {
+            let (icon, color) = ("⟳ UPD", YELLOW);
+            print_event(icon, color, after);
+            print_update_delta(before, after);
+        }
+        ResultDiff::Delete { data } => {
+            let (icon, color) = ("✕ DEL", RED);
+            print_event(icon, color, data);
+        }
+        _ => {}
+    }
+}
+
+fn print_event(icon: &str, color: &str, data: &serde_json::Value) {
+    let event_name = json_str(data, "event_name");
+    let module = json_str(data, "module");
+    let entity = json_str(data, "entity_id");
+    let sender = json_str(data, "sender");
+    let pool = json_str(data, "pool");
+    let ts = format_timestamp(data);
+
+    println!(
+        "  {color}{BOLD}{icon}{RESET}  {BOLD}{event_name}{RESET} {DIM}({module}){RESET}"
+    );
+    println!(
+        "        {DIM}entity:{RESET} {CYAN}{entity}{RESET}  \
+         {DIM}sender:{RESET} {sender}  \
+         {DIM}time:{RESET} {ts}"
+    );
+
+    if !pool.is_empty() {
+        print!("        {DIM}pool:{RESET} {pool}");
+    }
+
+    let details = extract_payload_highlights(data);
+    if !details.is_empty() {
+        if !pool.is_empty() {
+            print!("  ");
+        } else {
+            print!("        ");
+        }
+        print!("{MAGENTA}");
+        print!("{details}");
+        println!("{RESET}");
+    } else if !pool.is_empty() {
+        println!();
+    }
+
+    // Print the full payload JSON, pretty-printed and dimmed
+    if let Some(payload) = data.get("payload") {
+        if payload.is_object() && !payload.as_object().unwrap().is_empty() {
+            if let Ok(pretty) = serde_json::to_string_pretty(payload) {
+                println!("        {DIM}payload:{RESET}");
+                for line in pretty.lines() {
+                    println!("          {DIM}{line}{RESET}");
+                }
+            }
+        }
+    }
+
+    println!();
+}
+
+fn print_update_delta(before: &serde_json::Value, after: &serde_json::Value) {
+    let before_type = json_str(before, "change_type");
+    let after_type = json_str(after, "change_type");
+    if !before_type.is_empty() && before_type != after_type {
+        println!(
+            "        {DIM}transition:{RESET} {before_type} {YELLOW}→{RESET} {after_type}"
+        );
+        println!();
+    }
+}
+
+fn extract_payload_highlights(data: &serde_json::Value) -> String {
+    let payload = &data["payload"];
+    if payload.is_null() || !payload.is_object() {
+        return String::new();
+    }
+
+    let interesting: &[(&str, &str)] = &[
+        ("price", "price"),
+        ("size", "size"),
+        ("quantity", "qty"),
+        ("amount", "amount"),
+        ("base_quantity", "base_qty"),
+        ("quote_quantity", "quote_qty"),
+        ("balance", "balance"),
+        ("fee", "fee"),
+        ("maker_fee", "maker_fee"),
+        ("taker_fee", "taker_fee"),
+        ("is_bid", "side"),
+        ("side", "side"),
+        ("expire_timestamp", "expires"),
+    ];
+
+    let mut parts = Vec::new();
+    for (key, label) in interesting {
+        if let Some(val) = payload.get(key) {
+            let display = match val {
+                serde_json::Value::String(s) => {
+                    if *key == "is_bid" {
+                        if s == "true" { "BID".to_string() } else { "ASK".to_string() }
+                    } else {
+                        s.clone()
+                    }
+                }
+                serde_json::Value::Bool(b) => {
+                    if *key == "is_bid" {
+                        if *b { "BID".to_string() } else { "ASK".to_string() }
+                    } else {
+                        b.to_string()
+                    }
+                }
+                other => other.to_string(),
+            };
+            parts.push(format!("{label}={display}"));
+        }
+    }
+    parts.join("  ")
+}
+
+fn format_timestamp(data: &serde_json::Value) -> String {
+    data.get("timestamp_ms")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok())))
+        .and_then(|ms| Utc.timestamp_millis_opt(ms).single())
+        .map(|dt| dt.format("%H:%M:%S").to_string())
+        .unwrap_or_else(|| "—".to_string())
+}
+
+fn json_str(data: &serde_json::Value, key: &str) -> String {
+    data.get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn truncate_hex(hex: &str) -> String {
+    if hex.len() <= 14 {
+        return hex.to_string();
+    }
+    let prefix = &hex[..8];
+    let suffix = &hex[hex.len() - 6..];
+    format!("{prefix}…{suffix}")
+}

--- a/examples/lib/sui-deepbook-getting-started/main.rs
+++ b/examples/lib/sui-deepbook-getting-started/main.rs
@@ -13,24 +13,13 @@
 // limitations under the License.
 
 use anyhow::Result;
-use chrono::{TimeZone, Utc};
-use drasi_lib::channels::ResultDiff;
+use axum::{response::Html, Router};
 use drasi_lib::{DrasiLib, Query};
-use drasi_reaction_application::subscription::SubscriptionOptions;
-use drasi_reaction_application::ApplicationReaction;
-use drasi_source_sui_deepbook::{StartPosition, SuiDeepBookSource, DEFAULT_DEEPBOOK_PACKAGE_ID};
-use std::time::Duration;
+use drasi_reaction_sse::SseReaction;
+use drasi_source_sui_deepbook::{SuiDeepBookSource, DEFAULT_DEEPBOOK_PACKAGE_ID};
+use log::info;
 
-// ANSI colour helpers
-const RESET: &str = "\x1b[0m";
-const BOLD: &str = "\x1b[1m";
-const DIM: &str = "\x1b[2m";
-const GREEN: &str = "\x1b[32m";
-const YELLOW: &str = "\x1b[33m";
-const RED: &str = "\x1b[31m";
-const CYAN: &str = "\x1b[36m";
-const MAGENTA: &str = "\x1b[35m";
-const WHITE: &str = "\x1b[37m";
+const DASHBOARD_HTML: &str = include_str!("dashboard.html");
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -40,246 +29,180 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|_| "https://fullnode.mainnet.sui.io:443".to_string());
     let package_id = std::env::var("DEEPBOOK_PACKAGE_ID")
         .unwrap_or_else(|_| DEFAULT_DEEPBOOK_PACKAGE_ID.to_string());
+    let sse_port: u16 = std::env::var("SSE_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8080);
+    let dashboard_port: u16 = std::env::var("DASHBOARD_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3000);
 
+    // ── Source ──
+    // MoveModule filter ensures fast event retrieval from Sui RPC
     let source = SuiDeepBookSource::builder("deepbook-mainnet")
         .with_rpc_endpoint(rpc_endpoint.clone())
         .with_deepbook_package_id(package_id.clone())
         .with_poll_interval_ms(2_000)
-        .with_start_position(StartPosition::Now)
+        .with_start_from_now()
         .with_enable_pool_nodes(true)
         .with_enable_trader_nodes(true)
         .with_enable_order_nodes(true)
         .build()?;
 
-    let query = Query::cypher("deepbook-events")
+    // ── Queries ──
+    // 1. Live event feed – every DeepBook event as it arrives
+    let event_feed = Query::cypher("event-feed")
         .query(
             r#"
             MATCH (e:DeepBookEvent)
             RETURN
-              e.entity_id     AS entity_id,
-              e.event_name    AS event_name,
-              e.module        AS module,
-              e.change_type   AS change_type,
-              e.pool_id_short AS pool,
-              e.sender_short  AS sender,
-              e.timestamp_ms  AS timestamp_ms,
-              e.order_id      AS order_id,
-              e.payload       AS payload
-        "#,
+              e.entity_id    AS id,
+              e.event_name   AS event_name,
+              e.pool_id      AS pool_id,
+              e.timestamp_ms AS timestamp,
+              e.sender       AS sender,
+              e.payload      AS payload
+            "#,
         )
         .from_source("deepbook-mainnet")
         .auto_start(true)
         .build();
 
-    let (reaction, handle) = ApplicationReaction::builder("deepbook-app")
-        .with_query("deepbook-events")
+    // 2. Pool tracker – enrichment Pool nodes discovered from events
+    let pool_tracker = Query::cypher("pool-tracker")
+        .query(
+            r#"
+            MATCH (p:Pool)
+            RETURN
+              p.pool_id     AS pool_id,
+              p.base_asset  AS base_asset,
+              p.quote_asset AS quote_asset
+            "#,
+        )
+        .from_source("deepbook-mainnet")
+        .auto_start(true)
         .build();
 
+    // 3. Trader tracker – enrichment Trader nodes discovered from events
+    let trader_tracker = Query::cypher("trader-tracker")
+        .query(
+            r#"
+            MATCH (t:Trader)
+            RETURN t.address AS address
+            "#,
+        )
+        .from_source("deepbook-mainnet")
+        .auto_start(true)
+        .build();
+
+    // 4. Event type breakdown – aggregation by event name
+    let event_breakdown = Query::cypher("event-breakdown")
+        .query(
+            r#"
+            MATCH (e:DeepBookEvent)
+            RETURN e.event_name AS event_name, count(e) AS cnt
+            "#,
+        )
+        .from_source("deepbook-mainnet")
+        .auto_start(true)
+        .build();
+
+    // 5. Flash loan tracker – individual flash loan events
+    let flash_loan_tracker = Query::cypher("flash-loan-tracker")
+        .query(
+            r#"
+            MATCH (e:DeepBookEvent)
+            WHERE e.event_name = 'FlashLoanBorrowed'
+            RETURN e.entity_id AS id,
+              e.pool_id        AS pool_id,
+              e.sender         AS sender,
+              e.timestamp_ms   AS timestamp,
+              e.payload        AS payload
+            "#,
+        )
+        .from_source("deepbook-mainnet")
+        .auto_start(true)
+        .build();
+
+    // 6. Price oracle – conversion rate updates from PriceAdded events
+    let price_oracle = Query::cypher("price-oracle")
+        .query(
+            r#"
+            MATCH (e:DeepBookEvent)
+            WHERE e.event_name = 'PriceAdded'
+            RETURN e.entity_id AS id,
+              e.pool_id        AS pool_id,
+              e.timestamp_ms   AS timestamp,
+              e.payload        AS payload
+            "#,
+        )
+        .from_source("deepbook-mainnet")
+        .auto_start(true)
+        .build();
+
+    // ── SSE Reaction ──
+    let sse = SseReaction::builder("dashboard-sse")
+        .with_port(sse_port)
+        .with_query("event-feed")
+        .with_query("pool-tracker")
+        .with_query("trader-tracker")
+        .with_query("event-breakdown")
+        .with_query("flash-loan-tracker")
+        .with_query("price-oracle")
+        .build()?;
+
+    // ── Drasi Core ──
     let core = DrasiLib::builder()
-        .with_id("sui-deepbook-example")
+        .with_id("sui-deepbook-dashboard")
         .with_source(source)
-        .with_query(query)
-        .with_reaction(reaction)
+        .with_query(event_feed)
+        .with_query(pool_tracker)
+        .with_query(trader_tracker)
+        .with_query(event_breakdown)
+        .with_query(flash_loan_tracker)
+        .with_query(price_oracle)
+        .with_reaction(sse)
         .build()
         .await?;
 
     core.start().await?;
+    info!("Drasi core started");
 
-    print_banner(&rpc_endpoint, &package_id);
+    // ── Dashboard HTTP Server ──
+    let app = Router::new().route("/", axum::routing::get(|| async { Html(DASHBOARD_HTML) }));
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{dashboard_port}")).await?;
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
 
-    let mut subscription = handle
-        .subscribe_with_options(
-            SubscriptionOptions::default().with_timeout(Duration::from_secs(5)),
-        )
-        .await?;
+    print_banner(&rpc_endpoint, &package_id, sse_port, dashboard_port);
 
-    let ctrl_c = tokio::signal::ctrl_c();
-    tokio::pin!(ctrl_c);
-
-    loop {
-        tokio::select! {
-            _ = &mut ctrl_c => {
-                println!("\n{DIM}Shutting down…{RESET}");
-                break;
-            }
-            result = subscription.recv() => {
-                if let Some(query_result) = result {
-                    for diff in &query_result.results {
-                        print_diff(diff);
-                    }
-                }
-            }
-        }
-    }
-
+    // ── Wait for Ctrl+C ──
+    tokio::signal::ctrl_c().await?;
+    println!("\nShutting down…");
     core.stop().await?;
     Ok(())
 }
 
-fn print_banner(rpc_endpoint: &str, package_id: &str) {
-    let pkg_short = truncate_hex(package_id);
+fn print_banner(rpc: &str, pkg: &str, sse_port: u16, dash_port: u16) {
+    let pkg_short = if pkg.len() > 14 {
+        format!("{}…{}", &pkg[..8], &pkg[pkg.len() - 6..])
+    } else {
+        pkg.to_string()
+    };
     println!();
-    println!("{BOLD}{CYAN}╔══════════════════════════════════════════════════════════════╗{RESET}");
-    println!("{BOLD}{CYAN}║{RESET}  {BOLD}Sui DeepBook Live Event Monitor{RESET}                             {BOLD}{CYAN}║{RESET}");
-    println!("{BOLD}{CYAN}╠══════════════════════════════════════════════════════════════╣{RESET}");
-    println!("{BOLD}{CYAN}║{RESET}  RPC:     {WHITE}{rpc_endpoint}{RESET}");
-    println!("{BOLD}{CYAN}║{RESET}  Package: {WHITE}{pkg_short}{RESET}");
-    println!("{BOLD}{CYAN}║{RESET}  Mode:    {GREEN}Live streaming (start from now){RESET}");
-    println!("{BOLD}{CYAN}║{RESET}  Graph:   {GREEN}Pool + Trader + Order enrichment enabled{RESET}");
-    println!("{BOLD}{CYAN}╠══════════════════════════════════════════════════════════════╣{RESET}");
-    println!("{BOLD}{CYAN}║{RESET}  {DIM}Waiting for DeepBook events… (Ctrl+C to stop){RESET}");
-    println!("{BOLD}{CYAN}╚══════════════════════════════════════════════════════════════╝{RESET}");
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║  DeepBook DeFi Dashboard                                   ║");
+    println!("╠══════════════════════════════════════════════════════════════╣");
+    println!("║  RPC:       {rpc}");
+    println!("║  Package:   {pkg_short}");
+    println!("║  SSE:       http://localhost:{sse_port}/events");
+    println!("║  Dashboard: http://localhost:{dash_port}");
+    println!("║  Enrichment: Pool + Trader + Order nodes enabled");
+    println!("╠══════════════════════════════════════════════════════════════╣");
+    println!("║  Open the dashboard URL in your browser.                   ║");
+    println!("║  Press Ctrl+C to stop.                                     ║");
+    println!("╚══════════════════════════════════════════════════════════════╝");
     println!();
-}
-
-fn print_diff(diff: &ResultDiff) {
-    match diff {
-        ResultDiff::Add { data } => {
-            let (icon, color) = ("▶ ADD", GREEN);
-            print_event(icon, color, data);
-        }
-        ResultDiff::Update { before, after, .. } => {
-            let (icon, color) = ("⟳ UPD", YELLOW);
-            print_event(icon, color, after);
-            print_update_delta(before, after);
-        }
-        ResultDiff::Delete { data } => {
-            let (icon, color) = ("✕ DEL", RED);
-            print_event(icon, color, data);
-        }
-        _ => {}
-    }
-}
-
-fn print_event(icon: &str, color: &str, data: &serde_json::Value) {
-    let event_name = json_str(data, "event_name");
-    let module = json_str(data, "module");
-    let entity = json_str(data, "entity_id");
-    let sender = json_str(data, "sender");
-    let pool = json_str(data, "pool");
-    let ts = format_timestamp(data);
-
-    println!(
-        "  {color}{BOLD}{icon}{RESET}  {BOLD}{event_name}{RESET} {DIM}({module}){RESET}"
-    );
-    println!(
-        "        {DIM}entity:{RESET} {CYAN}{entity}{RESET}  \
-         {DIM}sender:{RESET} {sender}  \
-         {DIM}time:{RESET} {ts}"
-    );
-
-    if !pool.is_empty() {
-        print!("        {DIM}pool:{RESET} {pool}");
-    }
-
-    let details = extract_payload_highlights(data);
-    if !details.is_empty() {
-        if !pool.is_empty() {
-            print!("  ");
-        } else {
-            print!("        ");
-        }
-        print!("{MAGENTA}");
-        print!("{details}");
-        println!("{RESET}");
-    } else if !pool.is_empty() {
-        println!();
-    }
-
-    // Print the full payload JSON, pretty-printed and dimmed
-    if let Some(payload) = data.get("payload") {
-        if payload.is_object() && !payload.as_object().unwrap().is_empty() {
-            if let Ok(pretty) = serde_json::to_string_pretty(payload) {
-                println!("        {DIM}payload:{RESET}");
-                for line in pretty.lines() {
-                    println!("          {DIM}{line}{RESET}");
-                }
-            }
-        }
-    }
-
-    println!();
-}
-
-fn print_update_delta(before: &serde_json::Value, after: &serde_json::Value) {
-    let before_type = json_str(before, "change_type");
-    let after_type = json_str(after, "change_type");
-    if !before_type.is_empty() && before_type != after_type {
-        println!(
-            "        {DIM}transition:{RESET} {before_type} {YELLOW}→{RESET} {after_type}"
-        );
-        println!();
-    }
-}
-
-fn extract_payload_highlights(data: &serde_json::Value) -> String {
-    let payload = &data["payload"];
-    if payload.is_null() || !payload.is_object() {
-        return String::new();
-    }
-
-    let interesting: &[(&str, &str)] = &[
-        ("price", "price"),
-        ("size", "size"),
-        ("quantity", "qty"),
-        ("amount", "amount"),
-        ("base_quantity", "base_qty"),
-        ("quote_quantity", "quote_qty"),
-        ("balance", "balance"),
-        ("fee", "fee"),
-        ("maker_fee", "maker_fee"),
-        ("taker_fee", "taker_fee"),
-        ("is_bid", "is_bid"),
-        ("side", "side"),
-        ("expire_timestamp", "expires"),
-    ];
-
-    let mut parts = Vec::new();
-    for (key, label) in interesting {
-        if let Some(val) = payload.get(key) {
-            let display = match val {
-                serde_json::Value::String(s) => {
-                    if *key == "is_bid" {
-                        if s == "true" { "BID".to_string() } else { "ASK".to_string() }
-                    } else {
-                        s.clone()
-                    }
-                }
-                serde_json::Value::Bool(b) => {
-                    if *key == "is_bid" {
-                        if *b { "BID".to_string() } else { "ASK".to_string() }
-                    } else {
-                        b.to_string()
-                    }
-                }
-                other => other.to_string(),
-            };
-            parts.push(format!("{label}={display}"));
-        }
-    }
-    parts.join("  ")
-}
-
-fn format_timestamp(data: &serde_json::Value) -> String {
-    data.get("timestamp_ms")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok())))
-        .and_then(|ms| Utc.timestamp_millis_opt(ms).single())
-        .map(|dt| dt.format("%H:%M:%S").to_string())
-        .unwrap_or_else(|| "—".to_string())
-}
-
-fn json_str(data: &serde_json::Value, key: &str) -> String {
-    data.get(key)
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string()
-}
-
-fn truncate_hex(hex: &str) -> String {
-    if hex.len() <= 14 {
-        return hex.to_string();
-    }
-    let prefix = &hex[..8];
-    let suffix = &hex[hex.len() - 6..];
-    format!("{prefix}…{suffix}")
 }

--- a/examples/lib/sui-deepbook-getting-started/main.rs
+++ b/examples/lib/sui-deepbook-getting-started/main.rs
@@ -46,6 +46,9 @@ async fn main() -> Result<()> {
         .with_deepbook_package_id(package_id.clone())
         .with_poll_interval_ms(2_000)
         .with_start_position(StartPosition::Now)
+        .with_enable_pool_nodes(true)
+        .with_enable_trader_nodes(true)
+        .with_enable_order_nodes(true)
         .build()?;
 
     let query = Query::cypher("deepbook-events")
@@ -122,6 +125,7 @@ fn print_banner(rpc_endpoint: &str, package_id: &str) {
     println!("{BOLD}{CYAN}║{RESET}  RPC:     {WHITE}{rpc_endpoint}{RESET}");
     println!("{BOLD}{CYAN}║{RESET}  Package: {WHITE}{pkg_short}{RESET}");
     println!("{BOLD}{CYAN}║{RESET}  Mode:    {GREEN}Live streaming (start from now){RESET}");
+    println!("{BOLD}{CYAN}║{RESET}  Graph:   {GREEN}Pool + Trader + Order enrichment enabled{RESET}");
     println!("{BOLD}{CYAN}╠══════════════════════════════════════════════════════════════╣{RESET}");
     println!("{BOLD}{CYAN}║{RESET}  {DIM}Waiting for DeepBook events… (Ctrl+C to stop){RESET}");
     println!("{BOLD}{CYAN}╚══════════════════════════════════════════════════════════════╝{RESET}");

--- a/examples/lib/sui-deepbook-getting-started/quickstart.sh
+++ b/examples/lib/sui-deepbook-getting-started/quickstart.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+./setup.sh
+
+echo "Building example..."
+cargo build
+
+echo
+echo "Starting Sui DeepBook getting-started example..."
+echo "Press Ctrl+C to stop."
+echo
+
+cargo run

--- a/examples/lib/sui-deepbook-getting-started/setup.sh
+++ b/examples/lib/sui-deepbook-getting-started/setup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RPC_URL="${SUI_RPC_URL:-https://fullnode.mainnet.sui.io:443}"
+
+echo "=== Sui DeepBook setup ==="
+echo "RPC endpoint: ${RPC_URL}"
+echo "Checking endpoint health (60s timeout)..."
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "✗ curl is required"
+  exit 1
+fi
+
+for i in {1..30}; do
+  response="$(curl -s -X POST "${RPC_URL}" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"sui_getChainIdentifier","params":[]}' || true)"
+
+  if echo "${response}" | grep -q '"result"'; then
+    chain_id="$(echo "${response}" | sed -n 's/.*"result":"\([^"]*\)".*/\1/p')"
+    echo "✓ Sui RPC reachable (chain id: ${chain_id:-unknown})"
+    echo "✓ Setup complete"
+    exit 0
+  fi
+
+  if [ "${i}" -eq 30 ]; then
+    echo "✗ RPC endpoint did not become healthy within 60 seconds"
+    echo "Last response:"
+    echo "${response}"
+    exit 1
+  fi
+
+  if [ $((i % 5)) -eq 0 ]; then
+    echo "  still waiting... (${i}/30)"
+  fi
+  sleep 2
+done

--- a/examples/lib/sui-deepbook-getting-started/test-updates.sh
+++ b/examples/lib/sui-deepbook-getting-started/test-updates.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RPC_URL="${SUI_RPC_URL:-https://fullnode.mainnet.sui.io:443}"
+DEEPBOOK_PACKAGE_ID="${DEEPBOOK_PACKAGE_ID:-0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497}"
+MAX_PAGES="${MAX_PAGES:-100}"
+
+echo "=== DeepBook change detection smoke test ==="
+echo "Querying latest DeepBook events from package ${DEEPBOOK_PACKAGE_ID}"
+echo
+
+python3 - "${RPC_URL}" "${DEEPBOOK_PACKAGE_ID}" "${MAX_PAGES}" <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+
+rpc_url = sys.argv[1]
+package_id = sys.argv[2].lower()
+max_pages = max(int(sys.argv[3]), 1)
+
+cursor = None
+matches = []
+pages_scanned = 0
+
+for page in range(max_pages):
+    params = {
+        "query": {"All": []},
+        "limit": 50,
+        "descending_order": True,
+    }
+    if cursor is not None:
+        params["cursor"] = cursor
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": page + 1,
+        "method": "suix_queryEvents",
+        "params": params,
+    }
+
+    request = urllib.request.Request(
+        rpc_url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            body = json.load(response)
+    except urllib.error.URLError as err:
+        print(f"RPC request failed: {err}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as err:
+        print(f"Failed to parse RPC response as JSON: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    if "error" in body:
+        print(f"RPC error: {body['error']}", file=sys.stderr)
+        sys.exit(1)
+
+    result = body.get("result", {})
+    rows = result.get("data", [])
+    pages_scanned += 1
+
+    for event in rows:
+        if str(event.get("packageId", "")).lower() != package_id:
+            continue
+        matches.append(event)
+        if len(matches) >= 10:
+            break
+
+    if len(matches) >= 10:
+        break
+
+    cursor = result.get("nextCursor")
+    if not result.get("hasNextPage") or cursor is None:
+        break
+
+if matches:
+    for event in matches:
+        event_type = event.get("type", "<unknown>")
+        timestamp = event.get("timestampMs", "<unknown>")
+        print(f"{event_type} @ {timestamp}")
+else:
+    print(
+        f"No matching DeepBook events found after scanning {pages_scanned} page(s); retry in a few minutes."
+    )
+PY
+
+echo
+echo "If event types are listed above, the source should be able to ingest updates."

--- a/examples/lib/sui-deepbook-getting-started/test-updates.sh
+++ b/examples/lib/sui-deepbook-getting-started/test-updates.sh
@@ -24,13 +24,7 @@ matches = []
 pages_scanned = 0
 
 for page in range(max_pages):
-    params = {
-        "query": {"All": []},
-        "limit": 50,
-        "descending_order": True,
-    }
-    if cursor is not None:
-        params["cursor"] = cursor
+    params = [{"All": []}, cursor, 50, True]
 
     payload = {
         "jsonrpc": "2.0",


### PR DESCRIPTION
# Sui DeepBook V3 Source

## Overview

The Sui DeepBook Source is a Change Data Capture (CDC) plugin for Drasi that streams events from [DeepBook V3](https://deepbook.tech/) — the native central-limit order book (CLOB) on the [Sui blockchain](https://sui.io/). It polls the Sui JSON-RPC endpoint (`suix_queryEvents`) for on-chain events emitted by the DeepBook package and transforms them into Drasi `SourceChange` events for continuous query processing.

**Key Capabilities**:
- Real-time event streaming via Sui JSON-RPC polling
- Automatic cursor persistence and resume via `StateStoreProvider`
- Client-side filtering by event type and pool ID
- Configurable start position (beginning of chain, current tip, or specific timestamp)
- Automatic retry with configurable back-off on transient RPC errors
- Full event payload projection into queryable properties

**Use Cases**:
- Real-time order book monitoring (new orders, fills, cancellations)
- Liquidity analytics across DeepBook pools
- Trading signal generation from on-chain activity
- DeFi dashboards tracking pool health and volume
- Alerting on large trades or unusual order patterns
- Historical event replay for back-testing strategies

## Architecture

### Components

The source consists of four modules:

1. **Config** (`config.rs`): Builder-pattern configuration with validation — RPC endpoint, package ID, poll interval, request limits, filters, and start position
2. **RPC** (`rpc.rs`): HTTP JSON-RPC client wrapping `suix_queryEvents` with cursor-based pagination, timeout, and error handling
3. **Mapping** (`mapping.rs`): Transforms raw Sui events into Drasi `SourceChange` records with entity ID derivation, operation classification, label assignment, and property projection
4. **Descriptor** (`descriptor.rs`): Plugin descriptor for dynamic plugin loading via the Drasi plugin SDK

**Note**: Bootstrap functionality is provided by the separate `drasi-bootstrap-sui-deepbook` crate via the pluggable bootstrap provider pattern.

### Data Flow

```
Sui JSON-RPC  →  SuiRpcClient  →  Package-ID Filter  →  Event/Pool Filter  →  Mapping  →  SourceChange
(suix_queryEvents)    ↓                                                                         ↓
                  Cursor Mgmt                                                             Dispatcher → Queries
                      ↓
                  StateStore
```

### How Events Become Graph Nodes

> **📖 Full schema reference**: See [GRAPH_SCHEMA.md](GRAPH_SCHEMA.md) for the complete graph schema including all properties, entity ID rules, operation classification, known event types, type mappings, and query examples.

Each DeepBook event becomes a `Node` element in the Drasi graph with:

| Property | Source | Example |
|----------|--------|---------|
| `entity_id` | Derived from `order_id`, `pool_id`, or `tx:seq` | `order:42`, `pool:0xabc` |
| `event_type` | Full Move type path | `0x337…::events::OrderPlaced` |
| `event_name` | Short name from the type path | `OrderPlaced` |
| `module` | Move module that emitted the event | `deep_price`, `balance_manager` |
| `change_type` | Classified from event name | `insert`, `update`, `delete` |
| `tx_digest` | Transaction that emitted the event | `0x7fa2…` |
| `event_seq` | Sequence within the transaction | `0` |
| `package_id` | Originating package address | `0x337f…` |
| `sender` | Transaction sender address (full) | `0x1a2b3c…` |
| `sender_short` | Truncated sender for display | `0x1a2b…3c4d` |
| `timestamp_ms` | On-chain timestamp (milliseconds) | `1772923888171` |
| `order_id` | Extracted when present | `42` |
| `pool_id` | Pool address (full, when present) | `0xabc123…` |
| `pool_id_short` | Truncated pool address for display | `0xabc1…2345` |
| `payload` | Full `parsedJson` as nested object | `{size: "1000", …}` |
| `payload` | Nested object with all event fields | `e.payload.size`, `e.payload.price` |

Every node receives two labels:
- `DeepBookEvent` (constant, useful for broad queries)
- A secondary label derived from the event name, e.g. `OrderPlaced`, `BalanceEvent`

### Operation Classification

Events are classified based on keywords in their type name:

| Keyword(s) | Operation | SourceChange |
|------------|-----------|--------------|
| `cancel`, `delete`, `remove` | Delete | `SourceChange::Delete` |
| `fill`, `update`, `modify`, `amend` | Update | `SourceChange::Update` |
| Everything else | Insert | `SourceChange::Insert` |

## Prerequisites

- **Sui RPC Access**: A Sui full-node JSON-RPC endpoint. The default Sui mainnet endpoint (`https://fullnode.mainnet.sui.io:443`) works but may have rate limits. For production use, consider a dedicated provider (Shinami, BlastAPI, etc.).
- **Network Connectivity**: Outbound HTTPS to the RPC endpoint.
- **DeepBook Package ID**: The address of the DeepBook V3 package. The default targets Sui mainnet.

## Configuration

### Builder Pattern (Recommended)

```rust
use drasi_source_sui_deepbook::SuiDeepBookSource;

let source = SuiDeepBookSource::builder("deepbook-source")
    .with_rpc_endpoint("https://fullnode.mainnet.sui.io:443")
    .with_deepbook_package_id("0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497")
    .with_poll_interval_ms(2_000)
    .with_request_limit(50)
    .with_start_from_now()
    .build()?;
```

### Configuration Options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `rpc_endpoint` | `String` | `https://fullnode.mainnet.sui.io:443` | Sui JSON-RPC endpoint URL |
| `deepbook_package_id` | `String` | Mainnet DeepBook V3 address | Package ID to filter events by |
| `poll_interval_ms` | `u64` | `2000` | Milliseconds between poll cycles |
| `request_limit` | `u16` | `100` | Max events per RPC page (1–1000) |
| `event_filters` | `Vec<String>` | `[]` | Event type substrings to include (empty = all) |
| `pools` | `Vec<String>` | `[]` | Pool IDs to include (empty = all) |
| `start_position` | `StartPosition` | `Now` | Where to begin consuming events |

### Start Position

| Variant | Behaviour |
|---------|-----------|
| `StartPosition::Now` | Fetch the latest cursor and only process new events going forward |
| `StartPosition::Beginning` | Start from the earliest available event on chain |
| `StartPosition::Timestamp(ms)` | Start from the beginning but skip events with `timestamp_ms < ms` |

## Query Examples

### 1. Stream All DeepBook Events

```cypher
MATCH (e:DeepBookEvent)
RETURN e.entity_id, e.event_type, e.change_type, e.timestamp_ms
```

### 2. Monitor a Specific Pool

```cypher
MATCH (e:DeepBookEvent)
WHERE e.pool_id = '0xabc123…'
RETURN e.entity_id, e.event_type, e.payload.size, e.payload.price
```

### 3. Track Order Lifecycle

```cypher
MATCH (e:DeepBookEvent)
WHERE e.order_id IS NOT NULL
RETURN e.order_id, e.change_type, e.event_type, e.timestamp_ms
```

This query surfaces `insert` → `update` → `delete` transitions as orders are placed, filled, and cancelled.

### 4. Large-Trade Alert

```cypher
MATCH (e:OrderPlaced)
WHERE e.payload.size IS NOT NULL
RETURN e.entity_id, e.pool_id, e.payload.size, e.payload.price, e.sender
```

Pair with a reaction (e.g. webhook, Slack) to alert when new orders appear.

### 5. Filter to Specific Event Types (Builder-Side)

If you only care about order placement and cancellation, configure the source to filter before the query:

```rust
let source = SuiDeepBookSource::builder("deepbook-orders")
    .with_event_filters(vec![
        "OrderPlaced".into(),
        "OrderCancelled".into(),
    ])
    .with_start_from_beginning()
    .build()?;
```

Then query:

```cypher
MATCH (e:DeepBookEvent)
RETURN e.entity_id, e.event_type, e.change_type
```

### 6. Multi-Pool Monitoring

```rust
let source = SuiDeepBookSource::builder("multi-pool")
    .with_pools(vec![
        "0xpool_sui_usdc".into(),
        "0xpool_deep_sui".into(),
    ])
    .build()?;
```

```cypher
MATCH (e:DeepBookEvent)
RETURN e.pool_id, e.event_type, count(e) AS event_count
```

### 7. Using Bootstrap for Historical Replay

Load the last 50 pages of historical events before switching to live streaming:

```rust
use drasi_bootstrap_sui_deepbook::SuiDeepBookBootstrapProvider;

let bootstrap = SuiDeepBookBootstrapProvider::builder()
    .with_max_pages(50)
    .with_start_from_beginning()
    .build()?;

let source = SuiDeepBookSource::builder("deepbook-with-history")
    .with_bootstrap_provider(bootstrap)
    .with_start_from_beginning()
    .build()?;
```

## State Management

When a `StateStoreProvider` is injected (automatically by `DrasiLib`), the source persists the Sui event cursor under the key `cursor` in its state partition. On restart, polling resumes exactly where it left off — no events are lost or duplicated.

Without a state store, the source falls back to the configured `start_position` on each startup.

## Event Filtering Pipeline

Filtering happens in three stages — broadest first:

1. **Package ID** — only events from the configured `deepbook_package_id` are kept
2. **Event type** — if `event_filters` is non-empty, the event's type name must contain or end with one of the filter strings (case-insensitive)
3. **Pool ID** — if `pools` is non-empty, the event must contain a `pool_id`/`poolId`/`pool` field matching one of the configured IDs

## Error Handling

- Transient RPC failures are retried with the configured `poll_interval_ms` as back-off
- After 10 consecutive failures the source transitions to `Error` status
- Corrupted persisted cursors are automatically cleared and the source restarts from the configured `start_position`

## Testing

```bash
# Unit tests
cargo test -p drasi-source-sui-deepbook

# Integration test (mock RPC, verifies INSERT/UPDATE/DELETE + package-ID filtering)
cargo test -p drasi-source-sui-deepbook --test integration_test -- --ignored --nocapture
```

## Limitations

- **Polling, not push**: The Sui JSON-RPC does not support server-push subscriptions for `suix_queryEvents`. The source polls at the configured interval.
- **All-events query**: Sui full-nodes do not support the `{"Package": "0x…"}` event query filter. The source queries `{"All": []}` and filters client-side by package ID. This is bandwidth-inefficient on very busy networks; using a dedicated RPC provider helps.
- **No relationship edges**: All events are modelled as independent nodes. If you need edges, use a query-time join on shared keys like `order_id` or `pool_id`.
