### PR TITLE
Fix plugin build failures for adaptive reactions and musl targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# Cross-compilation target flags (used by `cross` tool)
+#
+# musl targets default to static CRT linking, which prevents building cdylib
+# shared libraries. Disabling crt-static enables cdylib output for plugins.
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/Dockerfile.cross-musl
+++ b/Dockerfile.cross-musl
@@ -1,9 +1,21 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:0.2.5
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:0.2.5 AS toolchain
 
-# Install build dependencies for vendored OpenSSL, protobuf, and jq
+FROM ubuntu:20.04
+
+# Remove symlink that conflicts with COPY from toolchain
+RUN rm -rf /usr/local/man
+
+# Copy musl cross-toolchain and runner script from the cross image
+COPY --from=toolchain /usr/local/ /usr/local/
+COPY --from=toolchain /linux-runner /linux-runner
+
+# Install build dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates gcc libc6-dev \
     perl make autoconf automake libtool \
     protobuf-compiler libprotobuf-dev \
+    libclang-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Build OpenSSL from source for musl
@@ -38,10 +50,15 @@ ENV LIBJQ_STATIC=1
 ENV LIBONIG_STATIC=1
 
 # Create a linker wrapper that appends necessary libraries at the end
-# to resolve symbol ordering issues with musl cross-compilation
-RUN printf '#!/bin/sh\nexec x86_64-linux-musl-gcc "$@" -Wl,--no-as-needed -lpthread -ldl -lm -lc\n' \
+# to resolve symbol ordering issues with musl cross-compilation.
+# Note: musl includes pthread/dl/m symbols in libc, so only -lc is needed.
+RUN printf '#!/bin/sh\nexec x86_64-linux-musl-gcc "$@" -Wl,--no-as-needed -lc\n' \
     > /usr/local/bin/musl-gcc-wrapper \
     && chmod +x /usr/local/bin/musl-gcc-wrapper
 
-# Override the linker to use our wrapper
+# Set cargo environment for cross-compilation
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc-wrapper
+ENV CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
+ENV CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
+ENV AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar
+ENV BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_musl="--sysroot=/usr/local/x86_64-linux-musl"

--- a/Dockerfile.cross-musl
+++ b/Dockerfile.cross-musl
@@ -49,9 +49,8 @@ ENV LIBJQ_STATIC=1
 ENV LIBONIG_STATIC=1
 
 # Create a linker wrapper that appends necessary libraries at the end
-# to resolve symbol ordering issues with musl cross-compilation.
-# Note: musl includes pthread/dl/m symbols in libc, so only -lc is needed.
-RUN printf '#!/bin/sh\nexec x86_64-linux-musl-gcc "$@" -Wl,--no-as-needed -lc\n' \
+# to resolve symbol ordering issues with musl cross-compilation
+RUN printf '#!/bin/sh\nexec x86_64-linux-musl-gcc "$@" -Wl,--no-as-needed -lpthread -ldl -lm -lc\n' \
     > /usr/local/bin/musl-gcc-wrapper \
     && chmod +x /usr/local/bin/musl-gcc-wrapper
 

--- a/Dockerfile.cross-musl
+++ b/Dockerfile.cross-musl
@@ -5,9 +5,8 @@ FROM ubuntu:20.04
 # Remove symlink that conflicts with COPY from toolchain
 RUN rm -rf /usr/local/man
 
-# Copy musl cross-toolchain and runner script from the cross image
+# Copy musl cross-toolchain from the cross image
 COPY --from=toolchain /usr/local/ /usr/local/
-COPY --from=toolchain /linux-runner /linux-runner
 
 # Install build dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.cross-musl-aarch64
+++ b/Dockerfile.cross-musl-aarch64
@@ -49,8 +49,9 @@ ENV CFLAGS_aarch64_unknown_linux_musl="-I/usr/local/musl-jq/include"
 ENV LIBJQ_STATIC=1
 ENV LIBONIG_STATIC=1
 
-# Create a linker wrapper that appends necessary libraries at the end
-RUN printf '#!/bin/sh\nexec aarch64-linux-musl-gcc "$@" -Wl,--no-as-needed -lpthread -ldl -lm -lc\n' \
+# Create a linker wrapper that appends necessary libraries at the end.
+# Note: musl includes pthread/dl/m symbols in libc, so only -lc is needed.
+RUN printf '#!/bin/sh\nexec aarch64-linux-musl-gcc "$@" -Wl,--no-as-needed -lc\n' \
     > /usr/local/bin/musl-gcc-wrapper \
     && chmod +x /usr/local/bin/musl-gcc-wrapper
 
@@ -60,4 +61,4 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="/qemu-runner aarch64"
 ENV CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
 ENV CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++
 ENV AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar
-ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl="--sysroot=/usr/local/aarch64-linux-musl -I/usr/local/lib/gcc/aarch64-linux-musl/9.2.0/include"
+ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl="--sysroot=/usr/local/aarch64-linux-musl"

--- a/Dockerfile.cross-musl-aarch64
+++ b/Dockerfile.cross-musl-aarch64
@@ -49,9 +49,8 @@ ENV CFLAGS_aarch64_unknown_linux_musl="-I/usr/local/musl-jq/include"
 ENV LIBJQ_STATIC=1
 ENV LIBONIG_STATIC=1
 
-# Create a linker wrapper that appends necessary libraries at the end.
-# Note: musl includes pthread/dl/m symbols in libc, so only -lc is needed.
-RUN printf '#!/bin/sh\nexec aarch64-linux-musl-gcc "$@" -Wl,--no-as-needed -lc\n' \
+# Create a linker wrapper that appends necessary libraries at the end
+RUN printf '#!/bin/sh\nexec aarch64-linux-musl-gcc "$@" -Wl,--no-as-needed -lpthread -ldl -lm -lc\n' \
     > /usr/local/bin/musl-gcc-wrapper \
     && chmod +x /usr/local/bin/musl-gcc-wrapper
 
@@ -61,4 +60,4 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="/qemu-runner aarch64"
 ENV CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
 ENV CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++
 ENV AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar
-ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl="--sysroot=/usr/local/aarch64-linux-musl"
+ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl="--sysroot=/usr/local/aarch64-linux-musl -I/usr/local/lib/gcc/aarch64-linux-musl/9.2.0/include"

--- a/components/reactions/grpc-adaptive/Cargo.toml
+++ b/components/reactions/grpc-adaptive/Cargo.toml
@@ -56,4 +56,4 @@ tonic-build = "0.11"
 
 [features]
 # default = []
-dynamic-plugin = ["drasi-reaction-grpc/dynamic-plugin"]
+dynamic-plugin = []

--- a/components/reactions/http-adaptive/Cargo.toml
+++ b/components/reactions/http-adaptive/Cargo.toml
@@ -51,4 +51,4 @@ utoipa = { workspace = true }
 
 [features]
 # default = []
-dynamic-plugin = ["drasi-reaction-http/dynamic-plugin"]
+dynamic-plugin = []

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -471,6 +471,7 @@ fn build_plugins(args: &[String]) {
     fs::create_dir_all(&plugins_dir).expect("failed to create plugins directory");
 
     let lib_ext = plugin_lib_ext(target.as_deref());
+    let mut missing_binaries = Vec::new();
 
     for info in &result.plugins {
         let name = &info.package.name;
@@ -484,6 +485,12 @@ fn build_plugins(args: &[String]) {
                 0
             });
             let _ = fs::remove_file(&src);
+        } else {
+            eprintln!(
+                "ERROR: expected cdylib not found after build: {}",
+                src.display()
+            );
+            missing_binaries.push(name.clone());
         }
 
         // Generate metadata.json alongside the plugin binary
@@ -507,6 +514,40 @@ fn build_plugins(args: &[String]) {
         });
 
         clean_build_artifacts(&build_dir, &lib_name);
+    }
+
+    if !missing_binaries.is_empty() {
+        eprintln!(
+            "\n=== {} of {} plugin binaries missing after build ===",
+            missing_binaries.len(),
+            result.plugins.len()
+        );
+        for name in &missing_binaries {
+            eprintln!("  - {name}");
+        }
+        eprintln!("\nContents of build directory ({}):", build_dir.display());
+        match fs::read_dir(&build_dir) {
+            Ok(entries) => {
+                let mut found_any = false;
+                for entry in entries.flatten() {
+                    let fname = entry.file_name();
+                    let fname = fname.to_string_lossy();
+                    if fname.ends_with(".so")
+                        || fname.ends_with(".dll")
+                        || fname.ends_with(".dylib")
+                        || fname.ends_with(".rlib")
+                    {
+                        eprintln!("  {fname}");
+                        found_any = true;
+                    }
+                }
+                if !found_any {
+                    eprintln!("  (no library files found)");
+                }
+            }
+            Err(e) => eprintln!("  Failed to list directory: {e}"),
+        }
+        std::process::exit(1);
     }
 
     println!("=== cdylib plugins output to {} ===", plugins_dir.display());


### PR DESCRIPTION
# Description

### Duplicate FFI symbols (linux-amd64)

**Issue:** The `dynamic-plugin` feature in `http-adaptive` and `grpc-adaptive` propagated to their base crates, causing `export_plugin!` to generate duplicate `#[no_mangle]` FFI entry points in both the adaptive crate and its dependency. The linker failed with multiple definition errors for `drasi_plugin_init`, `drasi_plugin_shutdown`, and `drasi_plugin_metadata`.

**Fix:** Changed `dynamic-plugin = ["drasi-reaction-http/dynamic-plugin"]` to `dynamic-plugin = []` in both adaptive crate Cargo.toml files. The base crates are only needed as libraries for their types/logic, not as plugins.

### Missing cdylib output (linux-musl-amd64 & linux-musl-arm64)

**Issue:** Rust's musl targets default to static CRT linking (`crt-static`), which makes `cdylib` unsupported. Cargo silently dropped the shared library output, producing no `.so` files.

**Fix:** Added `.cargo/config.toml` with `rustflags = ["-C", "target-feature=-crt-static"]` for both musl targets. Also rewrote `Dockerfile.cross-musl` to use the multi-stage build pattern with required dependencies.

### Silent build failures in xtask

**Issue:** `build-plugins` generated metadata JSON unconditionally and exited successfully even when no `.so` files were produced, deferring failure to the publish step with unclear errors.

**Fix:** Added fail-fast error reporting when plugin binaries are missing, with diagnostics listing the build directory contents.
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
