### PR TITLE
Postgres Source Replay Support

### DIFF
--- a/components/sources/postgres/src/connection.rs
+++ b/components/sources/postgres/src/connection.rs
@@ -570,12 +570,11 @@ impl ReplicationConnection {
     }
 }
 
-fn format_lsn(lsn: u64) -> String {
+pub(crate) fn format_lsn(lsn: u64) -> String {
     format!("{:X}/{:X}", lsn >> 32, lsn & 0xFFFFFFFF)
 }
 
-#[allow(dead_code)]
-fn parse_lsn(lsn_str: &str) -> Result<u64> {
+pub(crate) fn parse_lsn(lsn_str: &str) -> Result<u64> {
     let parts: Vec<&str> = lsn_str.split('/').collect();
     if parts.len() != 2 {
         return Err(anyhow!("Invalid LSN format: {lsn_str}"));

--- a/components/sources/postgres/src/lib.rs
+++ b/components/sources/postgres/src/lib.rs
@@ -179,18 +179,33 @@ pub mod types;
 
 pub use config::{PostgresSourceConfig, SslMode, TableKeyConfig};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use log::{error, info};
 use std::collections::HashMap;
-use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use tokio::sync::{oneshot, RwLock};
 
 use drasi_lib::channels::{DispatchMode, *};
 use drasi_lib::component_graph::ComponentStatusHandle;
 use drasi_lib::sources::base::{SourceBase, SourceBaseParams};
 use drasi_lib::Source;
 use tracing::Instrument;
+
+#[derive(Default)]
+pub(crate) struct ReplayState {
+    pub(crate) read_lsn: AtomicU64,
+    pub(crate) confirmed_lsn: AtomicU64,
+}
+
+impl ReplayState {
+    fn read_lsn(&self) -> u64 {
+        self.read_lsn.load(Ordering::Relaxed)
+    }
+}
 
 /// PostgreSQL replication source that captures changes via logical replication.
 ///
@@ -206,6 +221,8 @@ pub struct PostgresReplicationSource {
     base: SourceBase,
     /// PostgreSQL source configuration
     config: PostgresSourceConfig,
+    /// Shared replay progress for subscribe()/rewind decisions and WAL feedback.
+    replay_state: Arc<ReplayState>,
 }
 
 impl PostgresReplicationSource {
@@ -266,6 +283,7 @@ impl PostgresReplicationSource {
         Ok(Self {
             base: SourceBase::new(params)?,
             config,
+            replay_state: Arc::new(ReplayState::default()),
         })
     }
 
@@ -290,7 +308,136 @@ impl PostgresReplicationSource {
         Ok(Self {
             base: SourceBase::new(params)?,
             config,
+            replay_state: Arc::new(ReplayState::default()),
         })
+    }
+
+    async fn spawn_replication_task(&self, start_lsn: Option<u64>) -> Result<()> {
+        let config = self.config.clone();
+        let source_id = self.base.id.clone();
+        let dispatchers = self.base.dispatchers.clone();
+        let reporter = self.base.status_handle();
+        let base = self.base.clone_shared();
+        let replay_state = self.replay_state.clone();
+        let (ready_tx, ready_rx) = oneshot::channel::<std::result::Result<(), String>>();
+
+        let instance_id = self
+            .base
+            .context()
+            .await
+            .map(|c| c.instance_id)
+            .unwrap_or_default();
+
+        let source_id_for_span = source_id.clone();
+        let span = tracing::info_span!(
+            "postgres_replication_task",
+            instance_id = %instance_id,
+            component_id = %source_id_for_span,
+            component_type = "source",
+            start_lsn = ?start_lsn
+        );
+
+        let task = tokio::spawn(
+            async move {
+                info!("Starting replication for source {source_id}");
+
+                let mut stream = stream::ReplicationStream::new(
+                    config,
+                    source_id.clone(),
+                    dispatchers,
+                    reporter.clone(),
+                    base,
+                    replay_state,
+                    start_lsn,
+                );
+
+                if let Err(e) = stream.run(Some(ready_tx)).await {
+                    error!("Replication task failed for {source_id}: {e}");
+                    reporter
+                        .set_status(
+                            ComponentStatus::Error,
+                            Some(format!("Replication failed: {e}")),
+                        )
+                        .await;
+                }
+            }
+            .instrument(span),
+        );
+
+        *self.base.task_handle.write().await = Some(task);
+
+        match ready_rx.await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(message)) => {
+                let _ = self.base.task_handle.write().await.take();
+                Err(anyhow!(
+                    "Failed to establish PostgreSQL replication: {message}"
+                ))
+            }
+            Err(_) => {
+                let _ = self.base.task_handle.write().await.take();
+                Err(anyhow!(
+                    "PostgreSQL replication task exited before confirming startup"
+                ))
+            }
+        }
+    }
+
+    async fn restart_replication_from(&self, start_lsn: u64) -> Result<()> {
+        info!(
+            "Restarting PostgreSQL source '{}' from requested LSN {:x}",
+            self.base.id, start_lsn
+        );
+
+        self.base
+            .set_status(
+                ComponentStatus::Starting,
+                Some(format!(
+                    "Rewinding PostgreSQL replication to LSN {start_lsn:x}"
+                )),
+            )
+            .await;
+
+        if let Some(task) = self.base.task_handle.write().await.take() {
+            task.abort();
+            let _ = task.await;
+        }
+
+        self.spawn_replication_task(Some(start_lsn)).await?;
+
+        self.base
+            .set_status(
+                ComponentStatus::Running,
+                Some(format!(
+                    "PostgreSQL replication resumed from LSN {start_lsn:x}"
+                )),
+            )
+            .await;
+
+        Ok(())
+    }
+
+    async fn get_earliest_available_lsn(&self) -> Result<u64> {
+        let mut conn = connection::ReplicationConnection::connect(
+            &self.config.host,
+            self.config.port,
+            &self.config.database,
+            &self.config.user,
+            &self.config.password,
+        )
+        .await?;
+
+        let _ = conn.identify_system().await?;
+        let slot_info = conn
+            .create_replication_slot(&self.config.slot_name, false)
+            .await?;
+        let _ = conn.close().await;
+
+        if slot_info.consistent_point.is_empty() || slot_info.consistent_point == "0/0" {
+            Ok(0)
+        } else {
+            connection::parse_lsn(&slot_info.consistent_point)
+        }
     }
 }
 
@@ -318,6 +465,10 @@ impl Source for PostgresReplicationSource {
         self.base.get_auto_start()
     }
 
+    fn supports_replay(&self) -> bool {
+        true
+    }
+
     async fn start(&self) -> Result<()> {
         if self.base.get_status().await == ComponentStatus::Running {
             return Ok(());
@@ -325,47 +476,7 @@ impl Source for PostgresReplicationSource {
 
         self.base.set_status(ComponentStatus::Starting, None).await;
         info!("Starting PostgreSQL replication source: {}", self.base.id);
-
-        let config = self.config.clone();
-        let source_id = self.base.id.clone();
-        let dispatchers = self.base.dispatchers.clone();
-        let reporter = self.base.status_handle();
-
-        // Get instance_id from context for log routing isolation
-        let instance_id = self
-            .base
-            .context()
-            .await
-            .map(|c| c.instance_id)
-            .unwrap_or_default();
-
-        // Create span for spawned task so log::info!, log::error! etc are routed
-        let source_id_for_span = source_id.clone();
-        let span = tracing::info_span!(
-            "postgres_replication_task",
-            instance_id = %instance_id,
-            component_id = %source_id_for_span,
-            component_type = "source"
-        );
-
-        let task = tokio::spawn(
-            async move {
-                if let Err(e) =
-                    run_replication(source_id.clone(), config, dispatchers, reporter.clone()).await
-                {
-                    error!("Replication task failed for {source_id}: {e}");
-                    reporter
-                        .set_status(
-                            ComponentStatus::Error,
-                            Some(format!("Replication failed: {e}")),
-                        )
-                        .await;
-                }
-            }
-            .instrument(span),
-        );
-
-        *self.base.task_handle.write().await = Some(task);
+        self.spawn_replication_task(None).await?;
         self.base
             .set_status(
                 ComponentStatus::Running,
@@ -388,6 +499,7 @@ impl Source for PostgresReplicationSource {
         // Cancel the replication task
         if let Some(task) = self.base.task_handle.write().await.take() {
             task.abort();
+            let _ = task.await;
         }
 
         self.base
@@ -408,9 +520,37 @@ impl Source for PostgresReplicationSource {
         &self,
         settings: drasi_lib::config::SourceSubscriptionSettings,
     ) -> Result<SubscriptionResponse> {
-        self.base
+        let mut restart_from = None;
+
+        if let Some(resume_from) = settings.resume_from {
+            let earliest_available = self.get_earliest_available_lsn().await?;
+            if resume_from < earliest_available {
+                return Err(drasi_lib::SourceError::PositionUnavailable {
+                    source_id: self.base.id.clone(),
+                    requested: resume_from,
+                    earliest_available: Some(earliest_available),
+                }
+                .into());
+            }
+
+            let read_lsn = self.replay_state.read_lsn();
+            let is_running = self.base.get_status().await == ComponentStatus::Running;
+
+            if !is_running || read_lsn == 0 || resume_from < read_lsn {
+                restart_from = Some(resume_from);
+            }
+        }
+
+        let response = self
+            .base
             .subscribe_with_bootstrap(&settings, "PostgreSQL")
-            .await
+            .await?;
+
+        if let Some(start_lsn) = restart_from {
+            self.restart_replication_from(start_lsn).await?;
+        }
+
+        Ok(response)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -427,23 +567,6 @@ impl Source for PostgresReplicationSource {
     ) {
         self.base.set_bootstrap_provider(provider).await;
     }
-}
-
-async fn run_replication(
-    source_id: String,
-    config: PostgresSourceConfig,
-    dispatchers: Arc<
-        RwLock<
-            Vec<Box<dyn drasi_lib::channels::ChangeDispatcher<SourceEventWrapper> + Send + Sync>>,
-        >,
-    >,
-    status_handle: ComponentStatusHandle,
-) -> Result<()> {
-    info!("Starting replication for source {source_id}");
-
-    let mut stream = stream::ReplicationStream::new(config, source_id, dispatchers, status_handle);
-
-    stream.run().await
 }
 
 /// Builder for PostgreSQL source configuration.
@@ -655,6 +778,7 @@ impl PostgresSourceBuilder {
         Ok(PostgresReplicationSource {
             base: SourceBase::new(params)?,
             config,
+            replay_state: Arc::new(ReplayState::default()),
         })
     }
 }
@@ -734,6 +858,16 @@ mod tests {
                 .build()
                 .unwrap();
             assert_eq!(source.type_name(), "postgres");
+        }
+
+        #[test]
+        fn test_supports_replay_returns_true() {
+            let source = PostgresSourceBuilder::new("test")
+                .with_database("db")
+                .with_user("user")
+                .build()
+                .unwrap();
+            assert!(source.supports_replay());
         }
 
         #[test]

--- a/components/sources/postgres/src/lib.rs
+++ b/components/sources/postgres/src/lib.rs
@@ -383,9 +383,16 @@ impl PostgresReplicationSource {
         }
     }
 
-    async fn restart_replication_from(&self, start_lsn: u64) -> Result<()> {
+    async fn abort_replication_task(&self) {
+        if let Some(task) = self.base.task_handle.write().await.take() {
+            task.abort();
+            let _ = task.await;
+        }
+    }
+
+    async fn pause_replication_for_restart(&self, start_lsn: u64) {
         info!(
-            "Restarting PostgreSQL source '{}' from requested LSN {:x}",
+            "Pausing PostgreSQL source '{}' before replay from requested LSN {:x}",
             self.base.id, start_lsn
         );
 
@@ -398,11 +405,10 @@ impl PostgresReplicationSource {
             )
             .await;
 
-        if let Some(task) = self.base.task_handle.write().await.take() {
-            task.abort();
-            let _ = task.await;
-        }
+        self.abort_replication_task().await;
+    }
 
+    async fn resume_replication_from(&self, start_lsn: u64) -> Result<()> {
         self.spawn_replication_task(Some(start_lsn)).await?;
 
         self.base
@@ -415,6 +421,16 @@ impl PostgresReplicationSource {
             .await;
 
         Ok(())
+    }
+
+    async fn restart_replication_from(&self, start_lsn: u64) -> Result<()> {
+        info!(
+            "Restarting PostgreSQL source '{}' from requested LSN {:x}",
+            self.base.id, start_lsn
+        );
+
+        self.pause_replication_for_restart(start_lsn).await;
+        self.resume_replication_from(start_lsn).await
     }
 
     async fn get_earliest_available_lsn(&self) -> Result<u64> {
@@ -496,11 +512,7 @@ impl Source for PostgresReplicationSource {
 
         self.base.set_status(ComponentStatus::Stopping, None).await;
 
-        // Cancel the replication task
-        if let Some(task) = self.base.task_handle.write().await.take() {
-            task.abort();
-            let _ = task.await;
-        }
+        self.abort_replication_task().await;
 
         self.base
             .set_status(
@@ -521,6 +533,7 @@ impl Source for PostgresReplicationSource {
         settings: drasi_lib::config::SourceSubscriptionSettings,
     ) -> Result<SubscriptionResponse> {
         let mut restart_from = None;
+        let mut pause_before_subscribe = false;
 
         if let Some(resume_from) = settings.resume_from {
             let earliest_available = self.get_earliest_available_lsn().await?;
@@ -538,16 +551,42 @@ impl Source for PostgresReplicationSource {
 
             if !is_running || read_lsn == 0 || resume_from < read_lsn {
                 restart_from = Some(resume_from);
+                pause_before_subscribe = is_running;
             }
         }
 
-        let response = self
+        if let Some(start_lsn) = restart_from.filter(|_| pause_before_subscribe) {
+            // Quiesce the current replication task before attaching the resumed
+            // receiver so it cannot observe newer live events ahead of replayed
+            // older WAL entries.
+            self.pause_replication_for_restart(start_lsn).await;
+        }
+
+        let response = match self
             .base
             .subscribe_with_bootstrap(&settings, "PostgreSQL")
-            .await?;
+            .await
+        {
+            Ok(response) => response,
+            Err(err) => {
+                if pause_before_subscribe {
+                    self.base
+                        .set_status(
+                            ComponentStatus::Error,
+                            Some(format!("Failed to register replay subscription: {err}")),
+                        )
+                        .await;
+                }
+                return Err(err);
+            }
+        };
 
         if let Some(start_lsn) = restart_from {
-            self.restart_replication_from(start_lsn).await?;
+            if pause_before_subscribe {
+                self.resume_replication_from(start_lsn).await?;
+            } else {
+                self.restart_replication_from(start_lsn).await?;
+            }
         }
 
         Ok(response)
@@ -943,6 +982,27 @@ mod tests {
                 .build()
                 .unwrap();
             assert_eq!(source.status().await, ComponentStatus::Stopped);
+        }
+
+        #[tokio::test]
+        async fn test_pause_replication_for_restart_aborts_existing_task() {
+            let source = PostgresSourceBuilder::new("test")
+                .with_database("db")
+                .with_user("user")
+                .build()
+                .unwrap();
+
+            source.base.set_status(ComponentStatus::Running, None).await;
+
+            let task = tokio::spawn(async {
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            });
+            *source.base.task_handle.write().await = Some(task);
+
+            source.pause_replication_for_restart(42).await;
+
+            assert!(source.base.task_handle.read().await.is_none());
+            assert_eq!(source.status().await, ComponentStatus::Starting);
         }
     }
 

--- a/components/sources/postgres/src/stream.rs
+++ b/components/sources/postgres/src/stream.rs
@@ -16,16 +16,17 @@ use anyhow::{anyhow, Result};
 use chrono::Utc;
 use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{atomic::Ordering, Arc};
 use std::time::Duration;
-use tokio::sync::RwLock;
+use tokio::sync::{oneshot, RwLock};
 use tokio::time::{interval, sleep};
 
+use super::connection::parse_lsn;
 use super::connection::ReplicationConnection;
 use super::decoder::PgOutputDecoder;
 use super::protocol::BackendMessage;
 use super::types::{StandbyStatusUpdate, WalMessage};
-use super::PostgresSourceConfig;
+use super::{PostgresSourceConfig, ReplayState};
 use drasi_core::models::{Element, ElementMetadata, ElementReference, SourceChange};
 use drasi_lib::channels::{ComponentStatus, SourceEvent, SourceEventWrapper};
 use drasi_lib::component_graph::ComponentStatusHandle;
@@ -43,9 +44,14 @@ pub struct ReplicationStream {
     >,
     #[allow(dead_code)]
     status_handle: ComponentStatusHandle,
-    current_lsn: u64,
+    base: SourceBase,
+    replay_state: Arc<ReplayState>,
+    read_lsn: u64,
+    confirmed_lsn: u64,
+    current_sequence: u64,
+    start_lsn: Option<u64>,
     last_feedback_time: std::time::Instant,
-    pending_transaction: Option<Vec<SourceChange>>,
+    pending_transaction: Option<Vec<(SourceChange, u64)>>,
     relations: HashMap<u32, RelationMapping>,
     table_primary_keys: Arc<RwLock<HashMap<String, Vec<String>>>>,
 }
@@ -59,7 +65,7 @@ struct RelationMapping {
 }
 
 impl ReplicationStream {
-    pub fn new(
+    pub(crate) fn new(
         config: PostgresSourceConfig,
         source_id: String,
         dispatchers: Arc<
@@ -72,6 +78,9 @@ impl ReplicationStream {
             >,
         >,
         status_handle: ComponentStatusHandle,
+        base: SourceBase,
+        replay_state: Arc<ReplayState>,
+        start_lsn: Option<u64>,
     ) -> Self {
         Self {
             config,
@@ -80,7 +89,12 @@ impl ReplicationStream {
             decoder: PgOutputDecoder::new(),
             dispatchers,
             status_handle,
-            current_lsn: 0,
+            base,
+            replay_state,
+            read_lsn: 0,
+            confirmed_lsn: 0,
+            current_sequence: 0,
+            start_lsn,
             last_feedback_time: std::time::Instant::now(),
             pending_transaction: None,
             relations: HashMap::new(),
@@ -92,11 +106,22 @@ impl ReplicationStream {
     // Element IDs are generated from configured table_keys (in config.table_keys),
     // or fall back to using all column values if no keys are configured.
 
-    pub async fn run(&mut self) -> Result<()> {
+    pub async fn run(
+        &mut self,
+        ready_tx: Option<oneshot::Sender<std::result::Result<(), String>>>,
+    ) -> Result<()> {
         info!("Starting replication stream for source {}", self.source_id);
 
         // Connect and setup replication
-        self.connect_and_setup().await?;
+        if let Err(error) = self.connect_and_setup().await {
+            if let Some(tx) = ready_tx {
+                let _ = tx.send(Err(format!("{error:#}")));
+            }
+            return Err(error);
+        }
+        if let Some(tx) = ready_tx {
+            let _ = tx.send(Ok(()));
+        }
 
         // Start streaming loop
         let mut keepalive_interval = interval(Duration::from_secs(10));
@@ -177,12 +202,20 @@ impl ReplicationStream {
         info!("Using replication slot: {slot_info:?}");
 
         // Parse starting LSN
-        if !slot_info.consistent_point.is_empty() && slot_info.consistent_point != "0/0" {
-            self.current_lsn = parse_lsn(&slot_info.consistent_point)?;
-        } else {
-            // Start from beginning if no consistent point
-            self.current_lsn = 0;
-        }
+        self.confirmed_lsn =
+            if !slot_info.consistent_point.is_empty() && slot_info.consistent_point != "0/0" {
+                parse_lsn(&slot_info.consistent_point)?
+            } else {
+                0
+            };
+        self.read_lsn = self.start_lsn.unwrap_or(self.confirmed_lsn);
+        self.current_sequence = self.read_lsn;
+        self.replay_state
+            .read_lsn
+            .store(self.read_lsn, Ordering::Relaxed);
+        self.replay_state
+            .confirmed_lsn
+            .store(self.confirmed_lsn, Ordering::Relaxed);
 
         // Build replication options
         let mut options = HashMap::new();
@@ -193,11 +226,14 @@ impl ReplicationStream {
         );
 
         // Start replication
-        conn.start_replication(&self.config.slot_name, Some(self.current_lsn), options)
+        conn.start_replication(&self.config.slot_name, Some(self.read_lsn), options)
             .await?;
 
         self.connection = Some(conn);
-        info!("Replication started from LSN: {:x}", self.current_lsn);
+        info!(
+            "Replication started from read LSN {:x} with confirmed watermark {:x}",
+            self.read_lsn, self.confirmed_lsn
+        );
 
         Ok(())
     }
@@ -227,7 +263,10 @@ impl ReplicationStream {
                 timestamp: _,
                 reply,
             } => {
-                self.current_lsn = wal_end;
+                self.read_lsn = wal_end;
+                self.replay_state
+                    .read_lsn
+                    .store(self.read_lsn, Ordering::Relaxed);
                 if reply == 1 {
                     self.send_feedback(true).await?;
                 }
@@ -285,7 +324,11 @@ impl ReplicationStream {
         ]);
 
         // Update LSN
-        self.current_lsn = end_lsn;
+        self.read_lsn = end_lsn;
+        self.current_sequence = end_lsn;
+        self.replay_state
+            .read_lsn
+            .store(self.read_lsn, Ordering::Relaxed);
 
         // Decode the actual WAL message
         let wal_data = &data[24..];
@@ -341,7 +384,10 @@ impl ReplicationStream {
         ]);
         let reply = data[16];
 
-        self.current_lsn = wal_end;
+        self.read_lsn = wal_end;
+        self.replay_state
+            .read_lsn
+            .store(self.read_lsn, Ordering::Relaxed);
 
         if reply == 1 {
             self.send_feedback(true).await?;
@@ -360,31 +406,8 @@ impl ReplicationStream {
                 // Commit the transaction
                 if let Some(changes) = self.pending_transaction.take() {
                     // Send all changes in the transaction
-                    for change in changes {
-                        // Create profiling metadata with timestamps
-                        let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
-                        profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
-
-                        let wrapper = SourceEventWrapper::with_profiling(
-                            self.source_id.clone(),
-                            SourceEvent::Change(change),
-                            chrono::Utc::now(),
-                            profiling,
-                        );
-
-                        // Dispatch via helper
-                        if let Err(e) = SourceBase::dispatch_from_task(
-                            self.dispatchers.clone(),
-                            wrapper.clone(),
-                            &self.source_id,
-                        )
-                        .await
-                        {
-                            debug!(
-                                "[{}] Failed to dispatch change (no subscribers): {}",
-                                self.source_id, e
-                            );
-                        }
+                    for (change, sequence) in changes {
+                        self.dispatch_change(change, sequence).await;
                     }
                     debug!(
                         "Committed transaction {} with LSN {:x}",
@@ -411,32 +434,9 @@ impl ReplicationStream {
             WalMessage::Insert { relation_id, tuple } => {
                 if let Some(change) = self.convert_insert(relation_id, tuple).await? {
                     if let Some(tx) = &mut self.pending_transaction {
-                        tx.push(change);
+                        tx.push((change, self.current_sequence));
                     } else {
-                        // No transaction context, send immediately
-                        let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
-                        profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
-
-                        let wrapper = SourceEventWrapper::with_profiling(
-                            self.source_id.clone(),
-                            SourceEvent::Change(change),
-                            chrono::Utc::now(),
-                            profiling,
-                        );
-
-                        // Dispatch via helper
-                        if let Err(e) = SourceBase::dispatch_from_task(
-                            self.dispatchers.clone(),
-                            wrapper.clone(),
-                            &self.source_id,
-                        )
-                        .await
-                        {
-                            debug!(
-                                "[{}] Failed to dispatch change (no subscribers): {}",
-                                self.source_id, e
-                            );
-                        }
+                        self.dispatch_change(change, self.current_sequence).await;
                     }
                 }
             }
@@ -450,31 +450,9 @@ impl ReplicationStream {
                     .await?
                 {
                     if let Some(tx) = &mut self.pending_transaction {
-                        tx.push(change);
+                        tx.push((change, self.current_sequence));
                     } else {
-                        let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
-                        profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
-
-                        let wrapper = SourceEventWrapper::with_profiling(
-                            self.source_id.clone(),
-                            SourceEvent::Change(change),
-                            chrono::Utc::now(),
-                            profiling,
-                        );
-
-                        // Dispatch via helper
-                        if let Err(e) = SourceBase::dispatch_from_task(
-                            self.dispatchers.clone(),
-                            wrapper.clone(),
-                            &self.source_id,
-                        )
-                        .await
-                        {
-                            debug!(
-                                "[{}] Failed to dispatch change (no subscribers): {}",
-                                self.source_id, e
-                            );
-                        }
+                        self.dispatch_change(change, self.current_sequence).await;
                     }
                 }
             }
@@ -484,31 +462,9 @@ impl ReplicationStream {
             } => {
                 if let Some(change) = self.convert_delete(relation_id, old_tuple).await? {
                     if let Some(tx) = &mut self.pending_transaction {
-                        tx.push(change);
+                        tx.push((change, self.current_sequence));
                     } else {
-                        let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
-                        profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
-
-                        let wrapper = SourceEventWrapper::with_profiling(
-                            self.source_id.clone(),
-                            SourceEvent::Change(change),
-                            chrono::Utc::now(),
-                            profiling,
-                        );
-
-                        // Dispatch via helper
-                        if let Err(e) = SourceBase::dispatch_from_task(
-                            self.dispatchers.clone(),
-                            wrapper.clone(),
-                            &self.source_id,
-                        )
-                        .await
-                        {
-                            debug!(
-                                "[{}] Failed to dispatch change (no subscribers): {}",
-                                self.source_id, e
-                            );
-                        }
+                        self.dispatch_change(change, self.current_sequence).await;
                     }
                 }
             }
@@ -713,20 +669,53 @@ impl ReplicationStream {
     }
 
     async fn send_feedback(&mut self, reply_requested: bool) -> Result<()> {
+        if let Some(confirmed_lsn) = self.base.compute_confirmed_position().await {
+            self.confirmed_lsn = confirmed_lsn.min(self.read_lsn);
+            self.replay_state
+                .confirmed_lsn
+                .store(self.confirmed_lsn, Ordering::Relaxed);
+        }
+
         if let Some(conn) = &mut self.connection {
             let status = StandbyStatusUpdate {
-                write_lsn: self.current_lsn,
-                flush_lsn: self.current_lsn,
-                apply_lsn: self.current_lsn,
+                write_lsn: self.read_lsn,
+                flush_lsn: self.confirmed_lsn,
+                apply_lsn: self.confirmed_lsn,
                 reply_requested,
             };
 
             conn.send_standby_status(status).await?;
             self.last_feedback_time = std::time::Instant::now();
-            trace!("Sent feedback with LSN: {:x}", self.current_lsn);
+            trace!(
+                "Sent feedback with read_lsn {:x} and confirmed_lsn {:x}",
+                self.read_lsn,
+                self.confirmed_lsn
+            );
         }
 
         Ok(())
+    }
+
+    async fn dispatch_change(&self, change: SourceChange, sequence: u64) {
+        let mut profiling = drasi_lib::profiling::ProfilingMetadata::new();
+        profiling.source_send_ns = Some(drasi_lib::profiling::timestamp_ns());
+
+        let wrapper = SourceEventWrapper::with_sequence(
+            self.source_id.clone(),
+            SourceEvent::Change(change),
+            chrono::Utc::now(),
+            sequence,
+            Some(profiling),
+        );
+
+        if let Err(e) =
+            SourceBase::dispatch_from_task(self.dispatchers.clone(), wrapper, &self.source_id).await
+        {
+            debug!(
+                "[{}] Failed to dispatch change (no subscribers): {}",
+                self.source_id, e
+            );
+        }
     }
 
     #[allow(dead_code)]
@@ -766,18 +755,6 @@ impl ReplicationStream {
 
         Ok(())
     }
-}
-
-fn parse_lsn(lsn_str: &str) -> Result<u64> {
-    let parts: Vec<&str> = lsn_str.split('/').collect();
-    if parts.len() != 2 {
-        return Err(anyhow!("Invalid LSN format: {lsn_str}"));
-    }
-
-    let high = u64::from_str_radix(parts[0], 16)?;
-    let low = u64::from_str_radix(parts[1], 16)?;
-
-    Ok((high << 32) | low)
 }
 
 #[cfg(test)]

--- a/components/sources/postgres/tests/integration_tests.rs
+++ b/components/sources/postgres/tests/integration_tests.rs
@@ -19,7 +19,7 @@ use drasi_bootstrap_postgres::{
     PostgresBootstrapConfig, PostgresBootstrapProvider, SslMode as BootstrapSslMode,
     TableKeyConfig as BootstrapTableKeyConfig,
 };
-use drasi_lib::{DrasiLib, Query};
+use drasi_lib::{config::SourceSubscriptionSettings, DrasiLib, Query, Source, SourceError};
 use drasi_reaction_application::{ApplicationReaction, ApplicationReactionHandle};
 use drasi_source_postgres::{
     PostgresReplicationSource, PostgresSourceConfig, SslMode, TableKeyConfig,
@@ -27,10 +27,12 @@ use drasi_source_postgres::{
 use postgres_helpers::{
     create_decimal_test_table, create_logical_replication_slot, create_publication,
     create_test_table, create_test_table_replica_identity_default, delete_test_row,
-    grant_replication, grant_table_access, insert_decimal_test_row, insert_test_row,
-    setup_replication_postgres, update_test_row,
+    get_slot_confirmed_flush_lsn, grant_replication, grant_table_access, insert_decimal_test_row,
+    insert_test_row, setup_replication_postgres, update_test_row,
 };
 use serial_test::serial;
+use std::collections::HashSet;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -80,21 +82,7 @@ async fn build_core(
     config: &postgres_helpers::ReplicationPostgresConfig,
     slot_name: String,
 ) -> Result<(Arc<DrasiLib>, ApplicationReactionHandle)> {
-    let source_config = PostgresSourceConfig {
-        host: config.host.clone(),
-        port: config.port,
-        database: config.database.clone(),
-        user: config.user.clone(),
-        password: config.password.clone(),
-        tables: vec![TEST_TABLE.to_string()],
-        slot_name,
-        publication_name: TEST_PUBLICATION.to_string(),
-        ssl_mode: SslMode::Disable,
-        table_keys: vec![TableKeyConfig {
-            table: TEST_TABLE.to_string(),
-            key_columns: vec!["id".to_string()],
-        }],
-    };
+    let source_config = build_source_config(config, slot_name);
 
     let bootstrap_config = PostgresBootstrapConfig {
         host: source_config.host.clone(),
@@ -148,6 +136,83 @@ async fn build_core(
     Ok((core, handle))
 }
 
+fn build_source_config(
+    config: &postgres_helpers::ReplicationPostgresConfig,
+    slot_name: String,
+) -> PostgresSourceConfig {
+    PostgresSourceConfig {
+        host: config.host.clone(),
+        port: config.port,
+        database: config.database.clone(),
+        user: config.user.clone(),
+        password: config.password.clone(),
+        tables: vec![TEST_TABLE.to_string()],
+        slot_name,
+        publication_name: TEST_PUBLICATION.to_string(),
+        ssl_mode: SslMode::Disable,
+        table_keys: vec![TableKeyConfig {
+            table: TEST_TABLE.to_string(),
+            key_columns: vec!["id".to_string()],
+        }],
+    }
+}
+
+fn build_source(
+    config: &postgres_helpers::ReplicationPostgresConfig,
+    slot_name: String,
+) -> Result<PostgresReplicationSource> {
+    PostgresReplicationSource::builder("pg-direct-source")
+        .with_config(build_source_config(config, slot_name))
+        .build()
+}
+
+fn subscription_settings(
+    source_id: &str,
+    query_id: &str,
+    resume_from: Option<u64>,
+    request_position_handle: bool,
+) -> SourceSubscriptionSettings {
+    SourceSubscriptionSettings {
+        source_id: source_id.to_string(),
+        enable_bootstrap: false,
+        query_id: query_id.to_string(),
+        nodes: HashSet::new(),
+        relations: HashSet::new(),
+        resume_from,
+        request_position_handle,
+    }
+}
+
+async fn wait_for_source_event(
+    response: &mut drasi_lib::channels::SubscriptionResponse,
+) -> Result<Arc<drasi_lib::channels::SourceEventWrapper>> {
+    tokio::time::timeout(Duration::from_secs(15), response.receiver.recv()).await?
+}
+
+async fn wait_for_slot_confirmed_flush_lsn(
+    client: &tokio_postgres::Client,
+    slot_name: &str,
+    predicate: impl Fn(Option<u64>) -> bool,
+) -> Result<Option<u64>> {
+    let start = Instant::now();
+    let timeout = Duration::from_secs(20);
+
+    loop {
+        let lsn = get_slot_confirmed_flush_lsn(client, slot_name).await?;
+        if predicate(lsn) {
+            return Ok(lsn);
+        }
+
+        if start.elapsed() > timeout {
+            anyhow::bail!(
+                "Timed out waiting for confirmed_flush_lsn predicate for slot `{slot_name}`"
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
 #[tokio::test]
 #[serial]
 #[ignore]
@@ -197,6 +262,7 @@ async fn test_insert_detection() -> Result<()> {
 
     let (core, _handle) = build_core(pg.config(), slot_name).await?;
     core.start().await?;
+    wait_for_query_results(&core, "test-query", |results| results.is_empty()).await?;
 
     insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
 
@@ -232,6 +298,7 @@ async fn test_update_detection() -> Result<()> {
 
     let (core, _handle) = build_core(pg.config(), slot_name).await?;
     core.start().await?;
+    wait_for_query_results(&core, "test-query", |results| results.is_empty()).await?;
 
     insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
     wait_for_query_results(&core, "test-query", |results| {
@@ -274,6 +341,7 @@ async fn test_update_without_old_tuple_stays_update() -> Result<()> {
 
     let (core, _handle) = build_core(pg.config(), slot_name).await?;
     core.start().await?;
+    wait_for_query_results(&core, "test-query", |results| results.is_empty()).await?;
 
     insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
     wait_for_query_results(&core, "test-query", |results| {
@@ -317,6 +385,7 @@ async fn test_delete_detection() -> Result<()> {
 
     let (core, _handle) = build_core(pg.config(), slot_name).await?;
     core.start().await?;
+    wait_for_query_results(&core, "test-query", |results| results.is_empty()).await?;
 
     insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
     wait_for_query_results(&core, "test-query", |results| {
@@ -354,6 +423,7 @@ async fn test_full_crud_cycle() -> Result<()> {
 
     let (core, _handle) = build_core(pg.config(), slot_name).await?;
     core.start().await?;
+    wait_for_query_results(&core, "test-query", |results| results.is_empty()).await?;
 
     insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
     wait_for_query_results(&core, "test-query", |results| {
@@ -375,6 +445,250 @@ async fn test_full_crud_cycle() -> Result<()> {
     wait_for_query_results(&core, "test-query", |results| results.is_empty()).await?;
 
     core.stop().await?;
+    pg.cleanup().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_confirmed_flush_lsn_stays_pinned_without_subscribers() -> Result<()> {
+    init_logging();
+
+    let pg = setup_replication_postgres().await;
+    let client = pg.get_client().await?;
+
+    grant_replication(&client, "postgres").await?;
+    create_test_table(&client, TEST_TABLE).await?;
+    grant_table_access(&client, TEST_TABLE, "postgres").await?;
+    create_publication(&client, TEST_PUBLICATION, &[TEST_TABLE.to_string()]).await?;
+
+    let slot_name = slot_name();
+    create_logical_replication_slot(&client, &slot_name).await?;
+
+    let source = build_source(pg.config(), slot_name.clone())?;
+    source.start().await?;
+    let initial = get_slot_confirmed_flush_lsn(&client, &slot_name).await?;
+
+    insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
+    let after_first = get_slot_confirmed_flush_lsn(&client, &slot_name).await?;
+
+    insert_test_row(&client, TEST_TABLE, 2, "Bob").await?;
+    let after_second = get_slot_confirmed_flush_lsn(&client, &slot_name).await?;
+
+    assert_eq!(
+        after_first, initial,
+        "confirmed_flush_lsn should remain unchanged after the first insert with no subscribers"
+    );
+    assert_eq!(
+        after_second, initial,
+        "confirmed_flush_lsn should stay pinned when no subscriber position handles are active"
+    );
+
+    source.stop().await?;
+    pg.cleanup().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_resume_from_retained_lsn_replays_sequence_stamped_events() -> Result<()> {
+    init_logging();
+
+    let pg = setup_replication_postgres().await;
+    let client = pg.get_client().await?;
+
+    grant_replication(&client, "postgres").await?;
+    create_test_table(&client, TEST_TABLE).await?;
+    grant_table_access(&client, TEST_TABLE, "postgres").await?;
+    create_publication(&client, TEST_PUBLICATION, &[TEST_TABLE.to_string()]).await?;
+
+    let slot_name = slot_name();
+    create_logical_replication_slot(&client, &slot_name).await?;
+
+    let source = build_source(pg.config(), slot_name.clone())?;
+    source.start().await?;
+
+    let mut sub1 = source
+        .subscribe(subscription_settings(source.id(), "q1", None, true))
+        .await?;
+    let handle1 = sub1
+        .position_handle
+        .as_ref()
+        .expect("expected position handle for replay-capable subscription")
+        .clone();
+
+    insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
+    let event1 = wait_for_source_event(&mut sub1).await?;
+    let seq1 = event1
+        .sequence
+        .expect("expected WAL sequence on first event");
+    handle1.store(seq1, Ordering::Relaxed);
+
+    insert_test_row(&client, TEST_TABLE, 2, "Bob").await?;
+    let event2 = wait_for_source_event(&mut sub1).await?;
+    let seq2 = event2
+        .sequence
+        .expect("expected WAL sequence on second event");
+    assert!(seq2 >= seq1, "expected monotonic WAL sequences");
+    handle1.store(seq2, Ordering::Relaxed);
+
+    let mut resumed = source
+        .subscribe(subscription_settings(source.id(), "q2", Some(seq1), true))
+        .await?;
+
+    let replayed = wait_for_source_event(&mut resumed).await?;
+    let replay_seq = replayed
+        .sequence
+        .expect("expected sequence on replayed event");
+    assert!(
+        replay_seq >= seq1 && replay_seq <= seq2,
+        "expected replayed event from retained WAL range, got {replay_seq:x} outside [{seq1:x}, {seq2:x}]"
+    );
+
+    insert_test_row(&client, TEST_TABLE, 3, "Carol").await?;
+    let live = wait_for_source_event(&mut resumed).await?;
+    let live_seq = live.sequence.expect("expected sequence on live event");
+    assert!(
+        live_seq >= replay_seq,
+        "expected subsequent live event sequence to be >= replayed event sequence"
+    );
+
+    source.stop().await?;
+    pg.cleanup().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_resume_from_before_slot_watermark_returns_position_unavailable() -> Result<()> {
+    init_logging();
+
+    let pg = setup_replication_postgres().await;
+    let client = pg.get_client().await?;
+
+    grant_replication(&client, "postgres").await?;
+    create_test_table(&client, TEST_TABLE).await?;
+    grant_table_access(&client, TEST_TABLE, "postgres").await?;
+    create_publication(&client, TEST_PUBLICATION, &[TEST_TABLE.to_string()]).await?;
+
+    let slot_name = slot_name();
+    create_logical_replication_slot(&client, &slot_name).await?;
+
+    let source = build_source(pg.config(), slot_name.clone())?;
+    source.start().await?;
+
+    let mut sub = source
+        .subscribe(subscription_settings(
+            source.id(),
+            "watermark-q",
+            None,
+            true,
+        ))
+        .await?;
+    let handle = sub
+        .position_handle
+        .as_ref()
+        .expect("expected position handle")
+        .clone();
+
+    insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
+    let event1 = wait_for_source_event(&mut sub).await?;
+    let seq1 = event1.sequence.expect("expected first sequence");
+    handle.store(seq1, Ordering::Relaxed);
+
+    insert_test_row(&client, TEST_TABLE, 2, "Bob").await?;
+    let event2 = wait_for_source_event(&mut sub).await?;
+    let seq2 = event2.sequence.expect("expected second sequence");
+    handle.store(seq2, Ordering::Relaxed);
+
+    let earliest = wait_for_slot_confirmed_flush_lsn(
+        &client,
+        &slot_name,
+        |lsn| matches!(lsn, Some(value) if value >= seq2),
+    )
+    .await?
+    .expect("expected confirmed_flush_lsn after feedback");
+    assert!(earliest > 0, "expected a real slot watermark");
+
+    let requested = earliest.saturating_sub(1);
+    let err = match source
+        .subscribe(subscription_settings(
+            source.id(),
+            "stale-resume-q",
+            Some(requested),
+            true,
+        ))
+        .await
+    {
+        Ok(_) => panic!("expected stale resume_from to fail"),
+        Err(err) => err,
+    };
+
+    match err.downcast_ref::<SourceError>() {
+        Some(SourceError::PositionUnavailable {
+            source_id,
+            requested: actual_requested,
+            earliest_available: Some(actual_earliest),
+        }) => {
+            assert_eq!(source_id, source.id());
+            assert_eq!(*actual_requested, requested);
+            assert_eq!(*actual_earliest, earliest);
+        }
+        other => panic!("expected PositionUnavailable, got {other:?}"),
+    }
+
+    source.stop().await?;
+    pg.cleanup().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_start_surfaces_replication_setup_failure() -> Result<()> {
+    init_logging();
+
+    let pg = setup_replication_postgres().await;
+    let client = pg.get_client().await?;
+
+    grant_replication(&client, "postgres").await?;
+    create_test_table(&client, TEST_TABLE).await?;
+    grant_table_access(&client, TEST_TABLE, "postgres").await?;
+    create_publication(&client, TEST_PUBLICATION, &[TEST_TABLE.to_string()]).await?;
+
+    let mut source_config = build_source_config(pg.config(), slot_name());
+    source_config.slot_name = "invalid slot name".to_string();
+
+    let source = PostgresReplicationSource::builder("pg-bad-source")
+        .with_config(source_config)
+        .build()?;
+
+    let err = match source.start().await {
+        Ok(_) => panic!("expected source.start() to surface replication setup failure"),
+        Err(err) => err,
+    };
+
+    let message = err.to_string();
+    assert!(
+        message.contains("Failed to establish PostgreSQL replication")
+            || message.contains("START_REPLICATION failed")
+            || message.contains("publication"),
+        "unexpected error when replication setup failed: {message}"
+    );
+
+    assert_ne!(
+        source.status().await,
+        drasi_lib::channels::ComponentStatus::Running,
+        "source should not report Running when replication startup fails"
+    );
+
     pg.cleanup().await;
 
     Ok(())
@@ -467,6 +781,7 @@ async fn test_decimal_datatype_serialization() -> Result<()> {
     );
 
     core.start().await?;
+    wait_for_query_results(&core, "decimal-test-query", |results| results.is_empty()).await?;
 
     // Insert a row with decimal values
     // Using different precisions to test that NUMERIC columns handle various decimal formats

--- a/components/sources/postgres/tests/integration_tests.rs
+++ b/components/sources/postgres/tests/integration_tests.rs
@@ -566,6 +566,92 @@ async fn test_resume_from_retained_lsn_replays_sequence_stamped_events() -> Resu
 #[tokio::test]
 #[serial]
 #[ignore]
+async fn test_resume_subscription_replays_before_new_live_events() -> Result<()> {
+    init_logging();
+
+    let pg = setup_replication_postgres().await;
+    let client = pg.get_client().await?;
+
+    grant_replication(&client, "postgres").await?;
+    create_test_table(&client, TEST_TABLE).await?;
+    grant_table_access(&client, TEST_TABLE, "postgres").await?;
+    create_publication(&client, TEST_PUBLICATION, &[TEST_TABLE.to_string()]).await?;
+
+    let slot_name = slot_name();
+    create_logical_replication_slot(&client, &slot_name).await?;
+
+    let source = Arc::new(build_source(pg.config(), slot_name.clone())?);
+    source.start().await?;
+
+    let mut sub1 = source
+        .subscribe(subscription_settings(source.id(), "q1", None, true))
+        .await?;
+    let handle1 = sub1
+        .position_handle
+        .as_ref()
+        .expect("expected position handle for replay-capable subscription")
+        .clone();
+
+    insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
+    let event1 = wait_for_source_event(&mut sub1).await?;
+    let seq1 = event1
+        .sequence
+        .expect("expected WAL sequence on first event");
+    handle1.store(seq1, Ordering::Relaxed);
+
+    insert_test_row(&client, TEST_TABLE, 2, "Bob").await?;
+    let event2 = wait_for_source_event(&mut sub1).await?;
+    let seq2 = event2
+        .sequence
+        .expect("expected WAL sequence on second event");
+    handle1.store(seq2, Ordering::Relaxed);
+
+    let source_for_resume = source.clone();
+    let source_id = source.id().to_string();
+    let subscribe_task = tokio::spawn(async move {
+        source_for_resume
+            .subscribe(subscription_settings(&source_id, "q2", Some(seq1), true))
+            .await
+    });
+
+    tokio::task::yield_now().await;
+
+    let mut inserted_during_resume = false;
+    for next_id in 3..=12 {
+        if subscribe_task.is_finished() {
+            break;
+        }
+
+        insert_test_row(&client, TEST_TABLE, next_id, &format!("User {next_id}")).await?;
+        inserted_during_resume = true;
+        tokio::task::yield_now().await;
+    }
+
+    assert!(
+        inserted_during_resume,
+        "expected at least one live insert while the replaying subscription was pending"
+    );
+
+    let mut resumed = subscribe_task.await??;
+
+    let first = wait_for_source_event(&mut resumed).await?;
+    let first_seq = first
+        .sequence
+        .expect("expected sequence on first resumed event");
+    assert!(
+        first_seq <= seq2,
+        "expected resumed subscriber to receive replay backlog before newer live events, got {first_seq:x} > {seq2:x}"
+    );
+
+    source.stop().await?;
+    pg.cleanup().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
 async fn test_resume_from_before_slot_watermark_returns_position_unavailable() -> Result<()> {
     init_logging();
 
@@ -644,6 +730,23 @@ async fn test_resume_from_before_slot_watermark_returns_position_unavailable() -
     }
 
     source.stop().await?;
+    pg.cleanup().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_get_slot_confirmed_flush_lsn_returns_none_when_slot_missing() -> Result<()> {
+    init_logging();
+
+    let pg = setup_replication_postgres().await;
+    let client = pg.get_client().await?;
+
+    let lsn = get_slot_confirmed_flush_lsn(&client, "missing_slot").await?;
+    assert_eq!(lsn, None);
+
     pg.cleanup().await;
 
     Ok(())

--- a/components/sources/postgres/tests/postgres_helpers.rs
+++ b/components/sources/postgres/tests/postgres_helpers.rs
@@ -260,9 +260,15 @@ pub async fn create_logical_replication_slot(client: &Client, slot_name: &str) -
 
 pub async fn get_slot_confirmed_flush_lsn(client: &Client, slot_name: &str) -> Result<Option<u64>> {
     let sql = "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name = $1";
-    let row = client.query_one(sql, &[&slot_name]).await?;
-    let lsn: Option<String> = row.get(0);
-    lsn.map(|value| parse_lsn(&value)).transpose()
+    let row = client.query_opt(sql, &[&slot_name]).await?;
+
+    match row {
+        Some(row) => {
+            let lsn: Option<String> = row.get(0);
+            lsn.map(|value| parse_lsn(&value)).transpose()
+        }
+        None => Ok(None),
+    }
 }
 
 fn parse_lsn(lsn: &str) -> Result<u64> {

--- a/components/sources/postgres/tests/postgres_helpers.rs
+++ b/components/sources/postgres/tests/postgres_helpers.rs
@@ -157,8 +157,6 @@ async fn setup_postgres_raw() -> (ContainerAsync<GenericImage>, ReplicationPostg
         password: "postgres".to_string(),
     };
 
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
     (container, config)
 }
 
@@ -258,6 +256,24 @@ pub async fn create_logical_replication_slot(client: &Client, slot_name: &str) -
     let sql = "SELECT pg_create_logical_replication_slot($1, 'pgoutput')";
     let _ = client.query_one(sql, &[&slot_name]).await?;
     Ok(())
+}
+
+pub async fn get_slot_confirmed_flush_lsn(client: &Client, slot_name: &str) -> Result<Option<u64>> {
+    let sql = "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name = $1";
+    let row = client.query_one(sql, &[&slot_name]).await?;
+    let lsn: Option<String> = row.get(0);
+    lsn.map(|value| parse_lsn(&value)).transpose()
+}
+
+fn parse_lsn(lsn: &str) -> Result<u64> {
+    let parts: Vec<&str> = lsn.split('/').collect();
+    if parts.len() != 2 {
+        return Err(anyhow!("Invalid LSN format: {lsn}"));
+    }
+
+    let high = u64::from_str_radix(parts[0], 16)?;
+    let low = u64::from_str_radix(parts[1], 16)?;
+    Ok((high << 32) | low)
 }
 
 pub async fn create_decimal_test_table(client: &Client, table_name: &str) -> Result<()> {

--- a/components/sources/postgres/tests/postgres_helpers.rs
+++ b/components/sources/postgres/tests/postgres_helpers.rs
@@ -131,6 +131,10 @@ async fn setup_postgres_raw() -> (ContainerAsync<GenericImage>, ReplicationPostg
         .with_env_var("POSTGRES_PASSWORD", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_DB", "postgres")
+        .with_env_var(
+            "POSTGRES_INITDB_ARGS",
+            "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        )
         .with_cmd([
             "-c",
             "wal_level=logical",

--- a/lib-integration-tests/tests/postgres_log_capture.rs
+++ b/lib-integration-tests/tests/postgres_log_capture.rs
@@ -18,12 +18,39 @@
 //! from spawned tasks) are properly routed to the component log streaming
 //! infrastructure and accessible via the DrasiLib public API.
 
-use drasi_lib::{DrasiLib, LogLevel};
+use drasi_lib::{DrasiLib, LogLevel, LogMessage};
 use drasi_source_postgres::PostgresReplicationSource;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use testcontainers::{runners::AsyncRunner, ImageExt};
 use testcontainers_modules::postgres::Postgres;
 use tokio::time::timeout;
+
+async fn wait_for_source_logs(
+    drasi: &DrasiLib,
+    source_id: &str,
+    predicate: impl Fn(&[LogMessage]) -> bool,
+) -> Vec<LogMessage> {
+    let start = Instant::now();
+    let timeout = Duration::from_secs(10);
+
+    loop {
+        let (history, _receiver) = drasi
+            .subscribe_source_logs(source_id)
+            .await
+            .expect("Failed to subscribe to source logs");
+
+        if predicate(&history) {
+            return history;
+        }
+
+        assert!(
+            start.elapsed() <= timeout,
+            "Timed out waiting for logs for source `{source_id}`"
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
 
 /// Test that logs from a successfully connected PostgreSQL source are captured.
 /// This test requires Docker to be running.
@@ -31,6 +58,10 @@ use tokio::time::timeout;
 async fn test_postgres_source_logs_captured_on_success() {
     // Start a PostgreSQL container with logical replication enabled
     let container = Postgres::default()
+        .with_env_var(
+            "POSTGRES_INITDB_ARGS",
+            "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        )
         .with_cmd([
             "postgres",
             "-c",
@@ -99,14 +130,13 @@ async fn test_postgres_source_logs_captured_on_success() {
 
     drasi.start().await.expect("Failed to start DrasiLib");
 
-    // Give the source time to start, connect, and emit debug logs
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    // Use the DrasiLib public API to get logs
-    let (history, _receiver) = drasi
-        .subscribe_source_logs("test-pg-source")
-        .await
-        .expect("Failed to subscribe to source logs");
+    let history = wait_for_source_logs(&drasi, "test-pg-source", |history| {
+        !history.is_empty()
+            && history
+                .iter()
+                .any(|log| log.message.contains("replication") || log.message.contains("Starting"))
+    })
+    .await;
 
     assert!(
         !history.is_empty(),
@@ -168,16 +198,24 @@ async fn test_postgres_source_logs_captured_on_connection_failure() {
         .await
         .expect("Failed to build DrasiLib");
 
-    drasi.start().await.expect("Failed to start DrasiLib");
-
-    // Give the source time to attempt connection and fail
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    // Use the DrasiLib public API to get logs
-    let (history, _receiver) = drasi
-        .subscribe_source_logs("failing-pg-source")
+    let err = drasi
+        .start()
         .await
-        .expect("Failed to subscribe to source logs");
+        .expect_err("Expected DrasiLib start to surface the source connection failure");
+    assert!(
+        err.to_string().contains("failing-pg-source"),
+        "Expected failing source id in startup error, got: {err}"
+    );
+
+    let history = wait_for_source_logs(&drasi, "failing-pg-source", |history| {
+        history.iter().any(|log| {
+            log.level == LogLevel::Error
+                || log.message.to_lowercase().contains("error")
+                || log.message.to_lowercase().contains("failed")
+                || log.message.to_lowercase().contains("connection")
+        })
+    })
+    .await;
 
     // Should have at least lifecycle logs
     assert!(
@@ -242,7 +280,14 @@ async fn test_postgres_source_log_streaming() {
     // Initial history should be empty before start
     println!("Initial history before start: {initial_history:?}");
 
-    drasi.start().await.expect("Failed to start DrasiLib");
+    let err = drasi
+        .start()
+        .await
+        .expect_err("Expected DrasiLib start to surface the source connection failure");
+    assert!(
+        err.to_string().contains("streaming-pg-source"),
+        "Expected failing source id in startup error, got: {err}"
+    );
 
     // Wait for logs to stream in
     let mut received_logs = Vec::new();

--- a/lib/src/sources/base.rs
+++ b/lib/src/sources/base.rs
@@ -492,7 +492,11 @@ impl SourceBase {
         // queries are deliberately excluded from the min-watermark so they
         // cannot pin upstream advancement.
         let position_handle = if settings.request_position_handle {
-            Some(self.create_position_handle(&settings.query_id).await)
+            let handle = self.create_position_handle(&settings.query_id).await;
+            if let Some(sequence) = settings.resume_from {
+                handle.store(sequence, Ordering::Relaxed);
+            }
+            Some(handle)
         } else {
             None
         };
@@ -1108,6 +1112,22 @@ mod tests {
             response.bootstrap_receiver.is_none(),
             "resume_from must override enable_bootstrap"
         );
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_with_resume_from_initializes_position_handle() {
+        let base = make_base_with_bootstrap("sub-resume-handle");
+        let response = base
+            .subscribe_with_bootstrap(&make_settings("q1", false, Some(100), true), "test")
+            .await
+            .unwrap();
+        let handle = response.position_handle.expect("expected handle");
+        assert_eq!(
+            handle.load(Ordering::Relaxed),
+            100,
+            "resuming subscriber should pin the watermark immediately at its requested sequence"
+        );
+        assert_eq!(base.compute_confirmed_position().await, Some(100));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This pull request introduces replay support to the PostgreSQL source, allowing it to rewind and resume replication from a specific LSN (Log Sequence Number). It does so by tracking replication progress in a new `ReplayState` structure and refactoring the replication startup logic to support restarts and LSN validation. The changes also improve error handling during replication startup and add tests for the new replay capability.

Resolves https://github.com/drasi-project/drasi-core/issues/369