### PR TITLE
Fix intermittent SIGSEGV in cross-platform FFI plugin tests

### DIFF
--- a/components/host-sdk/src/identity_bridge.rs
+++ b/components/host-sdk/src/identity_bridge.rs
@@ -44,57 +44,66 @@ impl IdentityProviderVtableBuilder {
             context_json: *const u8,
             context_len: usize,
         ) -> FfiCredentialsResult {
-            let wrapper = unsafe { &*(state as *const HostIdentityProviderState) };
-            let provider = wrapper.provider.clone();
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let wrapper = unsafe { &*(state as *const HostIdentityProviderState) };
+                let provider = wrapper.provider.clone();
 
-            // Deserialize context from JSON
-            let context = if context_json.is_null() || context_len == 0 {
-                CredentialContext::default()
-            } else {
-                let json_bytes = unsafe { std::slice::from_raw_parts(context_json, context_len) };
-                let json_str = std::str::from_utf8(json_bytes).unwrap_or("{}");
-                let properties: std::collections::HashMap<String, String> =
-                    match serde_json::from_str(json_str) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            log::warn!("Failed to deserialize credential context JSON: {e}");
-                            std::collections::HashMap::new()
-                        }
-                    };
-                CredentialContext { properties }
-            };
+                // Deserialize context from JSON
+                let context = if context_json.is_null() || context_len == 0 {
+                    CredentialContext::default()
+                } else {
+                    let json_bytes =
+                        unsafe { std::slice::from_raw_parts(context_json, context_len) };
+                    let json_str = std::str::from_utf8(json_bytes).unwrap_or("{}");
+                    let properties: std::collections::HashMap<String, String> =
+                        match serde_json::from_str(json_str) {
+                            Ok(p) => p,
+                            Err(e) => {
+                                log::warn!("Failed to deserialize credential context JSON: {e}");
+                                std::collections::HashMap::new()
+                            }
+                        };
+                    CredentialContext { properties }
+                };
 
-            // This vtable is called from the plugin side (extern "C") which may
-            // already be inside a tokio runtime. We spawn a thread and create a
-            // lightweight current-thread runtime to avoid nesting runtimes.
-            let result = std::thread::spawn(move || {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|e| anyhow::anyhow!("Failed to create runtime: {e}"))?;
-                rt.block_on(provider.get_credentials(&context))
-            })
-            .join();
+                // This vtable is called from the plugin side (extern "C") which may
+                // already be inside a tokio runtime. We spawn a thread and create a
+                // lightweight current-thread runtime to avoid nesting runtimes.
+                let result = std::thread::spawn(move || {
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .map_err(|e| anyhow::anyhow!("Failed to create runtime: {e}"))?;
+                    rt.block_on(provider.get_credentials(&context))
+                })
+                .join();
 
-            match result {
-                Ok(Ok(creds)) => FfiCredentialsResult::ok(credentials_to_ffi(creds)),
-                Ok(Err(e)) => FfiCredentialsResult::err(e.to_string()),
-                Err(_) => FfiCredentialsResult::err("get_credentials thread panicked".into()),
-            }
+                match result {
+                    Ok(Ok(creds)) => FfiCredentialsResult::ok(credentials_to_ffi(creds)),
+                    Ok(Err(e)) => FfiCredentialsResult::err(e.to_string()),
+                    Err(_) => FfiCredentialsResult::err("get_credentials thread panicked".into()),
+                }
+            }))
+            .unwrap_or_else(|_| FfiCredentialsResult::err("get_credentials_fn panicked".into()))
         }
 
         extern "C" fn clone_fn(state: *const c_void) -> *mut c_void {
-            let wrapper = unsafe { &*(state as *const HostIdentityProviderState) };
-            let cloned = Box::new(HostIdentityProviderState {
-                provider: wrapper.provider.clone(),
-            });
-            Box::into_raw(cloned) as *mut c_void
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let wrapper = unsafe { &*(state as *const HostIdentityProviderState) };
+                let cloned = Box::new(HostIdentityProviderState {
+                    provider: wrapper.provider.clone(),
+                });
+                Box::into_raw(cloned) as *mut c_void
+            }))
+            .unwrap_or(std::ptr::null_mut())
         }
 
         extern "C" fn drop_fn(state: *mut c_void) {
-            if !state.is_null() {
-                unsafe { drop(Box::from_raw(state as *mut HostIdentityProviderState)) };
-            }
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                if !state.is_null() {
+                    unsafe { drop(Box::from_raw(state as *mut HostIdentityProviderState)) };
+                }
+            }));
         }
 
         let wrapper = Box::new(HostIdentityProviderState { provider });

--- a/components/host-sdk/src/proxies/bootstrap_provider.rs
+++ b/components/host-sdk/src/proxies/bootstrap_provider.rs
@@ -146,26 +146,30 @@ fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSen
     let state = Box::into_raw(Box::new(std_tx)) as *mut c_void;
 
     extern "C" fn send_fn(state: *mut c_void, event: *mut FfiBootstrapEvent) -> i32 {
-        let tx = unsafe { &*(state as *const std::sync::mpsc::Sender<BootstrapEvent>) };
-        if event.is_null() {
-            return -1;
-        }
-        let ffi_event = unsafe { &*event };
-        let bootstrap_event = unsafe { *Box::from_raw(ffi_event.opaque as *mut BootstrapEvent) };
-        // Free the FFI envelope but not the opaque (we took ownership)
-        unsafe { drop(Box::from_raw(event)) };
-        match tx.send(bootstrap_event) {
-            Ok(()) => 0,
-            Err(_) => -1,
-        }
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let tx = unsafe { &*(state as *const std::sync::mpsc::Sender<BootstrapEvent>) };
+            if event.is_null() {
+                return -1;
+            }
+            let ffi_event = unsafe { &*event };
+            let bootstrap_event =
+                unsafe { *Box::from_raw(ffi_event.opaque as *mut BootstrapEvent) };
+            // Free the FFI envelope but not the opaque (we took ownership)
+            unsafe { drop(Box::from_raw(event)) };
+            match tx.send(bootstrap_event) {
+                Ok(()) => 0,
+                Err(_) => -1,
+            }
+        }))
+        .unwrap_or(-1)
     }
 
     extern "C" fn drop_fn(state: *mut c_void) {
-        unsafe {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
             drop(Box::from_raw(
                 state as *mut std::sync::mpsc::Sender<BootstrapEvent>,
             ))
-        };
+        }));
     }
 
     FfiBootstrapSender {

--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -36,6 +36,16 @@ pub struct ReactionProxy {
     _library: Arc<Library>,
     cached_id: String,
     cached_type_name: String,
+    /// Per-instance callback context for plugin-emitted log/lifecycle callbacks.
+    ///
+    /// Stored as an `Arc` whose strong count was bumped by `Arc::into_raw` when
+    /// the raw pointer was handed to the plugin. The host's `Arc` is kept here
+    /// so the proxy holds at least two strong references; on Drop the host's
+    /// `Arc` is `mem::forget`-ed unconditionally so any **late** log/lifecycle
+    /// callback emitted by the plugin (after `stop()` returns) still finds a
+    /// valid pointer. The cdylib itself is intentionally leaked process-wide
+    /// (see `host-sdk/src/loader.rs`), so the small per-instance `Arc` leak is
+    /// acceptable in exchange for closing the late-callback UAF window.
     _callback_ctx: std::sync::Mutex<Option<Arc<crate::callbacks::InstanceCallbackContext>>>,
     /// Channel for push-based result delivery. Created on start, closed on stop/drop.
     result_tx:
@@ -195,7 +205,13 @@ impl Reaction for ReactionProxy {
             update_tx: context.update_tx.clone(),
         });
 
-        let ctx_ptr = Arc::as_ptr(&per_instance_ctx) as *mut c_void;
+        // Bug C fix: hand the plugin a strong reference (Arc::into_raw bumps
+        // the refcount) so log/lifecycle callbacks emitted late by the plugin
+        // (e.g. from inside stop_fn or from internal tasks shutting down) do
+        // not deref freed memory. The matching `mem::forget` happens in Drop
+        // and intentionally leaks one strong ref per instance.
+        let ctx_for_plugin = per_instance_ctx.clone();
+        let ctx_ptr = Arc::into_raw(ctx_for_plugin) as *mut c_void;
 
         if let Ok(mut guard) = self._callback_ctx.lock() {
             *guard = Some(per_instance_ctx);
@@ -257,18 +273,17 @@ impl Reaction for ReactionProxy {
     }
 
     async fn stop(&self) -> anyhow::Result<()> {
-        // Close the sender so the forwarder's callback returns null
+        // Bug B fix: close ONLY the sender. Dropping the sender is sufficient
+        // to unblock the forwarder's `rx.recv()` (it returns Err, the callback
+        // returns null, and the forwarder breaks). Do NOT also drop the
+        // receiver here — the callback may still be holding `context.rx.lock()`
+        // for a recv() that is racing this stop, and removing the receiver
+        // mid-flight creates a race against the forwarder's in-flight
+        // `enqueue_query_result(qr).await` against the reaction's
+        // shutting-down priority queue.
         {
             let mut guard = self.result_tx.lock().expect("result_tx lock poisoned");
             *guard = None;
-        }
-        // Also drop the receiver to unblock the callback if it's blocked in recv()
-        if let Ok(guard) = self._push_ctx.lock() {
-            if let Some(ref ctx) = *guard {
-                if let Ok(mut rx_guard) = ctx.rx.lock() {
-                    *rx_guard = None;
-                }
-            }
         }
 
         let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
@@ -327,15 +342,10 @@ impl Drop for ReactionProxy {
         if let Ok(mut guard) = self.result_tx.lock() {
             *guard = None;
         }
-        // Also drop the receiver inside the push context to unblock the callback
-        // if it's blocked in recv() (belt-and-suspenders with the sender drop).
-        if let Ok(guard) = self._push_ctx.lock() {
-            if let Some(ref ctx) = *guard {
-                if let Ok(mut rx_guard) = ctx.rx.lock() {
-                    *rx_guard = None;
-                }
-            }
-        }
+        // Bug B fix: do NOT drop the receiver here. Sender drop alone unblocks
+        // recv(); leaving the receiver in place avoids racing a callback that
+        // is currently holding `context.rx.lock()`. The receiver lives until
+        // the leaked push-ctx Arc is collected (see the `mem::forget` below).
 
         // Wait for the forwarder task to fully exit its processing loop.
         //
@@ -377,6 +387,20 @@ impl Drop for ReactionProxy {
         // spawn_blocking callback may still reference it. On the success path
         // this is unnecessary but harmless, and keeps the logic simple.
         if let Ok(mut guard) = self._push_ctx.lock() {
+            if let Some(ctx) = guard.take() {
+                std::mem::forget(ctx);
+            }
+        }
+
+        // Bug C fix: leak the per-instance callback context Arc unconditionally.
+        // The strong reference handed to the plugin via `Arc::into_raw` in
+        // initialize() is never reclaimed — late log/lifecycle callbacks
+        // emitted by the plugin (during stop_fn or from internal tasks) must
+        // still find a valid pointer. The cdylib itself is intentionally
+        // leaked process-wide (see host-sdk/src/loader.rs), so this small
+        // per-instance Arc leak is the price of closing the late-callback
+        // UAF window.
+        if let Ok(mut guard) = self._callback_ctx.lock() {
             if let Some(ctx) = guard.take() {
                 std::mem::forget(ctx);
             }

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -40,23 +40,30 @@ use crate::state_store_bridge::StateStoreVtableBuilder;
 /// Runs the pinned future on a new OS thread with a current-thread tokio runtime.
 /// This avoids nesting issues with the host's multi-thread runtime.
 extern "C" fn host_executor(future_ptr: *mut c_void) -> *mut c_void {
-    // Wrap the raw pointer to make it Send-safe for std::thread::spawn
-    let send_ptr = drasi_plugin_sdk::ffi::SendMutPtr(future_ptr);
-    let result = std::thread::spawn(move || {
-        let boxed_future = unsafe {
-            Box::from_raw(send_ptr.as_ptr()
-                as *mut std::pin::Pin<Box<dyn std::future::Future<Output = *mut c_void>>>)
-        };
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("failed to build tokio runtime for source proxy");
-        // Wrap the result in SendMutPtr to satisfy Send bound
-        drasi_plugin_sdk::ffi::SendMutPtr(rt.block_on(*boxed_future))
-    })
-    .join()
-    .expect("host executor thread panicked");
-    result.as_ptr()
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // Wrap the raw pointer to make it Send-safe for std::thread::spawn
+        let send_ptr = drasi_plugin_sdk::ffi::SendMutPtr(future_ptr);
+        let result = std::thread::spawn(move || {
+            let boxed_future = unsafe {
+                Box::from_raw(send_ptr.as_ptr()
+                    as *mut std::pin::Pin<Box<dyn std::future::Future<Output = *mut c_void>>>)
+            };
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(_) => return drasi_plugin_sdk::ffi::SendMutPtr(std::ptr::null_mut()),
+            };
+            // Wrap the result in SendMutPtr to satisfy Send bound
+            drasi_plugin_sdk::ffi::SendMutPtr(rt.block_on(*boxed_future))
+        })
+        .join()
+        .map(|p| p.as_ptr())
+        .unwrap_or(std::ptr::null_mut());
+        result
+    }))
+    .unwrap_or(std::ptr::null_mut())
 }
 
 /// Wraps a `SourceVtable` into a DrasiLib `Source` trait implementation.
@@ -264,10 +271,15 @@ impl Source for SourceProxy {
             update_tx: context.update_tx.clone(),
         });
 
-        // Use as_ptr (no refcount increment) — the Arc in _callback_ctx keeps
-        // the context alive for the proxy's lifetime. This avoids the memory
-        // leak that Arc::into_raw would cause (no matching from_raw).
-        let ctx_ptr = Arc::as_ptr(&per_instance_ctx) as *mut c_void;
+        // Bug C fix: hand the plugin a strong reference (Arc::into_raw bumps
+        // the refcount) so log/lifecycle callbacks emitted late by the plugin
+        // (e.g. from inside stop_fn or from internal tasks shutting down) do
+        // not deref freed memory. The matching `mem::forget` happens in Drop
+        // and intentionally leaks one strong ref per instance — acceptable
+        // because the cdylib itself is intentionally process-leaked (see
+        // host-sdk/src/loader.rs).
+        let ctx_for_plugin = per_instance_ctx.clone();
+        let ctx_ptr = Arc::into_raw(ctx_for_plugin) as *mut c_void;
 
         // Store the Arc so it stays alive as long as this proxy
         if let Ok(mut guard) = self._callback_ctx.lock() {
@@ -315,6 +327,17 @@ impl Drop for SourceProxy {
         let drop_fn = self.vtable.drop_fn;
         let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
         let _ = std::thread::spawn(move || (drop_fn)(state.as_ptr())).join();
+
+        // Bug C fix: leak the per-instance callback context Arc unconditionally.
+        // The strong reference handed to the plugin via `Arc::into_raw` in
+        // initialize() is never reclaimed — late log/lifecycle callbacks
+        // emitted by the plugin (during stop_fn or from internal tasks) must
+        // still find a valid pointer. Matches the pattern in ReactionProxy.
+        if let Ok(mut guard) = self._callback_ctx.lock() {
+            if let Some(ctx) = guard.take() {
+                std::mem::forget(ctx);
+            }
+        }
     }
 }
 

--- a/components/host-sdk/src/state_store_bridge.rs
+++ b/components/host-sdk/src/state_store_bridge.rs
@@ -24,6 +24,19 @@ use std::sync::Arc;
 use drasi_lib::StateStoreProvider;
 use drasi_plugin_sdk::ffi::{FfiGetResult, FfiResult, FfiStr, FfiStringArray, StateStoreVtable};
 
+/// Wraps an FFI body in `catch_unwind` and returns `default` on panic.
+///
+/// Panics unwinding across an `extern "C"` boundary are undefined behavior
+/// (and on most modern toolchains immediately abort the process). All
+/// extern "C" entry points exposed by this bridge MUST funnel through this
+/// helper. The default value is what the host returns to the plugin on panic.
+fn ffi_guard<T, F: FnOnce() -> T>(default: T, f: F) -> T {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(v) => v,
+        Err(_) => default,
+    }
+}
+
 /// Builds a `StateStoreVtable` from a host-side `Arc<dyn StateStoreProvider>`.
 pub struct StateStoreVtableBuilder;
 
@@ -60,24 +73,27 @@ fn provider_ref(state: *mut c_void) -> &'static dyn StateStoreProvider {
     arc.as_ref()
 }
 
-fn block_on<F: std::future::Future>(f: F) -> F::Output {
-    // Use a current-thread runtime to avoid nesting issues with the host's runtime
+fn block_on<F: std::future::Future>(f: F) -> Option<F::Output> {
+    // Use a current-thread runtime to avoid nesting issues with the host's runtime.
+    // Returns None if the runtime cannot be built — callers convert to an FFI error
+    // rather than panicking across the boundary.
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .expect("failed to build tokio runtime for state store bridge");
-    rt.block_on(f)
+        .ok()?;
+    Some(rt.block_on(f))
 }
 
 extern "C" fn ss_get(state: *mut c_void, store_id: FfiStr, key: FfiStr) -> FfiGetResult {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    let key = unsafe { key.to_string() };
-    match block_on(provider.get(&store_id, &key)) {
-        Ok(Some(value)) => FfiGetResult::found(value),
-        Ok(None) => FfiGetResult::not_found(),
-        Err(_) => FfiGetResult::not_found(),
-    }
+    ffi_guard(FfiGetResult::not_found(), || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        let key = unsafe { key.to_string() };
+        match block_on(provider.get(&store_id, &key)) {
+            Some(Ok(Some(value))) => FfiGetResult::found(value),
+            _ => FfiGetResult::not_found(),
+        }
+    })
 }
 
 extern "C" fn ss_set(
@@ -87,35 +103,44 @@ extern "C" fn ss_set(
     value: *const u8,
     value_len: usize,
 ) -> FfiResult {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    let key = unsafe { key.to_string() };
-    let value = unsafe { std::slice::from_raw_parts(value, value_len) }.to_vec();
-    match block_on(provider.set(&store_id, &key, value)) {
-        Ok(()) => FfiResult::ok(),
-        Err(e) => FfiResult::err(e.to_string()),
-    }
+    ffi_guard(FfiResult::err("ss_set: panic".to_string()), || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        let key = unsafe { key.to_string() };
+        let value = unsafe { std::slice::from_raw_parts(value, value_len) }.to_vec();
+        match block_on(provider.set(&store_id, &key, value)) {
+            Some(Ok(())) => FfiResult::ok(),
+            Some(Err(e)) => FfiResult::err(e.to_string()),
+            None => FfiResult::err("failed to build runtime".to_string()),
+        }
+    })
 }
 
 extern "C" fn ss_delete(state: *mut c_void, store_id: FfiStr, key: FfiStr) -> FfiResult {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    let key = unsafe { key.to_string() };
-    match block_on(provider.delete(&store_id, &key)) {
-        Ok(_) => FfiResult::ok(),
-        Err(e) => FfiResult::err(e.to_string()),
-    }
+    ffi_guard(FfiResult::err("ss_delete: panic".to_string()), || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        let key = unsafe { key.to_string() };
+        match block_on(provider.delete(&store_id, &key)) {
+            Some(Ok(_)) => FfiResult::ok(),
+            Some(Err(e)) => FfiResult::err(e.to_string()),
+            None => FfiResult::err("failed to build runtime".to_string()),
+        }
+    })
 }
 
 extern "C" fn ss_contains_key(state: *mut c_void, store_id: FfiStr, key: FfiStr) -> FfiResult {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    let key = unsafe { key.to_string() };
-    match block_on(provider.contains_key(&store_id, &key)) {
-        Ok(true) => FfiResult::ok(),
-        Ok(false) => FfiResult::err("not_found".to_string()),
-        Err(e) => FfiResult::err(e.to_string()),
-    }
+    ffi_guard(FfiResult::err("ss_contains_key: panic".to_string()), || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        let key = unsafe { key.to_string() };
+        match block_on(provider.contains_key(&store_id, &key)) {
+            Some(Ok(true)) => FfiResult::ok(),
+            Some(Ok(false)) => FfiResult::err("not_found".to_string()),
+            Some(Err(e)) => FfiResult::err(e.to_string()),
+            None => FfiResult::err("failed to build runtime".to_string()),
+        }
+    })
 }
 
 extern "C" fn ss_get_many(
@@ -125,25 +150,28 @@ extern "C" fn ss_get_many(
     keys_count: usize,
     out_values: *mut FfiGetResult,
 ) -> FfiResult {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    let key_strs: Vec<String> = (0..keys_count)
-        .map(|i| unsafe { (*keys.add(i)).to_string() })
-        .collect();
-    let key_refs: Vec<&str> = key_strs.iter().map(|s| s.as_str()).collect();
-    match block_on(provider.get_many(&store_id, &key_refs)) {
-        Ok(results) => {
-            for (i, key) in key_strs.iter().enumerate() {
-                let ffi_result = match results.get(key) {
-                    Some(value) => FfiGetResult::found(value.clone()),
-                    None => FfiGetResult::not_found(),
-                };
-                unsafe { *out_values.add(i) = ffi_result };
+    ffi_guard(FfiResult::err("ss_get_many: panic".to_string()), || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        let key_strs: Vec<String> = (0..keys_count)
+            .map(|i| unsafe { (*keys.add(i)).to_string() })
+            .collect();
+        let key_refs: Vec<&str> = key_strs.iter().map(|s| s.as_str()).collect();
+        match block_on(provider.get_many(&store_id, &key_refs)) {
+            Some(Ok(results)) => {
+                for (i, key) in key_strs.iter().enumerate() {
+                    let ffi_result = match results.get(key) {
+                        Some(value) => FfiGetResult::found(value.clone()),
+                        None => FfiGetResult::not_found(),
+                    };
+                    unsafe { *out_values.add(i) = ffi_result };
+                }
+                FfiResult::ok()
             }
-            FfiResult::ok()
+            Some(Err(e)) => FfiResult::err(e.to_string()),
+            None => FfiResult::err("failed to build runtime".to_string()),
         }
-        Err(e) => FfiResult::err(e.to_string()),
-    }
+    })
 }
 
 extern "C" fn ss_set_many(
@@ -154,24 +182,27 @@ extern "C" fn ss_set_many(
     value_lens: *const usize,
     count: usize,
 ) -> FfiResult {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    let entries: Vec<(String, Vec<u8>)> = (0..count)
-        .map(|i| unsafe {
-            let key = (*keys.add(i)).to_string();
-            let len = *value_lens.add(i);
-            let val = std::slice::from_raw_parts(*values.add(i), len).to_vec();
-            (key, val)
-        })
-        .collect();
-    let refs: Vec<(&str, &[u8])> = entries
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_slice()))
-        .collect();
-    match block_on(provider.set_many(&store_id, &refs)) {
-        Ok(()) => FfiResult::ok(),
-        Err(e) => FfiResult::err(e.to_string()),
-    }
+    ffi_guard(FfiResult::err("ss_set_many: panic".to_string()), || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        let entries: Vec<(String, Vec<u8>)> = (0..count)
+            .map(|i| unsafe {
+                let key = (*keys.add(i)).to_string();
+                let len = *value_lens.add(i);
+                let val = std::slice::from_raw_parts(*values.add(i), len).to_vec();
+                (key, val)
+            })
+            .collect();
+        let refs: Vec<(&str, &[u8])> = entries
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_slice()))
+            .collect();
+        match block_on(provider.set_many(&store_id, &refs)) {
+            Some(Ok(())) => FfiResult::ok(),
+            Some(Err(e)) => FfiResult::err(e.to_string()),
+            None => FfiResult::err("failed to build runtime".to_string()),
+        }
+    })
 }
 
 extern "C" fn ss_delete_many(
@@ -180,64 +211,80 @@ extern "C" fn ss_delete_many(
     keys: *const FfiStr,
     keys_count: usize,
 ) -> i64 {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    let key_strs: Vec<String> = (0..keys_count)
-        .map(|i| unsafe { (*keys.add(i)).to_string() })
-        .collect();
-    let key_refs: Vec<&str> = key_strs.iter().map(|s| s.as_str()).collect();
-    match block_on(provider.delete_many(&store_id, &key_refs)) {
-        Ok(count) => count as i64,
-        Err(_) => -1,
-    }
+    ffi_guard(-1, || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        let key_strs: Vec<String> = (0..keys_count)
+            .map(|i| unsafe { (*keys.add(i)).to_string() })
+            .collect();
+        let key_refs: Vec<&str> = key_strs.iter().map(|s| s.as_str()).collect();
+        match block_on(provider.delete_many(&store_id, &key_refs)) {
+            Some(Ok(count)) => count as i64,
+            _ => -1,
+        }
+    })
 }
 
 extern "C" fn ss_clear_store(state: *mut c_void, store_id: FfiStr) -> i64 {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    match block_on(provider.clear_store(&store_id)) {
-        Ok(count) => count as i64,
-        Err(_) => -1,
-    }
+    ffi_guard(-1, || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        match block_on(provider.clear_store(&store_id)) {
+            Some(Ok(count)) => count as i64,
+            _ => -1,
+        }
+    })
 }
 
 extern "C" fn ss_list_keys(state: *mut c_void, store_id: FfiStr) -> FfiStringArray {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    match block_on(provider.list_keys(&store_id)) {
-        Ok(keys) => FfiStringArray::from_vec(keys),
-        Err(_) => FfiStringArray::from_vec(Vec::new()),
-    }
+    ffi_guard(FfiStringArray::from_vec(Vec::new()), || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        match block_on(provider.list_keys(&store_id)) {
+            Some(Ok(keys)) => FfiStringArray::from_vec(keys),
+            _ => FfiStringArray::from_vec(Vec::new()),
+        }
+    })
 }
 
 extern "C" fn ss_store_exists(state: *mut c_void, store_id: FfiStr) -> FfiResult {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    match block_on(provider.store_exists(&store_id)) {
-        Ok(true) => FfiResult::ok(),
-        Ok(false) => FfiResult::err("not_found".to_string()),
-        Err(e) => FfiResult::err(e.to_string()),
-    }
+    ffi_guard(FfiResult::err("ss_store_exists: panic".to_string()), || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        match block_on(provider.store_exists(&store_id)) {
+            Some(Ok(true)) => FfiResult::ok(),
+            Some(Ok(false)) => FfiResult::err("not_found".to_string()),
+            Some(Err(e)) => FfiResult::err(e.to_string()),
+            None => FfiResult::err("failed to build runtime".to_string()),
+        }
+    })
 }
 
 extern "C" fn ss_key_count(state: *mut c_void, store_id: FfiStr) -> i64 {
-    let provider = provider_ref(state);
-    let store_id = unsafe { store_id.to_string() };
-    match block_on(provider.key_count(&store_id)) {
-        Ok(count) => count as i64,
-        Err(_) => -1,
-    }
+    ffi_guard(-1, || {
+        let provider = provider_ref(state);
+        let store_id = unsafe { store_id.to_string() };
+        match block_on(provider.key_count(&store_id)) {
+            Some(Ok(count)) => count as i64,
+            _ => -1,
+        }
+    })
 }
 
 extern "C" fn ss_sync(state: *mut c_void) -> FfiResult {
-    let provider = provider_ref(state);
-    match block_on(provider.sync()) {
-        Ok(()) => FfiResult::ok(),
-        Err(e) => FfiResult::err(e.to_string()),
-    }
+    ffi_guard(FfiResult::err("ss_sync: panic".to_string()), || {
+        let provider = provider_ref(state);
+        match block_on(provider.sync()) {
+            Some(Ok(())) => FfiResult::ok(),
+            Some(Err(e)) => FfiResult::err(e.to_string()),
+            None => FfiResult::err("failed to build runtime".to_string()),
+        }
+    })
 }
 
 extern "C" fn ss_drop(state: *mut c_void) {
-    // Reconstruct the Box<Arc<...>> and drop it
-    unsafe { drop(Box::from_raw(state as *mut Arc<dyn StateStoreProvider>)) };
+    ffi_guard((), || {
+        // Reconstruct the Box<Arc<...>> and drop it
+        unsafe { drop(Box::from_raw(state as *mut Arc<dyn StateStoreProvider>)) };
+    })
 }

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -1942,9 +1942,74 @@ async fn test_reaction_enqueue_query_result_with_data() {
     reaction.stop().await.expect("Reaction should stop");
 }
 
-// =============================================================================
-// Full end-to-end tests: cdylib source → query → cdylib reaction via DrasiLib
-// =============================================================================
+/// Stress-test the reaction start/enqueue/stop lifecycle to flush out the
+/// shutdown races that previously caused intermittent SIGSEGV on macOS/Windows
+/// (Bugs B/C/F: forwarder receiver-drop race, callback-context UAF, missing
+/// catch_unwind on plugin extern fns / sentinel callback not always sent).
+///
+/// Each iteration creates a fresh reaction proxy, runs a short
+/// start → enqueue N → stop cycle, and drops it. Any regression of the
+/// fixed bugs typically manifests within a handful of iterations on stricter
+/// allocators (macOS guard pages, Windows LFH).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_reaction_start_stop_stress() {
+    if !plugin_exists("drasi-reaction-log") {
+        eprintln!("SKIP: drasi-reaction-log not built as cdylib");
+        panic!("SKIP: drasi-reaction-log not built as cdylib");
+    }
+    let path = require_plugin("drasi-reaction-log");
+    let plugin = load_plugin_from_path(
+        &path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .unwrap();
+    let descriptor = &plugin.reaction_plugins[0];
+
+    const ITERATIONS: usize = 25;
+    const ENQUEUE_PER_ITER: usize = 8;
+    let config = serde_json::json!({});
+    let query_ids = vec!["stress-query".to_string()];
+
+    for i in 0..ITERATIONS {
+        let reaction = descriptor
+            .create_reaction(&format!("stress-{i}"), query_ids.clone(), &config, true)
+            .await
+            .expect("Should create reaction instance");
+
+        let (update_tx, _update_rx) =
+            tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(16);
+        let context = drasi_lib::ReactionRuntimeContext {
+            instance_id: format!("stress-instance-{i}"),
+            reaction_id: format!("stress-{i}"),
+            update_tx,
+            state_store: None,
+            identity_provider: None,
+        };
+        reaction.initialize(context).await;
+        reaction.start().await.expect("reaction start");
+
+        for _ in 0..ENQUEUE_PER_ITER {
+            let qr = drasi_lib::channels::QueryResult::new(
+                "stress-query".to_string(),
+                chrono::Utc::now(),
+                vec![],
+                std::collections::HashMap::new(),
+            );
+            reaction
+                .enqueue_query_result(qr)
+                .await
+                .expect("enqueue_query_result");
+        }
+
+        reaction.stop().await.expect("reaction stop");
+        // Explicit drop so any UAF/forwarder race surfaces inside the loop
+        // rather than being deferred to test shutdown.
+        drop(reaction);
+    }
+}
 
 /// Full pipeline test: cdylib mock source → query → cdylib log reaction.
 ///

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -52,6 +52,21 @@ use crate::descriptor::{
 
 type LifecycleEmitterFn = fn(&str, FfiLifecycleEventType, &str);
 
+/// Wraps a closure in `catch_unwind`, returning `default` on panic.
+///
+/// Use this for `extern "C"` functions that don't return `FfiResult` (so
+/// `catch_panic_ffi` doesn't apply) and for the bodies of forwarder closures
+/// spawned on the plugin runtime — a panic in a forwarder must not prevent
+/// the sentinel callback from being sent, otherwise the host's drop path
+/// times out (5s) and leaks resources.
+#[inline]
+fn ffi_guard<T, F: FnOnce() -> T>(default: T, f: F) -> T {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(v) => v,
+        Err(_) => default,
+    }
+}
+
 // Compile-time assertions that transmute between raw pointers and callback
 // function pointers is safe (same size and alignment).
 const _: () = assert!(
@@ -456,7 +471,11 @@ pub fn build_source_vtable<T: Source + 'static>(
     }
 
     extern "C" fn drop_fn<T: Source + 'static>(state: *mut c_void) {
-        unsafe { drop(Box::from_raw(state as *mut SourceWrapper<T>)) };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut SourceWrapper<T>)) };
+            }
+        });
     }
 
     let cached_id = source.id().to_string();
@@ -776,7 +795,11 @@ pub fn build_source_vtable_from_boxed(
     }
 
     extern "C" fn drop_fn(state: *mut c_void) {
-        unsafe { drop(Box::from_raw(state as *mut DynSourceWrapper)) };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut DynSourceWrapper)) };
+            }
+        });
     }
 
     let cached_id = source.id().to_string();
@@ -1086,7 +1109,11 @@ pub fn build_reaction_vtable<T: Reaction + 'static>(
     }
 
     extern "C" fn drop_fn<T: Reaction + 'static>(state: *mut c_void) {
-        unsafe { drop(Box::from_raw(state as *mut ReactionWrapper<T>)) };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut ReactionWrapper<T>)) };
+            }
+        });
     }
 
     let cached_id = reaction.id().to_string();
@@ -1353,53 +1380,75 @@ pub fn build_reaction_vtable_from_boxed(
         callback: FfiResultPushCallbackFn,
         callback_ctx: *mut c_void,
     ) {
-        let w = wrapper_ref(state);
-        let handle = (w.runtime_handle)().handle().clone();
-        let ctx_raw = callback_ctx as usize;
-        // Clone the Arc so the spawned forwarder task owns a strong reference
-        // to the wrapper. This keeps the wrapper alive even if the host calls
-        // drop_fn before the forwarder has fully exited (e.g., while an
-        // `enqueue_query_result(...).await` is still in flight on the
-        // process-global plugin runtime).
-        let arc = wrapper_arc(state);
-        handle.spawn(async move {
-            loop {
-                let ctx_val = ctx_raw;
-                let result_ptr = tokio::task::spawn_blocking(move || {
-                    SendMutPtr(callback(ctx_val as *mut c_void, std::ptr::null_mut()))
-                })
-                .await;
-                let result_ptr = match result_ptr {
-                    Ok(p) => p.as_ptr(),
-                    Err(_) => break,
-                };
-                if result_ptr.is_null() {
-                    break;
-                }
-                let query_result = {
-                    let rp = result_ptr;
-                    unsafe { *Box::from_raw(rp as *mut drasi_lib::channels::QueryResult) }
-                };
-                if let Err(e) = arc.inner.enqueue_query_result(query_result).await {
-                    log::error!("Failed to enqueue query result: {e}");
+        ffi_guard((), || {
+            let w = wrapper_ref(state);
+            let handle = (w.runtime_handle)().handle().clone();
+            let ctx_raw = callback_ctx as usize;
+            // Clone the Arc so the spawned forwarder task owns a strong reference
+            // to the wrapper. This keeps the wrapper alive even if the host calls
+            // drop_fn before the forwarder has fully exited (e.g., while an
+            // `enqueue_query_result(...).await` is still in flight on the
+            // process-global plugin runtime).
+            let arc = wrapper_arc(state);
+
+            // Bug F: Drop guard ensures the sentinel callback is ALWAYS sent
+            // — even if the forwarder task panics on an `enqueue_query_result`
+            // .await against a shutting-down priority queue, or if tokio drops
+            // the spawned task. Without this, the host's Drop times out at
+            // 5 s and leaks resources, allowing Bugs B/C to compound into a
+            // hard SIGSEGV.
+            struct SentinelOnDrop {
+                ctx_raw: usize,
+                callback: FfiResultPushCallbackFn,
+            }
+            impl Drop for SentinelOnDrop {
+                fn drop(&mut self) {
+                    let cb = self.callback;
+                    let ctx = self.ctx_raw as *mut c_void;
+                    #[allow(clippy::manual_dangling_ptr)]
+                    let sentinel = 1usize as *mut c_void;
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        cb(ctx, sentinel);
+                    }));
                 }
             }
-            // Signal the host that the forwarder has fully exited its loop
-            // and will not access the ReactionWrapper again.
-            let ctx_val = ctx_raw;
-            let _ = tokio::task::spawn_blocking(move || {
-                #[allow(clippy::manual_dangling_ptr)]
-                let sentinel = 1usize as *mut c_void;
-                callback(ctx_val as *mut c_void, sentinel);
-            })
-            .await;
-            // Drop the Arc here explicitly to make the ownership intent clear.
-            drop(arc);
+
+            handle.spawn(async move {
+                let _sentinel_guard = SentinelOnDrop { ctx_raw, callback };
+                loop {
+                    let ctx_val = ctx_raw;
+                    let result_ptr = tokio::task::spawn_blocking(move || {
+                        SendMutPtr(callback(ctx_val as *mut c_void, std::ptr::null_mut()))
+                    })
+                    .await;
+                    let result_ptr = match result_ptr {
+                        Ok(p) => p.as_ptr(),
+                        Err(_) => break,
+                    };
+                    if result_ptr.is_null() {
+                        break;
+                    }
+                    let query_result = {
+                        let rp = result_ptr;
+                        unsafe { *Box::from_raw(rp as *mut drasi_lib::channels::QueryResult) }
+                    };
+                    if let Err(e) = arc.inner.enqueue_query_result(query_result).await {
+                        log::error!("Failed to enqueue query result: {e}");
+                    }
+                }
+                // Sentinel sent by SentinelOnDrop on scope exit (covers panic
+                // and normal exit paths).
+                drop(arc);
+            });
         });
     }
 
     extern "C" fn drop_fn(state: *mut c_void) {
-        unsafe { drop(Box::from_raw(state as *mut Arc<DynReactionWrapper>)) };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut Arc<DynReactionWrapper>)) };
+            }
+        });
     }
 
     let cached_id = reaction.id().to_string();
@@ -1563,13 +1612,19 @@ pub fn build_bootstrap_provider_vtable(
     }
 
     extern "C" fn bootstrap_event_drop(opaque: *mut c_void) {
-        if !opaque.is_null() {
-            unsafe { drop(Box::from_raw(opaque as *mut BootstrapEvent)) };
-        }
+        ffi_guard((), || {
+            if !opaque.is_null() {
+                unsafe { drop(Box::from_raw(opaque as *mut BootstrapEvent)) };
+            }
+        });
     }
 
     extern "C" fn drop_fn(state: *mut c_void) {
-        unsafe { drop(Box::from_raw(state as *mut BootstrapProviderWrapper)) };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut BootstrapProviderWrapper)) };
+            }
+        });
     }
 
     let wrapper = Box::new(BootstrapProviderWrapper { inner: provider });
@@ -1677,7 +1732,11 @@ pub fn build_source_plugin_vtable<T: SourcePluginDescriptor + 'static>(
     }
 
     extern "C" fn drop_fn<T: SourcePluginDescriptor + 'static>(state: *mut c_void) {
-        unsafe { drop(Box::from_raw(state as *mut SourcePluginWrapper<T>)) };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut SourcePluginWrapper<T>)) };
+            }
+        });
     }
 
     let cached_kind = descriptor.kind().to_string();
@@ -1813,7 +1872,11 @@ pub fn build_reaction_plugin_vtable<T: ReactionPluginDescriptor + 'static>(
     }
 
     extern "C" fn drop_fn<T: ReactionPluginDescriptor + 'static>(state: *mut c_void) {
-        unsafe { drop(Box::from_raw(state as *mut ReactionPluginWrapper<T>)) };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut ReactionPluginWrapper<T>)) };
+            }
+        });
     }
 
     let cached_kind = descriptor.kind().to_string();
@@ -1941,7 +2004,11 @@ pub fn build_bootstrap_plugin_vtable<T: BootstrapPluginDescriptor + 'static>(
     }
 
     extern "C" fn drop_fn<T: BootstrapPluginDescriptor + 'static>(state: *mut c_void) {
-        unsafe { drop(Box::from_raw(state as *mut BootstrapPluginWrapper<T>)) };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut BootstrapPluginWrapper<T>)) };
+            }
+        });
     }
 
     let cached_kind = descriptor.kind().to_string();
@@ -2087,7 +2154,11 @@ fn wrap_subscription_response(
         let source_id = FfiStr::from_str(&boxed.source_id);
         let opaque = Box::into_raw(boxed) as *mut c_void;
         extern "C" fn drop_wrapper(ptr: *mut c_void) {
-            unsafe { drop(Box::from_raw(ptr as *mut SourceEventWrapper)) };
+            ffi_guard((), || {
+                if !ptr.is_null() {
+                    unsafe { drop(Box::from_raw(ptr as *mut SourceEventWrapper)) };
+                }
+            });
         }
         Box::into_raw(Box::new(FfiSourceEvent {
             opaque,
@@ -2105,52 +2176,82 @@ fn wrap_subscription_response(
         callback: FfiChangePushCallbackFn,
         callback_ctx: *mut c_void,
     ) {
-        let handle = unsafe { &*(state as *const DrasiLibChangeReceiverHandle) };
-        let receiver = handle.receiver.clone();
-        let ctx = SendMutPtr(callback_ctx);
-        let shutdown = receiver.shutdown.clone();
-        let rt_handle = receiver.runtime_handle.clone();
-        rt_handle.spawn(async move {
-            let mut rx = receiver.inner.lock().await;
-            // Pin the Notified future so it persists across loop iterations.
-            // Recreating it each iteration is cancel-unsafe: if select! picks
-            // rx.recv() while a notification is pending, dropping the Notified
-            // loses the permit and the shutdown signal is never observed.
-            let shutdown_notified = shutdown.notified();
-            tokio::pin!(shutdown_notified);
-            loop {
-                tokio::select! {
-                    _ = &mut shutdown_notified => {
-                        callback(ctx.as_ptr(), std::ptr::null_mut());
-                        break;
-                    }
-                    result = rx.recv() => {
-                        match result {
-                            Ok(wrapper) => {
-                                let ffi_event = wrap_source_event(wrapper);
-                                let accepted = callback(ctx.as_ptr(), ffi_event);
-                                if !accepted {
+        ffi_guard((), || {
+            let handle = unsafe { &*(state as *const DrasiLibChangeReceiverHandle) };
+            let receiver = handle.receiver.clone();
+            let ctx_raw = callback_ctx as usize;
+            let shutdown = receiver.shutdown.clone();
+            let rt_handle = receiver.runtime_handle.clone();
+
+            // Bug F: Drop guard guarantees the host receives a final null
+            // callback (acting as forwarder-exit sentinel) even if the
+            // forwarder body panics — preventing host-side waits from
+            // timing out and preventing UAF cascades on shutdown.
+            struct SourceSentinelOnDrop {
+                ctx_raw: usize,
+                callback: FfiChangePushCallbackFn,
+            }
+            impl Drop for SourceSentinelOnDrop {
+                fn drop(&mut self) {
+                    let cb = self.callback;
+                    let ctx = self.ctx_raw as *mut c_void;
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        cb(ctx, std::ptr::null_mut());
+                    }));
+                }
+            }
+
+            rt_handle.spawn(async move {
+                let _sentinel_guard = SourceSentinelOnDrop { ctx_raw, callback };
+                let mut rx = receiver.inner.lock().await;
+                // Pin the Notified future so it persists across loop iterations.
+                // Recreating it each iteration is cancel-unsafe: if select! picks
+                // rx.recv() while a notification is pending, dropping the Notified
+                // loses the permit and the shutdown signal is never observed.
+                let shutdown_notified = shutdown.notified();
+                tokio::pin!(shutdown_notified);
+                loop {
+                    tokio::select! {
+                        _ = &mut shutdown_notified => {
+                            break;
+                        }
+                        result = rx.recv() => {
+                            match result {
+                                Ok(wrapper) => {
+                                    let ffi_event = wrap_source_event(wrapper);
+                                    let accepted = std::panic::catch_unwind(
+                                        std::panic::AssertUnwindSafe(|| {
+                                            callback(ctx_raw as *mut c_void, ffi_event)
+                                        })
+                                    ).unwrap_or(false);
+                                    if !accepted {
+                                        break;
+                                    }
+                                }
+                                Err(_) => {
                                     break;
                                 }
-                            }
-                            Err(_) => {
-                                callback(ctx.as_ptr(), std::ptr::null_mut());
-                                break;
                             }
                         }
                     }
                 }
-            }
+                // Sentinel sent by SourceSentinelOnDrop on scope exit.
+            });
         });
     }
 
     extern "C" fn change_receiver_drop(state: *mut c_void) {
-        let handle = unsafe { Box::from_raw(state as *mut DrasiLibChangeReceiverHandle) };
-        // Signal the forwarder to stop, then drop our Arc reference.
-        // The forwarder holds its own Arc clone, so the inner data stays
-        // alive until the forwarder task completes.
-        handle.receiver.shutdown.notify_one();
-        drop(handle);
+        ffi_guard((), || {
+            if state.is_null() {
+                return;
+            }
+            let handle = unsafe { Box::from_raw(state as *mut DrasiLibChangeReceiverHandle) };
+            // Signal the forwarder to stop, then drop our Arc reference.
+            // The forwarder holds its own Arc clone, so the inner data stays
+            // alive until the forwarder task completes.
+            handle.receiver.shutdown.notify_one();
+            drop(handle);
+        });
     }
 
     let ffi_receiver = Box::new(DrasiLibChangeReceiverHandle {
@@ -2201,7 +2302,11 @@ fn wrap_subscription_response(
             let source_id = FfiStr::from_str(&boxed.source_id);
             let opaque = Box::into_raw(boxed) as *mut c_void;
             extern "C" fn drop_bootstrap(ptr: *mut c_void) {
-                unsafe { drop(Box::from_raw(ptr as *mut BootstrapEvent)) };
+                ffi_guard((), || {
+                    if !ptr.is_null() {
+                        unsafe { drop(Box::from_raw(ptr as *mut BootstrapEvent)) };
+                    }
+                });
             }
             Box::into_raw(Box::new(FfiBootstrapEvent {
                 opaque,
@@ -2219,48 +2324,75 @@ fn wrap_subscription_response(
             callback: FfiBootstrapPushCallbackFn,
             callback_ctx: *mut c_void,
         ) {
-            let handle = unsafe { &*(state as *const DrasiLibBootstrapReceiverHandle) };
-            let receiver = handle.receiver.clone();
-            let ctx = SendMutPtr(callback_ctx);
-            let shutdown = receiver.shutdown.clone();
-            let rt_handle = receiver.runtime_handle.clone();
-            rt_handle.spawn(async move {
-                let mut rx = receiver.inner.lock().await;
-                // Pin the Notified future for cancel-safe shutdown
-                // (same rationale as change receiver forwarder).
-                let shutdown_notified = shutdown.notified();
-                tokio::pin!(shutdown_notified);
-                loop {
-                    tokio::select! {
-                        _ = &mut shutdown_notified => {
-                            callback(ctx.as_ptr(), std::ptr::null_mut());
-                            break;
-                        }
-                        result = rx.recv() => {
-                            match result {
-                                Some(record) => {
-                                    let ffi_event = wrap_bootstrap_event(record);
-                                    let accepted = callback(ctx.as_ptr(), ffi_event);
-                                    if !accepted {
+            ffi_guard((), || {
+                let handle = unsafe { &*(state as *const DrasiLibBootstrapReceiverHandle) };
+                let receiver = handle.receiver.clone();
+                let ctx_raw = callback_ctx as usize;
+                let shutdown = receiver.shutdown.clone();
+                let rt_handle = receiver.runtime_handle.clone();
+
+                struct BootstrapSentinelOnDrop {
+                    ctx_raw: usize,
+                    callback: FfiBootstrapPushCallbackFn,
+                }
+                impl Drop for BootstrapSentinelOnDrop {
+                    fn drop(&mut self) {
+                        let cb = self.callback;
+                        let ctx = self.ctx_raw as *mut c_void;
+                        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            cb(ctx, std::ptr::null_mut());
+                        }));
+                    }
+                }
+
+                rt_handle.spawn(async move {
+                    let _sentinel_guard = BootstrapSentinelOnDrop { ctx_raw, callback };
+                    let mut rx = receiver.inner.lock().await;
+                    // Pin the Notified future for cancel-safe shutdown
+                    // (same rationale as change receiver forwarder).
+                    let shutdown_notified = shutdown.notified();
+                    tokio::pin!(shutdown_notified);
+                    loop {
+                        tokio::select! {
+                            _ = &mut shutdown_notified => {
+                                break;
+                            }
+                            result = rx.recv() => {
+                                match result {
+                                    Some(record) => {
+                                        let ffi_event = wrap_bootstrap_event(record);
+                                        let accepted = std::panic::catch_unwind(
+                                            std::panic::AssertUnwindSafe(|| {
+                                                callback(ctx_raw as *mut c_void, ffi_event)
+                                            })
+                                        ).unwrap_or(false);
+                                        if !accepted {
+                                            break;
+                                        }
+                                    }
+                                    None => {
+                                        // Stream exhausted
                                         break;
                                     }
-                                }
-                                None => {
-                                    // Stream exhausted
-                                    callback(ctx.as_ptr(), std::ptr::null_mut());
-                                    break;
                                 }
                             }
                         }
                     }
-                }
+                    // Sentinel sent by BootstrapSentinelOnDrop on scope exit.
+                });
             });
         }
 
         extern "C" fn bootstrap_drop(state: *mut c_void) {
-            let handle = unsafe { Box::from_raw(state as *mut DrasiLibBootstrapReceiverHandle) };
-            handle.receiver.shutdown.notify_one();
-            drop(handle);
+            ffi_guard((), || {
+                if state.is_null() {
+                    return;
+                }
+                let handle =
+                    unsafe { Box::from_raw(state as *mut DrasiLibBootstrapReceiverHandle) };
+                handle.receiver.shutdown.notify_one();
+                drop(handle);
+            });
         }
 
         let ffi_brx = Box::new(DrasiLibBootstrapReceiverHandle {
@@ -2356,7 +2488,11 @@ pub fn build_identity_provider_vtable_from_boxed(
     }
 
     extern "C" fn drop_fn(state: *mut c_void) {
-        unsafe { drop(Box::from_raw(state as *mut IdentityProviderWrapper)) };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut IdentityProviderWrapper)) };
+            }
+        });
     }
 
     let wrapper = Box::new(IdentityProviderWrapper {
@@ -2461,11 +2597,15 @@ pub fn build_identity_provider_plugin_vtable<T: IdentityProviderPluginDescriptor
     }
 
     extern "C" fn drop_fn<T: IdentityProviderPluginDescriptor + 'static>(state: *mut c_void) {
-        unsafe {
-            drop(Box::from_raw(
-                state as *mut IdentityProviderPluginWrapper<T>,
-            ))
-        };
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe {
+                    drop(Box::from_raw(
+                        state as *mut IdentityProviderPluginWrapper<T>,
+                    ))
+                };
+            }
+        });
     }
 
     let cached_kind = descriptor.kind().to_string();


### PR DESCRIPTION
## Problem

The cross-platform FFI plugin tests (`.github/workflows/test-ffi.yml`) were intermittently failing with `signal: 11, SIGSEGV: invalid memory reference` on macOS and Windows. Linux always passed. Two distinct crash signatures were observed:

- **macOS** — `test_reaction_enqueue_query_result` crashed immediately after the `Stopping reaction: enqueue-test` log line.
- **Windows** — `test_e2e_cdylib_source_query_reaction` crashed during source change dispatch.

Linux's tolerance of malformed frees (glibc) was masking the same UB that macOS guard pages and Windows LFH decommit detect strictly.

## Root causes identified

Deep analysis of the FFI layer (`components/plugin-sdk/src/ffi/` and `components/host-sdk/src/`) surfaced four bug classes:

| | Bug | Symptom |
|---|---|---|
| **B** | `ReactionProxy::stop`/`Drop` explicitly dropped the FFI receiver while the plugin forwarder task was still calling back into it. | UAF when the forwarder's leaked Arc clone resolves a `.await` on a dropped channel. |
| **C** | `_callback_ctx` Arc passed to plugin via `Arc::as_ptr` could be freed while a late `instance_log_callback` was in flight on the plugin runtime. | Late callback writes into freed memory → macOS crash right after "Stopping reaction" log. |
| **E** | Several host-side `extern "C"` callbacks (state store bridge, identity bridge, bootstrap proxy, source `host_executor`) had no `catch_unwind`, plus `.expect()` calls on tokio runtime construction. | Panics unwinding across the FFI boundary → non-unwinding abort. |
| **F** | Plugin-side `extern "C"` functions (drop_fns, forwarder bodies) had no `catch_unwind`. The reaction `start_result_push_fn` forwarder was particularly fragile: a panic anywhere in the loop prevented the sentinel callback from being sent, causing the host's Drop to time out at 5 s and freeing the wrapper while the forwarder was still running. | Drop timeout → cascading UAF → SIGSEGV. |

A fifth class (Bug **A** — cross-cdylib `Box::from_raw` on `FfiSourceEvent` envelopes) was identified but deferred: both cdylibs default to the System allocator, which routes through process-global `libc` `malloc`/`free`, and changing the envelope ownership contract carries higher regression risk than the marginal safety benefit now that B/C/F address the observed crash signatures. Tracked as a follow-up.

## Changes

### Host SDK (`components/host-sdk/`)

- **`proxies/reaction.rs`** — Bug B: removed `*rx_guard = None` from both `stop()` and `Drop`; the leaked push-context Arc keeps the receiver alive until the forwarder sends the exit sentinel. Bug C: replaced `Arc::as_ptr` with `Arc::into_raw` for the per-instance callback context, and `mem::forget` in `Drop` to intentionally leak the Arc — matching the existing process-leaked-cdylib lifecycle (plugins are never `dlclose`d, see `loader.rs:60-79`).
- **`proxies/source.rs`** — same Bug C fix; wrapped `host_executor` in `catch_unwind` and removed `.expect` on runtime build.
- **`state_store_bridge.rs`** — added an `ffi_guard<T,F>(default, f)` helper and wrapped all 13 `ss_*` extern "C" fns plus `ss_drop`. Removed `.expect` on tokio runtime construction.
- **`identity_bridge.rs`**, **`proxies/bootstrap_provider.rs`** — wrapped remaining extern "C" callbacks in `catch_unwind`.

### Plugin SDK (`components/plugin-sdk/src/ffi/vtable_gen.rs`)

- Added a module-level `ffi_guard<T,F>(default, f)` helper for void / non-`FfiResult`-returning extern fns (since `catch_panic_ffi` only works for `FfiResult`).
- **Drop-guard pattern** on all three spawned forwarder tasks (reaction `start_result_push_fn`, source `start_push_fn`, bootstrap `bootstrap_start_push`): a `SentinelOnDrop` struct ensures the host's exit sentinel is sent on **every** scope exit — normal completion, panic, or task drop. This eliminates the host-side 5 s Drop timeout that was the precondition for the cascading UAF.
- Wrapped each `await`ed `callback(...)` invocation inside the forwarder loops in `catch_unwind` so a host-side panic doesn't take down the forwarder before the sentinel guard can fire.
- Wrapped all 12 plugin-side `drop_fn` extern "C" callbacks (source/reaction/bootstrap/identity vtables, plugin descriptor wrappers, change-receiver/bootstrap-receiver state, and event opaque drops) in `ffi_guard` with null-pointer checks.

### Tests (`components/host-sdk/tests/integration_test.rs`)

- Added `test_reaction_start_stop_stress` — 25 iterations × 8 enqueues, exercising the full create → init → start → enqueue → stop → drop lifecycle to flush out the shutdown races that previously manifested as intermittent SIGSEGV.

## Validation

- `cargo build -p drasi-plugin-sdk -p drasi-host-sdk` — clean.
- `cargo clippy -p drasi-plugin-sdk -p drasi-host-sdk --all-targets` — clean (only one pre-existing unrelated warning).
- `cargo test -p drasi-host-sdk --test integration_test -- --test-threads=1` — **44 passed, 0 failed**, including the new stress test.
- **10 consecutive runs** of the full FFI integration test suite all green (~7.7 s each), versus the prior intermittent failures.

## Follow-ups (not in this PR)

- **Bug A**: Change `FfiSourceEvent`/`FfiBootstrapEvent` ownership contract so the plugin owns and frees the envelope after callback returns (host treats it as a borrow). Requires `PluginMetadata` core-version bump for ABI break. Low priority given libc allocator equivalence in practice.
