### PR TITLE
Replayable Sources 09: CheckpointWriter trait and backend implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/drasi-project/drasi-core"
@@ -98,21 +98,21 @@ categories = ["database"]
 drasi-query-ast = { version = "0.3.3", path = "query-ast" }
 drasi-query-cypher = { version = "0.3.3", path = "query-cypher" }
 drasi-query-gql = { version = "0.3.3", path = "query-gql" }
-drasi-core = { version = "0.4.2", path = "core" }
+drasi-core = { version = "0.5.0", path = "core" }
 drasi-functions-cypher = { version = "0.4.2", path = "functions-cypher" }
 drasi-functions-gql = { version = "0.4.2", path = "functions-gql" }
 drasi-middleware = { version = "0.4.2", path = "middleware" }
 drasi-identity-azure = { version = "0.1.1", path = "components/identity/azure" }
 drasi-identity-aws = { version = "0.1.1", path = "components/identity/aws" }
-drasi-lib = { version = "0.6.0", path = "lib" }
-drasi-ffi-primitives = { version = "0.6.0", path = "components/ffi-primitives" }
-drasi-plugin-sdk = { version = "0.6.0", path = "components/plugin-sdk" }
-drasi-host-sdk = { version = "0.6.0", path = "components/host-sdk" }
+drasi-lib = { version = "0.7.0", path = "lib" }
+drasi-ffi-primitives = { version = "0.7.0", path = "components/ffi-primitives" }
+drasi-plugin-sdk = { version = "0.7.0", path = "components/plugin-sdk" }
+drasi-host-sdk = { version = "0.7.0", path = "components/host-sdk" }
 
 # Common dependencies
 utoipa = { version = "4", features = ["chrono"] }
-drasi-index-rocksdb = { version = "0.3.2", path = "components/indexes/rocksdb" }
-drasi-index-garnet = { version = "0.1.9", path = "components/indexes/garnet" }
+drasi-index-rocksdb = { version = "0.4.0", path = "components/indexes/rocksdb" }
+drasi-index-garnet = { version = "0.2.0", path = "components/indexes/garnet" }
 
 # Component plugins
 drasi-source-mssql = { version = "0.1.5", path = "components/sources/mssql" }

--- a/components/indexes/garnet/Cargo.toml
+++ b/components/indexes/garnet/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-index-garnet"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Drasi Core Garnet/Redis Index Plugin"

--- a/components/indexes/garnet/src/checkpoint.rs
+++ b/components/indexes/garnet/src/checkpoint.rs
@@ -1,0 +1,160 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Garnet/Redis checkpoint writer for source sequence tracking and config hashing.
+//!
+//! Implements [`CheckpointWriter`] backed by a single Redis hash per query.
+//! `stage_checkpoint` writes go through the shared [`GarnetSessionState`]'s
+//! `WriteBuffer` so they land in the same `MULTI/EXEC` pipeline as index
+//! updates; all read methods and standalone writes execute directly against
+//! a cloned `MultiplexedConnection`, returning committed state only.
+//!
+//! # Key layout
+//!
+//! All checkpoint state for a query lives in a single hash keyed
+//! `ss:{<query_id>}`, with fields:
+//! - `source_sequence:{source_id}` — decimal ASCII u64
+//! - `config_hash` — decimal ASCII u64
+//!
+//! The hash-tag braces (`{<query_id>}`) ensure all checkpoint keys hash to the
+//! same Redis Cluster slot as the corresponding `ei:`, `ari:`, and `fqi:` keys
+//! for that query, so cross-key operations (and any future `MULTI/EXEC` that
+//! spans these CFs) are slot-safe.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use drasi_core::interface::{CheckpointWriter, IndexError};
+use redis::{aio::MultiplexedConnection, AsyncCommands};
+
+use crate::session_state::{GarnetSessionState, SessionStateError};
+
+const SOURCE_SEQUENCE_PREFIX: &str = "source_sequence:";
+const CONFIG_HASH_FIELD: &str = "config_hash";
+
+/// Garnet implementation of [`CheckpointWriter`].
+///
+/// Holds a [`MultiplexedConnection`] for direct (non-session) reads and writes
+/// (`HGET`/`HSET`/`HGETALL`/`DEL`), and an `Arc<GarnetSessionState>` for staging
+/// into the active session's `WriteBuffer`.
+pub(crate) struct GarnetCheckpointWriter {
+    query_id: Arc<str>,
+    connection: MultiplexedConnection,
+    session_state: Arc<GarnetSessionState>,
+}
+
+impl GarnetCheckpointWriter {
+    pub(crate) fn new(
+        query_id: impl Into<Arc<str>>,
+        connection: MultiplexedConnection,
+        session_state: Arc<GarnetSessionState>,
+    ) -> Self {
+        Self {
+            query_id: query_id.into(),
+            connection,
+            session_state,
+        }
+    }
+
+    fn ss_key(&self) -> String {
+        format!("ss:{{{}}}", self.query_id)
+    }
+}
+
+fn source_sequence_field(source_id: &str) -> String {
+    format!("{SOURCE_SEQUENCE_PREFIX}{source_id}")
+}
+
+fn parse_decimal_u64(bytes: &[u8]) -> Result<u64, IndexError> {
+    let s = std::str::from_utf8(bytes).map_err(|_| IndexError::CorruptedData)?;
+    s.parse::<u64>().map_err(|_| IndexError::CorruptedData)
+}
+
+#[async_trait]
+impl CheckpointWriter for GarnetCheckpointWriter {
+    async fn stage_checkpoint(&self, source_id: &str, sequence: u64) -> Result<(), IndexError> {
+        let key = self.ss_key();
+        let field = source_sequence_field(source_id);
+        let value = sequence.to_string().into_bytes();
+
+        let mut guard = self.session_state.lock()?;
+        let buffer = guard.as_mut().ok_or_else(|| {
+            IndexError::other(SessionStateError(
+                "stage_checkpoint requires an active session".to_string(),
+            ))
+        })?;
+        buffer.hash_set(key, &field, value);
+        Ok(())
+    }
+
+    async fn read_checkpoint(&self, source_id: &str) -> Result<Option<u64>, IndexError> {
+        let key = self.ss_key();
+        let field = source_sequence_field(source_id);
+        let mut con = self.connection.clone();
+        let raw: Option<Vec<u8>> = con.hget(&key, &field).await.map_err(IndexError::other)?;
+        match raw {
+            Some(bytes) => Ok(Some(parse_decimal_u64(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn read_all_checkpoints(&self) -> Result<HashMap<String, u64>, IndexError> {
+        // Startup-time read: no session involvement, direct HGETALL.
+        let key = self.ss_key();
+        let mut con = self.connection.clone();
+        let entries: HashMap<String, Vec<u8>> =
+            con.hgetall(&key).await.map_err(IndexError::other)?;
+
+        let mut out = HashMap::with_capacity(entries.len());
+        for (field, value) in entries {
+            if let Some(source_id) = field.strip_prefix(SOURCE_SEQUENCE_PREFIX) {
+                let sequence = parse_decimal_u64(&value)?;
+                out.insert(source_id.to_string(), sequence);
+            }
+        }
+        Ok(out)
+    }
+
+    async fn clear_checkpoints(&self) -> Result<(), IndexError> {
+        // Single DEL of the whole hash — atomic, no MULTI/EXEC needed.
+        let key = self.ss_key();
+        let mut con = self.connection.clone();
+        let _: i64 = con.del(&key).await.map_err(IndexError::other)?;
+        Ok(())
+    }
+
+    async fn write_config_hash(&self, hash: u64) -> Result<(), IndexError> {
+        let key = self.ss_key();
+        let mut con = self.connection.clone();
+        let _: i64 = con
+            .hset(&key, CONFIG_HASH_FIELD, hash.to_string())
+            .await
+            .map_err(IndexError::other)?;
+        Ok(())
+    }
+
+    async fn read_config_hash(&self) -> Result<Option<u64>, IndexError> {
+        let key = self.ss_key();
+        let mut con = self.connection.clone();
+        let raw: Option<Vec<u8>> = con
+            .hget(&key, CONFIG_HASH_FIELD)
+            .await
+            .map_err(IndexError::other)?;
+        match raw {
+            Some(bytes) => Ok(Some(parse_decimal_u64(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+}

--- a/components/indexes/garnet/src/lib.rs
+++ b/components/indexes/garnet/src/lib.rs
@@ -33,6 +33,7 @@
 use drasi_core::interface::IndexError;
 use redis::{aio::MultiplexedConnection, cmd, AsyncCommands};
 
+mod checkpoint;
 pub mod element_index;
 pub mod future_queue;
 mod plugin;

--- a/components/indexes/garnet/src/plugin.rs
+++ b/components/indexes/garnet/src/plugin.rs
@@ -31,9 +31,10 @@
 //! ```
 
 use async_trait::async_trait;
-use drasi_core::interface::{IndexBackendPlugin, IndexError, IndexSet};
+use drasi_core::interface::{CreatedIndexes, IndexBackendPlugin, IndexError, IndexSet};
 use std::sync::Arc;
 
+use crate::checkpoint::GarnetCheckpointWriter;
 use crate::element_index::GarnetElementIndex;
 use crate::future_queue::GarnetFutureQueue;
 use crate::result_index::GarnetResultIndex;
@@ -120,7 +121,7 @@ impl GarnetIndexProvider {
 
 #[async_trait]
 impl IndexBackendPlugin for GarnetIndexProvider {
-    async fn create_index_set(&self, query_id: &str) -> Result<IndexSet, IndexError> {
+    async fn create_indexes(&self, query_id: &str) -> Result<CreatedIndexes, IndexError> {
         let client = redis::Client::open(self.connection_string.as_str())
             .map_err(IndexError::connection_failed)?;
         let connection = client
@@ -142,14 +143,27 @@ impl IndexBackendPlugin for GarnetIndexProvider {
             connection.clone(),
             session_state.clone(),
         ));
-        let future_queue = Arc::new(GarnetFutureQueue::new(query_id, connection, session_state));
+        let future_queue = Arc::new(GarnetFutureQueue::new(
+            query_id,
+            connection.clone(),
+            session_state.clone(),
+        ));
 
-        Ok(IndexSet {
-            element_index: element_index.clone(),
-            archive_index: element_index,
-            result_index,
-            future_queue,
-            session_control,
+        let checkpoint_writer = Arc::new(GarnetCheckpointWriter::new(
+            query_id,
+            connection,
+            session_state,
+        ));
+
+        Ok(CreatedIndexes {
+            set: IndexSet {
+                element_index: element_index.clone(),
+                archive_index: element_index,
+                result_index,
+                future_queue,
+                session_control,
+            },
+            checkpoint_writer: Some(checkpoint_writer),
         })
     }
 

--- a/components/indexes/garnet/src/session_state.rs
+++ b/components/indexes/garnet/src/session_state.rs
@@ -670,7 +670,7 @@ impl std::fmt::Display for PoisonError {
 impl std::error::Error for PoisonError {}
 
 #[derive(Debug)]
-struct SessionStateError(String);
+pub(crate) struct SessionStateError(pub(crate) String);
 
 impl std::fmt::Display for SessionStateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/components/indexes/garnet/tests/checkpoint_tests.rs
+++ b/components/indexes/garnet/tests/checkpoint_tests.rs
@@ -1,0 +1,237 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for [`GarnetCheckpointWriter`].
+//!
+//! Exercises the writer through its public trait interface, paired with a
+//! `SessionControl` from the same `CreatedIndexes`, against a Redis instance
+//! brought up via `shared_tests::redis_helpers::setup_redis`. Each test uses
+//! a unique query id so they can run in parallel without interfering.
+
+use std::sync::Arc;
+
+use drasi_core::interface::{CheckpointWriter, IndexBackendPlugin, SessionControl};
+use drasi_index_garnet::GarnetIndexProvider;
+use shared_tests::redis_helpers::{setup_redis, RedisGuard};
+use tokio::sync::OnceCell;
+use uuid::Uuid;
+
+/// Shared Redis container for all tests in this file. Each test uses a unique
+/// query id to avoid interference.
+static SHARED_REDIS: OnceCell<RedisGuard> = OnceCell::const_new();
+
+async fn shared_redis() -> &'static RedisGuard {
+    SHARED_REDIS
+        .get_or_init(|| async { setup_redis().await })
+        .await
+}
+
+struct CheckpointFixture {
+    session_control: Arc<dyn SessionControl>,
+    checkpoint_writer: Arc<dyn CheckpointWriter>,
+}
+
+async fn fixture() -> CheckpointFixture {
+    let redis = shared_redis().await;
+    let provider = GarnetIndexProvider::new(redis.url(), None, false);
+    let query_id = format!("ckpt-{}", Uuid::new_v4());
+    let created = provider
+        .create_indexes(&query_id)
+        .await
+        .expect("create_indexes failed");
+    CheckpointFixture {
+        session_control: created.set.session_control,
+        checkpoint_writer: created
+            .checkpoint_writer
+            .expect("garnet should produce a checkpoint writer"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stage_then_read_after_commit() {
+    let fx = fixture().await;
+
+    fx.session_control.begin().await.unwrap();
+    fx.checkpoint_writer
+        .stage_checkpoint("source-a", 42)
+        .await
+        .unwrap();
+    fx.session_control.commit().await.unwrap();
+
+    assert_eq!(
+        fx.checkpoint_writer
+            .read_checkpoint("source-a")
+            .await
+            .unwrap(),
+        Some(42)
+    );
+    assert!(fx
+        .checkpoint_writer
+        .read_checkpoint("source-b")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rollback_discards_staged_checkpoint() {
+    let fx = fixture().await;
+
+    fx.session_control.begin().await.unwrap();
+    fx.checkpoint_writer
+        .stage_checkpoint("source-a", 100)
+        .await
+        .unwrap();
+    fx.session_control.rollback().unwrap();
+
+    assert!(fx
+        .checkpoint_writer
+        .read_checkpoint("source-a")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stage_without_session_errors() {
+    let fx = fixture().await;
+    let result = fx.checkpoint_writer.stage_checkpoint("source-a", 1).await;
+    assert!(
+        result.is_err(),
+        "stage_checkpoint without session should error"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn read_all_returns_every_source() {
+    let fx = fixture().await;
+
+    fx.session_control.begin().await.unwrap();
+    fx.checkpoint_writer
+        .stage_checkpoint("source-a", 10)
+        .await
+        .unwrap();
+    fx.checkpoint_writer
+        .stage_checkpoint("source-b", 20)
+        .await
+        .unwrap();
+    fx.checkpoint_writer
+        .stage_checkpoint("source-c", 30)
+        .await
+        .unwrap();
+    fx.session_control.commit().await.unwrap();
+
+    let all = fx.checkpoint_writer.read_all_checkpoints().await.unwrap();
+    assert_eq!(all.len(), 3);
+    assert_eq!(all.get("source-a"), Some(&10));
+    assert_eq!(all.get("source-b"), Some(&20));
+    assert_eq!(all.get("source-c"), Some(&30));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_hash_round_trip() {
+    let fx = fixture().await;
+
+    assert!(fx
+        .checkpoint_writer
+        .read_config_hash()
+        .await
+        .unwrap()
+        .is_none());
+    fx.checkpoint_writer
+        .write_config_hash(0xDEAD_BEEF)
+        .await
+        .unwrap();
+    assert_eq!(
+        fx.checkpoint_writer.read_config_hash().await.unwrap(),
+        Some(0xDEAD_BEEF)
+    );
+
+    fx.checkpoint_writer
+        .write_config_hash(0x1234_5678)
+        .await
+        .unwrap();
+    assert_eq!(
+        fx.checkpoint_writer.read_config_hash().await.unwrap(),
+        Some(0x1234_5678)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn clear_checkpoints_wipes_everything() {
+    let fx = fixture().await;
+
+    fx.session_control.begin().await.unwrap();
+    fx.checkpoint_writer
+        .stage_checkpoint("source-a", 1)
+        .await
+        .unwrap();
+    fx.checkpoint_writer
+        .stage_checkpoint("source-b", 2)
+        .await
+        .unwrap();
+    fx.session_control.commit().await.unwrap();
+    fx.checkpoint_writer.write_config_hash(99).await.unwrap();
+
+    fx.checkpoint_writer.clear_checkpoints().await.unwrap();
+
+    assert!(fx
+        .checkpoint_writer
+        .read_checkpoint("source-a")
+        .await
+        .unwrap()
+        .is_none());
+    assert!(fx
+        .checkpoint_writer
+        .read_checkpoint("source-b")
+        .await
+        .unwrap()
+        .is_none());
+    assert!(fx
+        .checkpoint_writer
+        .read_all_checkpoints()
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(fx
+        .checkpoint_writer
+        .read_config_hash()
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nested_session_commits_atomically() {
+    let fx = fixture().await;
+
+    // Outer begin (lib's wrap), inner begin (core's process_source_change)
+    fx.session_control.begin().await.unwrap();
+    fx.session_control.begin().await.unwrap();
+    // Core would do its index writes here; we simulate just the checkpoint stage.
+    fx.session_control.commit().await.unwrap(); // inner no-op
+    fx.checkpoint_writer
+        .stage_checkpoint("source-a", 555)
+        .await
+        .unwrap();
+    fx.session_control.commit().await.unwrap(); // outer real commit
+
+    assert_eq!(
+        fx.checkpoint_writer
+            .read_checkpoint("source-a")
+            .await
+            .unwrap(),
+        Some(555)
+    );
+}

--- a/components/indexes/rocksdb/Cargo.toml
+++ b/components/indexes/rocksdb/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-index-rocksdb"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Drasi Core RocksDb Index Plugin"

--- a/components/indexes/rocksdb/src/checkpoint.rs
+++ b/components/indexes/rocksdb/src/checkpoint.rs
@@ -1,0 +1,363 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! RocksDB checkpoint writer for source sequence tracking and config hashing.
+//!
+//! Implements [`CheckpointWriter`] backed by a dedicated `stream_state` column
+//! family. `stage_checkpoint` writes go through the shared
+//! [`RocksDbSessionState`] so they land in the same transaction as index updates;
+//! all other operations are standalone.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use drasi_core::interface::{CheckpointWriter, IndexError};
+use rocksdb::{ColumnFamilyDescriptor, OptimisticTransactionDB, Options};
+use tokio::task;
+
+use crate::RocksDbSessionState;
+
+/// Column family that stores source checkpoints and the config hash.
+///
+/// Kept separate from the graph CFs (`elements`, `values`, etc.) because
+/// sequence numbers are overwritten on every event — a high-frequency overwrite
+/// pattern that would otherwise trigger unnecessary compactions of graph state.
+pub const STREAM_STATE_CF: &str = "stream_state";
+
+const SOURCE_SEQUENCE_PREFIX: &[u8] = b"source_sequence:";
+const CONFIG_HASH_KEY: &[u8] = b"config_hash";
+
+/// Column family options for `stream_state`.
+///
+/// Optimized for point lookup of small fixed-size values (8-byte u64s).
+/// Mirrors the `metadata` CF in [`super::result_index::get_metadata_cf_options`].
+pub(crate) fn get_stream_state_cf_options() -> Options {
+    let mut opts = Options::default();
+    opts.optimize_for_point_lookup(1);
+    opts
+}
+
+/// Column family descriptor for `stream_state`.
+pub(crate) fn stream_state_cf_descriptors() -> Vec<ColumnFamilyDescriptor> {
+    vec![ColumnFamilyDescriptor::new(
+        STREAM_STATE_CF,
+        get_stream_state_cf_options(),
+    )]
+}
+
+/// RocksDB implementation of [`CheckpointWriter`].
+///
+/// Holds an `Arc<OptimisticTransactionDB>` for direct (non-session) reads and
+/// writes, and an `Arc<RocksDbSessionState>` for staging into the active
+/// session transaction.
+pub(crate) struct RocksDbCheckpointWriter {
+    db: Arc<OptimisticTransactionDB>,
+    session_state: Arc<RocksDbSessionState>,
+}
+
+impl RocksDbCheckpointWriter {
+    pub(crate) fn new(
+        db: Arc<OptimisticTransactionDB>,
+        session_state: Arc<RocksDbSessionState>,
+    ) -> Self {
+        Self { db, session_state }
+    }
+}
+
+fn source_sequence_key(source_id: &str) -> Vec<u8> {
+    let mut key = Vec::with_capacity(SOURCE_SEQUENCE_PREFIX.len() + source_id.len());
+    key.extend_from_slice(SOURCE_SEQUENCE_PREFIX);
+    key.extend_from_slice(source_id.as_bytes());
+    key
+}
+
+fn decode_u64(bytes: &[u8]) -> Result<u64, IndexError> {
+    let arr: [u8; 8] = bytes.try_into().map_err(|_| IndexError::CorruptedData)?;
+    Ok(u64::from_be_bytes(arr))
+}
+
+#[async_trait]
+impl CheckpointWriter for RocksDbCheckpointWriter {
+    async fn stage_checkpoint(&self, source_id: &str, sequence: u64) -> Result<(), IndexError> {
+        let db = self.db.clone();
+        let session_state = self.session_state.clone();
+        let key = source_sequence_key(source_id);
+        let task = task::spawn_blocking(move || {
+            let cf = db
+                .cf_handle(STREAM_STATE_CF)
+                .expect("stream_state cf not found");
+            session_state.with_txn(|txn| {
+                txn.put_cf(&cf, &key, sequence.to_be_bytes())
+                    .map_err(IndexError::other)
+            })
+        });
+        match task.await {
+            Ok(v) => v,
+            Err(e) => Err(IndexError::other(e)),
+        }
+    }
+
+    async fn read_checkpoint(&self, source_id: &str) -> Result<Option<u64>, IndexError> {
+        let db = self.db.clone();
+        let key = source_sequence_key(source_id);
+        let task = task::spawn_blocking(move || {
+            let cf = db
+                .cf_handle(STREAM_STATE_CF)
+                .expect("stream_state cf not found");
+            match db.get_cf(&cf, &key) {
+                Ok(Some(bytes)) => Ok(Some(decode_u64(&bytes)?)),
+                Ok(None) => Ok(None),
+                Err(e) => Err(IndexError::other(e)),
+            }
+        });
+        match task.await {
+            Ok(v) => v,
+            Err(e) => Err(IndexError::other(e)),
+        }
+    }
+
+    async fn read_all_checkpoints(&self) -> Result<HashMap<String, u64>, IndexError> {
+        let db = self.db.clone();
+        let task = task::spawn_blocking(move || {
+            let cf = db
+                .cf_handle(STREAM_STATE_CF)
+                .expect("stream_state cf not found");
+            let mut out = HashMap::new();
+            for item in db.prefix_iterator_cf(&cf, SOURCE_SEQUENCE_PREFIX) {
+                let (raw_key, raw_value) = item.map_err(IndexError::other)?;
+                // prefix_iterator_cf may yield keys past the prefix; filter strictly.
+                if !raw_key.starts_with(SOURCE_SEQUENCE_PREFIX) {
+                    break;
+                }
+                let source_id = std::str::from_utf8(&raw_key[SOURCE_SEQUENCE_PREFIX.len()..])
+                    .map_err(IndexError::other)?
+                    .to_string();
+                let sequence = decode_u64(&raw_value)?;
+                out.insert(source_id, sequence);
+            }
+            Ok(out)
+        });
+        match task.await {
+            Ok(v) => v,
+            Err(e) => Err(IndexError::other(e)),
+        }
+    }
+
+    async fn clear_checkpoints(&self) -> Result<(), IndexError> {
+        let db = self.db.clone();
+        let task = task::spawn_blocking(move || {
+            let cf = db
+                .cf_handle(STREAM_STATE_CF)
+                .expect("stream_state cf not found");
+            let txn = db.transaction();
+            // Collect first so the iterator borrow ends before delete_cf calls.
+            let mut keys: Vec<Vec<u8>> = Vec::new();
+            for item in db.prefix_iterator_cf(&cf, SOURCE_SEQUENCE_PREFIX) {
+                let (raw_key, _) = item.map_err(IndexError::other)?;
+                if !raw_key.starts_with(SOURCE_SEQUENCE_PREFIX) {
+                    break;
+                }
+                keys.push(raw_key.to_vec());
+            }
+            for k in keys {
+                txn.delete_cf(&cf, &k).map_err(IndexError::other)?;
+            }
+            txn.delete_cf(&cf, CONFIG_HASH_KEY)
+                .map_err(IndexError::other)?;
+            txn.commit().map_err(IndexError::other)
+        });
+        match task.await {
+            Ok(v) => v,
+            Err(e) => Err(IndexError::other(e)),
+        }
+    }
+
+    async fn write_config_hash(&self, hash: u64) -> Result<(), IndexError> {
+        let db = self.db.clone();
+        let task = task::spawn_blocking(move || {
+            let cf = db
+                .cf_handle(STREAM_STATE_CF)
+                .expect("stream_state cf not found");
+            db.put_cf(&cf, CONFIG_HASH_KEY, hash.to_be_bytes())
+                .map_err(IndexError::other)
+        });
+        match task.await {
+            Ok(v) => v,
+            Err(e) => Err(IndexError::other(e)),
+        }
+    }
+
+    async fn read_config_hash(&self) -> Result<Option<u64>, IndexError> {
+        let db = self.db.clone();
+        let task = task::spawn_blocking(move || {
+            let cf = db
+                .cf_handle(STREAM_STATE_CF)
+                .expect("stream_state cf not found");
+            match db.get_cf(&cf, CONFIG_HASH_KEY) {
+                Ok(Some(bytes)) => Ok(Some(decode_u64(&bytes)?)),
+                Ok(None) => Ok(None),
+                Err(e) => Err(IndexError::other(e)),
+            }
+        });
+        match task.await {
+            Ok(v) => v,
+            Err(e) => Err(IndexError::other(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::open_unified_db;
+    use crate::{element_index::RocksIndexOptions, RocksDbSessionControl};
+    use drasi_core::interface::SessionControl;
+    use tempfile::TempDir;
+
+    fn open_writer(
+        temp: &TempDir,
+        query_id: &str,
+    ) -> (RocksDbCheckpointWriter, Arc<RocksDbSessionControl>) {
+        let path = temp.path().to_string_lossy().to_string();
+        let options = RocksIndexOptions {
+            archive_enabled: false,
+            direct_io: false,
+        };
+        let db = open_unified_db(&path, query_id, &options).expect("open db");
+        let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
+        let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
+        let writer = RocksDbCheckpointWriter::new(db, session_state);
+        (writer, session_control)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stage_then_read_after_commit() {
+        let temp = TempDir::new().unwrap();
+        let (writer, sc) = open_writer(&temp, "q1");
+
+        sc.begin().await.unwrap();
+        writer.stage_checkpoint("source-a", 42).await.unwrap();
+        sc.commit().await.unwrap();
+
+        assert_eq!(writer.read_checkpoint("source-a").await.unwrap(), Some(42));
+        assert!(writer.read_checkpoint("source-b").await.unwrap().is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rollback_discards_staged_checkpoint() {
+        let temp = TempDir::new().unwrap();
+        let (writer, sc) = open_writer(&temp, "q1");
+
+        sc.begin().await.unwrap();
+        writer.stage_checkpoint("source-a", 100).await.unwrap();
+        sc.rollback().unwrap();
+
+        assert!(writer.read_checkpoint("source-a").await.unwrap().is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stage_without_session_errors() {
+        let temp = TempDir::new().unwrap();
+        let (writer, _sc) = open_writer(&temp, "q1");
+
+        let err = writer.stage_checkpoint("source-a", 1).await;
+        assert!(
+            err.is_err(),
+            "stage_checkpoint without session should error"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn read_all_returns_every_source() {
+        let temp = TempDir::new().unwrap();
+        let (writer, sc) = open_writer(&temp, "q1");
+
+        sc.begin().await.unwrap();
+        writer.stage_checkpoint("source-a", 10).await.unwrap();
+        writer.stage_checkpoint("source-b", 20).await.unwrap();
+        writer.stage_checkpoint("source-c", 30).await.unwrap();
+        sc.commit().await.unwrap();
+
+        let all = writer.read_all_checkpoints().await.unwrap();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all.get("source-a"), Some(&10));
+        assert_eq!(all.get("source-b"), Some(&20));
+        assert_eq!(all.get("source-c"), Some(&30));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn config_hash_round_trip() {
+        let temp = TempDir::new().unwrap();
+        let (writer, _sc) = open_writer(&temp, "q1");
+
+        assert!(writer.read_config_hash().await.unwrap().is_none());
+        writer.write_config_hash(0xDEAD_BEEF).await.unwrap();
+        assert_eq!(writer.read_config_hash().await.unwrap(), Some(0xDEAD_BEEF));
+
+        writer.write_config_hash(0x1234_5678).await.unwrap();
+        assert_eq!(writer.read_config_hash().await.unwrap(), Some(0x1234_5678));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clear_checkpoints_wipes_everything() {
+        let temp = TempDir::new().unwrap();
+        let (writer, sc) = open_writer(&temp, "q1");
+
+        sc.begin().await.unwrap();
+        writer.stage_checkpoint("source-a", 1).await.unwrap();
+        writer.stage_checkpoint("source-b", 2).await.unwrap();
+        sc.commit().await.unwrap();
+        writer.write_config_hash(99).await.unwrap();
+
+        writer.clear_checkpoints().await.unwrap();
+
+        assert!(writer.read_checkpoint("source-a").await.unwrap().is_none());
+        assert!(writer.read_checkpoint("source-b").await.unwrap().is_none());
+        assert!(writer.read_all_checkpoints().await.unwrap().is_empty());
+        assert!(writer.read_config_hash().await.unwrap().is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn checkpoints_survive_db_reopen() {
+        let temp = TempDir::new().unwrap();
+        {
+            let (writer, sc) = open_writer(&temp, "q1");
+            sc.begin().await.unwrap();
+            writer.stage_checkpoint("source-a", 777).await.unwrap();
+            sc.commit().await.unwrap();
+            writer.write_config_hash(0xABCD).await.unwrap();
+        }
+        // Drop the writer + session above; reopen the DB and create a fresh writer.
+        let (writer, _sc) = open_writer(&temp, "q1");
+        assert_eq!(writer.read_checkpoint("source-a").await.unwrap(), Some(777));
+        assert_eq!(writer.read_config_hash().await.unwrap(), Some(0xABCD));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn nested_session_commits_atomically() {
+        let temp = TempDir::new().unwrap();
+        let (writer, sc) = open_writer(&temp, "q1");
+
+        // Outer begin (lib's wrap), inner begin (core's process_source_change)
+        sc.begin().await.unwrap();
+        sc.begin().await.unwrap();
+        // Core would do its index writes here; we simulate just the checkpoint stage.
+        sc.commit().await.unwrap(); // inner no-op
+        writer.stage_checkpoint("source-a", 555).await.unwrap();
+        sc.commit().await.unwrap(); // outer real commit
+
+        assert_eq!(writer.read_checkpoint("source-a").await.unwrap(), Some(555));
+    }
+}

--- a/components/indexes/rocksdb/src/lib.rs
+++ b/components/indexes/rocksdb/src/lib.rs
@@ -30,6 +30,7 @@
 //!     .build()?;
 //! ```
 
+mod checkpoint;
 pub mod element_index;
 pub mod future_queue;
 mod plugin;

--- a/components/indexes/rocksdb/src/plugin.rs
+++ b/components/indexes/rocksdb/src/plugin.rs
@@ -31,11 +31,12 @@
 //! ```
 
 use async_trait::async_trait;
-use drasi_core::interface::{IndexBackendPlugin, IndexError, IndexSet};
+use drasi_core::interface::{CreatedIndexes, IndexBackendPlugin, IndexError, IndexSet};
 use rocksdb::{OptimisticTransactionDB, Options};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::checkpoint::{self, RocksDbCheckpointWriter};
 use crate::element_index::{self, RocksDbElementIndex, RocksIndexOptions};
 use crate::future_queue::{self, RocksDbFutureQueue};
 use crate::result_index::{self, RocksDbResultIndex};
@@ -76,6 +77,7 @@ pub fn open_unified_db(
     let mut cfs = element_index::element_cf_descriptors(options);
     cfs.extend(result_index::result_cf_descriptors());
     cfs.extend(future_queue::future_queue_cf_descriptors());
+    cfs.extend(checkpoint::stream_state_cf_descriptors());
 
     let db = OptimisticTransactionDB::open_cf_descriptors(&db_opts, db_path, cfs)
         .map_err(IndexError::other)?;
@@ -147,7 +149,7 @@ impl RocksDbIndexProvider {
 
 #[async_trait]
 impl IndexBackendPlugin for RocksDbIndexProvider {
-    async fn create_index_set(&self, query_id: &str) -> Result<IndexSet, IndexError> {
+    async fn create_indexes(&self, query_id: &str) -> Result<CreatedIndexes, IndexError> {
         let path = self.path.to_string_lossy().to_string();
         let options = RocksIndexOptions {
             archive_enabled: self.enable_archive,
@@ -170,14 +172,19 @@ impl IndexBackendPlugin for RocksDbIndexProvider {
             session_state.clone(),
         ));
         let result_index = Arc::new(RocksDbResultIndex::new(db.clone(), session_state.clone()));
-        let future_queue = Arc::new(RocksDbFutureQueue::new(db, session_state));
+        let future_queue = Arc::new(RocksDbFutureQueue::new(db.clone(), session_state.clone()));
 
-        Ok(IndexSet {
-            element_index: element_index.clone(),
-            archive_index: element_index,
-            result_index,
-            future_queue,
-            session_control,
+        let checkpoint_writer = Arc::new(RocksDbCheckpointWriter::new(db, session_state));
+
+        Ok(CreatedIndexes {
+            set: IndexSet {
+                element_index: element_index.clone(),
+                archive_index: element_index,
+                result_index,
+                future_queue,
+                session_control,
+            },
+            checkpoint_writer: Some(checkpoint_writer),
         })
     }
 
@@ -229,26 +236,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rocksdb_create_index_set() {
+    async fn test_rocksdb_create_indexes() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
 
-        let result = provider.create_index_set("test_query").await;
-        assert!(result.is_ok());
+        let result = provider.create_indexes("test_query").await.unwrap();
+        assert!(result.checkpoint_writer.is_some());
     }
 
     #[tokio::test]
-    async fn test_rocksdb_create_index_set_multiple_queries() {
+    async fn test_rocksdb_create_indexes_multiple_queries() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let provider = RocksDbIndexProvider::new(temp_dir.path(), false, false);
 
-        let result1 = provider.create_index_set("query1").await;
-        let result2 = provider.create_index_set("query2").await;
-        let result3 = provider.create_index_set("query3").await;
+        let result1 = provider.create_indexes("query1").await;
+        let result2 = provider.create_indexes("query2").await;
+        let result3 = provider.create_indexes("query3").await;
 
         assert!(result1.is_ok());
         assert!(result2.is_ok());
         assert!(result3.is_ok());
+        assert!(result1.unwrap().checkpoint_writer.is_some());
     }
 
     #[test]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-core"
-version = "0.4.2"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 description = "Drasi Core"

--- a/core/src/interface/checkpoint_writer.rs
+++ b/core/src/interface/checkpoint_writer.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Checkpoint Writer Trait
+//!
+//! Atomic checkpoint persistence for source sequence tracking and config hashing.
+//!
+//! Implementations are paired with an [`IndexBackendPlugin`](super::IndexBackendPlugin)
+//! and share the same session state. [`CheckpointWriter::stage_checkpoint`] writes
+//! into the currently-active session transaction (opened by
+//! [`SessionControl::begin`](super::SessionControl)) and is committed by the
+//! session's outer commit alongside the index updates. All other methods operate
+//! outside a session transaction and commit independently.
+//!
+//! This trait lives in core (not lib) so that index plugins can implement it
+//! without taking a reverse dependency on `drasi-lib`. The orchestration logic
+//! that consumes the writer (deciding when to call `stage_checkpoint`, wrapping
+//! `process_source_change` in an outer transaction, etc.) lives in `drasi-lib`.
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+use super::IndexError;
+
+/// Atomic checkpoint persistence for source sequence tracking and config hashing.
+///
+/// See the [module-level documentation](self) for usage context.
+///
+/// # Method semantics
+///
+/// - [`stage_checkpoint`](Self::stage_checkpoint) MUST be called between
+///   `SessionControl::begin` and `SessionControl::commit`. The write is staged
+///   into the active session transaction and persisted by the outer commit.
+/// - All other methods operate independently of the session transaction and
+///   commit on their own.
+///
+/// # Encoding
+///
+/// `sequence` and `hash` are `u64` values. Implementations choose a backend-
+/// idiomatic encoding (RocksDB uses big-endian raw bytes; Garnet uses decimal
+/// ASCII strings). The encoding is internal to each implementation.
+#[async_trait]
+pub trait CheckpointWriter: Send + Sync {
+    /// Stage a source checkpoint into the active session transaction.
+    ///
+    /// Must be called inside an open session (between `SessionControl::begin`
+    /// and `SessionControl::commit`). Returns an error if no session is active.
+    async fn stage_checkpoint(&self, source_id: &str, sequence: u64) -> Result<(), IndexError>;
+
+    /// Read the committed checkpoint for a single source.
+    ///
+    /// Returns `None` if no checkpoint has been written for `source_id`.
+    /// Reads committed state directly; does not require an active session.
+    async fn read_checkpoint(&self, source_id: &str) -> Result<Option<u64>, IndexError>;
+
+    /// Read all committed source checkpoints, keyed by source id.
+    ///
+    /// Returns an empty map if no checkpoints have been written.
+    /// Reads committed state directly; does not require an active session.
+    async fn read_all_checkpoints(&self) -> Result<HashMap<String, u64>, IndexError>;
+
+    /// Delete all source checkpoints and the config hash.
+    ///
+    /// Used during auto-reset recovery and `delete_query(cleanup: true)`.
+    /// Standalone commit; not part of any outer session transaction.
+    async fn clear_checkpoints(&self) -> Result<(), IndexError>;
+
+    /// Write the query config hash.
+    ///
+    /// Used at startup to detect query configuration changes that require a
+    /// full re-bootstrap. Standalone commit.
+    async fn write_config_hash(&self, hash: u64) -> Result<(), IndexError>;
+
+    /// Read the stored config hash.
+    ///
+    /// Returns `None` if no hash has been written. Called at startup before
+    /// any session transaction begins.
+    async fn read_config_hash(&self) -> Result<Option<u64>, IndexError>;
+}

--- a/core/src/interface/index_backend.rs
+++ b/core/src/interface/index_backend.rs
@@ -31,7 +31,8 @@ use std::fmt;
 use std::sync::Arc;
 
 use super::{
-    ElementArchiveIndex, ElementIndex, FutureQueue, IndexError, ResultIndex, SessionControl,
+    CheckpointWriter, ElementArchiveIndex, ElementIndex, FutureQueue, IndexError, ResultIndex,
+    SessionControl,
 };
 
 /// Set of indexes for a query.
@@ -65,6 +66,36 @@ impl fmt::Debug for IndexSet {
     }
 }
 
+/// Result of [`IndexBackendPlugin::create_indexes`].
+///
+/// Bundles the [`IndexSet`] together with an optional [`CheckpointWriter`]
+/// that shares the same underlying session state. Persistent backends return
+/// `Some(writer)`; volatile (in-memory) backends return `None`.
+///
+/// The writer's `stage_checkpoint` calls land in the same database transaction
+/// as index updates because both are derived from the same `SessionControl` /
+/// session state instance — that is why the plugin returns them together
+/// rather than via two separate calls.
+pub struct CreatedIndexes {
+    /// The set of indexes for the query.
+    pub set: IndexSet,
+    /// Atomic checkpoint writer paired with the set's session state.
+    /// `None` for volatile backends (no persistent storage to checkpoint into).
+    pub checkpoint_writer: Option<Arc<dyn CheckpointWriter>>,
+}
+
+impl fmt::Debug for CreatedIndexes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CreatedIndexes")
+            .field("set", &self.set)
+            .field(
+                "checkpoint_writer",
+                &self.checkpoint_writer.as_ref().map(|_| "<trait object>"),
+            )
+            .finish()
+    }
+}
+
 /// Plugin trait for external index storage backends.
 ///
 /// Each storage backend (RocksDB, Garnet, etc.) implements this trait to provide
@@ -77,7 +108,7 @@ impl fmt::Debug for IndexSet {
 /// # Example
 ///
 /// ```ignore
-/// use drasi_core::interface::{IndexBackendPlugin, IndexSet};
+/// use drasi_core::interface::{CreatedIndexes, IndexBackendPlugin, IndexError};
 ///
 /// pub struct MyIndexProvider {
 ///     // configuration fields
@@ -85,21 +116,28 @@ impl fmt::Debug for IndexSet {
 ///
 /// #[async_trait]
 /// impl IndexBackendPlugin for MyIndexProvider {
-///     async fn create_index_set(&self, query_id: &str) -> Result<IndexSet, IndexError> {
-///         // Create and return all indexes from a shared backend instance
+///     async fn create_indexes(&self, query_id: &str) -> Result<CreatedIndexes, IndexError> {
+///         // Create and return all indexes (and an optional checkpoint writer)
+///         // from a shared backend instance
 ///     }
 ///     fn is_volatile(&self) -> bool { false }
 /// }
 /// ```
 #[async_trait]
 pub trait IndexBackendPlugin: Send + Sync {
-    /// Create all indexes for a query from a single shared backend instance.
+    /// Create all indexes (and an optional checkpoint writer) for a query
+    /// from a single shared backend instance.
     ///
     /// This method creates the element index, archive index, result index,
     /// future queue, and session control backed by a shared storage resource
     /// (e.g., a single RocksDB database or Redis connection). This reduces
     /// resource overhead and enables cross-index atomic transactions.
-    async fn create_index_set(&self, query_id: &str) -> Result<IndexSet, IndexError>;
+    ///
+    /// Persistent backends additionally return a [`CheckpointWriter`] that
+    /// shares the same session state as the returned `SessionControl`, so
+    /// `stage_checkpoint` writes land in the same database transaction as
+    /// index updates. Volatile backends return `checkpoint_writer: None`.
+    async fn create_indexes(&self, query_id: &str) -> Result<CreatedIndexes, IndexError>;
 
     /// Returns true if this backend is volatile (data lost on restart).
     ///

--- a/core/src/interface/mod.rs
+++ b/core/src/interface/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod checkpoint_writer;
 mod element_index;
 mod future_queue;
 mod index_backend;
@@ -23,6 +24,7 @@ mod source_middleware;
 use std::error::Error;
 use std::fmt::Display;
 
+pub use checkpoint_writer::CheckpointWriter;
 use drasi_query_ast::api::QueryParseError;
 pub use element_index::ElementArchiveIndex;
 pub use element_index::ElementIndex;
@@ -32,6 +34,7 @@ pub use future_queue::FutureElementRef;
 pub use future_queue::FutureQueue;
 pub use future_queue::FutureQueueConsumer;
 pub use future_queue::PushType;
+pub use index_backend::CreatedIndexes;
 pub use index_backend::IndexBackendPlugin;
 pub use index_backend::IndexSet;
 pub use query_clock::QueryClock;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-lib"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 authors = ["Drasi Project"]
 description = "Embedded Drasi for in-process data change processing using continuous queries"

--- a/lib/src/indexes/factory.rs
+++ b/lib/src/indexes/factory.rs
@@ -17,7 +17,7 @@ use crate::indexes::IndexBackendPlugin;
 use drasi_core::in_memory_index::in_memory_element_index::InMemoryElementIndex;
 use drasi_core::in_memory_index::in_memory_future_queue::InMemoryFutureQueue;
 use drasi_core::in_memory_index::in_memory_result_index::InMemoryResultIndex;
-use drasi_core::interface::{IndexSet, NoOpSessionControl};
+use drasi_core::interface::{CreatedIndexes, IndexSet, NoOpSessionControl};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -120,7 +120,8 @@ impl IndexFactory {
         Self { backends, plugin }
     }
 
-    /// Build an IndexSet for a query using the specified storage backend
+    /// Build a [`CreatedIndexes`] (index set plus optional checkpoint writer)
+    /// for a query using the specified storage backend
     ///
     /// # Arguments
     /// * `backend_ref` - Reference to storage backend (named or inline)
@@ -135,7 +136,7 @@ impl IndexFactory {
         &self,
         backend_ref: &StorageBackendRef,
         query_id: &str,
-    ) -> Result<IndexSet, IndexError> {
+    ) -> Result<CreatedIndexes, IndexError> {
         let spec = match backend_ref {
             StorageBackendRef::Named(name) => self
                 .backends
@@ -147,12 +148,12 @@ impl IndexFactory {
         self.build_from_spec(spec, query_id).await
     }
 
-    /// Build an IndexSet from a storage backend specification
+    /// Build a CreatedIndexes from a storage backend specification
     async fn build_from_spec(
         &self,
         spec: &StorageBackendSpec,
         query_id: &str,
-    ) -> Result<IndexSet, IndexError> {
+    ) -> Result<CreatedIndexes, IndexError> {
         // Validate configuration before building
         spec.validate().map_err(IndexError::InitializationFailed)?;
 
@@ -174,8 +175,8 @@ impl IndexFactory {
         }
     }
 
-    /// Build in-memory indexes
-    fn build_memory_indexes(&self, enable_archive: bool) -> Result<IndexSet, IndexError> {
+    /// Build in-memory indexes. Volatile backend, so no checkpoint writer.
+    fn build_memory_indexes(&self, enable_archive: bool) -> Result<CreatedIndexes, IndexError> {
         let mut element_index = InMemoryElementIndex::new();
         if enable_archive {
             element_index.enable_archive();
@@ -184,12 +185,15 @@ impl IndexFactory {
         let result_index = InMemoryResultIndex::new();
         let future_queue = InMemoryFutureQueue::new();
 
-        Ok(IndexSet {
-            element_index: element_index.clone(),
-            archive_index: element_index,
-            result_index: Arc::new(result_index),
-            future_queue: Arc::new(future_queue),
-            session_control: Arc::new(NoOpSessionControl),
+        Ok(CreatedIndexes {
+            set: IndexSet {
+                element_index: element_index.clone(),
+                archive_index: element_index,
+                result_index: Arc::new(result_index),
+                future_queue: Arc::new(future_queue),
+                session_control: Arc::new(NoOpSessionControl),
+            },
+            checkpoint_writer: None,
         })
     }
 
@@ -198,11 +202,11 @@ impl IndexFactory {
         &self,
         plugin: &Arc<dyn IndexBackendPlugin>,
         query_id: &str,
-    ) -> Result<IndexSet, IndexError> {
-        plugin.create_index_set(query_id).await.map_err(|e| {
-            log::error!("Failed to create index set for query '{query_id}': {e}");
+    ) -> Result<CreatedIndexes, IndexError> {
+        plugin.create_indexes(query_id).await.map_err(|e| {
+            log::error!("Failed to create indexes for query '{query_id}': {e}");
             IndexError::InitializationFailed(format!(
-                "Failed to create index set for query '{query_id}': {e}"
+                "Failed to create indexes for query '{query_id}': {e}"
             ))
         })
     }
@@ -265,9 +269,10 @@ mod tests {
 
         let factory = IndexFactory::new(backends, None);
         let backend_ref = StorageBackendRef::Named("memory_test".to_string());
-        let result = factory.build(&backend_ref, "test_query").await;
+        let created = factory.build(&backend_ref, "test_query").await.unwrap();
 
-        assert!(result.is_ok());
+        // Volatile backend should not produce a checkpoint writer.
+        assert!(created.checkpoint_writer.is_none());
     }
 
     #[tokio::test]
@@ -291,9 +296,9 @@ mod tests {
         let backend_ref = StorageBackendRef::Inline(StorageBackendSpec::Memory {
             enable_archive: false,
         });
-        let result = factory.build(&backend_ref, "test_query").await;
+        let created = factory.build(&backend_ref, "test_query").await.unwrap();
 
-        assert!(result.is_ok());
+        assert!(created.checkpoint_writer.is_none());
     }
 
     #[tokio::test]
@@ -473,11 +478,11 @@ mod tests {
 
         // Use tokio runtime for async test
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let index_set = rt
+        let created = rt
             .block_on(factory.build(&StorageBackendRef::Named("memory_test".to_string()), "q1"))
             .unwrap();
 
-        let debug_str = format!("{index_set:?}");
+        let debug_str = format!("{:?}", created.set);
         assert!(debug_str.contains("IndexSet"));
         assert!(debug_str.contains("element_index"));
         assert!(debug_str.contains("archive_index"));
@@ -510,10 +515,10 @@ mod tests {
 
         #[async_trait]
         impl IndexBackendPlugin for MockPlugin {
-            async fn create_index_set(
+            async fn create_indexes(
                 &self,
                 _query_id: &str,
-            ) -> Result<drasi_core::interface::IndexSet, drasi_core::interface::IndexError>
+            ) -> Result<drasi_core::interface::CreatedIndexes, drasi_core::interface::IndexError>
             {
                 unimplemented!()
             }
@@ -536,8 +541,8 @@ mod tests {
         let backend_ref = StorageBackendRef::Inline(StorageBackendSpec::Memory {
             enable_archive: false,
         });
-        let result = factory.build(&backend_ref, "test_query").await;
-        assert!(result.is_ok());
+        let created = factory.build(&backend_ref, "test_query").await.unwrap();
+        assert!(created.checkpoint_writer.is_none());
     }
 
     #[tokio::test]
@@ -546,7 +551,7 @@ mod tests {
         let backend_ref = StorageBackendRef::Inline(StorageBackendSpec::Memory {
             enable_archive: true,
         });
-        let result = factory.build(&backend_ref, "test_query").await;
-        assert!(result.is_ok());
+        let created = factory.build(&backend_ref, "test_query").await.unwrap();
+        assert!(created.checkpoint_writer.is_none());
     }
 }

--- a/lib/src/indexes/mod.rs
+++ b/lib/src/indexes/mod.rs
@@ -72,6 +72,9 @@ pub mod factory;
 pub use config::{StorageBackendConfig, StorageBackendRef, StorageBackendSpec};
 pub use factory::{IndexError, IndexFactory};
 
-// Re-export IndexSet and IndexBackendPlugin from drasi_core for plugin developers
+// Re-export CheckpointWriter, CreatedIndexes, IndexBackendPlugin, and IndexSet
+// from drasi_core for plugin developers
+pub use drasi_core::interface::CheckpointWriter;
+pub use drasi_core::interface::CreatedIndexes;
 pub use drasi_core::interface::IndexBackendPlugin;
 pub use drasi_core::interface::IndexSet;

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -423,10 +423,13 @@ impl Query for DrasiQuery {
             );
             let index_factory = self.index_factory.clone();
 
-            let index_set = index_factory
+            let created = index_factory
                 .build(backend_ref, &self.base.config.id)
                 .await
-                .context("Failed to build index set")?;
+                .context("Failed to build indexes")?;
+            // The checkpoint_writer is intentionally unused in this PR; #370
+            // (query processor checkpoint integration) will consume it.
+            let index_set = created.set;
 
             builder = builder
                 .with_element_index(index_set.element_index)


### PR DESCRIPTION
Part 09 of the checkpoint-based recovery effort (design: drasi-project/design-documents/drasi-lib/Source-Checkpoints). Builds on #361 / PR #372 (nested transaction support).

## What this adds

A `CheckpointWriter` trait in `drasi-core` that pairs with an `IndexBackendPlugin` and shares its session state. `stage_checkpoint` writes go into the currently active session transaction (opened by `SessionControl::begin`) so the checkpoint commits atomically with index updates. All other methods (`read_*`, `clear_checkpoints`, `write_config_hash`, `read_config_hash`) operate outside the session transaction and commit on their own.

Implementations in the two persistent backends:

* `drasi-index-rocksdb` adds a dedicated `stream_state` column family kept separate from graph CFs to avoid compaction churn on the high-frequency sequence overwrites. Keys: `source_sequence:{src}` and `config_hash`, encoded as u64 big-endian.
* `drasi-index-garnet` stores a single cluster-hash-tagged hash key `ss:{<query_id>}` with decimal-ASCII u64 values, matching the existing `metadata:{<query_id>}:sequence` convention in the result index.

## Design decisions worth flagging

* Trait lives in `drasi-core` rather than `drasi-lib` so index plugins can implement it without a reverse dep on lib.
* Plugin returns the writer alongside the index set in one call to guarantee they share the same `Arc<SessionState>`. The trait method `IndexBackendPlugin::create_index_set` is renamed to `create_indexes` and now returns `CreatedIndexes { set, checkpoint_writer }`. This is a breaking change; no deprecation shim since there are no external implementors.
* Trait surface uses primitives only so a future FFI proxy is a drop-in addition.
* Volatile (in-memory) backends return `checkpoint_writer: None`, which the query processor will branch on in #370.
* Per-backend u64 encoding follows existing precedent: `u64::to_be_bytes` for RocksDB (`result_index.rs:307`), decimal ASCII for Garnet (`result_index.rs:370`).

## Scope

Backend plumbing only. No query-processor wiring, no `resume_from`, no dedup, no outer-transaction wrapping. Those are #370 and #371.

## Version bumps

* `drasi-core` 0.4.1 to 0.5.0
* `drasi-index-rocksdb` 0.3.1 to 0.4.0
* `drasi-index-garnet` 0.1.8 to 0.2.0
* `drasi-lib` / `drasi-ffi-primitives` / `drasi-plugin-sdk` / `drasi-host-sdk` 0.6.0 to 0.7.0 (shared workspace package version; `drasi-lib`'s public factory now returns `CreatedIndexes`)

## Tests

* \`drasi-core\`: 679 passed
* \`drasi-index-rocksdb\`: 25 passed (8 new inline checkpoint tests, covering stage-inside-session round-trip, rollback discards stage, stage-without-session errors, read_all, config hash round-trip, clear, survives close/reopen, nested session commits atomically)
* \`drasi-index-garnet\`: 7 new integration tests in \`tests/checkpoint_tests.rs\` passing against a testcontainers Redis
* \`drasi-lib\`: 639 passed
* \`cargo clippy -p drasi-core -p drasi-index-rocksdb -p drasi-index-garnet -p drasi-lib --all-targets -- -D warnings\` clean

Fixes #367