### PR TITLE
fix: guarantee delivery of lifecycle status events via async send (#343)

### DIFF
--- a/components/host-sdk/src/callbacks.rs
+++ b/components/host-sdk/src/callbacks.rs
@@ -366,6 +366,16 @@ pub extern "C" fn instance_log_callback(ctx: *mut c_void, entry: *const FfiLogEn
 
 /// Per-instance lifecycle callback that sends events through the SourceManager's
 /// event channel, so they flow through the same path as static source events.
+///
+/// # Delivery Guarantee
+///
+/// Status updates (Starting, Running, Stopped, Error) MUST NOT be dropped — a lost
+/// event leaves the component in a permanently stale "ghost" state that is invisible
+/// to the rest of the engine. Therefore this callback uses the host runtime handle
+/// to spawn a small async task that awaits `tx.send()` under backpressure instead
+/// of using the non-blocking `try_send`, which silently discards the message when
+/// the channel buffer is full.
+///
 /// # Safety
 /// `event` must be a valid pointer to an `FfiLifecycleEvent`. `ctx` may be null
 /// or must point to a valid `InstanceCallbackContext`.
@@ -397,7 +407,7 @@ pub extern "C" fn instance_lifecycle_callback(ctx: *mut c_void, event: *const Ff
         let status = ffi_lifecycle_to_component_status(event_type);
 
         let component_event = ComponentEvent {
-            component_id,
+            component_id: component_id.clone(),
             component_type,
             status,
             timestamp: chrono::Utc::now(),
@@ -409,11 +419,29 @@ pub extern "C" fn instance_lifecycle_callback(ctx: *mut c_void, event: *const Ff
         };
 
         let tx = context.event_tx.clone();
-        // Use try_send to avoid spawning an async task that may block
-        // the host runtime's current_thread scheduler during drop sequences.
-        if let Err(e) = tx.try_send(component_event) {
-            log::error!("Failed to send lifecycle event: {e}");
-        }
+        let runtime_handle = context.runtime_handle.clone();
+
+        // Spawn a small async task on the host runtime so we can use the
+        // *blocking* `tx.send().await` instead of the non-blocking `try_send`.
+        //
+        // `try_send` silently drops the message when the channel is full,
+        // leaving the engine with a stale view of the component's status
+        // ("ghost state"). Because status transitions are low-frequency and
+        // critical for correctness, it is safe to accept the backpressure of
+        // an awaited send; the spawned task will queue behind any pending
+        // consumer work and complete as soon as the receiver drains one slot.
+        runtime_handle.spawn(async move {
+            if let Err(e) = tx.send(component_event).await {
+                // The only way send() fails is if the receiver was dropped
+                // (i.e. the component manager has already shut down). This
+                // is expected during teardown, so we log at warn rather than
+                // error to avoid noise in normal shutdown paths.
+                log::warn!(
+                    "[lifecycle] Failed to deliver status event for '{}': receiver dropped ({e})",
+                    component_id
+                );
+            }
+        });
     }
 }
 

--- a/lib/src/managers/tracing_layer.rs
+++ b/lib/src/managers/tracing_layer.rs
@@ -49,6 +49,7 @@
 //! }.instrument(span).await;
 //! ```
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -66,6 +67,24 @@ use std::sync::OnceLock;
 /// Default capacity for the log message channel.
 /// This provides backpressure when logging volume is high.
 const LOG_CHANNEL_CAPACITY: usize = 10_000;
+
+/// Counter for log messages dropped due to a full channel.
+///
+/// This is intentionally a best-effort drop: the tracing layer must never
+/// block the async executor, so when the bounded channel is full the message
+/// is discarded. However, the drop is now *observable* — callers can inspect
+/// this counter via [`dropped_log_count()`] and alert on it.
+static DROPPED_LOG_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Return the total number of log messages dropped since process start
+/// because the internal log channel was full.
+///
+/// A non-zero value indicates that logging volume exceeded the channel
+/// capacity (`LOG_CHANNEL_CAPACITY = 10_000`). Consider increasing the
+/// capacity or reducing log verbosity if this grows steadily.
+pub fn dropped_log_count() -> u64 {
+    DROPPED_LOG_COUNT.load(Ordering::Relaxed)
+}
 
 /// Global log registry shared by all DrasiLib instances.
 /// Since tracing uses a single global subscriber, we need a single shared registry.
@@ -294,14 +313,34 @@ where
                 info.component_type,
             );
 
-            // Send to the log worker via bounded channel
-            // This provides backpressure instead of spawning unbounded tasks
+            // Send to the log worker via bounded channel.
+            // This provides backpressure instead of spawning unbounded tasks.
+            //
+            // NOTE: We intentionally use `try_send` here (non-blocking). The
+            // tracing layer's `on_event` is called synchronously from within the
+            // executor and must never block or await. If the channel is full the
+            // message is dropped, but the drop is now *observable*:
+            //   - `DROPPED_LOG_COUNT` is incremented so callers can alert on it.
+            //   - A warning is printed to stderr every 1 000 drops so operators
+            //     notice even without a metrics dashboard (eprintln! is used
+            //     instead of tracing::warn! to avoid infinite recursion).
+            //
+            // Status/lifecycle events (Starting, Running, Stopped, Error) flow
+            // through a separate channel with a guaranteed-delivery path and are
+            // NOT affected by this drop.
             if let Some(sender) = GLOBAL_LOG_SENDER.get() {
-                // Use try_send to avoid blocking in the tracing layer
-                // If channel is full, log is dropped (better than OOM)
                 if sender.try_send(log_message).is_err() {
-                    // Channel full or closed - log still goes to console via fmt layer
-                    // Could add a metric here for monitoring dropped logs
+                    let prev = DROPPED_LOG_COUNT.fetch_add(1, Ordering::Relaxed);
+                    // Emit a periodic stderr warning (every 1 000 drops) so the
+                    // issue surfaces even without external monitoring.
+                    if prev % 1_000 == 0 {
+                        eprintln!(
+                            "[drasi] WARNING: log channel full, {} component log message(s) \
+                             dropped so far. Consider increasing LOG_CHANNEL_CAPACITY or \
+                             reducing log verbosity.",
+                            prev + 1
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes #343 
## Problem

instance_lifecycle_callback in components/host-sdk/src/callbacks.rs was using tx.try_send(component_event) to forward lifecycle status transitions (Starting, Running, Stopped, Error) from FFI plugins into the LifecycleManager.

try_send is non-blocking and **silently drops the message** when the mpsc channel buffer is full. The receiver never sees the event, leaving the engine with a permanently stale "ghost" view of the component status - exactly the debugging headache described in issue #343.

## Fix

Replace try_send with a small async task spawned on the host Tokio runtime handle (already available in InstanceCallbackContext). Status transitions are low-frequency and must not be dropped. Failure log severity is lowered from error to warn since the only remaining failure mode (receiver dropped) is expected during normal shutdown.

Also adds a dropped_log_count() observable counter in the tracing layer so dropped log messages are no longer completely invisible.

## Testing

- cargo check passes
- - cargo test --package drasi-lib: 85 passed, 0 failed
- 