### PR TITLE
Replayable Sources 04: Query Checkpoint Types & Infrastructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/drasi-project/drasi-core"
@@ -104,10 +104,10 @@ drasi-functions-gql = { version = "0.4.1", path = "functions-gql" }
 drasi-middleware = { version = "0.4.1", path = "middleware" }
 drasi-identity-azure = { version = "0.1.0", path = "components/identity/azure" }
 drasi-identity-aws = { version = "0.1.0", path = "components/identity/aws" }
-drasi-lib = { version = "0.4.2", path = "lib" }
-drasi-ffi-primitives = { version = "0.4.3", path = "components/ffi-primitives" }
-drasi-plugin-sdk = { version = "0.4.3", path = "components/plugin-sdk" }
-drasi-host-sdk = { version = "0.4.3", path = "components/host-sdk" }
+drasi-lib = { version = "0.5.0", path = "lib" }
+drasi-ffi-primitives = { version = "0.5.0", path = "components/ffi-primitives" }
+drasi-plugin-sdk = { version = "0.5.0", path = "components/plugin-sdk" }
+drasi-host-sdk = { version = "0.5.0", path = "components/host-sdk" }
 
 # Common dependencies
 utoipa = { version = "4", features = ["chrono"] }

--- a/components/bootstrappers/README.md
+++ b/components/bootstrappers/README.md
@@ -91,7 +91,9 @@ All bootstrap providers must implement the `BootstrapProvider` trait from `drasi
 ```rust
 use anyhow::Result;
 use async_trait::async_trait;
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
 use drasi_lib::channels::BootstrapEventSender;
 use drasi_lib::config::SourceSubscriptionSettings;
 
@@ -99,7 +101,7 @@ use drasi_lib::config::SourceSubscriptionSettings;
 pub trait BootstrapProvider: Send + Sync {
     /// Perform bootstrap operation for the given request.
     /// Sends bootstrap events to the provided channel.
-    /// Returns the number of elements sent.
+    /// Returns a `BootstrapResult` with the event count plus handover metadata.
     ///
     /// # Arguments
     /// * `request` - Bootstrap request with query ID and labels
@@ -112,7 +114,7 @@ pub trait BootstrapProvider: Send + Sync {
         context: &BootstrapContext,
         event_tx: BootstrapEventSender,
         settings: Option<&SourceSubscriptionSettings>,
-    ) -> Result<usize>;
+    ) -> Result<BootstrapResult>;
 }
 ```
 
@@ -122,7 +124,9 @@ pub trait BootstrapProvider: Send + Sync {
 - **Channel-based delivery**: Events sent via MPSC channel, not returned directly
 - **Label filtering**: Both `request` and `settings` contain labels for filtering
 - **Sequence numbering**: Use `context.next_sequence()` for each event
-- **Return count**: Return the number of elements sent for logging/metrics
+- **Return metadata**: Return a `BootstrapResult` with the event count plus
+  handover metadata (`last_sequence`, `sequences_aligned`) for the
+  bootstrap-to-streaming handover protocol
 
 ## Core Types
 
@@ -373,7 +377,7 @@ impl BootstrapProvider for MyBootstrapProvider {
         context: &BootstrapContext,
         event_tx: BootstrapEventSender,
         _settings: Option<&SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         info!(
             "Starting bootstrap for query {} from source {}",
             request.query_id, context.source_id
@@ -430,7 +434,11 @@ impl BootstrapProvider for MyBootstrapProvider {
             request.query_id, count
         );
 
-        Ok(count)
+        Ok(BootstrapResult {
+            event_count: count,
+            last_sequence: None,
+            sequences_aligned: false,
+        })
     }
 }
 
@@ -707,7 +715,8 @@ When creating a new bootstrap provider plugin:
 - [ ] Implement label filtering for nodes and relations
 - [ ] Use `context.next_sequence()` for each event
 - [ ] Send events via `event_tx.send(event).await`
-- [ ] Return count of events sent
+- [ ] Return a `BootstrapResult` with the event count (and, when applicable,
+      `last_sequence` / `sequences_aligned` for the handover protocol)
 - [ ] Implement builder pattern for ergonomic construction
 - [ ] Implement `Default` trait if sensible defaults exist
 - [ ] Add unit tests for:
@@ -759,7 +768,7 @@ impl MyBootstrapProvider {
 Filter early to avoid unnecessary data processing:
 
 ```rust
-async fn bootstrap(&self, request: BootstrapRequest, ...) -> Result<usize> {
+async fn bootstrap(&self, request: BootstrapRequest, ...) -> Result<BootstrapResult> {
     let mut count = 0;
 
     for item in self.fetch_data().await? {
@@ -774,7 +783,11 @@ async fn bootstrap(&self, request: BootstrapRequest, ...) -> Result<usize> {
         count += 1;
     }
 
-    Ok(count)
+    Ok(BootstrapResult {
+        event_count: count,
+        last_sequence: None,
+        sequences_aligned: false,
+    })
 }
 ```
 
@@ -821,7 +834,7 @@ async fn bootstrap(
     context: &BootstrapContext,
     event_tx: BootstrapEventSender,
     settings: Option<&SourceSubscriptionSettings>,
-) -> Result<usize> {
+) -> Result<BootstrapResult> {
     // Log additional context if available
     if let Some(s) = settings {
         info!(

--- a/components/bootstrappers/application/README.md
+++ b/components/bootstrappers/application/README.md
@@ -390,7 +390,7 @@ let provider = ApplicationBootstrapProviderBuilder::default().build();
 
 ### BootstrapProvider Trait Implementation
 
-##### `bootstrap(&self, request: BootstrapRequest, context: &BootstrapContext, event_tx: BootstrapEventSender) -> Result<usize>`
+##### `bootstrap(&self, request: BootstrapRequest, context: &BootstrapContext, event_tx: BootstrapEventSender, settings: Option<&SourceSubscriptionSettings>) -> Result<BootstrapResult>`
 
 Processes a bootstrap request from a query subscription.
 
@@ -398,9 +398,13 @@ Processes a bootstrap request from a query subscription.
 - `request`: Bootstrap request containing query ID and required labels
 - `context`: Bootstrap context (currently unused by this provider)
 - `event_tx`: Channel for sending bootstrap events (currently unused - ApplicationSource handles event sending)
+- `settings`: Optional subscription settings with additional query context
 
 **Returns**:
-- `Result<usize>`: Number of matching events found, or error if bootstrap fails
+- `Result<BootstrapResult>`: A `BootstrapResult` whose `event_count` is the
+  number of matching events found. `last_sequence` is `None` and
+  `sequences_aligned` is `false` — application-source bootstrap does not share
+  a sequence namespace with the streaming path.
 
 **Behavior**:
 1. Logs the bootstrap request details

--- a/components/bootstrappers/application/src/application.rs
+++ b/components/bootstrappers/application/src/application.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use drasi_lib::bootstrap::BootstrapRequest;
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider};
+use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapResult};
 
 /// Bootstrap provider for application sources that replays stored insert events
 pub struct ApplicationBootstrapProvider {
@@ -174,7 +174,7 @@ impl BootstrapProvider for ApplicationBootstrapProvider {
         _context: &BootstrapContext,
         _event_tx: drasi_lib::channels::BootstrapEventSender,
         _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         info!(
             "ApplicationBootstrapProvider processing bootstrap request for query '{}' with {} node labels and {} relation labels",
             request.query_id,
@@ -190,7 +190,7 @@ impl BootstrapProvider for ApplicationBootstrapProvider {
                 "ApplicationBootstrapProvider: No stored events to replay for query '{}'",
                 request.query_id
             );
-            return Ok(0);
+            return Ok(BootstrapResult::default());
         }
 
         info!(
@@ -213,7 +213,11 @@ impl BootstrapProvider for ApplicationBootstrapProvider {
             "ApplicationBootstrapProvider sent {} bootstrap events for query '{}'",
             count, request.query_id
         );
-        Ok(count)
+        Ok(BootstrapResult {
+            event_count: count,
+            last_sequence: None,
+            sequences_aligned: false,
+        })
     }
 }
 

--- a/components/bootstrappers/mssql/src/mssql.rs
+++ b/components/bootstrappers/mssql/src/mssql.rs
@@ -20,7 +20,7 @@ use drasi_core::models::{
     Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
 };
 use drasi_lib::bootstrap::BootstrapProvider;
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapRequest};
+use drasi_lib::bootstrap::{BootstrapContext, BootstrapRequest, BootstrapResult};
 use drasi_lib::channels::{BootstrapEvent, SourceChangeEvent};
 use drasi_mssql_common::{
     validate_sql_identifier, MsSqlConnection, MsSqlSourceConfig, PrimaryKeyCache,
@@ -65,7 +65,7 @@ impl BootstrapProvider for MsSqlBootstrapProvider {
         context: &BootstrapContext,
         event_tx: tokio::sync::mpsc::Sender<drasi_lib::channels::BootstrapEvent>,
         _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         info!(
             "Starting MS SQL bootstrap for query '{}' with {} node labels",
             request.query_id,
@@ -83,7 +83,11 @@ impl BootstrapProvider for MsSqlBootstrapProvider {
 
         info!("Completed MS SQL bootstrap for query {query_id}: sent {count} records");
 
-        Ok(count)
+        Ok(BootstrapResult {
+            event_count: count,
+            last_sequence: None,
+            sequences_aligned: false,
+        })
     }
 }
 

--- a/components/bootstrappers/noop/README.md
+++ b/components/bootstrappers/noop/README.md
@@ -171,13 +171,14 @@ impl BootstrapProvider for NoOpBootstrapProvider {
         request: BootstrapRequest,
         context: &BootstrapContext,
         event_tx: BootstrapEventSender,
-    ) -> Result<usize>;
+        settings: Option<&SourceSubscriptionSettings>,
+    ) -> Result<BootstrapResult>;
 }
 ```
 
-**Behavior**: Logs the bootstrap request for the query and immediately returns `Ok(0)` without sending any events.
+**Behavior**: Logs the bootstrap request for the query and immediately returns `BootstrapResult::default()` (event_count = 0) without sending any events.
 
-**Returns**: `Result<usize>` - Always returns `Ok(0)` indicating zero elements were sent.
+**Returns**: `Result<BootstrapResult>` — always returns a default `BootstrapResult` (`event_count: 0`, `last_sequence: None`, `sequences_aligned: false`) indicating zero elements were sent.
 
 ### NoOpBootstrapProviderBuilder
 
@@ -274,12 +275,13 @@ impl BootstrapProvider for NoOpBootstrapProvider {
         request: BootstrapRequest,
         _context: &BootstrapContext,
         _event_tx: BootstrapEventSender,
-    ) -> Result<usize> {
+        _settings: Option<&SourceSubscriptionSettings>,
+    ) -> Result<BootstrapResult> {
         info!(
             "No-op bootstrap for query {}: returning no data",
             request.query_id
         );
-        Ok(0)
+        Ok(BootstrapResult::default())
     }
 }
 ```

--- a/components/bootstrappers/noop/src/lib.rs
+++ b/components/bootstrappers/noop/src/lib.rs
@@ -21,7 +21,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use log::info;
 
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
 use drasi_lib::channels::BootstrapEventSender;
 
 /// Bootstrap provider that returns no data
@@ -77,12 +79,12 @@ impl BootstrapProvider for NoOpBootstrapProvider {
         _context: &BootstrapContext,
         _event_tx: BootstrapEventSender,
         _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         info!(
             "No-op bootstrap for query {}: returning no data",
             request.query_id
         );
-        Ok(0)
+        Ok(BootstrapResult::default())
     }
 }
 

--- a/components/bootstrappers/platform/src/platform.rs
+++ b/components/bootstrappers/platform/src/platform.rs
@@ -30,7 +30,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use drasi_core::models::{Element, ElementMetadata, ElementReference, SourceChange};
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
 use drasi_lib::sources::manager::convert_json_to_element_properties;
 
 /// Request format for Query API subscription
@@ -297,7 +299,7 @@ impl BootstrapProvider for PlatformBootstrapProvider {
         context: &BootstrapContext,
         event_tx: drasi_lib::channels::BootstrapEventSender,
         _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         info!(
             "Starting platform bootstrap for query {} from source {}",
             request.query_id, context.source_id
@@ -380,7 +382,11 @@ impl BootstrapProvider for PlatformBootstrapProvider {
             request.query_id, sent_count
         );
 
-        Ok(sent_count)
+        Ok(BootstrapResult {
+            event_count: sent_count,
+            last_sequence: None,
+            sequences_aligned: false,
+        })
     }
 }
 

--- a/components/bootstrappers/postgres/src/postgres.rs
+++ b/components/bootstrappers/postgres/src/postgres.rs
@@ -24,7 +24,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio_postgres::{Client, NoTls, Row, Transaction};
 
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
 use drasi_lib::channels::SourceChangeEvent;
 
 pub use crate::config::{PostgresBootstrapConfig, SslMode, TableKeyConfig};
@@ -204,7 +206,7 @@ impl BootstrapProvider for PostgresBootstrapProvider {
         context: &BootstrapContext,
         event_tx: drasi_lib::channels::BootstrapEventSender,
         _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         info!(
             "Starting PostgreSQL bootstrap for query '{}' with {} node labels and {} relation labels",
             request.query_id,
@@ -224,7 +226,16 @@ impl BootstrapProvider for PostgresBootstrapProvider {
 
         info!("Completed PostgreSQL bootstrap for query {query_id}: sent {count} records");
 
-        Ok(count)
+        // `last_sequence` / `sequences_aligned` are intentionally left at their
+        // defaults here. The handler already captures the snapshot LSN via
+        // `SELECT pg_current_wal_lsn()`; a follow-up issue will parse that LSN
+        // and populate these fields so Postgres→Postgres handover can dedup
+        // buffered stream events.
+        Ok(BootstrapResult {
+            event_count: count,
+            last_sequence: None,
+            sequences_aligned: false,
+        })
     }
 }
 

--- a/components/bootstrappers/scriptfile/src/script_file.rs
+++ b/components/bootstrappers/scriptfile/src/script_file.rs
@@ -23,7 +23,9 @@ use std::sync::Arc;
 
 use crate::script_reader::BootstrapScriptReader;
 use crate::script_types::{BootstrapScriptRecord, NodeRecord, RelationRecord};
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
 use drasi_lib::sources::manager::convert_json_to_element_properties;
 
 use drasi_lib::bootstrap::ScriptFileBootstrapConfig;
@@ -305,7 +307,7 @@ impl BootstrapProvider for ScriptFileBootstrapProvider {
         context: &BootstrapContext,
         event_tx: drasi_lib::channels::BootstrapEventSender,
         _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         info!(
             "Starting script file bootstrap for query {} from {} file(s)",
             request.query_id,
@@ -338,7 +340,11 @@ impl BootstrapProvider for ScriptFileBootstrapProvider {
             request.query_id, count, request.node_labels, request.relation_labels
         );
 
-        Ok(count)
+        Ok(BootstrapResult {
+            event_count: count,
+            last_sequence: None,
+            sequences_aligned: false,
+        })
     }
 }
 

--- a/components/host-sdk/src/proxies/bootstrap_provider.rs
+++ b/components/host-sdk/src/proxies/bootstrap_provider.rs
@@ -19,7 +19,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
 use drasi_lib::channels::events::{BootstrapEvent, BootstrapEventSender};
 use drasi_lib::config::SourceSubscriptionSettings;
 use drasi_plugin_sdk::descriptor::BootstrapPluginDescriptor;
@@ -57,7 +59,7 @@ impl BootstrapProvider for BootstrapProviderProxy {
         context: &BootstrapContext,
         event_tx: BootstrapEventSender,
         _settings: Option<&SourceSubscriptionSettings>,
-    ) -> anyhow::Result<usize> {
+    ) -> anyhow::Result<BootstrapResult> {
         // Build FfiStr arrays for node/relation labels
         let node_label_strs: Vec<String> = request.node_labels.clone();
         let rel_label_strs: Vec<String> = request.relation_labels.clone();
@@ -110,7 +112,14 @@ impl BootstrapProvider for BootstrapProviderProxy {
             return Err(anyhow::anyhow!("Bootstrap failed with code {count}"));
         }
 
-        Ok(count as usize)
+        // The FFI ABI (bootstrap_fn in vtables.rs) returns only a count.
+        // `last_sequence` / `sequences_aligned` require a future extension of
+        // the C ABI to flow across the plugin boundary.
+        Ok(BootstrapResult {
+            event_count: count as usize,
+            last_sequence: None,
+            sequences_aligned: false,
+        })
     }
 }
 

--- a/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
+++ b/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
@@ -23,7 +23,7 @@ use std::sync::Mutex;
 
 use super::types::{now_us, FfiStr};
 use super::vtables::{BootstrapProviderVtable, FfiBootstrapEvent, FfiBootstrapSender};
-use drasi_lib::bootstrap::BootstrapProvider;
+use drasi_lib::bootstrap::{BootstrapProvider, BootstrapResult};
 
 /// Plugin-side proxy: wraps a `BootstrapProviderVtable` into a local `BootstrapProvider`.
 pub struct FfiBootstrapProviderProxy {
@@ -41,7 +41,7 @@ impl BootstrapProvider for FfiBootstrapProviderProxy {
         context: &drasi_lib::bootstrap::BootstrapContext,
         event_tx: drasi_lib::channels::events::BootstrapEventSender,
         settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
-    ) -> anyhow::Result<usize> {
+    ) -> anyhow::Result<BootstrapResult> {
         // Extract vtable fields under the lock, then release immediately
         let (vtable_state, vtable_bootstrap_fn) = {
             let vtable = self.vtable.lock().expect("vtable mutex poisoned");
@@ -139,6 +139,13 @@ impl BootstrapProvider for FfiBootstrapProviderProxy {
         .await
         .expect("forwarding task panicked");
 
-        Ok(count)
+        // The FFI ABI (bootstrap_fn in vtables.rs) returns only a count.
+        // `last_sequence` / `sequences_aligned` require a future extension of
+        // the C ABI to flow across the plugin boundary.
+        Ok(BootstrapResult {
+            event_count: count,
+            last_sequence: None,
+            sequences_aligned: false,
+        })
     }
 }

--- a/components/sources/README.md
+++ b/components/sources/README.md
@@ -443,7 +443,7 @@ Bootstrap provides initial data to newly subscribing queries. The bootstrap syst
 pub trait BootstrapProvider: Send + Sync {
     /// Perform bootstrap operation for the given request.
     /// Sends bootstrap events to the provided channel.
-    /// Returns the number of elements sent.
+    /// Returns a `BootstrapResult` with the event count plus handover metadata.
     ///
     /// # Arguments
     /// * `request` - Bootstrap request with query ID and labels
@@ -456,7 +456,19 @@ pub trait BootstrapProvider: Send + Sync {
         context: &BootstrapContext,
         event_tx: BootstrapEventSender,
         settings: Option<&SourceSubscriptionSettings>,
-    ) -> Result<usize>;  // Returns count of events sent
+    ) -> Result<BootstrapResult>;
+}
+
+pub struct BootstrapResult {
+    /// Number of bootstrap events sent through the channel.
+    pub event_count: usize,
+    /// The snapshot's position in the source's sequence space (e.g., a
+    /// Postgres WAL LSN). `None` for providers without a positional concept.
+    pub last_sequence: Option<u64>,
+    /// Whether the bootstrap's sequence namespace matches the streaming
+    /// source's sequence namespace (typically `true` only for homogeneous
+    /// source + bootstrapper pairs, e.g., Postgres / Postgres).
+    pub sequences_aligned: bool,
 }
 
 pub struct BootstrapRequest {

--- a/components/sources/mock/src/tests.rs
+++ b/components/sources/mock/src/tests.rs
@@ -1377,7 +1377,9 @@ mod default_config {
 mod source_trait {
     use crate::{DataType, MockSource, MockSourceBuilder};
     use async_trait::async_trait;
-    use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+    use drasi_lib::bootstrap::{
+        BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+    };
     use drasi_lib::channels::BootstrapEventSender;
     use drasi_lib::config::SourceSubscriptionSettings;
     use drasi_lib::Source;
@@ -1430,9 +1432,9 @@ mod source_trait {
                 _context: &BootstrapContext,
                 _event_tx: BootstrapEventSender,
                 _settings: Option<&SourceSubscriptionSettings>,
-            ) -> anyhow::Result<usize> {
+            ) -> anyhow::Result<BootstrapResult> {
                 self.was_called.store(true, Ordering::SeqCst);
-                Ok(0)
+                Ok(BootstrapResult::default())
             }
         }
 
@@ -1460,8 +1462,8 @@ mod source_trait {
                 _context: &BootstrapContext,
                 _event_tx: BootstrapEventSender,
                 _settings: Option<&SourceSubscriptionSettings>,
-            ) -> anyhow::Result<usize> {
-                Ok(0)
+            ) -> anyhow::Result<BootstrapResult> {
+                Ok(BootstrapResult::default())
             }
         }
 

--- a/examples/lib/constructor/main.rs
+++ b/examples/lib/constructor/main.rs
@@ -179,6 +179,7 @@ async fn main() -> Result<()> {
         dispatch_buffer_capacity: None,
         dispatch_mode: None,
         storage_backend: None,
+        recovery_policy: None,
     };
 
     // =========================================================================

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-lib"
-version = "0.4.2"
+version = "0.5.0"
 edition.workspace = true
 authors = ["Drasi Project"]
 description = "Embedded Drasi for in-process data change processing using continuous queries"
@@ -82,6 +82,7 @@ ordered-float = "3.7"
 petgraph = "0.6"
 rand = "0.8"
 futures = "0.3"
+fnv = "1.0.7"
 
 
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -269,6 +269,7 @@ let config = Query::gql("active-orders")
 | `with_dispatch_buffer_capacity(usize)` | Override instance-level buffer size | Inherited |
 | `with_dispatch_mode(DispatchMode)` | `Channel` (backpressure) or `Broadcast` (fanout) | `Channel` |
 | `with_storage_backend(StorageBackendRef)` | Persistent storage for this query | In-memory |
+| `with_recovery_policy(RecoveryPolicy)` | Gap-recovery behavior for persistent queries (`Strict` fails on gap, `AutoReset` wipes + re-bootstraps) | `Strict` (via global default) |
 | `with_middleware(SourceMiddlewareConfig)` | Add middleware transformation | `[]` |
 | `build() -> QueryConfig` | Build the configuration | — |
 
@@ -920,6 +921,7 @@ let core = builder
 | `joins` | `joins` | `Option<Vec<QueryJoinConfig>>` | `None` |
 | `dispatch_mode` | `dispatch_mode` | `Option<DispatchMode>` | `Channel` |
 | `storage_backend` | `storage_backend` | `Option<StorageBackendRef>` | In-memory |
+| `recovery_policy` | `recoveryPolicy` | `Option<RecoveryPolicy>` | `Strict` (via global default) |
 
 ---
 

--- a/lib/src/bootstrap/component_graph.rs
+++ b/lib/src/bootstrap/component_graph.rs
@@ -26,7 +26,7 @@ use log::info;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use crate::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use crate::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult};
 use crate::channels::*;
 use crate::component_graph::{ComponentGraph, ComponentKind, RelationshipKind};
 use crate::config::SourceSubscriptionSettings;
@@ -56,7 +56,7 @@ impl BootstrapProvider for ComponentGraphBootstrapProvider {
         _context: &BootstrapContext,
         event_tx: BootstrapEventSender,
         _settings: Option<&SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         info!(
             "Component graph bootstrap for query '{}' starting",
             request.query_id
@@ -210,7 +210,11 @@ impl BootstrapProvider for ComponentGraphBootstrapProvider {
             "Component graph bootstrap complete: {} elements for query '{}'",
             count, request.query_id
         );
-        Ok(count as usize)
+        Ok(BootstrapResult {
+            event_count: count as usize,
+            last_sequence: None,
+            sequences_aligned: false,
+        })
     }
 }
 
@@ -254,13 +258,13 @@ mod tests {
         let request = make_request("test-query");
         let context = make_context();
 
-        let count = provider
+        let result = provider
             .bootstrap(request, &context, tx, None)
             .await
             .unwrap();
 
         // Only the instance root node is present; it is emitted as DrasiInstance
-        assert_eq!(count, 1);
+        assert_eq!(result.event_count, 1);
 
         let event = rx.recv().await.unwrap();
         match &event.change {
@@ -295,7 +299,7 @@ mod tests {
         let request = make_request("test-query");
         let context = make_context();
 
-        let count = provider
+        let result = provider
             .bootstrap(request, &context, tx, None)
             .await
             .unwrap();
@@ -305,7 +309,7 @@ mod tests {
             events.push(event);
         }
 
-        assert_eq!(count, events.len());
+        assert_eq!(result.event_count, events.len());
 
         let mut node_count = 0;
         let mut relation_count = 0;
@@ -323,7 +327,7 @@ mod tests {
         assert_eq!(node_count, 4);
         // 5 relations: HAS_SOURCE×2 + HAS_QUERY×1 + SUBSCRIBES_TO×2
         assert_eq!(relation_count, 5);
-        assert_eq!(count, 9);
+        assert_eq!(result.event_count, 9);
     }
 
     #[tokio::test]

--- a/lib/src/bootstrap/mod.rs
+++ b/lib/src/bootstrap/mod.rs
@@ -122,13 +122,34 @@ impl BootstrapContext {
 
 use crate::channels::BootstrapEventSender;
 
+/// Result of a bootstrap operation, carrying the event count plus handover
+/// metadata that lets the query transition cleanly from bootstrap to streaming.
+///
+/// See design doc 02 §5 — Bootstrap-to-Streaming Handover.
+///
+/// # Fields
+/// * `event_count` - Number of bootstrap events sent through the channel.
+/// * `last_sequence` - The snapshot's position in the source's sequence space
+///   (e.g., a Postgres WAL LSN), when known. `None` for providers that have no
+///   positional concept (e.g., script file, no-op).
+/// * `sequences_aligned` - Whether the bootstrap's sequence namespace matches
+///   the streaming source's sequence namespace. `true` only when the query
+///   can safely dedup buffered stream events against `last_sequence`
+///   (typically homogeneous source + bootstrapper, e.g., Postgres / Postgres).
+#[derive(Debug, Clone, Default)]
+pub struct BootstrapResult {
+    pub event_count: usize,
+    pub last_sequence: Option<u64>,
+    pub sequences_aligned: bool,
+}
+
 /// Trait for bootstrap providers that handle initial data delivery
-/// for newly subscribed queries
+/// for newly subscribed queries.
 #[async_trait]
 pub trait BootstrapProvider: Send + Sync {
-    /// Perform bootstrap operation for the given request
-    /// Sends bootstrap events to the provided channel
-    /// Returns the number of elements sent
+    /// Perform bootstrap operation for the given request.
+    /// Sends bootstrap events to the provided channel.
+    /// Returns a [`BootstrapResult`] carrying the event count and handover metadata.
     ///
     /// # Arguments
     /// * `request` - Bootstrap request with query ID and labels
@@ -141,7 +162,7 @@ pub trait BootstrapProvider: Send + Sync {
         context: &BootstrapContext,
         event_tx: BootstrapEventSender,
         settings: Option<&crate::config::SourceSubscriptionSettings>,
-    ) -> Result<usize>;
+    ) -> Result<BootstrapResult>;
 }
 
 /// Blanket implementation of BootstrapProvider for boxed trait objects.
@@ -154,7 +175,7 @@ impl BootstrapProvider for Box<dyn BootstrapProvider> {
         context: &BootstrapContext,
         event_tx: BootstrapEventSender,
         settings: Option<&crate::config::SourceSubscriptionSettings>,
-    ) -> Result<usize> {
+    ) -> Result<BootstrapResult> {
         (**self)
             .bootstrap(request, context, event_tx, settings)
             .await

--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -548,6 +548,7 @@ pub struct Query {
     dispatch_buffer_capacity: Option<usize>,
     dispatch_mode: Option<DispatchMode>,
     storage_backend: Option<crate::indexes::StorageBackendRef>,
+    recovery_policy: Option<crate::recovery::RecoveryPolicy>,
 }
 
 impl Query {
@@ -567,6 +568,7 @@ impl Query {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         }
     }
 
@@ -586,6 +588,7 @@ impl Query {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         }
     }
 
@@ -678,6 +681,13 @@ impl Query {
         self
     }
 
+    /// Set the recovery policy. Applies only to queries with a persistent
+    /// storage backend. See [`RecoveryPolicy`](crate::RecoveryPolicy).
+    pub fn with_recovery_policy(mut self, policy: crate::recovery::RecoveryPolicy) -> Self {
+        self.recovery_policy = Some(policy);
+        self
+    }
+
     /// Build the query configuration.
     pub fn build(self) -> QueryConfig {
         QueryConfig {
@@ -694,6 +704,7 @@ impl Query {
             dispatch_buffer_capacity: self.dispatch_buffer_capacity,
             dispatch_mode: self.dispatch_mode,
             storage_backend: self.storage_backend,
+            recovery_policy: self.recovery_policy,
         }
     }
 }

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -301,13 +301,6 @@ pub struct BootstrapEvent {
     pub sequence: u64,
 }
 
-/// Bootstrap completion signal
-#[derive(Debug, Clone)]
-pub struct BootstrapComplete {
-    pub source_id: String,
-    pub total_events: u64,
-}
-
 /// Subscription request from Query to Source
 #[derive(Debug, Clone)]
 pub struct SubscriptionRequest {
@@ -459,8 +452,6 @@ pub type QueryResultBroadcastReceiver = broadcast::Receiver<ArcQueryResult>;
 // Bootstrap channel types for dedicated bootstrap data delivery
 pub type BootstrapEventSender = mpsc::Sender<BootstrapEvent>;
 pub type BootstrapEventReceiver = mpsc::Receiver<BootstrapEvent>;
-pub type BootstrapCompleteSender = mpsc::Sender<BootstrapComplete>;
-pub type BootstrapCompleteReceiver = mpsc::Receiver<BootstrapComplete>;
 
 /// Control signals for coordination
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/src/config/schema.rs
+++ b/lib/src/config/schema.rs
@@ -18,6 +18,7 @@ use std::collections::HashSet;
 
 use crate::channels::DispatchMode;
 use crate::indexes::{StorageBackendConfig, StorageBackendRef};
+use crate::recovery::RecoveryPolicy;
 use drasi_core::models::SourceMiddlewareConfig;
 
 /// Query language for continuous queries
@@ -416,6 +417,15 @@ pub struct QueryConfig {
     /// Can reference a named backend or provide inline configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_backend: Option<StorageBackendRef>,
+    /// Recovery policy when a source cannot honor a requested resume position.
+    /// `None` inherits the global default (itself defaulting to `Strict`).
+    /// See [`RecoveryPolicy`](crate::RecoveryPolicy).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "recoveryPolicy"
+    )]
+    pub recovery_policy: Option<RecoveryPolicy>,
 }
 
 /// Synthetic join configuration for queries

--- a/lib/src/config/tests.rs
+++ b/lib/src/config/tests.rs
@@ -141,6 +141,7 @@ mod schema_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         });
 
         assert_eq!(config.queries.len(), 1);
@@ -179,6 +180,7 @@ mod persistence_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         });
 
         // Serialize to YAML
@@ -251,6 +253,7 @@ mod persistence_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         });
 
         // Save config
@@ -296,6 +299,7 @@ mod runtime_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         };
 
         let runtime = QueryRuntime::from(config.clone());
@@ -338,6 +342,7 @@ mod runtime_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         };
 
         let runtime = QueryRuntime::from(config.clone());
@@ -560,6 +565,7 @@ mod runtime_tests {
                 dispatch_buffer_capacity: None,
                 dispatch_mode: None,
                 storage_backend: None,
+                recovery_policy: None,
             }],
         };
 
@@ -600,6 +606,7 @@ mod runtime_tests {
                     dispatch_buffer_capacity: None,
                     dispatch_mode: None,
                     storage_backend: None,
+                    recovery_policy: None,
                 },
                 QueryConfig {
                     id: "q2".to_string(),
@@ -615,6 +622,7 @@ mod runtime_tests {
                     dispatch_buffer_capacity: None,
                     dispatch_mode: None,
                     storage_backend: None,
+                    recovery_policy: None,
                 },
             ],
         };
@@ -799,6 +807,7 @@ mod dispatch_mode_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: Some(DispatchMode::Channel),
             storage_backend: None,
+            recovery_policy: None,
         });
 
         config.queries.push(QueryConfig {
@@ -820,6 +829,7 @@ mod dispatch_mode_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: Some(DispatchMode::Broadcast),
             storage_backend: None,
+            recovery_policy: None,
         });
 
         config.queries.push(QueryConfig {
@@ -841,6 +851,7 @@ mod dispatch_mode_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None, // Default
             storage_backend: None,
+            recovery_policy: None,
         });
 
         assert_eq!(config.queries.len(), 3);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -49,6 +49,9 @@ pub mod error;
 /// Identity providers for authentication credentials
 pub mod identity;
 
+/// Recovery policy and error types for checkpoint-based recovery
+pub mod recovery;
+
 // ============================================================================
 // Internal Modules (crate-private, but visible to integration tests)
 // ============================================================================
@@ -121,6 +124,9 @@ pub use lib_core::DrasiLib;
 
 /// Error types for drasi-lib
 pub use error::{DrasiError, Result};
+
+/// Recovery policy and error types for checkpoint-based recovery
+pub use recovery::{RecoveryError, RecoveryPolicy};
 
 /// Component status type for monitoring component states
 pub use channels::ComponentStatus;

--- a/lib/src/queries/base.rs
+++ b/lib/src/queries/base.rs
@@ -286,6 +286,7 @@ mod tests {
             dispatch_buffer_capacity: Some(100),
             dispatch_mode: mode,
             storage_backend: None,
+            recovery_policy: None,
         }
     }
 
@@ -526,6 +527,7 @@ mod tests {
             dispatch_buffer_capacity: Some(100),
             dispatch_mode: Some(DispatchMode::Broadcast),
             storage_backend: None,
+            recovery_policy: None,
         };
 
         let base = QueryBase::new(config).unwrap();
@@ -572,6 +574,7 @@ mod tests {
             dispatch_buffer_capacity: Some(100),
             dispatch_mode: Some(DispatchMode::Channel),
             storage_backend: None,
+            recovery_policy: None,
         };
 
         let base = QueryBase::new(config).unwrap();

--- a/lib/src/queries/config_hash.rs
+++ b/lib/src/queries/config_hash.rs
@@ -1,0 +1,527 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Configuration hashing for checkpoint validation.
+//!
+//! On query restart with a persistent index, we compare a hash of the query's
+//! identity-defining config against the hash stored alongside the index. A
+//! mismatch triggers an automatic wipe + re-bootstrap
+//! (see design doc 02 §3 — Reading Checkpoints on Startup).
+//!
+//! We use `fnv` rather than `std::hash::DefaultHasher` because `DefaultHasher`
+//! is explicitly documented as unstable across Rust versions — upgrading the
+//! toolchain would silently invalidate every persistent query's config hash,
+//! causing spurious re-bootstraps. `fnv` is a fixed algorithm, already in the
+//! workspace (via the rocksdb and garnet index plugins), and deterministic
+//! across versions and platforms.
+
+use std::hash::{Hash, Hasher};
+
+use serde::Serialize;
+
+use crate::config::{
+    QueryConfig, QueryJoinConfig, QueryJoinKeyConfig, QueryLanguage, SourceSubscriptionConfig,
+};
+use drasi_core::models::SourceMiddlewareConfig;
+
+/// Minimal projection of `QueryConfig` containing only identity-defining fields.
+///
+/// Fields included (changes trigger index wipe + re-bootstrap):
+///   - `query` text
+///   - `query_language`
+///   - `middleware` (order preserved — pipeline order matters)
+///   - `sources` (sorted by `source_id`; within each source, `nodes` and
+///     `relations` are sorted + deduped because they are consumed as `HashSet`s
+///     downstream in `SubscriptionSettingsBuilder`)
+///   - `joins` (sorted by `id`; within each join, `keys` are sorted because
+///     each key is one side of a synthetic edge and has no inherent order)
+///
+/// Fields excluded (operational tuning — changes MUST NOT wipe the index):
+///   - `id`, `auto_start`, `enable_bootstrap`, `bootstrap_buffer_size`,
+///     `priority_queue_capacity`, `dispatch_buffer_capacity`, `dispatch_mode`,
+///     `storage_backend`, `recovery_policy`.
+#[derive(Serialize)]
+struct QueryIdentity<'a> {
+    query: &'a str,
+    query_language: &'a QueryLanguage,
+    middleware: &'a [SourceMiddlewareConfig],
+    sources: Vec<SourceIdentity<'a>>,
+    joins: Option<Vec<JoinIdentity<'a>>>,
+}
+
+/// Canonical projection of a `SourceSubscriptionConfig`.
+///
+/// `nodes` and `relations` are sorted and deduped to match downstream set
+/// semantics. `pipeline` preserves insertion order (it is a middleware pipeline
+/// where order determines which transformation runs first).
+#[derive(Serialize)]
+struct SourceIdentity<'a> {
+    source_id: &'a str,
+    nodes: Vec<&'a String>,
+    relations: Vec<&'a String>,
+    pipeline: &'a [String],
+}
+
+/// Canonical projection of a `QueryJoinConfig`.
+///
+/// `keys` are sorted by `(label, property)` because each key is an independent
+/// side of a synthetic edge definition and has no inherent order.
+#[derive(Serialize)]
+struct JoinIdentity<'a> {
+    id: &'a str,
+    keys: Vec<&'a QueryJoinKeyConfig>,
+}
+
+fn canonicalize_source(source: &SourceSubscriptionConfig) -> SourceIdentity<'_> {
+    let mut nodes: Vec<&String> = source.nodes.iter().collect();
+    nodes.sort();
+    nodes.dedup();
+
+    let mut relations: Vec<&String> = source.relations.iter().collect();
+    relations.sort();
+    relations.dedup();
+
+    SourceIdentity {
+        source_id: &source.source_id,
+        nodes,
+        relations,
+        pipeline: &source.pipeline,
+    }
+}
+
+fn canonicalize_join(join: &QueryJoinConfig) -> JoinIdentity<'_> {
+    let mut keys: Vec<&QueryJoinKeyConfig> = join.keys.iter().collect();
+    keys.sort_by(|a, b| (&a.label, &a.property).cmp(&(&b.label, &b.property)));
+
+    JoinIdentity { id: &join.id, keys }
+}
+
+/// Compute a deterministic hash of the identity-defining portion of a query config.
+///
+/// The hash is stable across processes, platforms, and Rust toolchain versions,
+/// and it is invariant under cosmetic reordering of `sources`, `joins`, a
+/// source's `nodes` / `relations`, and a join's `keys`.
+pub fn compute_config_hash(config: &QueryConfig) -> u64 {
+    let mut sources: Vec<SourceIdentity> = config.sources.iter().map(canonicalize_source).collect();
+    sources.sort_by(|a, b| a.source_id.cmp(b.source_id));
+
+    let joins = config.joins.as_ref().map(|j| {
+        let mut v: Vec<JoinIdentity> = j.iter().map(canonicalize_join).collect();
+        v.sort_by(|a, b| a.id.cmp(b.id));
+        v
+    });
+
+    let identity = QueryIdentity {
+        query: &config.query,
+        query_language: &config.query_language,
+        middleware: &config.middleware,
+        sources,
+        joins,
+    };
+
+    // `Serialize` on all included types is infallible for the data shapes we
+    // use (no non-JSON-representable primitives), so the `unwrap` is safe.
+    let json =
+        serde_json::to_string(&identity).expect("QueryIdentity should always serialize to JSON");
+
+    let mut hasher = fnv::FnvHasher::default();
+    json.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channels::DispatchMode;
+    use crate::config::{QueryJoinKeyConfig, SourceSubscriptionConfig};
+    use crate::recovery::RecoveryPolicy;
+    use drasi_core::models::SourceMiddlewareConfig;
+    use serde_json::{Map, Value};
+    use std::sync::Arc;
+
+    fn base() -> QueryConfig {
+        QueryConfig {
+            id: "q1".into(),
+            query: "MATCH (n) RETURN n".into(),
+            query_language: QueryLanguage::Cypher,
+            middleware: vec![],
+            sources: vec![SourceSubscriptionConfig {
+                source_id: "s1".into(),
+                nodes: vec!["A".into()],
+                relations: vec![],
+                pipeline: vec![],
+            }],
+            auto_start: true,
+            joins: None,
+            enable_bootstrap: true,
+            bootstrap_buffer_size: 10000,
+            priority_queue_capacity: None,
+            dispatch_buffer_capacity: None,
+            dispatch_mode: None,
+            storage_backend: None,
+            recovery_policy: None,
+        }
+    }
+
+    #[test]
+    fn same_config_same_hash() {
+        let a = base();
+        let b = base();
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn different_query_different_hash() {
+        let a = base();
+        let mut b = base();
+        b.query = "MATCH (m) RETURN m".into();
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn different_query_language_different_hash() {
+        let a = base();
+        let mut b = base();
+        b.query_language = QueryLanguage::GQL;
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn different_source_id_different_hash() {
+        let a = base();
+        let mut b = base();
+        b.sources[0].source_id = "s2".into();
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn different_source_labels_different_hash() {
+        let a = base();
+        let mut b = base();
+        b.sources[0].nodes = vec!["B".into()];
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn different_middleware_name_different_hash() {
+        let mut a = base();
+        a.middleware = vec![SourceMiddlewareConfig {
+            kind: Arc::from("map"),
+            name: Arc::from("m1"),
+            config: Map::new(),
+        }];
+
+        let mut b = base();
+        b.middleware = vec![SourceMiddlewareConfig {
+            kind: Arc::from("map"),
+            name: Arc::from("m2"),
+            config: Map::new(),
+        }];
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn different_middleware_config_different_hash() {
+        let mut a = base();
+        a.middleware = vec![SourceMiddlewareConfig {
+            kind: Arc::from("map"),
+            name: Arc::from("m1"),
+            config: Map::new(),
+        }];
+
+        let mut b = base();
+        let mut cfg = Map::new();
+        cfg.insert("k".into(), Value::String("v".into()));
+        b.middleware = vec![SourceMiddlewareConfig {
+            kind: Arc::from("map"),
+            name: Arc::from("m1"),
+            config: cfg,
+        }];
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn different_join_property_different_hash() {
+        let mut a = base();
+        a.joins = Some(vec![QueryJoinConfig {
+            id: "J1".into(),
+            keys: vec![QueryJoinKeyConfig {
+                label: "A".into(),
+                property: "x".into(),
+            }],
+        }]);
+
+        let mut b = base();
+        b.joins = Some(vec![QueryJoinConfig {
+            id: "J1".into(),
+            keys: vec![QueryJoinKeyConfig {
+                label: "A".into(),
+                property: "y".into(),
+            }],
+        }]);
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    // ----------------------------------------------------------------
+    // Operational tuning fields — MUST NOT affect the hash.
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn id_change_same_hash() {
+        let a = base();
+        let mut b = base();
+        b.id = "q-other".into();
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn auto_start_change_same_hash() {
+        let a = base();
+        let mut b = base();
+        b.auto_start = !b.auto_start;
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn enable_bootstrap_change_same_hash() {
+        let a = base();
+        let mut b = base();
+        b.enable_bootstrap = !b.enable_bootstrap;
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn bootstrap_buffer_size_change_same_hash() {
+        let a = base();
+        let mut b = base();
+        b.bootstrap_buffer_size = 99999;
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn priority_queue_capacity_change_same_hash() {
+        let a = base();
+        let mut b = base();
+        b.priority_queue_capacity = Some(123456);
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn dispatch_buffer_capacity_change_same_hash() {
+        let a = base();
+        let mut b = base();
+        b.dispatch_buffer_capacity = Some(42);
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn dispatch_mode_change_same_hash() {
+        let a = base();
+        let mut b = base();
+        b.dispatch_mode = Some(DispatchMode::Broadcast);
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn recovery_policy_change_same_hash() {
+        let a = base();
+        let mut b = base();
+        b.recovery_policy = Some(RecoveryPolicy::AutoReset);
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    // ----------------------------------------------------------------
+    // Ordering invariance.
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn source_reorder_same_hash() {
+        let mut a = base();
+        a.sources = vec![
+            SourceSubscriptionConfig {
+                source_id: "s1".into(),
+                nodes: vec!["A".into()],
+                relations: vec![],
+                pipeline: vec![],
+            },
+            SourceSubscriptionConfig {
+                source_id: "s2".into(),
+                nodes: vec!["B".into()],
+                relations: vec![],
+                pipeline: vec![],
+            },
+        ];
+
+        let mut b = base();
+        b.sources = vec![
+            SourceSubscriptionConfig {
+                source_id: "s2".into(),
+                nodes: vec!["B".into()],
+                relations: vec![],
+                pipeline: vec![],
+            },
+            SourceSubscriptionConfig {
+                source_id: "s1".into(),
+                nodes: vec!["A".into()],
+                relations: vec![],
+                pipeline: vec![],
+            },
+        ];
+
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn joins_reorder_same_hash() {
+        let mut a = base();
+        a.joins = Some(vec![
+            QueryJoinConfig {
+                id: "JA".into(),
+                keys: vec![],
+            },
+            QueryJoinConfig {
+                id: "JB".into(),
+                keys: vec![],
+            },
+        ]);
+
+        let mut b = base();
+        b.joins = Some(vec![
+            QueryJoinConfig {
+                id: "JB".into(),
+                keys: vec![],
+            },
+            QueryJoinConfig {
+                id: "JA".into(),
+                keys: vec![],
+            },
+        ]);
+
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn nodes_reorder_same_hash() {
+        let mut a = base();
+        a.sources[0].nodes = vec!["Order".into(), "Customer".into()];
+
+        let mut b = base();
+        b.sources[0].nodes = vec!["Customer".into(), "Order".into()];
+
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn relations_reorder_same_hash() {
+        let mut a = base();
+        a.sources[0].relations = vec!["PLACED_BY".into(), "CONTAINS".into()];
+
+        let mut b = base();
+        b.sources[0].relations = vec!["CONTAINS".into(), "PLACED_BY".into()];
+
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn duplicate_nodes_same_hash_as_deduped() {
+        let mut a = base();
+        a.sources[0].nodes = vec!["Order".into(), "Order".into(), "Customer".into()];
+
+        let mut b = base();
+        b.sources[0].nodes = vec!["Order".into(), "Customer".into()];
+
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn duplicate_relations_same_hash_as_deduped() {
+        let mut a = base();
+        a.sources[0].relations = vec!["R".into(), "R".into()];
+
+        let mut b = base();
+        b.sources[0].relations = vec!["R".into()];
+
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn join_keys_reorder_same_hash() {
+        let mut a = base();
+        a.joins = Some(vec![QueryJoinConfig {
+            id: "J1".into(),
+            keys: vec![
+                QueryJoinKeyConfig {
+                    label: "A".into(),
+                    property: "x".into(),
+                },
+                QueryJoinKeyConfig {
+                    label: "B".into(),
+                    property: "y".into(),
+                },
+            ],
+        }]);
+
+        let mut b = base();
+        b.joins = Some(vec![QueryJoinConfig {
+            id: "J1".into(),
+            keys: vec![
+                QueryJoinKeyConfig {
+                    label: "B".into(),
+                    property: "y".into(),
+                },
+                QueryJoinKeyConfig {
+                    label: "A".into(),
+                    property: "x".into(),
+                },
+            ],
+        }]);
+
+        assert_eq!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn pipeline_reorder_different_hash() {
+        let mut a = base();
+        a.sources[0].pipeline = vec!["decode".into(), "map".into()];
+
+        let mut b = base();
+        b.sources[0].pipeline = vec!["map".into(), "decode".into()];
+
+        // Pipeline order within a source is semantically meaningful.
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+
+    #[test]
+    fn middleware_reorder_different_hash() {
+        let m1 = SourceMiddlewareConfig {
+            kind: Arc::from("map"),
+            name: Arc::from("first"),
+            config: Map::new(),
+        };
+        let m2 = SourceMiddlewareConfig {
+            kind: Arc::from("map"),
+            name: Arc::from("second"),
+            config: Map::new(),
+        };
+
+        let mut a = base();
+        a.middleware = vec![m1.clone(), m2.clone()];
+
+        let mut b = base();
+        b.middleware = vec![m2, m1];
+
+        // Pipeline order is semantically meaningful — swapping changes the hash.
+        assert_ne!(compute_config_hash(&a), compute_config_hash(&b));
+    }
+}

--- a/lib/src/queries/joins_test.rs
+++ b/lib/src/queries/joins_test.rs
@@ -69,6 +69,7 @@ mod query_joins_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         }
     }
 

--- a/lib/src/queries/mod.rs
+++ b/lib/src/queries/mod.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 pub mod base;
+pub mod config_hash;
 pub mod label_extractor;
 pub mod manager;
 pub mod priority_queue;
+pub mod sequence_dedup;
 pub mod subscription_builder;
 
 #[cfg(test)]
@@ -25,7 +27,9 @@ mod tests;
 mod joins_test;
 
 pub use base::QueryBase;
+pub use config_hash::compute_config_hash;
 pub use label_extractor::*;
 pub use manager::*;
 pub use priority_queue::*;
+pub use sequence_dedup::SequenceDedup;
 pub use subscription_builder::*;

--- a/lib/src/queries/sequence_dedup.rs
+++ b/lib/src/queries/sequence_dedup.rs
@@ -1,0 +1,200 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Per-source sequence-based dedup cache.
+//!
+//! In-memory mirror of the persistent `source_checkpoint:{source_id}` entries
+//! maintained by the checkpoint-based recovery design
+//! (see design doc 02 §4 — Dedup on Replay).
+//!
+//! Populated on startup from persisted checkpoints, and updated after each
+//! successful commit. Used by the query processor loop to filter
+//! already-processed events during replay (e.g., after crash recovery or when
+//! a source rewinds to serve a late-joining subscriber).
+//!
+//! This is a pure data structure with no I/O — the processor loop owns it
+//! and is single-threaded, so no synchronization is needed.
+
+use std::collections::HashMap;
+
+/// Per-source checkpoint cache used for dedup filtering during replay.
+#[derive(Debug, Default, Clone)]
+pub struct SequenceDedup {
+    checkpoints: HashMap<String, u64>,
+}
+
+impl SequenceDedup {
+    /// Construct a new cache seeded with the given per-source checkpoints
+    /// (typically loaded from the persistent index on query startup).
+    pub fn new(checkpoints: HashMap<String, u64>) -> Self {
+        Self { checkpoints }
+    }
+
+    /// Returns `true` iff this event has already been processed for its source
+    /// (i.e., its sequence is `<=` the stored checkpoint).
+    ///
+    /// Events without a sequence (`None`) always pass through — they originate
+    /// from volatile sources that cannot be replayed, so dedup does not apply.
+    pub fn should_skip(&self, source_id: &str, sequence: Option<u64>) -> bool {
+        match sequence {
+            Some(seq) => self.checkpoints.get(source_id).is_some_and(|&cp| seq <= cp),
+            None => false,
+        }
+    }
+
+    /// Advance the checkpoint for a source after a successful commit.
+    ///
+    /// Monotonic: older sequences are ignored. In practice events are
+    /// processed in timestamp / sequence order, but this defensive guard
+    /// means a regression cannot rewind the cache.
+    pub fn advance(&mut self, source_id: &str, sequence: u64) {
+        // Fast path: source already present — `get_mut` uses `Borrow<str>` so
+        // no allocation occurs. Only allocate a new `String` on first-seen
+        // source (bounded by the number of distinct sources).
+        if let Some(entry) = self.checkpoints.get_mut(source_id) {
+            if sequence > *entry {
+                *entry = sequence;
+            }
+        } else {
+            self.checkpoints.insert(source_id.to_string(), sequence);
+        }
+    }
+
+    /// Get the current checkpoint for a given source, if any.
+    pub fn checkpoint_for(&self, source_id: &str) -> Option<u64> {
+        self.checkpoints.get(source_id).copied()
+    }
+
+    /// Borrow the full checkpoint map.
+    pub fn all_checkpoints(&self) -> &HashMap<String, u64> {
+        &self.checkpoints
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_dedup_passes_everything() {
+        let d = SequenceDedup::default();
+        assert!(!d.should_skip("s1", Some(1)));
+        assert!(!d.should_skip("s1", Some(u64::MAX)));
+        assert!(!d.should_skip("s1", None));
+    }
+
+    #[test]
+    fn skips_events_at_or_below_checkpoint() {
+        let mut checkpoints = HashMap::new();
+        checkpoints.insert("s1".to_string(), 100u64);
+        let d = SequenceDedup::new(checkpoints);
+
+        assert!(d.should_skip("s1", Some(1)));
+        assert!(d.should_skip("s1", Some(99)));
+        assert!(d.should_skip("s1", Some(100))); // equal is a skip
+    }
+
+    #[test]
+    fn passes_events_above_checkpoint() {
+        let mut checkpoints = HashMap::new();
+        checkpoints.insert("s1".to_string(), 100u64);
+        let d = SequenceDedup::new(checkpoints);
+
+        assert!(!d.should_skip("s1", Some(101)));
+        assert!(!d.should_skip("s1", Some(u64::MAX)));
+    }
+
+    #[test]
+    fn none_sequence_always_passes() {
+        let mut checkpoints = HashMap::new();
+        checkpoints.insert("s1".to_string(), 100u64);
+        let d = SequenceDedup::new(checkpoints);
+
+        assert!(!d.should_skip("s1", None));
+    }
+
+    #[test]
+    fn unknown_source_passes() {
+        let mut checkpoints = HashMap::new();
+        checkpoints.insert("s1".to_string(), 100u64);
+        let d = SequenceDedup::new(checkpoints);
+
+        assert!(!d.should_skip("other", Some(1)));
+        assert!(!d.should_skip("other", Some(200)));
+    }
+
+    #[test]
+    fn advance_inserts_new_source() {
+        let mut d = SequenceDedup::default();
+        d.advance("s1", 42);
+        assert_eq!(d.checkpoint_for("s1"), Some(42));
+    }
+
+    #[test]
+    fn advance_updates_checkpoint() {
+        let mut d = SequenceDedup::default();
+        d.advance("s1", 42);
+        d.advance("s1", 100);
+        assert_eq!(d.checkpoint_for("s1"), Some(100));
+    }
+
+    #[test]
+    fn advance_is_monotonic() {
+        let mut d = SequenceDedup::default();
+        d.advance("s1", 100);
+        d.advance("s1", 42); // regression — should be ignored
+        assert_eq!(d.checkpoint_for("s1"), Some(100));
+    }
+
+    #[test]
+    fn advance_equal_is_noop() {
+        let mut d = SequenceDedup::default();
+        d.advance("s1", 100);
+        d.advance("s1", 100);
+        assert_eq!(d.checkpoint_for("s1"), Some(100));
+    }
+
+    #[test]
+    fn per_source_isolation() {
+        let mut d = SequenceDedup::default();
+        d.advance("s1", 100);
+        d.advance("s2", 50);
+
+        assert_eq!(d.checkpoint_for("s1"), Some(100));
+        assert_eq!(d.checkpoint_for("s2"), Some(50));
+
+        assert!(d.should_skip("s1", Some(50)));
+        assert!(!d.should_skip("s2", Some(75)));
+    }
+
+    #[test]
+    fn all_checkpoints_returns_full_map() {
+        let mut d = SequenceDedup::default();
+        d.advance("a", 1);
+        d.advance("b", 2);
+        d.advance("c", 3);
+
+        let map = d.all_checkpoints();
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.get("a"), Some(&1));
+        assert_eq!(map.get("b"), Some(&2));
+        assert_eq!(map.get("c"), Some(&3));
+    }
+
+    #[test]
+    fn checkpoint_for_unknown_returns_none() {
+        let d = SequenceDedup::default();
+        assert_eq!(d.checkpoint_for("missing"), None);
+    }
+}

--- a/lib/src/queries/subscription_builder.rs
+++ b/lib/src/queries/subscription_builder.rs
@@ -179,6 +179,7 @@ mod tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         }
     }
 

--- a/lib/src/queries/tests.rs
+++ b/lib/src/queries/tests.rs
@@ -56,6 +56,7 @@ mod manager_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         }
     }
 
@@ -83,6 +84,7 @@ mod manager_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         }
     }
 
@@ -901,6 +903,7 @@ mod query_core_tests {
                 dispatch_buffer_capacity: None,
                 dispatch_mode: None,
                 storage_backend: None,
+                recovery_policy: None,
             };
 
             // Just verify the config can be created
@@ -924,6 +927,7 @@ mod query_core_tests {
             dispatch_buffer_capacity: None,
             dispatch_mode: None,
             storage_backend: None,
+            recovery_policy: None,
         };
 
         // Empty queries should be caught during validation

--- a/lib/src/recovery.rs
+++ b/lib/src/recovery.rs
@@ -1,0 +1,116 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Recovery policy and error types for checkpoint-based recovery.
+//!
+//! See the design doc at
+//! <https://github.com/drasi-project/design-documents/tree/main/drasi-lib/Source-Checkpoints>
+//! (doc 03 §4 — Recovery Policies) for the semantic rationale.
+
+use serde::{Deserialize, Serialize};
+
+/// Behavior when a source cannot honor a requested resume position.
+///
+/// Configured per-query via `QueryConfig::recovery_policy`. When the field is
+/// `None`, a future global default applies (which itself defaults to `Strict`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryPolicy {
+    /// Fail startup if the source cannot honor the requested resume position
+    /// (e.g., WAL pruned past the checkpoint, replication slot invalidated).
+    /// Requires manual intervention. Favors correctness over availability.
+    #[default]
+    Strict,
+    /// Automatically wipe the query's persistent index and perform a full
+    /// re-bootstrap on gap detection. Favors availability over consistency.
+    AutoReset,
+}
+
+/// Errors specific to checkpoint-based recovery.
+#[derive(Debug, thiserror::Error)]
+pub enum RecoveryError {
+    /// A persistent query requires all of its sources to support positional
+    /// replay, but one or more do not (e.g., transient HTTP source with WAL
+    /// disabled).
+    #[error("Incompatible source '{source_id}' for persistent query '{query_id}': {reason}")]
+    IncompatibleSource {
+        query_id: String,
+        source_id: String,
+        reason: String,
+    },
+
+    /// The `AutoReset` recovery policy fired: the query's index has been
+    /// wiped and a full bootstrap will follow.
+    #[error("Auto-reset triggered for query '{query_id}': {reason}")]
+    AutoResetTriggered { query_id: String, reason: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_strict() {
+        assert_eq!(RecoveryPolicy::default(), RecoveryPolicy::Strict);
+    }
+
+    #[test]
+    fn json_round_trip_strict() {
+        let json = serde_json::to_string(&RecoveryPolicy::Strict).unwrap();
+        assert_eq!(json, "\"strict\"");
+        let back: RecoveryPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, RecoveryPolicy::Strict);
+    }
+
+    #[test]
+    fn json_round_trip_auto_reset() {
+        let json = serde_json::to_string(&RecoveryPolicy::AutoReset).unwrap();
+        assert_eq!(json, "\"auto_reset\"");
+        let back: RecoveryPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, RecoveryPolicy::AutoReset);
+    }
+
+    #[test]
+    fn yaml_round_trip() {
+        for policy in [RecoveryPolicy::Strict, RecoveryPolicy::AutoReset] {
+            let yaml = serde_yaml::to_string(&policy).unwrap();
+            let back: RecoveryPolicy = serde_yaml::from_str(&yaml).unwrap();
+            assert_eq!(back, policy);
+        }
+    }
+
+    #[test]
+    fn incompatible_source_message() {
+        let err = RecoveryError::IncompatibleSource {
+            query_id: "q1".into(),
+            source_id: "s1".into(),
+            reason: "no WAL".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("q1"));
+        assert!(msg.contains("s1"));
+        assert!(msg.contains("no WAL"));
+    }
+
+    #[test]
+    fn auto_reset_message() {
+        let err = RecoveryError::AutoResetTriggered {
+            query_id: "q1".into(),
+            reason: "gap".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("q1"));
+        assert!(msg.contains("gap"));
+    }
+}

--- a/lib/src/sources/base.rs
+++ b/lib/src/sources/base.rs
@@ -462,11 +462,15 @@ impl SourceBase {
                         .bootstrap(request, &context, bootstrap_tx, Some(&settings_clone))
                         .await
                     {
-                        Ok(count) => {
+                        Ok(result) => {
                             info!(
-                                "Bootstrap completed successfully for query '{}', sent {count} events",
-                                settings_clone.query_id
+                                "Bootstrap completed successfully for query '{}', sent {} events",
+                                settings_clone.query_id, result.event_count
                             );
+                            // `result.last_sequence` / `result.sequences_aligned`
+                            // are intentionally unused at this call site — a
+                            // future query-processor integration issue will
+                            // plumb them through to the handover protocol.
                         }
                         Err(e) => {
                             error!(


### PR DESCRIPTION
Implements #363. Lands the foundational types and pure logic modules needed by a future query processor integration for checkpoint-based recovery in drasi-lib. Everything here is self-contained and testable
with no wiring into the processor loop yet. Independent of #345 and #346.

`BootstrapProvider::bootstrap()` now returns `Result<BootstrapResult>` instead of `Result<usize>`. The new struct carries the event count plus handover metadata (`last_sequence`, `sequences_aligned`) that a future issue will consume to dedup buffered stream events after bootstrap.

All 11 implementations across bootstrapper crates, FFI proxies, test providers, and the in-lib `ComponentGraphBootstrapProvider` are updated, along with the `SourceBase` call site. Existing providers preserve today's behavior by returning defaults for the new metadata fields.

Adds a new `lib/src/recovery` module with `RecoveryPolicy` (Strict / AutoReset) and `RecoveryError`, an optional `recovery_policy` field on `QueryConfig`, and a `Query::with_recovery_policy` builder method.

Adds two new query-side modules in `lib/src/queries/`. `compute_config_hash` hashes a projected `QueryIdentity` (identity-defining fields only, tuning fields excluded) via `fnv` for stability across Rust toolchains, sorting sources and joins so that cosmetic reordering does not invalidate the persistent index. `SequenceDedup` is a pure per-source checkpoint cache for future replay-side dedup filtering.

Removes dead `BootstrapComplete` types from `channels/events.rs`.

Design docs: https://github.com/drasi-project/design-documents/tree/main/drasi-lib/Source-Checkpoints

Workspace builds clean. `cargo test -p drasi-lib --lib` reports 676 passed including 37 new unit tests in the three new modules. Clippy and fmt clean.

Fixes #363 