### PR TITLE
Add sequence stamping and replay contracts to sources (#345)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/drasi-project/drasi-core"
@@ -104,10 +104,10 @@ drasi-functions-gql = { version = "0.4.1", path = "functions-gql" }
 drasi-middleware = { version = "0.4.1", path = "middleware" }
 drasi-identity-azure = { version = "0.1.0", path = "components/identity/azure" }
 drasi-identity-aws = { version = "0.1.0", path = "components/identity/aws" }
-drasi-lib = { version = "0.5.0", path = "lib" }
-drasi-ffi-primitives = { version = "0.5.0", path = "components/ffi-primitives" }
-drasi-plugin-sdk = { version = "0.5.0", path = "components/plugin-sdk" }
-drasi-host-sdk = { version = "0.5.0", path = "components/host-sdk" }
+drasi-lib = { version = "0.6.0", path = "lib" }
+drasi-ffi-primitives = { version = "0.6.0", path = "components/ffi-primitives" }
+drasi-plugin-sdk = { version = "0.6.0", path = "components/plugin-sdk" }
+drasi-host-sdk = { version = "0.6.0", path = "components/host-sdk" }
 
 # Common dependencies
 utoipa = { version = "4", features = ["chrono"] }

--- a/components/bootstrappers/README.md
+++ b/components/bootstrappers/README.md
@@ -226,6 +226,10 @@ pub struct SourceSubscriptionSettings {
     pub nodes: HashSet<String>,
     /// Set of relation labels the query needs from this source
     pub relations: HashSet<String>,
+    /// If set, the subscribing query requests events replayed from this sequence position.
+    pub resume_from: Option<u64>,
+    /// If true, the query requests a shared position handle for feedback.
+    pub request_position_handle: bool,
 }
 ```
 

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -222,6 +222,7 @@ impl Source for SourceProxy {
             source_id,
             receiver,
             bootstrap_receiver,
+            position_handle: None,
         })
     }
 

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -2423,6 +2423,8 @@ async fn test_cdylib_source_dispatches_events() {
         query_id: "test-query".to_string(),
         nodes: std::collections::HashSet::new(),
         relations: std::collections::HashSet::new(),
+        resume_from: None,
+        request_position_handle: false,
     };
     let sub = source.subscribe(settings).await.expect("Should subscribe");
     let receiver = sub.receiver;
@@ -2501,6 +2503,8 @@ async fn test_stress_rapid_subscribe_drop_under_load() {
             query_id: format!("stress-query-{i}"),
             nodes: std::collections::HashSet::new(),
             relations: std::collections::HashSet::new(),
+            resume_from: None,
+            request_position_handle: false,
         };
         let sub = source.subscribe(settings).await.expect("Should subscribe");
         let mut receiver = sub.receiver;

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -376,6 +376,8 @@ pub fn build_source_vtable<T: Source + 'static>(
             query_id: qid,
             nodes,
             relations,
+            resume_from: None,
+            request_position_handle: false,
         };
 
         let handle = (w.runtime_handle)().handle().clone();
@@ -700,6 +702,8 @@ pub fn build_source_vtable_from_boxed(
             query_id: qid,
             nodes,
             relations,
+            resume_from: None,
+            request_position_handle: false,
         };
 
         let handle = (w.runtime_handle)().handle().clone();

--- a/components/sources/README.md
+++ b/components/sources/README.md
@@ -106,6 +106,13 @@ pub trait Source: Send + Sync {
         true
     }
 
+    /// Whether this source supports positional replay via `resume_from`.
+    /// Sources backed by a persistent log (e.g., Postgres WAL, Kafka) should
+    /// override this to return `true`. Default is `false`.
+    fn supports_replay(&self) -> bool {
+        false
+    }
+
     /// Start the source - begins data ingestion and event generation
     async fn start(&self) -> Result<()>;
 
@@ -124,6 +131,11 @@ pub trait Source: Send + Sync {
     /// - `enable_bootstrap`: Whether to request initial data
     /// - `nodes`: Set of node labels the query is interested in
     /// - `relations`: Set of relation labels the query is interested in
+    /// - `resume_from`: Optional sequence position to replay from (replay-capable sources)
+    /// - `request_position_handle`: Whether the query wants a feedback handle
+    ///
+    /// Replay-capable sources return `Err(SourceError::PositionUnavailable { .. })`
+    /// if they cannot honor `resume_from`.
     async fn subscribe(
         &self,
         settings: SourceSubscriptionSettings,
@@ -176,6 +188,12 @@ pub struct SourceSubscriptionSettings {
     pub nodes: HashSet<String>,
     /// Set of relation labels the query is interested in from this source
     pub relations: HashSet<String>,
+    /// If set, the subscribing query requests events replayed from this sequence position.
+    /// Only meaningful when the source returns `supports_replay() == true`.
+    pub resume_from: Option<u64>,
+    /// If true, the query requests a shared `Arc<AtomicU64>` position handle in the
+    /// `SubscriptionResponse` for reporting its durably-processed position back to the source.
+    pub request_position_handle: bool,
 }
 ```
 
@@ -183,6 +201,8 @@ This enables:
 - **Label filtering at source**: Sources can pre-filter data to only send relevant labels
 - **Bootstrap optimization**: Bootstrap providers can fetch only the data types needed
 - **Efficient joins**: Multi-source queries receive label allocations for each source
+- **Positional replay**: Replay-capable sources can resume from a requested sequence position
+- **Position feedback**: Queries can share their durably-processed position back to the source
 
 ## Using SourceBase
 
@@ -367,6 +387,10 @@ pub struct SubscriptionResponse {
     pub source_id: String,
     pub receiver: Box<dyn ChangeReceiver<SourceEventWrapper>>,
     pub bootstrap_receiver: Option<BootstrapEventReceiver>,
+    /// Shared handle for the query to report its last durably-processed sequence position.
+    /// Created by replay-capable sources when `request_position_handle` is true.
+    /// Initialized to `u64::MAX` (meaning "no position confirmed yet").
+    pub position_handle: Option<Arc<AtomicU64>>,
 }
 ```
 
@@ -1023,6 +1047,8 @@ mod tests {
             enable_bootstrap: false,
             nodes: ["Item"].iter().map(|s| s.to_string()).collect(),
             relations: HashSet::new(),
+            resume_from: None,
+            request_position_handle: false,
         };
 
         let response = source.subscribe(settings).await.unwrap();

--- a/components/sources/mock/src/tests.rs
+++ b/components/sources/mock/src/tests.rs
@@ -1401,6 +1401,8 @@ mod source_trait {
             query_id: "test-query".to_string(),
             nodes: HashSet::new(),
             relations: HashSet::new(),
+            resume_from: None,
+            request_position_handle: false,
         };
 
         let result = source.subscribe(settings).await;

--- a/components/sources/source-documentation-standards.md
+++ b/components/sources/source-documentation-standards.md
@@ -591,15 +591,10 @@ impl Source for MySource {
 
     async fn subscribe(
         &self,
-        query_id: String,
-        enable_bootstrap: bool,
-        node_labels: Vec<String>,
-        relation_labels: Vec<String>,
+        settings: SourceSubscriptionSettings,
     ) -> Result<SubscriptionResponse> {
         // Delegate to base for bootstrap handling
-        self.base.subscribe_with_bootstrap(
-            query_id, enable_bootstrap, node_labels, relation_labels, "MySource"
-        ).await
+        self.base.subscribe_with_bootstrap(&settings, "MySource").await
     }
 }
 ```

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-lib"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors = ["Drasi Project"]
 description = "Embedded Drasi for in-process data change processing using continuous queries"

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -16,6 +16,7 @@ use crate::profiling::ProfilingMetadata;
 use drasi_core::models::SourceChange;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
 
@@ -216,6 +217,10 @@ pub struct SourceEventWrapper {
     pub timestamp: chrono::DateTime<chrono::Utc>,
     /// Optional profiling metadata for performance tracking
     pub profiling: Option<ProfilingMetadata>,
+    /// Monotonic, replayable sequence number stamped by the source.
+    /// `None` for volatile sources that don't support replay.
+    /// When present, must be strictly increasing per source.
+    pub sequence: Option<u64>,
 }
 
 impl SourceEventWrapper {
@@ -230,6 +235,7 @@ impl SourceEventWrapper {
             event,
             timestamp,
             profiling: None,
+            sequence: None,
         }
     }
 
@@ -245,6 +251,24 @@ impl SourceEventWrapper {
             event,
             timestamp,
             profiling: Some(profiling),
+            sequence: None,
+        }
+    }
+
+    /// Create a new SourceEventWrapper with a sequence number (and optional profiling)
+    pub fn with_sequence(
+        source_id: String,
+        event: SourceEvent,
+        timestamp: chrono::DateTime<chrono::Utc>,
+        sequence: u64,
+        profiling: Option<ProfilingMetadata>,
+    ) -> Self {
+        Self {
+            source_id,
+            event,
+            timestamp,
+            profiling,
+            sequence: Some(sequence),
         }
     }
 
@@ -257,8 +281,15 @@ impl SourceEventWrapper {
         SourceEvent,
         chrono::DateTime<chrono::Utc>,
         Option<ProfilingMetadata>,
+        Option<u64>,
     ) {
-        (self.source_id, self.event, self.timestamp, self.profiling)
+        (
+            self.source_id,
+            self.event,
+            self.timestamp,
+            self.profiling,
+            self.sequence,
+        )
     }
 
     /// Try to extract components from an Arc<SourceEventWrapper>.
@@ -275,6 +306,7 @@ impl SourceEventWrapper {
             SourceEvent,
             chrono::DateTime<chrono::Utc>,
             Option<ProfilingMetadata>,
+            Option<u64>,
         ),
         Arc<Self>,
     > {
@@ -317,6 +349,12 @@ pub struct SubscriptionResponse {
     pub source_id: String,
     pub receiver: Box<dyn super::ChangeReceiver<SourceEventWrapper>>,
     pub bootstrap_receiver: Option<BootstrapEventReceiver>,
+    /// Shared handle for the query to report its last durably-processed sequence position.
+    /// Created by replay-capable sources when `request_position_handle` is true.
+    /// The query writes to this atomically after each commit; the source reads the
+    /// minimum across all subscribers to advance its upstream cursor.
+    /// Sources should initialize this to `u64::MAX` (meaning "no position confirmed yet").
+    pub position_handle: Option<Arc<AtomicU64>>,
 }
 
 /// Subscription response from Query to Reaction
@@ -548,7 +586,7 @@ mod tests {
             chrono::Utc::now(),
         );
 
-        let (source_id, event, _timestamp, profiling) = wrapper.into_parts();
+        let (source_id, event, _timestamp, profiling, _sequence) = wrapper.into_parts();
 
         assert_eq!(source_id, "test-source");
         assert!(matches!(event, SourceEvent::Change(_)));
@@ -569,7 +607,7 @@ mod tests {
         let result = SourceEventWrapper::try_unwrap_arc(arc);
         assert!(result.is_ok());
 
-        let (source_id, event, _timestamp, _profiling) = result.unwrap();
+        let (source_id, event, _timestamp, _profiling, _sequence) = result.unwrap();
         assert_eq!(source_id, "test-source");
         assert!(matches!(event, SourceEvent::Change(_)));
     }
@@ -606,7 +644,7 @@ mod tests {
         let arc = Arc::new(wrapper);
 
         // This is the zero-copy path - when we have sole ownership
-        let (source_id, event, _timestamp, _profiling) =
+        let (source_id, event, _timestamp, _profiling, _sequence) =
             match SourceEventWrapper::try_unwrap_arc(arc) {
                 Ok(parts) => parts,
                 Err(arc) => {
@@ -616,6 +654,7 @@ mod tests {
                         arc.event.clone(),
                         arc.timestamp,
                         arc.profiling.clone(),
+                        arc.sequence,
                     )
                 }
             };
@@ -628,5 +667,63 @@ mod tests {
 
         assert_eq!(source_id, "test-source");
         assert!(source_change.is_some());
+    }
+
+    #[test]
+    fn test_source_event_wrapper_with_sequence() {
+        let change = create_test_source_change();
+        let wrapper = SourceEventWrapper::with_sequence(
+            "test-source".to_string(),
+            SourceEvent::Change(change),
+            chrono::Utc::now(),
+            42,
+            None,
+        );
+        assert_eq!(wrapper.sequence, Some(42));
+        assert!(wrapper.profiling.is_none());
+
+        let (_source_id, _event, _timestamp, _profiling, sequence) = wrapper.into_parts();
+        assert_eq!(sequence, Some(42));
+    }
+
+    #[test]
+    fn test_source_event_wrapper_new_has_no_sequence() {
+        let change = create_test_source_change();
+        let wrapper = SourceEventWrapper::new(
+            "test-source".to_string(),
+            SourceEvent::Change(change),
+            chrono::Utc::now(),
+        );
+        assert!(wrapper.sequence.is_none());
+    }
+
+    #[test]
+    fn test_subscription_response_with_position_handle() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::sync::Arc;
+
+        let handle = Arc::new(AtomicU64::new(u64::MAX));
+        assert_eq!(handle.load(Ordering::Relaxed), u64::MAX);
+
+        // Verify the handle can be cloned and read (simulates source reading query's position)
+        let handle_clone = handle.clone();
+        handle.store(500, Ordering::Relaxed);
+        assert_eq!(handle_clone.load(Ordering::Relaxed), 500);
+    }
+
+    #[test]
+    fn test_subscription_settings_with_resume_from() {
+        use std::collections::HashSet;
+        let settings = crate::config::SourceSubscriptionSettings {
+            source_id: "test-source".to_string(),
+            enable_bootstrap: false,
+            query_id: "test-query".to_string(),
+            nodes: HashSet::new(),
+            relations: HashSet::new(),
+            resume_from: Some(500),
+            request_position_handle: true,
+        };
+        assert_eq!(settings.resume_from, Some(500));
+        assert!(settings.request_position_handle);
     }
 }

--- a/lib/src/channels/events_test.rs
+++ b/lib/src/channels/events_test.rs
@@ -93,6 +93,7 @@ mod tests {
             event: SourceEvent::Change(change),
             timestamp: chrono::Utc::now(),
             profiling: None,
+            sequence: None,
         };
 
         assert_eq!(wrapper.source_id, "test-source");

--- a/lib/src/config/schema.rs
+++ b/lib/src/config/schema.rs
@@ -150,6 +150,8 @@ pub struct SourceSubscriptionConfig {
 ///     query_id: "my-query".to_string(),
 ///     nodes: ["Order", "Customer"].iter().map(|s| s.to_string()).collect(),
 ///     relations: ["PLACED_BY"].iter().map(|s| s.to_string()).collect(),
+///     resume_from: None,
+///     request_position_handle: false,
 /// };
 /// ```
 #[derive(Debug, Clone)]
@@ -159,6 +161,12 @@ pub struct SourceSubscriptionSettings {
     pub query_id: String,
     pub nodes: HashSet<String>,
     pub relations: HashSet<String>,
+    /// If set, the subscribing query requests events replayed from this sequence position.
+    /// Only meaningful when the source returns `supports_replay() == true`.
+    pub resume_from: Option<u64>,
+    /// If true, the query requests a shared `Arc<AtomicU64>` position handle in the
+    /// `SubscriptionResponse` for reporting its durably-processed position back to the source.
+    pub request_position_handle: bool,
 }
 
 /// Root configuration for drasi-lib

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -172,6 +172,9 @@ pub use indexes::{StorageBackendConfig, StorageBackendRef, StorageBackendSpec};
 /// Source trait for implementing source plugins
 pub use sources::Source;
 
+/// Structured error type for source operations (e.g., replay position unavailable)
+pub use sources::SourceError;
+
 /// Reaction traits for implementing reaction plugins
 pub use reactions::Reaction;
 

--- a/lib/src/lib_core.rs
+++ b/lib/src/lib_core.rs
@@ -1291,6 +1291,7 @@ mod tests {
                     source_id: self.id.clone(),
                     receiver,
                     bootstrap_receiver: None,
+                    position_handle: None,
                 })
             }
             fn as_any(&self) -> &dyn std::any::Any {

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -1051,7 +1051,7 @@ impl Query for DrasiQuery {
                         // Dequeue events from priority queue (blocks until available)
                         arc_event = priority_queue.dequeue() => {
                             // Try to extract without cloning if we have sole ownership (zero-copy path).
-                            let (source_id, event, _timestamp, profiling_opt) =
+                            let (source_id, event, _timestamp, profiling_opt, _sequence) =
                                 match SourceEventWrapper::try_unwrap_arc(arc_event) {
                                     Ok(parts) => parts,
                                     Err(arc) => {
@@ -1060,6 +1060,7 @@ impl Query for DrasiQuery {
                                             arc.event.clone(),
                                             arc.timestamp,
                                             arc.profiling.clone(),
+                                            arc.sequence,
                                         )
                                     }
                                 };

--- a/lib/src/queries/subscription_builder.rs
+++ b/lib/src/queries/subscription_builder.rs
@@ -36,6 +36,8 @@ impl SubscriptionSettingsBuilder {
                 query_id: query_config.id.clone(),
                 nodes: source_config.nodes.iter().cloned().collect(),
                 relations: source_config.relations.iter().cloned().collect(),
+                resume_from: None,
+                request_position_handle: false,
             })
             .collect();
 

--- a/lib/src/sources/base.rs
+++ b/lib/src/sources/base.rs
@@ -399,6 +399,7 @@ impl SourceBase {
             source_id: self.id.clone(),
             receiver,
             bootstrap_receiver,
+            position_handle: None,
         })
     }
 

--- a/lib/src/sources/mod.rs
+++ b/lib/src/sources/mod.rs
@@ -35,8 +35,9 @@ pub trait Publisher: Send + Sync {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }
 
-// Re-export the Source trait
+// Re-export the Source trait and error types
 pub use traits::Source;
+pub use traits::SourceError;
 
 pub use base::{SourceBase, SourceBaseParams};
 pub use component_graph_source::{ComponentGraphSource, COMPONENT_GRAPH_SOURCE_ID};

--- a/lib/src/sources/tests.rs
+++ b/lib/src/sources/tests.rs
@@ -142,6 +142,7 @@ impl Source for TestMockSource {
             source_id: self.id.clone(),
             receiver,
             bootstrap_receiver: None,
+            position_handle: None,
         })
     }
 
@@ -248,6 +249,7 @@ impl Source for TestBootstrapMockSource {
             source_id: self.id.clone(),
             receiver,
             bootstrap_receiver: self.bootstrap_rx.lock().await.take(),
+            position_handle: None,
         })
     }
 
@@ -345,6 +347,64 @@ impl Source for LoggingTestSource {
 
     async fn initialize(&self, context: crate::context::SourceRuntimeContext) {
         self.base.initialize(context).await;
+    }
+}
+
+#[cfg(test)]
+mod contract_tests {
+    use super::*;
+
+    #[test]
+    fn test_source_supports_replay_default_false() {
+        let source = create_test_mock_source("test-replay".to_string());
+        assert!(!source.supports_replay());
+    }
+
+    #[test]
+    fn test_source_error_position_unavailable_display() {
+        use crate::sources::SourceError;
+
+        let err = SourceError::PositionUnavailable {
+            source_id: "postgres-1".to_string(),
+            requested: 1000,
+            earliest_available: Some(5000),
+        };
+
+        // Verify display formatting
+        let msg = format!("{err}");
+        assert!(msg.contains("postgres-1"));
+        assert!(msg.contains("1000"));
+        assert!(msg.contains("5000"));
+
+        // Verify anyhow round-trip: SourceError → anyhow::Error → downcast
+        let anyhow_err: anyhow::Error = err.into();
+        let downcasted = anyhow_err.downcast_ref::<SourceError>();
+        assert!(downcasted.is_some());
+        match downcasted.unwrap() {
+            SourceError::PositionUnavailable {
+                source_id,
+                requested,
+                earliest_available,
+            } => {
+                assert_eq!(source_id, "postgres-1");
+                assert_eq!(*requested, 1000);
+                assert_eq!(*earliest_available, Some(5000));
+            }
+        }
+    }
+
+    #[test]
+    fn test_source_error_position_unavailable_no_earliest() {
+        use crate::sources::SourceError;
+
+        let err = SourceError::PositionUnavailable {
+            source_id: "http-wal".to_string(),
+            requested: 42,
+            earliest_available: None,
+        };
+
+        let msg = format!("{err}");
+        assert!(msg.contains("None"));
     }
 }
 

--- a/lib/src/sources/traits.rs
+++ b/lib/src/sources/traits.rs
@@ -38,9 +38,33 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use thiserror::Error;
 
 use crate::channels::*;
 use crate::context::SourceRuntimeContext;
+
+/// Structured error type for source operations.
+///
+/// Sources return these errors (via `anyhow::Error`) from trait methods like `subscribe()`.
+/// The orchestration layer can downcast to check for specific error variants:
+/// ```ignore
+/// if let Some(source_err) = err.downcast_ref::<SourceError>() {
+///     match source_err {
+///         SourceError::PositionUnavailable { .. } => { /* handle */ }
+///     }
+/// }
+/// ```
+#[derive(Error, Debug)]
+pub enum SourceError {
+    /// The requested resume position is no longer available.
+    /// The caller should consult its recovery_policy to decide next steps.
+    #[error("Source '{source_id}' cannot resume from position {requested}: position unavailable (earliest available: {earliest_available:?})")]
+    PositionUnavailable {
+        source_id: String,
+        requested: u64,
+        earliest_available: Option<u64>,
+    },
+}
 
 /// Trait defining the interface for all source implementations.
 ///
@@ -121,6 +145,15 @@ pub trait Source: Send + Sync {
     /// should only be started manually via `start_source()`.
     fn auto_start(&self) -> bool {
         true
+    }
+
+    /// Whether this source supports positional replay via `resume_from`.
+    ///
+    /// Sources backed by a persistent log (e.g., Postgres WAL, Kafka) should
+    /// override this to return `true`. The orchestration layer uses this to
+    /// validate compatibility with persistent queries and to request position handles.
+    fn supports_replay(&self) -> bool {
+        false
     }
 
     /// Start the source
@@ -223,6 +256,10 @@ impl Source for Box<dyn Source + 'static> {
 
     fn auto_start(&self) -> bool {
         (**self).auto_start()
+    }
+
+    fn supports_replay(&self) -> bool {
+        (**self).supports_replay()
     }
 
     async fn start(&self) -> Result<()> {


### PR DESCRIPTION
## Summary

Lays the contract and plumbing for [checkpoint-based recovery](https://github.com/drasi-project/design-documents/tree/main/drasi-lib/Source-Checkpoints) (design doc 01) without behavioral changes. All new fields default to `None`/`false` — zero overhead for volatile pipelines.

- `SourceEventWrapper` + `sequence: Option<u64>` — monotonic position stamped by replay-capable sources
- `Source` trait + `supports_replay()` — sources advertise replay capability
- `SourceError::PositionUnavailable` — typed rejection when a source can't honor `resume_from`
- `SourceSubscriptionSettings` + `resume_from`, `request_position_handle` — queries request replay position and feedback handle
- `SubscriptionResponse` + `position_handle: Option<Arc<AtomicU64>>` — shared atomic for confirmed-position feedback

No changes to drasi-core. No changes to FFI structs/signatures (new fields travel in opaque pointers or default to None at construction sites).

Resolves #345