### PR TITLE
drasi-lib changes required by Drasi Server PR 84 (https://github.com/drasi-project/drasi-server/pull/84)

### DIFF
--- a/components/bootstrappers/platform/src/platform.rs
+++ b/components/bootstrappers/platform/src/platform.rs
@@ -401,8 +401,7 @@ fn matches_labels(element_labels: &[String], requested_labels: &[String]) -> boo
 /// a Node or Relation based on presence of start_id/end_id fields.
 fn transform_element(source_id: &str, bootstrap_elem: BootstrapElement) -> Result<Element> {
     // Convert properties from JSON Map to ElementPropertyMap
-    let properties = convert_json_to_element_properties(&bootstrap_elem.properties)
-        .context("Failed to convert element properties")?;
+    let properties = convert_json_to_element_properties(&bootstrap_elem.properties);
 
     // Convert labels to Arc slice
     let labels: Arc<[Arc<str>]> = bootstrap_elem

--- a/components/bootstrappers/scriptfile/src/lib.rs
+++ b/components/bootstrappers/scriptfile/src/lib.rs
@@ -30,7 +30,7 @@
 //!     .build();
 //!
 //! // Or using configuration
-//! use drasi_lib::bootstrap::ScriptFileBootstrapConfig;
+//! use drasi_bootstrap_scriptfile::ScriptFileBootstrapConfig;
 //!
 //! let config = ScriptFileBootstrapConfig {
 //!     file_paths: vec!["/path/to/data.jsonl".to_string()],

--- a/components/bootstrappers/scriptfile/src/script_file.rs
+++ b/components/bootstrappers/scriptfile/src/script_file.rs
@@ -112,7 +112,7 @@ impl ScriptFileBootstrapProvider {
     fn convert_node_to_element(source_id: &str, node: &NodeRecord) -> Result<Element> {
         // Convert properties from JSON to ElementPropertyMap
         let properties = if let serde_json::Value::Object(obj) = &node.properties {
-            convert_json_to_element_properties(obj)?
+            convert_json_to_element_properties(obj)
         } else if node.properties.is_null() {
             Default::default()
         } else {
@@ -146,7 +146,7 @@ impl ScriptFileBootstrapProvider {
     fn convert_relation_to_element(source_id: &str, relation: &RelationRecord) -> Result<Element> {
         // Convert properties from JSON to ElementPropertyMap
         let properties = if let serde_json::Value::Object(obj) = &relation.properties {
-            convert_json_to_element_properties(obj)?
+            convert_json_to_element_properties(obj)
         } else if relation.properties.is_null() {
             Default::default()
         } else {

--- a/components/host-sdk/src/lifecycle.rs
+++ b/components/host-sdk/src/lifecycle.rs
@@ -15,7 +15,7 @@
 //! Plugin lifecycle management — reusable runtime lifecycle for all Drasi hosts.
 //!
 //! The [`PluginLifecycleManager`] owns the mutable [`PluginRegistry`] and provides
-//! operations to load and retire plugins at runtime. It emits [`PluginEvent`]s
+//! operations to load plugins at runtime. It emits [`PluginEvent`]s
 //! through a broadcast channel so host applications can react to plugin changes.
 //!
 //! This lives in `host-sdk` so it is available to any Drasi host implementation,
@@ -23,7 +23,6 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::{broadcast, RwLock};
@@ -43,22 +42,17 @@ pub struct LoadedPluginState {
     pub plugin_id: String,
     pub status: PluginStatus,
     pub kinds: Vec<PluginKindEntry>,
-    pub generation: u64,
     pub metadata_info: Option<String>,
 }
 
-/// Manages plugin loading, registration, and retirement at the host-sdk level.
+/// Manages plugin loading and registration at the host-sdk level.
 ///
 /// The `PluginLifecycleManager` is the reusable core that any Drasi host can use
 /// to manage plugin lifecycles. It owns the `PluginRegistry` (via `Arc<RwLock>`)
 /// and emits `PluginEvent`s through a broadcast channel.
-///
-/// Server-level concerns like drain-then-retire orchestration, component migration,
-/// and REST API exposure belong in the host application's `PluginOrchestrator`.
 pub struct PluginLifecycleManager {
     registry: Arc<RwLock<PluginRegistry>>,
     loaded_plugins: RwLock<HashMap<String, LoadedPluginState>>,
-    generation_counter: AtomicU64,
     event_tx: broadcast::Sender<PluginEvent>,
 }
 
@@ -69,7 +63,6 @@ impl PluginLifecycleManager {
         Self {
             registry,
             loaded_plugins: RwLock::new(HashMap::new()),
-            generation_counter: AtomicU64::new(0),
             event_tx,
         }
     }
@@ -95,7 +88,6 @@ impl PluginLifecycleManager {
         plugin_id: &str,
         mut loaded: LoadedPlugin,
     ) -> Vec<PluginKindEntry> {
-        let generation = self.generation_counter.fetch_add(1, Ordering::SeqCst);
         let mut kinds = Vec::new();
         let metadata_info = loaded.metadata_info.take();
 
@@ -113,7 +105,7 @@ impl PluginLifecycleManager {
                 config_version: SourcePluginDescriptor::config_version(&source).to_string(),
                 config_schema_name: SourcePluginDescriptor::config_schema_name(&source).to_string(),
             });
-            reg.register_source_with_metadata(Arc::new(source), plugin_id, generation);
+            reg.register_source_with_metadata(Arc::new(source), plugin_id);
         }
 
         for reaction in reactions {
@@ -124,7 +116,7 @@ impl PluginLifecycleManager {
                 config_schema_name: ReactionPluginDescriptor::config_schema_name(&reaction)
                     .to_string(),
             });
-            reg.register_reaction_with_metadata(Arc::new(reaction), plugin_id, generation);
+            reg.register_reaction_with_metadata(Arc::new(reaction), plugin_id);
         }
 
         for bootstrap in bootstraps {
@@ -135,7 +127,7 @@ impl PluginLifecycleManager {
                 config_schema_name: BootstrapPluginDescriptor::config_schema_name(&bootstrap)
                     .to_string(),
             });
-            reg.register_bootstrapper_with_metadata(Arc::new(bootstrap), plugin_id, generation);
+            reg.register_bootstrapper_with_metadata(Arc::new(bootstrap), plugin_id);
         }
 
         drop(reg);
@@ -145,7 +137,6 @@ impl PluginLifecycleManager {
             plugin_id: plugin_id.to_string(),
             status: PluginStatus::Loaded,
             kinds: kinds.clone(),
-            generation,
             metadata_info,
         };
 
@@ -214,30 +205,6 @@ impl PluginLifecycleManager {
         Ok((plugin_id, kinds))
     }
 
-    /// Retire a plugin by deregistering all its descriptors.
-    ///
-    /// The library remains mapped in memory (retire-only semantics).
-    /// Returns the number of descriptors deregistered.
-    pub async fn retire_plugin(&self, plugin_id: &str) -> anyhow::Result<usize> {
-        let removed = {
-            let mut reg = self.registry.write().await;
-            reg.deregister_all_for_plugin(plugin_id)
-        };
-
-        {
-            let mut plugins = self.loaded_plugins.write().await;
-            if let Some(state) = plugins.get_mut(plugin_id) {
-                state.status = PluginStatus::Retired;
-            }
-        }
-
-        let _ = self.event_tx.send(PluginEvent::Retired {
-            plugin_id: plugin_id.to_string(),
-        });
-
-        Ok(removed)
-    }
-
     /// Update a plugin's status (for use by the orchestrator layer).
     pub async fn set_plugin_status(&self, plugin_id: &str, status: PluginStatus) {
         let mut plugins = self.loaded_plugins.write().await;
@@ -264,11 +231,6 @@ impl PluginLifecycleManager {
             .map(|s| (s.plugin_id.clone(), s.status, s.kinds.clone()))
             .collect()
     }
-
-    /// Get the current generation counter value.
-    pub fn current_generation(&self) -> u64 {
-        self.generation_counter.load(Ordering::SeqCst)
-    }
 }
 
 #[cfg(test)]
@@ -280,7 +242,6 @@ mod tests {
         let registry = Arc::new(RwLock::new(PluginRegistry::new()));
         let manager = PluginLifecycleManager::new(registry.clone());
 
-        assert_eq!(manager.current_generation(), 0);
         assert!(manager.list_plugins().await.is_empty());
     }
 
@@ -290,15 +251,6 @@ mod tests {
         let manager = PluginLifecycleManager::new(registry);
 
         let _rx = manager.subscribe();
-    }
-
-    #[tokio::test]
-    async fn test_retire_nonexistent_plugin() {
-        let registry = Arc::new(RwLock::new(PluginRegistry::new()));
-        let manager = PluginLifecycleManager::new(registry);
-
-        let removed = manager.retire_plugin("nonexistent").await.expect("ok");
-        assert_eq!(removed, 0);
     }
 
     #[tokio::test]
@@ -315,7 +267,6 @@ mod tests {
                     plugin_id: "test-plugin".to_string(),
                     status: PluginStatus::Loaded,
                     kinds: vec![],
-                    generation: 0,
                     metadata_info: None,
                 },
             );
@@ -334,84 +285,6 @@ mod tests {
             manager.get_plugin_status("test-plugin").await,
             Some(PluginStatus::Active)
         );
-    }
-
-    #[tokio::test]
-    async fn test_retire_updates_status() {
-        let registry = Arc::new(RwLock::new(PluginRegistry::new()));
-        let manager = PluginLifecycleManager::new(registry);
-
-        // Insert a fake plugin with a known status
-        {
-            let mut plugins = manager.loaded_plugins.write().await;
-            plugins.insert(
-                "my-plugin".to_string(),
-                LoadedPluginState {
-                    plugin_id: "my-plugin".to_string(),
-                    status: PluginStatus::Active,
-                    kinds: vec![PluginKindEntry {
-                        category: PluginCategory::Source,
-                        kind: "mock".to_string(),
-                        config_version: "1.0.0".to_string(),
-                        config_schema_name: "MockConfig".to_string(),
-                    }],
-                    generation: 1,
-                    metadata_info: None,
-                },
-            );
-        }
-
-        // Retire it
-        let removed = manager.retire_plugin("my-plugin").await.expect("ok");
-        // No actual descriptors registered in the registry, so removed == 0
-        assert_eq!(removed, 0);
-
-        // But the status should be updated to Retired
-        assert_eq!(
-            manager.get_plugin_status("my-plugin").await,
-            Some(PluginStatus::Retired)
-        );
-
-        // list_plugins should reflect the retired status
-        let plugins = manager.list_plugins().await;
-        assert_eq!(plugins.len(), 1);
-        assert_eq!(plugins[0].1, PluginStatus::Retired);
-    }
-
-    #[tokio::test]
-    async fn test_event_subscription() {
-        let registry = Arc::new(RwLock::new(PluginRegistry::new()));
-        let manager = PluginLifecycleManager::new(registry);
-
-        // Subscribe before triggering events
-        let mut rx = manager.subscribe();
-
-        // Insert a fake plugin state so retire has something to update
-        {
-            let mut plugins = manager.loaded_plugins.write().await;
-            plugins.insert(
-                "evt-plugin".to_string(),
-                LoadedPluginState {
-                    plugin_id: "evt-plugin".to_string(),
-                    status: PluginStatus::Loaded,
-                    kinds: vec![],
-                    generation: 0,
-                    metadata_info: None,
-                },
-            );
-        }
-
-        // Retire the plugin (this emits a PluginEvent::Retired)
-        manager.retire_plugin("evt-plugin").await.expect("ok");
-
-        // Verify we receive the Retired event
-        let event = rx.try_recv().expect("should receive event");
-        match event {
-            PluginEvent::Retired { plugin_id } => {
-                assert_eq!(plugin_id, "evt-plugin");
-            }
-            other => panic!("Expected PluginEvent::Retired, got {other:?}"),
-        }
     }
 
     #[tokio::test]
@@ -434,52 +307,5 @@ mod tests {
 
         // Still no plugins
         assert!(manager.list_plugins().await.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_generation_increments_on_register() {
-        let registry = Arc::new(RwLock::new(PluginRegistry::new()));
-        let manager = PluginLifecycleManager::new(registry);
-        assert_eq!(manager.current_generation(), 0);
-
-        // Simulate two plugin registrations using fake LoadedPlugin data
-        // by directly inserting into loaded_plugins with different generations
-        {
-            let mut plugins = manager.loaded_plugins.write().await;
-            plugins.insert(
-                "p1".to_string(),
-                LoadedPluginState {
-                    plugin_id: "p1".to_string(),
-                    status: PluginStatus::Loaded,
-                    kinds: vec![],
-                    generation: 0,
-                    metadata_info: None,
-                },
-            );
-        }
-
-        // The generation counter is only incremented by register_loaded_plugin,
-        // which we can't easily call without a real LoadedPlugin. Verify baseline.
-        assert_eq!(manager.current_generation(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_retire_emits_event_even_with_no_descriptors() {
-        let registry = Arc::new(RwLock::new(PluginRegistry::new()));
-        let manager = PluginLifecycleManager::new(registry);
-
-        let mut rx = manager.subscribe();
-
-        // Retire a plugin that was never loaded - should still emit event
-        let removed = manager.retire_plugin("ghost").await.expect("ok");
-        assert_eq!(removed, 0);
-
-        let event = rx.try_recv().expect("should receive event");
-        match event {
-            PluginEvent::Retired { plugin_id } => {
-                assert_eq!(plugin_id, "ghost");
-            }
-            other => panic!("Expected Retired event, got {other:?}"),
-        }
     }
 }

--- a/components/host-sdk/src/plugin_registry.rs
+++ b/components/host-sdk/src/plugin_registry.rs
@@ -17,7 +17,7 @@
 //! The [`PluginRegistry`] holds all known plugin descriptors (sources, reactions,
 //! bootstrappers) and provides lookup, creation, and schema introspection methods.
 //!
-//! This registry supports runtime mutation (registration and deregistration) and
+//! This registry supports runtime mutation (registration) and
 //! should be wrapped in `Arc<RwLock<PluginRegistry>>` for concurrent access.
 
 use chrono::{DateTime, Utc};
@@ -35,8 +35,6 @@ pub struct RegisteredDescriptor<T: ?Sized> {
     pub plugin_id: String,
     /// Timestamp when this descriptor was registered.
     pub registered_at: DateTime<Utc>,
-    /// Library generation counter for drain-then-replace.
-    pub generation: u64,
 }
 
 impl<T: ?Sized> std::fmt::Debug for RegisteredDescriptor<T> {
@@ -44,7 +42,6 @@ impl<T: ?Sized> std::fmt::Debug for RegisteredDescriptor<T> {
         f.debug_struct("RegisteredDescriptor")
             .field("plugin_id", &self.plugin_id)
             .field("registered_at", &self.registered_at)
-            .field("generation", &self.generation)
             .finish()
     }
 }
@@ -68,7 +65,7 @@ pub struct PluginKindInfo {
 
 /// Registry of all known plugin descriptors.
 ///
-/// Plugins are registered at startup and can be dynamically registered/deregistered
+/// Plugins are registered at startup and can be dynamically registered
 /// at runtime. The registry should be wrapped in `Arc<RwLock<PluginRegistry>>` for
 /// thread-safe access.
 pub struct PluginRegistry {
@@ -91,7 +88,7 @@ impl PluginRegistry {
         }
     }
 
-    /// Current mutation version. Incremented on every register/deregister operation.
+    /// Current mutation version. Incremented on every register operation.
     pub fn version(&self) -> u64 {
         self.version
     }
@@ -107,7 +104,6 @@ impl PluginRegistry {
                 descriptor,
                 plugin_id: String::new(),
                 registered_at: Utc::now(),
-                generation: 0,
             },
         );
         self.version += 1;
@@ -118,7 +114,6 @@ impl PluginRegistry {
         &mut self,
         descriptor: Arc<dyn SourcePluginDescriptor>,
         plugin_id: &str,
-        generation: u64,
     ) {
         let kind = descriptor.kind().to_string();
         self.sources.insert(
@@ -127,7 +122,6 @@ impl PluginRegistry {
                 descriptor,
                 plugin_id: plugin_id.to_string(),
                 registered_at: Utc::now(),
-                generation,
             },
         );
         self.version += 1;
@@ -142,7 +136,6 @@ impl PluginRegistry {
                 descriptor,
                 plugin_id: String::new(),
                 registered_at: Utc::now(),
-                generation: 0,
             },
         );
         self.version += 1;
@@ -153,7 +146,6 @@ impl PluginRegistry {
         &mut self,
         descriptor: Arc<dyn ReactionPluginDescriptor>,
         plugin_id: &str,
-        generation: u64,
     ) {
         let kind = descriptor.kind().to_string();
         self.reactions.insert(
@@ -162,7 +154,6 @@ impl PluginRegistry {
                 descriptor,
                 plugin_id: plugin_id.to_string(),
                 registered_at: Utc::now(),
-                generation,
             },
         );
         self.version += 1;
@@ -177,7 +168,6 @@ impl PluginRegistry {
                 descriptor,
                 plugin_id: String::new(),
                 registered_at: Utc::now(),
-                generation: 0,
             },
         );
         self.version += 1;
@@ -188,7 +178,6 @@ impl PluginRegistry {
         &mut self,
         descriptor: Arc<dyn BootstrapPluginDescriptor>,
         plugin_id: &str,
-        generation: u64,
     ) {
         let kind = descriptor.kind().to_string();
         self.bootstrappers.insert(
@@ -197,56 +186,9 @@ impl PluginRegistry {
                 descriptor,
                 plugin_id: plugin_id.to_string(),
                 registered_at: Utc::now(),
-                generation,
             },
         );
         self.version += 1;
-    }
-
-    /// Deregister a source descriptor by kind. Returns true if it existed.
-    pub fn deregister_source(&mut self, kind: &str) -> bool {
-        let removed = self.sources.remove(kind).is_some();
-        if removed {
-            self.version += 1;
-        }
-        removed
-    }
-
-    /// Deregister a reaction descriptor by kind. Returns true if it existed.
-    pub fn deregister_reaction(&mut self, kind: &str) -> bool {
-        let removed = self.reactions.remove(kind).is_some();
-        if removed {
-            self.version += 1;
-        }
-        removed
-    }
-
-    /// Deregister a bootstrap descriptor by kind. Returns true if it existed.
-    pub fn deregister_bootstrapper(&mut self, kind: &str) -> bool {
-        let removed = self.bootstrappers.remove(kind).is_some();
-        if removed {
-            self.version += 1;
-        }
-        removed
-    }
-
-    /// Deregister all descriptors provided by a specific plugin.
-    /// Returns the number of descriptors removed.
-    pub fn deregister_all_for_plugin(&mut self, plugin_id: &str) -> usize {
-        let before = self.descriptor_count();
-
-        self.sources
-            .retain(|_, v| v.plugin_id != plugin_id || plugin_id.is_empty());
-        self.reactions
-            .retain(|_, v| v.plugin_id != plugin_id || plugin_id.is_empty());
-        self.bootstrappers
-            .retain(|_, v| v.plugin_id != plugin_id || plugin_id.is_empty());
-
-        let removed = before - self.descriptor_count();
-        if removed > 0 {
-            self.version += 1;
-        }
-        removed
     }
 
     /// Look up a source plugin descriptor by kind.
@@ -358,128 +300,6 @@ impl PluginRegistry {
             .collect();
         infos.sort_by(|a, b| a.kind.cmp(&b.kind));
         infos
-    }
-
-    // ── Side-by-side versioned registration and promotion ──
-
-    /// Register a source descriptor under a versioned kind key (e.g., "postgres@0.4.2").
-    /// Does not affect the unversioned key.
-    pub fn register_source_versioned(
-        &mut self,
-        versioned_key: &str,
-        descriptor: Arc<dyn SourcePluginDescriptor>,
-        plugin_id: &str,
-        generation: u64,
-    ) {
-        self.sources.insert(
-            versioned_key.to_string(),
-            RegisteredDescriptor {
-                descriptor,
-                plugin_id: plugin_id.to_string(),
-                registered_at: Utc::now(),
-                generation,
-            },
-        );
-        self.version += 1;
-    }
-
-    /// Promote a versioned source descriptor to be the incumbent (unversioned key).
-    /// Returns true if successful, false if the versioned key doesn't exist.
-    pub fn promote_source(&mut self, versioned_key: &str) -> bool {
-        if let Some(reg) = self.sources.get(versioned_key) {
-            let kind = reg.descriptor.kind().to_string();
-            let promoted = RegisteredDescriptor {
-                descriptor: reg.descriptor.clone(),
-                plugin_id: reg.plugin_id.clone(),
-                registered_at: Utc::now(),
-                generation: reg.generation,
-            };
-            self.sources.insert(kind, promoted);
-            self.version += 1;
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Register a reaction descriptor under a versioned kind key (e.g., "log@0.4.2").
-    /// Does not affect the unversioned key.
-    pub fn register_reaction_versioned(
-        &mut self,
-        versioned_key: &str,
-        descriptor: Arc<dyn ReactionPluginDescriptor>,
-        plugin_id: &str,
-        generation: u64,
-    ) {
-        self.reactions.insert(
-            versioned_key.to_string(),
-            RegisteredDescriptor {
-                descriptor,
-                plugin_id: plugin_id.to_string(),
-                registered_at: Utc::now(),
-                generation,
-            },
-        );
-        self.version += 1;
-    }
-
-    /// Promote a versioned reaction descriptor to be the incumbent (unversioned key).
-    /// Returns true if successful, false if the versioned key doesn't exist.
-    pub fn promote_reaction(&mut self, versioned_key: &str) -> bool {
-        if let Some(reg) = self.reactions.get(versioned_key) {
-            let kind = reg.descriptor.kind().to_string();
-            let promoted = RegisteredDescriptor {
-                descriptor: reg.descriptor.clone(),
-                plugin_id: reg.plugin_id.clone(),
-                registered_at: Utc::now(),
-                generation: reg.generation,
-            };
-            self.reactions.insert(kind, promoted);
-            self.version += 1;
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Register a bootstrap descriptor under a versioned kind key.
-    /// Does not affect the unversioned key.
-    pub fn register_bootstrapper_versioned(
-        &mut self,
-        versioned_key: &str,
-        descriptor: Arc<dyn BootstrapPluginDescriptor>,
-        plugin_id: &str,
-        generation: u64,
-    ) {
-        self.bootstrappers.insert(
-            versioned_key.to_string(),
-            RegisteredDescriptor {
-                descriptor,
-                plugin_id: plugin_id.to_string(),
-                registered_at: Utc::now(),
-                generation,
-            },
-        );
-        self.version += 1;
-    }
-
-    /// Promote a versioned bootstrapper descriptor to be the incumbent (unversioned key).
-    /// Returns true if successful, false if the versioned key doesn't exist.
-    pub fn promote_bootstrapper(&mut self, versioned_key: &str) -> bool {
-        if let Some(reg) = self.bootstrappers.get(versioned_key) {
-            let kind = reg.descriptor.kind().to_string();
-            let promoted = RegisteredDescriptor {
-                descriptor: reg.descriptor.clone(),
-                plugin_id: reg.plugin_id.clone(),
-                registered_at: Utc::now(),
-                generation: reg.generation,
-            };
-            self.bootstrappers.insert(kind, promoted);
-            self.version += 1;
-            true
-        } else {
-            false
-        }
     }
 
     /// Returns true if the registry contains no descriptors.
@@ -595,68 +415,11 @@ mod tests {
     }
 
     #[test]
-    fn test_register_with_metadata() {
-        let mut registry = PluginRegistry::new();
-        registry.register_source_with_metadata(
-            Arc::new(MockSourceDescriptor { kind: "mock" }),
-            "drasi-source-mock",
-            42,
-        );
-
-        let reg = registry.get_source_registration("mock").expect("exists");
-        assert_eq!(reg.plugin_id, "drasi-source-mock");
-        assert_eq!(reg.generation, 42);
-    }
-
-    #[test]
-    fn test_deregister_source() {
-        let mut registry = PluginRegistry::new();
-        registry.register_source(Arc::new(MockSourceDescriptor { kind: "mock" }));
-        assert_eq!(registry.version(), 1);
-
-        let removed = registry.deregister_source("mock");
-        assert!(removed);
-        assert!(registry.get_source("mock").is_none());
-        assert_eq!(registry.version(), 2);
-
-        let removed_again = registry.deregister_source("mock");
-        assert!(!removed_again);
-        assert_eq!(registry.version(), 2); // no change
-    }
-
-    #[test]
-    fn test_deregister_all_for_plugin() {
-        let mut registry = PluginRegistry::new();
-        registry.register_source_with_metadata(
-            Arc::new(MockSourceDescriptor { kind: "postgres" }),
-            "drasi-source-postgres",
-            1,
-        );
-        registry.register_source_with_metadata(
-            Arc::new(MockSourceDescriptor { kind: "mock" }),
-            "drasi-source-mock",
-            1,
-        );
-        registry.register_reaction_with_metadata(
-            Arc::new(MockReactionDescriptor { kind: "log" }),
-            "drasi-source-postgres", // hypothetical multi-descriptor plugin
-            1,
-        );
-
-        let removed = registry.deregister_all_for_plugin("drasi-source-postgres");
-        assert_eq!(removed, 2); // postgres source + log reaction
-        assert!(registry.get_source("postgres").is_none());
-        assert!(registry.get_reaction("log").is_none());
-        assert!(registry.get_source("mock").is_some()); // different plugin
-    }
-
-    #[test]
     fn test_source_plugin_infos_includes_plugin_id() {
         let mut registry = PluginRegistry::new();
         registry.register_source_with_metadata(
             Arc::new(MockSourceDescriptor { kind: "mock" }),
             "drasi-source-mock",
-            1,
         );
 
         let infos = registry.source_plugin_infos();
@@ -674,9 +437,6 @@ mod tests {
 
         registry.register_reaction(Arc::new(MockReactionDescriptor { kind: "b" }));
         assert_eq!(registry.version(), 2);
-
-        registry.deregister_source("a");
-        assert_eq!(registry.version(), 3);
     }
 
     #[test]
@@ -700,51 +460,6 @@ mod tests {
     }
 
     #[test]
-    fn test_deregister_reaction() {
-        let mut registry = PluginRegistry::new();
-        registry.register_reaction(Arc::new(MockReactionDescriptor { kind: "log" }));
-        assert_eq!(registry.reaction_kinds(), vec!["log"]);
-        assert_eq!(registry.version(), 1);
-
-        let removed = registry.deregister_reaction("log");
-        assert!(removed);
-        assert!(registry.get_reaction("log").is_none());
-        assert!(registry.reaction_kinds().is_empty());
-        assert_eq!(registry.version(), 2);
-    }
-
-    #[test]
-    fn test_deregister_nonexistent_returns_false() {
-        let mut registry = PluginRegistry::new();
-
-        assert!(!registry.deregister_source("nope"));
-        assert!(!registry.deregister_reaction("nope"));
-        assert!(!registry.deregister_bootstrapper("nope"));
-    }
-
-    #[test]
-    fn test_version_not_incremented_on_noop_deregister() {
-        let mut registry = PluginRegistry::new();
-        registry.register_source(Arc::new(MockSourceDescriptor { kind: "a" }));
-        let v = registry.version();
-
-        // Deregistering a nonexistent kind should not bump the version
-        registry.deregister_source("nonexistent");
-        assert_eq!(registry.version(), v);
-
-        registry.deregister_reaction("nonexistent");
-        assert_eq!(registry.version(), v);
-
-        registry.deregister_bootstrapper("nonexistent");
-        assert_eq!(registry.version(), v);
-
-        // deregister_all_for_plugin with an unknown plugin_id also should not bump
-        let removed = registry.deregister_all_for_plugin("unknown-plugin");
-        assert_eq!(removed, 0);
-        assert_eq!(registry.version(), v);
-    }
-
-    #[test]
     fn test_register_with_metadata_tracks_plugin_id() {
         let mut registry = PluginRegistry::new();
 
@@ -752,13 +467,11 @@ mod tests {
         registry.register_source_with_metadata(
             Arc::new(MockSourceDescriptor { kind: "pg" }),
             "drasi-source-pg",
-            10,
         );
         // Register reaction with metadata
         registry.register_reaction_with_metadata(
             Arc::new(MockReactionDescriptor { kind: "webhook" }),
             "drasi-reaction-webhook",
-            20,
         );
 
         // Verify source registration
@@ -766,14 +479,12 @@ mod tests {
             .get_source_registration("pg")
             .expect("source exists");
         assert_eq!(src_reg.plugin_id, "drasi-source-pg");
-        assert_eq!(src_reg.generation, 10);
 
         // Verify reaction registration
         let rx_reg = registry
             .get_reaction_registration("webhook")
             .expect("reaction exists");
         assert_eq!(rx_reg.plugin_id, "drasi-reaction-webhook");
-        assert_eq!(rx_reg.generation, 20);
 
         // Verify plugin_id propagates to plugin_infos
         let src_infos = registry.source_plugin_infos();
@@ -788,21 +499,6 @@ mod tests {
     }
 
     #[test]
-    fn test_deregister_all_for_plugin_ignores_empty_plugin_id() {
-        let mut registry = PluginRegistry::new();
-        // register_source (without metadata) sets plugin_id to ""
-        registry.register_source(Arc::new(MockSourceDescriptor { kind: "core_src" }));
-        registry.register_reaction(Arc::new(MockReactionDescriptor { kind: "core_rx" }));
-
-        // Attempting to deregister_all_for_plugin("") should NOT remove
-        // descriptors with empty plugin_id (per the retain guard).
-        let removed = registry.deregister_all_for_plugin("");
-        assert_eq!(removed, 0);
-        assert!(registry.get_source("core_src").is_some());
-        assert!(registry.get_reaction("core_rx").is_some());
-    }
-
-    #[test]
     fn test_descriptor_count_across_categories() {
         let mut registry = PluginRegistry::new();
         assert_eq!(registry.descriptor_count(), 0);
@@ -812,9 +508,6 @@ mod tests {
         registry.register_reaction(Arc::new(MockReactionDescriptor { kind: "r1" }));
         assert_eq!(registry.descriptor_count(), 3);
         assert!(!registry.is_empty());
-
-        registry.deregister_source("s1");
-        assert_eq!(registry.descriptor_count(), 2);
     }
 
     #[test]
@@ -831,19 +524,16 @@ mod tests {
         registry.register_source_with_metadata(
             Arc::new(MockSourceDescriptor { kind: "pg" }),
             "plugin-v1",
-            1,
         );
 
-        // Replace same kind with a different plugin_id and generation
+        // Replace same kind with a different plugin_id
         registry.register_source_with_metadata(
             Arc::new(MockSourceDescriptor { kind: "pg" }),
             "plugin-v2",
-            5,
         );
 
         let reg = registry.get_source_registration("pg").expect("exists");
         assert_eq!(reg.plugin_id, "plugin-v2");
-        assert_eq!(reg.generation, 5);
         assert_eq!(registry.descriptor_count(), 1); // still just one
     }
 
@@ -861,110 +551,5 @@ mod tests {
         let debug_str = format!("{registry:?}");
         assert!(debug_str.contains("PluginRegistry"));
         assert!(debug_str.contains("mock"));
-    }
-
-    #[test]
-    fn test_register_source_versioned_does_not_affect_unversioned() {
-        let mut registry = PluginRegistry::new();
-        // Register the incumbent under the unversioned key
-        registry.register_source_with_metadata(
-            Arc::new(MockSourceDescriptor { kind: "postgres" }),
-            "plugin-v1",
-            1,
-        );
-        let v_before = registry.version();
-
-        // Register a new version under a versioned key
-        registry.register_source_versioned(
-            "postgres@0.4.2",
-            Arc::new(MockSourceDescriptor { kind: "postgres" }),
-            "plugin-v2",
-            2,
-        );
-
-        // The unversioned key should still point to the old plugin
-        let incumbent = registry
-            .get_source_registration("postgres")
-            .expect("exists");
-        assert_eq!(incumbent.plugin_id, "plugin-v1");
-
-        // The versioned key should exist separately
-        let versioned = registry
-            .get_source_registration("postgres@0.4.2")
-            .expect("exists");
-        assert_eq!(versioned.plugin_id, "plugin-v2");
-
-        // Both keys count as separate descriptors
-        assert!(registry.version() > v_before);
-    }
-
-    #[test]
-    fn test_promote_source_updates_unversioned_key() {
-        let mut registry = PluginRegistry::new();
-        // Register incumbent
-        registry.register_source_with_metadata(
-            Arc::new(MockSourceDescriptor { kind: "postgres" }),
-            "plugin-v1",
-            1,
-        );
-        // Register versioned
-        registry.register_source_versioned(
-            "postgres@0.4.2",
-            Arc::new(MockSourceDescriptor { kind: "postgres" }),
-            "plugin-v2",
-            2,
-        );
-
-        // Promote
-        let promoted = registry.promote_source("postgres@0.4.2");
-        assert!(promoted);
-
-        // Unversioned key should now point to plugin-v2
-        let incumbent = registry
-            .get_source_registration("postgres")
-            .expect("exists");
-        assert_eq!(incumbent.plugin_id, "plugin-v2");
-        assert_eq!(incumbent.generation, 2);
-    }
-
-    #[test]
-    fn test_promote_source_nonexistent_returns_false() {
-        let mut registry = PluginRegistry::new();
-        let promoted = registry.promote_source("nonexistent@1.0.0");
-        assert!(!promoted);
-    }
-
-    #[test]
-    fn test_promote_reaction() {
-        let mut registry = PluginRegistry::new();
-        registry.register_reaction_with_metadata(
-            Arc::new(MockReactionDescriptor { kind: "log" }),
-            "plugin-v1",
-            1,
-        );
-        registry.register_reaction_versioned(
-            "log@2.0.0",
-            Arc::new(MockReactionDescriptor { kind: "log" }),
-            "plugin-v2",
-            2,
-        );
-
-        let promoted = registry.promote_reaction("log@2.0.0");
-        assert!(promoted);
-
-        let incumbent = registry.get_reaction_registration("log").expect("exists");
-        assert_eq!(incumbent.plugin_id, "plugin-v2");
-    }
-
-    #[test]
-    fn test_promote_reaction_nonexistent_returns_false() {
-        let mut registry = PluginRegistry::new();
-        assert!(!registry.promote_reaction("nope@1.0"));
-    }
-
-    #[test]
-    fn test_promote_bootstrapper_nonexistent_returns_false() {
-        let mut registry = PluginRegistry::new();
-        assert!(!registry.promote_bootstrapper("nope@1.0"));
     }
 }

--- a/components/host-sdk/src/plugin_types.rs
+++ b/components/host-sdk/src/plugin_types.rs
@@ -52,10 +52,6 @@ pub enum PluginStatus {
     Loaded,
     /// Has running component instances.
     Active,
-    /// Being replaced: instances migrating to new version.
-    Draining,
-    /// No active instances, descriptors deregistered, library remains mapped.
-    Retired,
     /// Load or initialization failed.
     Failed,
 }
@@ -65,8 +61,6 @@ impl std::fmt::Display for PluginStatus {
         match self {
             PluginStatus::Loaded => write!(f, "Loaded"),
             PluginStatus::Active => write!(f, "Active"),
-            PluginStatus::Draining => write!(f, "Draining"),
-            PluginStatus::Retired => write!(f, "Retired"),
             PluginStatus::Failed => write!(f, "Failed"),
         }
     }
@@ -75,50 +69,15 @@ impl std::fmt::Display for PluginStatus {
 /// Events emitted by the plugin lifecycle layer.
 ///
 /// These are broadcast through a `tokio::sync::broadcast` channel and can be
-/// consumed by server-level SSE, UI updates, or logging.
+/// consumed by server-level logging or UI updates.
 #[derive(Debug, Clone)]
 pub enum PluginEvent {
-    /// A new plugin was loaded (no prior version existed).
+    /// A new plugin was loaded.
     Loaded {
         plugin_id: String,
         version: String,
         kinds: Vec<PluginKindEntry>,
     },
-    /// A new version was loaded side-by-side with an existing version.
-    LoadedSideBySide {
-        plugin_id: String,
-        version: String,
-        incumbent_plugin_id: String,
-        versioned_kinds: Vec<String>,
-    },
-    /// An upgrade (drain-then-replace) completed successfully.
-    Upgraded {
-        plugin_id: String,
-        old_version: String,
-        new_version: String,
-        migrated_components: Vec<String>,
-    },
-    /// An upgrade completed but some components failed to migrate.
-    UpgradePartialFailure {
-        plugin_id: String,
-        old_version: String,
-        new_version: String,
-        migrated: Vec<String>,
-        failed: Vec<(String, String)>,
-    },
-    /// A plugin is being drained (upgrade in progress).
-    Draining {
-        plugin_id: String,
-        affected_components: Vec<String>,
-    },
-    /// A side-by-side version was promoted to incumbent.
-    Promoted {
-        plugin_id: String,
-        promoted_kinds: Vec<String>,
-        previous_incumbent: String,
-    },
-    /// A plugin was retired.
-    Retired { plugin_id: String },
     /// A plugin failed to load.
     LoadFailed { path: PathBuf, error: String },
 }
@@ -126,8 +85,8 @@ pub enum PluginEvent {
 /// Raw filesystem events emitted by the `PluginWatcher`.
 ///
 /// These are policy-neutral: the watcher does not decide whether a file change
-/// means load, upgrade, side-by-side, or retire. That decision belongs to the
-/// host application's orchestrator layer.
+/// means load or reload. That decision belongs to the host application's
+/// orchestrator layer.
 #[derive(Debug, Clone)]
 pub enum PluginFileEvent {
     Added(PathBuf),
@@ -150,8 +109,6 @@ mod tests {
     fn plugin_status_display() {
         assert_eq!(PluginStatus::Loaded.to_string(), "Loaded");
         assert_eq!(PluginStatus::Active.to_string(), "Active");
-        assert_eq!(PluginStatus::Draining.to_string(), "Draining");
-        assert_eq!(PluginStatus::Retired.to_string(), "Retired");
         assert_eq!(PluginStatus::Failed.to_string(), "Failed");
     }
 

--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -237,6 +237,8 @@ impl Reaction for ReactionProxy {
             FfiComponentStatus::Stopped => ComponentStatus::Stopped,
             FfiComponentStatus::Reconfiguring => ComponentStatus::Reconfiguring,
             FfiComponentStatus::Error => ComponentStatus::Error,
+            FfiComponentStatus::Added => ComponentStatus::Added,
+            FfiComponentStatus::Removed => ComponentStatus::Removed,
         }
     }
 

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -154,6 +154,8 @@ impl Source for SourceProxy {
             FfiComponentStatus::Stopped => ComponentStatus::Stopped,
             FfiComponentStatus::Reconfiguring => ComponentStatus::Reconfiguring,
             FfiComponentStatus::Error => ComponentStatus::Error,
+            FfiComponentStatus::Added => ComponentStatus::Added,
+            FfiComponentStatus::Removed => ComponentStatus::Removed,
         }
     }
 

--- a/components/host-sdk/src/watcher.rs
+++ b/components/host-sdk/src/watcher.rs
@@ -15,9 +15,8 @@
 //! Policy-neutral plugin filesystem watcher.
 //!
 //! The [`PluginWatcher`] monitors a plugins directory and emits raw
-//! [`PluginFileEvent`]s. It does not decide whether a file change means load,
-//! upgrade, side-by-side, or retire — that policy belongs in the host
-//! application's orchestrator layer.
+//! [`PluginFileEvent`]s. It does not decide whether a file change means load
+//! or reload — that policy belongs in the host application's orchestrator layer.
 //!
 //! ## Backends
 //!
@@ -56,9 +55,8 @@ impl Default for PluginWatcherConfig {
 /// Watches a plugins directory and emits raw filesystem events.
 ///
 /// The watcher is policy-neutral: it only emits [`PluginFileEvent`]s and does
-/// not make any loading or retirement decisions. The host application's
-/// orchestrator subscribes to these events and applies its own policy
-/// (e.g., upgrade vs side-by-side based on `hotReloadMode` config).
+/// not make any loading decisions. The host application's orchestrator
+/// subscribes to these events and applies its own policy.
 pub struct PluginWatcher {
     config: PluginWatcherConfig,
     event_tx: broadcast::Sender<PluginFileEvent>,

--- a/components/plugin-sdk/src/ffi/types.rs
+++ b/components/plugin-sdk/src/ffi/types.rs
@@ -37,6 +37,8 @@ pub enum FfiComponentStatus {
     Stopping = 3,
     Reconfiguring = 4,
     Error = 5,
+    Added = 6,
+    Removed = 7,
 }
 
 /// Change operation type, FFI-safe.

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -108,6 +108,8 @@ fn component_status_to_ffi(s: ComponentStatus) -> FfiComponentStatus {
         ComponentStatus::Stopping => FfiComponentStatus::Stopping,
         ComponentStatus::Reconfiguring => FfiComponentStatus::Reconfiguring,
         ComponentStatus::Error => FfiComponentStatus::Error,
+        ComponentStatus::Added => FfiComponentStatus::Added,
+        ComponentStatus::Removed => FfiComponentStatus::Removed,
     }
 }
 

--- a/components/sources/mock/src/conversion.rs
+++ b/components/sources/mock/src/conversion.rs
@@ -35,8 +35,9 @@ use serde_json::Value;
 /// (e.g., unsupported JSON structure).
 #[allow(dead_code)]
 pub fn safe_json_to_element_value(json_value: &Value) -> Result<drasi_core::models::ElementValue> {
-    drasi_lib::sources::convert_json_to_element_value(json_value)
-        .with_context(|| format!("Failed to convert JSON value to Element value: {json_value:?}"))
+    Ok(drasi_lib::sources::convert_json_to_element_value(
+        json_value,
+    ))
 }
 
 /// Converts a JSON value to an Element value, returning a default on failure.
@@ -55,15 +56,9 @@ pub fn safe_json_to_element_value(json_value: &Value) -> Result<drasi_core::mode
 /// if conversion fails (with a warning logged).
 pub fn json_to_element_value_or_default(
     json_value: &Value,
-    default: drasi_core::models::ElementValue,
+    _default: drasi_core::models::ElementValue,
 ) -> drasi_core::models::ElementValue {
-    match drasi_lib::sources::convert_json_to_element_value(json_value) {
-        Ok(value) => value,
-        Err(e) => {
-            log::warn!("Failed to convert JSON to Element value, using default: {e}");
-            default
-        }
-    }
+    drasi_lib::sources::convert_json_to_element_value(json_value)
 }
 
 /// Converts multiple JSON values to Element values, filtering failures.
@@ -85,17 +80,7 @@ pub fn batch_json_to_element_values<'a>(
     values: impl Iterator<Item = &'a Value>,
 ) -> Vec<drasi_core::models::ElementValue> {
     values
-        .filter_map(|json_value| {
-            match drasi_lib::sources::convert_json_to_element_value(json_value) {
-                Ok(value) => Some(value),
-                Err(e) => {
-                    log::debug!(
-                        "Skipping unconvertible JSON value during batch conversion: {json_value:?}, error: {e}"
-                    );
-                    None
-                }
-            }
-        })
+        .map(drasi_lib::sources::convert_json_to_element_value)
         .collect()
 }
 

--- a/components/sources/platform/src/lib.rs
+++ b/components/sources/platform/src/lib.rs
@@ -1375,7 +1375,7 @@ fn transform_platform_event(
             .as_object()
             .ok_or_else(|| anyhow::anyhow!("Missing or invalid 'properties' field"))?;
 
-        let properties = convert_json_to_element_properties(properties_obj)?;
+        let properties = convert_json_to_element_properties(properties_obj);
 
         // Build element based on type
         let element = match element_type {

--- a/components/sources/postgres/src/stream.rs
+++ b/components/sources/postgres/src/stream.rs
@@ -543,7 +543,7 @@ impl ReplicationStream {
                 if !json_value.is_null() {
                     properties.insert(
                         &column.name,
-                        drasi_lib::sources::manager::convert_json_to_element_value(&json_value)?,
+                        drasi_lib::sources::manager::convert_json_to_element_value(&json_value),
                     );
                 }
             }
@@ -599,7 +599,7 @@ impl ReplicationStream {
                 if !json_value.is_null() {
                     after_properties.insert(
                         &column.name,
-                        drasi_lib::sources::manager::convert_json_to_element_value(&json_value)?,
+                        drasi_lib::sources::manager::convert_json_to_element_value(&json_value),
                     );
                 }
             }

--- a/lib-integration-tests/tests/log_event_streaming.rs
+++ b/lib-integration-tests/tests/log_event_streaming.rs
@@ -386,11 +386,13 @@ async fn test_source_event_streaming() {
         .await
         .expect("Failed to subscribe to source events");
 
-    // Initial events should be empty before start
-    assert!(
-        initial_events.is_empty(),
-        "Expected no events before start, got: {initial_events:?}"
+    // Initial events should contain the Added event from registration
+    assert_eq!(
+        initial_events.len(),
+        1,
+        "Expected exactly one initial event (Added), got: {initial_events:?}"
     );
+    assert_eq!(initial_events[0].status, ComponentStatus::Added);
 
     // Start the server
     drasi.start().await.expect("Failed to start DrasiLib");
@@ -455,11 +457,13 @@ async fn test_query_event_streaming() {
         .await
         .expect("Failed to subscribe to query events");
 
-    // Initial events should be empty before start
-    assert!(
-        initial_events.is_empty(),
-        "Expected no events before start, got: {initial_events:?}"
+    // Initial events should contain the Added event from registration
+    assert_eq!(
+        initial_events.len(),
+        1,
+        "Expected exactly one initial event (Added), got: {initial_events:?}"
     );
+    assert_eq!(initial_events[0].status, ComponentStatus::Added);
 
     // Start the server
     drasi.start().await.expect("Failed to start DrasiLib");
@@ -565,11 +569,13 @@ async fn test_reaction_event_streaming() {
         .await
         .expect("Failed to subscribe to reaction events");
 
-    // Initial events should be empty before start
-    assert!(
-        initial_events.is_empty(),
-        "Expected no events before start, got: {initial_events:?}"
+    // Initial events should contain the Added event from registration
+    assert_eq!(
+        initial_events.len(),
+        1,
+        "Expected exactly one initial event (Added), got: {initial_events:?}"
     );
+    assert_eq!(initial_events[0].status, ComponentStatus::Added);
 
     // Start the server
     drasi.start().await.expect("Failed to start DrasiLib");

--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -279,7 +279,7 @@ impl DrasiLibBuilder {
     /// Add a source instance with additional component metadata.
     ///
     /// Like [`with_source`](Self::with_source) but merges `extra_metadata`
-    /// (e.g. `pluginId`, `pluginGeneration`) into the component graph node.
+    /// (e.g. `pluginId`) into the component graph node.
     pub fn with_source_metadata(
         mut self,
         source: impl SourceTrait + 'static,
@@ -318,7 +318,7 @@ impl DrasiLibBuilder {
     /// Add a reaction instance with additional component metadata.
     ///
     /// Like [`with_reaction`](Self::with_reaction) but merges `extra_metadata`
-    /// (e.g. `pluginId`, `pluginGeneration`) into the component graph node.
+    /// (e.g. `pluginId`) into the component graph node.
     pub fn with_reaction_metadata(
         mut self,
         reaction: impl ReactionTrait + 'static,

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -47,17 +47,19 @@ pub enum ComponentType {
 /// A typical component lifecycle follows this progression:
 ///
 /// ```text
-/// Stopped → Starting → Running → Stopping → Stopped
-///                ↓
-///              Error
+/// Added → Starting → Running → Stopping → Stopped
+///              ↓                              ↓
+///            Error                         Removed
 /// ```
 ///
 /// # Status Values
 ///
+/// - **Added**: Component has been registered in the graph but not yet started
 /// - **Starting**: Component is initializing (connecting to resources, loading data, etc.)
 /// - **Running**: Component is actively processing (ingesting, querying, or delivering)
 /// - **Stopping**: Component is shutting down gracefully
-/// - **Stopped**: Component is not running (initial or final state)
+/// - **Stopped**: Component is not running (stopped after previously running)
+/// - **Removed**: Component has been removed from the graph
 /// - **Error**: Component encountered an error and cannot continue (see error_message)
 ///
 /// # Usage
@@ -160,10 +162,14 @@ pub enum ComponentType {
 /// ```
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum ComponentStatus {
+    /// Component has been registered in the graph but not yet started.
+    Added,
     Starting,
     Running,
     Stopping,
     Stopped,
+    /// Component has been removed from the graph.
+    Removed,
     Reconfiguring,
     Error,
 }

--- a/lib/src/component_graph/graph.rs
+++ b/lib/src/component_graph/graph.rs
@@ -413,7 +413,7 @@ impl ComponentGraph {
 
     /// Remove a component node and all its edges from the graph.
     ///
-    /// Emits a [`ComponentEvent`] with status [`ComponentStatus::Stopped`] to all
+    /// Emits a [`ComponentEvent`] with status [`ComponentStatus::Removed`] to all
     /// subscribers. Returns the removed node data, or an error if the component
     /// doesn't exist. The instance root node cannot be removed.
     pub fn remove_component(&mut self, id: &str) -> anyhow::Result<ComponentNode> {
@@ -444,7 +444,7 @@ impl ComponentGraph {
         self.emit_event(
             id,
             &kind,
-            ComponentStatus::Stopped,
+            ComponentStatus::Removed,
             Some(format!("{kind} removed")),
         );
 
@@ -889,7 +889,7 @@ impl ComponentGraph {
         let node = ComponentNode {
             id: id.to_string(),
             kind: ComponentKind::Source,
-            status: ComponentStatus::Stopped,
+            status: ComponentStatus::Added,
             metadata,
         };
         let mut txn = self.begin();
@@ -927,7 +927,7 @@ impl ComponentGraph {
         let node = ComponentNode {
             id: id.to_string(),
             kind: ComponentKind::Query,
-            status: ComponentStatus::Stopped,
+            status: ComponentStatus::Added,
             metadata,
         };
         let mut txn = self.begin();
@@ -968,7 +968,7 @@ impl ComponentGraph {
         let node = ComponentNode {
             id: id.to_string(),
             kind: ComponentKind::Reaction,
-            status: ComponentStatus::Stopped,
+            status: ComponentStatus::Added,
             metadata,
         };
         let mut txn = self.begin();
@@ -1043,7 +1043,7 @@ impl ComponentGraph {
         let node = ComponentNode {
             id: id.to_string(),
             kind: ComponentKind::BootstrapProvider,
-            status: ComponentStatus::Stopped,
+            status: ComponentStatus::Added,
             metadata,
         };
         let mut txn = self.begin();
@@ -1089,7 +1089,7 @@ impl ComponentGraph {
         let node = ComponentNode {
             id: id.to_string(),
             kind: ComponentKind::IdentityProvider,
-            status: ComponentStatus::Stopped,
+            status: ComponentStatus::Added,
             metadata,
         };
         let mut txn = self.begin();
@@ -1212,25 +1212,30 @@ pub(super) fn is_valid_relationship(
 /// Check if a status transition is valid according to the component lifecycle state machine.
 ///
 /// ```text
-/// Stopped ──→ Starting ──→ Running ──→ Stopping ──→ Stopped
-///    │            │            │            │
-///    │            ↓            ↓            ↓
-///    │          Error        Error        Error
-///    │            │
-///    │            ↓
-///    │         Stopped (aborted start)
-///    │
-///    ↓
+/// Added ──→ Starting ──→ Running ──→ Stopping ──→ Stopped
+///   │           │            │            │
+///   │           ↓            ↓            ↓
+///   │         Error        Error        Error
+///   │           │
+///   │           ↓
+///   │        Stopped (aborted start)
+///   │
+///   ↓
 /// Reconfiguring ──→ Stopped | Starting | Error
 ///
 /// Error ──→ Starting (retry) | Stopped (reset)
+///
+/// Note: Added and Removed are set by the graph on add/remove_component()
+/// and are NOT valid targets for validate_and_transition().
 /// ```
 pub(super) fn is_valid_transition(from: &ComponentStatus, to: &ComponentStatus) -> bool {
     use ComponentStatus::*;
     matches!(
         (from, to),
         // Normal lifecycle
-        (Stopped, Starting)
+        (Added, Starting)
+            | (Added, Stopped) // immediate deactivation without starting
+            | (Stopped, Starting)
             | (Starting, Running)
             | (Starting, Error)
             | (Starting, Stopped) // aborted start
@@ -1243,6 +1248,7 @@ pub(super) fn is_valid_transition(from: &ComponentStatus, to: &ComponentStatus) 
             | (Error, Starting) // retry
             | (Error, Stopped) // reset
             // Reconfiguration (from any stable state)
+            | (Added, Reconfiguring)
             | (Stopped, Reconfiguring)
             | (Running, Reconfiguring)
             | (Error, Reconfiguring)

--- a/lib/src/component_graph/graph.rs
+++ b/lib/src/component_graph/graph.rs
@@ -97,7 +97,7 @@ pub struct ComponentGraph {
     /// component in the graph. Events are recorded by [`apply_update()`] and
     /// [`remove_component()`]. Managers delegate event queries here rather than
     /// maintaining their own per-manager histories.
-    event_history: ComponentEventHistory,
+    pub(super) event_history: ComponentEventHistory,
 }
 
 /// Default broadcast channel capacity for component events.
@@ -364,7 +364,8 @@ impl ComponentGraph {
     pub fn add_component(&mut self, node: ComponentNode) -> anyhow::Result<NodeIndex> {
         let (node_idx, event, _, _) = self.add_component_internal(node)?;
         if let Some(event) = event {
-            let _ = self.event_tx.send(event);
+            let _ = self.event_tx.send(event.clone());
+            self.event_history.record_event(event);
         }
         Ok(node_idx)
     }
@@ -1163,13 +1164,13 @@ impl ComponentGraph {
 
     /// Subscribe to live lifecycle events for a component.
     ///
-    /// Returns the current history and a broadcast receiver for new events.
-    /// Creates the component's event channel if it doesn't exist.
+    /// Returns the current history and a broadcast receiver for new events,
+    /// or `None` if the component has no event channel yet.
     pub fn subscribe_events(
-        &mut self,
+        &self,
         component_id: &str,
-    ) -> (Vec<ComponentEvent>, broadcast::Receiver<ComponentEvent>) {
-        self.event_history.subscribe(component_id)
+    ) -> Option<(Vec<ComponentEvent>, broadcast::Receiver<ComponentEvent>)> {
+        self.event_history.try_subscribe(component_id)
     }
 }
 

--- a/lib/src/component_graph/tests.rs
+++ b/lib/src/component_graph/tests.rs
@@ -13,7 +13,7 @@ fn source_node(id: &str) -> ComponentNode {
     ComponentNode {
         id: id.to_string(),
         kind: ComponentKind::Source,
-        status: ComponentStatus::Stopped,
+        status: ComponentStatus::Added,
         metadata: HashMap::new(),
     }
 }
@@ -22,7 +22,7 @@ fn query_node(id: &str) -> ComponentNode {
     ComponentNode {
         id: id.to_string(),
         kind: ComponentKind::Query,
-        status: ComponentStatus::Stopped,
+        status: ComponentStatus::Added,
         metadata: HashMap::new(),
     }
 }
@@ -31,7 +31,7 @@ fn reaction_node(id: &str) -> ComponentNode {
     ComponentNode {
         id: id.to_string(),
         kind: ComponentKind::Reaction,
-        status: ComponentStatus::Stopped,
+        status: ComponentStatus::Added,
         metadata: HashMap::new(),
     }
 }
@@ -179,10 +179,10 @@ fn test_update_status() {
 
     assert_eq!(
         graph.get_component("source-1").unwrap().status,
-        ComponentStatus::Stopped
+        ComponentStatus::Added
     );
 
-    // Follow valid transitions: Stopped → Starting → Running
+    // Follow valid transitions: Added → Starting → Running
     graph
         .update_status("source-1", ComponentStatus::Starting)
         .unwrap();
@@ -541,23 +541,23 @@ fn test_update_status_rejects_invalid_transition() {
     let mut graph = create_test_graph();
     graph.add_component(source_node("source-1")).unwrap();
 
-    // source-1 starts as Stopped
+    // source-1 starts as Added
     assert_eq!(
         graph.get_component("source-1").unwrap().status,
-        ComponentStatus::Stopped
+        ComponentStatus::Added
     );
 
-    // Invalid: Stopped → Running (must go through Starting)
+    // Invalid: Added → Running (must go through Starting)
     let result = graph.update_status("source-1", ComponentStatus::Running);
     assert!(result.is_ok());
-    // The update should return None (skipped) and status should remain Stopped
+    // The update should return None (skipped) and status should remain Added
     assert!(result.unwrap().is_none());
     assert_eq!(
         graph.get_component("source-1").unwrap().status,
-        ComponentStatus::Stopped
+        ComponentStatus::Added
     );
 
-    // Valid: Stopped → Starting
+    // Valid: Added → Starting
     let result = graph.update_status("source-1", ComponentStatus::Starting);
     assert!(result.is_ok());
     assert!(result.unwrap().is_some());
@@ -583,7 +583,7 @@ fn test_register_source() {
     );
     assert_eq!(
         graph.get_component("source-1").unwrap().status,
-        ComponentStatus::Stopped
+        ComponentStatus::Added
     );
     // 2 ownership edges
     assert_eq!(graph.edge_count(), 2);
@@ -754,7 +754,7 @@ fn test_validate_and_transition_idempotent_same_state() {
     let mut graph = create_test_graph();
     graph.add_component(source_node("s1")).unwrap();
 
-    let result = graph.validate_and_transition("s1", ComponentStatus::Stopped, None);
+    let result = graph.validate_and_transition("s1", ComponentStatus::Added, None);
     assert!(result.is_ok());
     assert!(result.unwrap().is_none()); // no event for same-state
 }
@@ -789,12 +789,13 @@ fn test_validate_and_transition_invalid_stop_while_stopped() {
     let mut graph = create_test_graph();
     graph.add_component(source_node("s1")).unwrap();
 
+    // Added → Stopping is not valid
     let result = graph.validate_and_transition("s1", ComponentStatus::Stopping, None);
     assert!(result.is_err());
     let err_msg = result.unwrap_err().to_string();
     assert!(
-        err_msg.contains("already stopped"),
-        "Expected 'already stopped' in: {err_msg}"
+        err_msg.contains("Added") && err_msg.contains("Stopping"),
+        "Expected invalid transition message mentioning Added → Stopping in: {err_msg}"
     );
 }
 
@@ -906,7 +907,7 @@ fn test_register_bootstrap_provider_standalone() {
     );
     assert_eq!(
         graph.get_component("bp-1").unwrap().status,
-        ComponentStatus::Stopped
+        ComponentStatus::Added
     );
     // 2 ownership edges (Owns + OwnedBy)
     assert_eq!(graph.edge_count(), 2);
@@ -967,7 +968,7 @@ fn test_register_identity_provider_standalone() {
     );
     assert_eq!(
         graph.get_component("ip-1").unwrap().status,
-        ComponentStatus::Stopped
+        ComponentStatus::Added
     );
     // 2 ownership edges (Owns + OwnedBy)
     assert_eq!(graph.edge_count(), 2);
@@ -1292,7 +1293,7 @@ fn test_subscribe_receives_add_event() {
     let event = event_rx.try_recv().unwrap();
     assert_eq!(event.component_id, "source-1");
     assert_eq!(event.component_type, ComponentType::Source);
-    assert_eq!(event.status, ComponentStatus::Stopped);
+    assert_eq!(event.status, ComponentStatus::Added);
 }
 
 #[test]
@@ -1303,7 +1304,7 @@ fn test_subscribe_receives_status_change_event() {
     graph.add_component(source_node("source-1")).unwrap();
     let _add_event = event_rx.try_recv().unwrap(); // consume add event
 
-    // Transition Stopped → Starting
+    // Transition Added → Starting
     graph
         .validate_and_transition("source-1", ComponentStatus::Starting, None)
         .unwrap();
@@ -1388,7 +1389,7 @@ fn test_apply_update_invalid_transition_returns_none() {
     let (mut graph, _rx) = ComponentGraph::new("test-instance");
     graph.add_component(source_node("source-1")).unwrap();
 
-    // Stopped → Running is not a valid transition (must go through Starting)
+    // Added → Running is not a valid transition (must go through Starting)
     let event = graph.apply_update(ComponentUpdate::Status {
         component_id: "source-1".into(),
         status: ComponentStatus::Running,
@@ -1396,10 +1397,10 @@ fn test_apply_update_invalid_transition_returns_none() {
     });
 
     assert!(event.is_none());
-    // Status should remain Stopped
+    // Status should remain Added
     assert_eq!(
         graph.get_component("source-1").unwrap().status,
-        ComponentStatus::Stopped
+        ComponentStatus::Added
     );
 }
 
@@ -1410,7 +1411,7 @@ fn test_apply_update_same_status_is_noop() {
 
     let event = graph.apply_update(ComponentUpdate::Status {
         component_id: "source-1".into(),
-        status: ComponentStatus::Stopped,
+        status: ComponentStatus::Added,
         message: None,
     });
 
@@ -1542,17 +1543,17 @@ async fn test_wait_for_status_already_reached() {
         g.add_component(source_node("source-1")).unwrap();
     }
 
-    // source-1 starts as Stopped, so waiting for Stopped should return immediately
+    // source-1 starts as Added, so waiting for Added should return immediately
     let result = wait_for_status(
         &graph,
         "source-1",
-        &[ComponentStatus::Stopped],
+        &[ComponentStatus::Added],
         std::time::Duration::from_millis(100),
     )
     .await;
 
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), ComponentStatus::Stopped);
+    assert_eq!(result.unwrap(), ComponentStatus::Added);
 }
 
 #[tokio::test]
@@ -1645,17 +1646,17 @@ async fn test_wait_for_status_multiple_targets() {
         g.add_component(source_node("source-1")).unwrap();
     }
 
-    // Stopped matches the second target
+    // Added matches the second target
     let result = wait_for_status(
         &graph,
         "source-1",
-        &[ComponentStatus::Running, ComponentStatus::Stopped],
+        &[ComponentStatus::Running, ComponentStatus::Added],
         std::time::Duration::from_millis(100),
     )
     .await;
 
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), ComponentStatus::Stopped);
+    assert_eq!(result.unwrap(), ComponentStatus::Added);
 }
 
 // ========================================================================
@@ -1694,7 +1695,7 @@ fn test_transaction_commit_events_have_correct_status() {
     }
 
     let event = event_rx.try_recv().unwrap();
-    assert_eq!(event.status, ComponentStatus::Stopped);
+    assert_eq!(event.status, ComponentStatus::Added);
     assert_eq!(event.component_type, ComponentType::Source);
 }
 

--- a/lib/src/component_graph/tests.rs
+++ b/lib/src/component_graph/tests.rs
@@ -1850,7 +1850,9 @@ fn test_subscribe_events_returns_history_and_receiver() {
     };
     graph.record_event(event);
 
-    let (history, _rx) = graph.subscribe_events("source-1");
+    let (history, _rx) = graph
+        .subscribe_events("source-1")
+        .expect("channel should exist after recording an event");
     assert_eq!(history.len(), 1);
     assert_eq!(history[0].status, ComponentStatus::Starting);
 }
@@ -1860,7 +1862,9 @@ fn test_subscribe_events_receives_new_events() {
     let (mut graph, _rx) = ComponentGraph::new("test-instance");
     graph.add_component(source_node("source-1")).unwrap();
 
-    let (_history, mut event_rx) = graph.subscribe_events("source-1");
+    let (_history, mut event_rx) = graph
+        .subscribe_events("source-1")
+        .expect("channel should exist after add_component");
 
     // Record a new event after subscribing
     let event = ComponentEvent {
@@ -1878,10 +1882,13 @@ fn test_subscribe_events_receives_new_events() {
 
 #[test]
 fn test_subscribe_events_empty_history_for_new_component() {
-    let (mut graph, _rx) = ComponentGraph::new("test-instance");
+    let (graph, _rx) = ComponentGraph::new("test-instance");
 
-    let (history, _rx) = graph.subscribe_events("brand-new");
-    assert!(history.is_empty());
+    let result = graph.subscribe_events("brand-new");
+    assert!(
+        result.is_none(),
+        "subscribe_events should return None for a component with no event channel"
+    );
 }
 
 // ========================================================================

--- a/lib/src/component_graph/transaction.rs
+++ b/lib/src/component_graph/transaction.rs
@@ -129,6 +129,7 @@ impl<'g> GraphTransaction<'g> {
         self.committed = true;
         for event in &self.pending_events {
             let _ = self.graph.event_tx.send(event.clone());
+            self.graph.event_history.record_event(event.clone());
         }
     }
 }

--- a/lib/src/inspection.rs
+++ b/lib/src/inspection.rs
@@ -896,7 +896,7 @@ mod tests {
         core.add_source(source).await.unwrap();
 
         let status = core.get_source_status("status-src").await.unwrap();
-        assert_eq!(status, ComponentStatus::Stopped);
+        assert_eq!(status, ComponentStatus::Added);
     }
 
     #[tokio::test]
@@ -936,7 +936,7 @@ mod tests {
     async fn get_query_status_found() {
         let core = build_with_source_and_query().await;
         let status = core.get_query_status("q1").await.unwrap();
-        assert_eq!(status, ComponentStatus::Stopped);
+        assert_eq!(status, ComponentStatus::Added);
     }
 
     #[tokio::test]
@@ -982,7 +982,7 @@ mod tests {
         core.add_reaction(reaction).await.unwrap();
 
         let status = core.get_reaction_status("r1").await.unwrap();
-        assert_eq!(status, ComponentStatus::Stopped);
+        assert_eq!(status, ComponentStatus::Added);
     }
 
     #[tokio::test]

--- a/lib/src/lib_core.rs
+++ b/lib/src/lib_core.rs
@@ -1600,7 +1600,7 @@ mod tests {
             assert!(
                 matches!(
                     src.status,
-                    crate::channels::ComponentStatus::Stopped
+                    crate::channels::ComponentStatus::Added
                         | crate::channels::ComponentStatus::Running
                 ),
                 "Source status should be captured: {:?}",

--- a/lib/src/lib_core_ops/graph_ops.rs
+++ b/lib/src/lib_core_ops/graph_ops.rs
@@ -110,7 +110,7 @@ impl DrasiLib {
 
     /// Check if a component can be safely removed without breaking dependents.
     ///
-    /// Returns `Ok(())` if safe to remove, or `Err(DrasiError::HasDependents)`
+    /// Returns `Ok(())` if safe to remove, or `Err(DrasiError::Validation { .. })`
     /// with the list of dependent component IDs if removal would break the graph.
     ///
     /// # Example

--- a/lib/src/lib_core_ops/query_ops.rs
+++ b/lib/src/lib_core_ops/query_ops.rs
@@ -535,9 +535,9 @@ mod tests {
             .build();
         core.add_query(config).await.unwrap();
 
-        // Query added without auto-start should be Stopped
+        // Query added without auto-start should be Added
         let status = core.get_query_status("q-status").await.unwrap();
-        assert_eq!(status, ComponentStatus::Stopped);
+        assert_eq!(status, ComponentStatus::Added);
     }
 
     #[tokio::test]

--- a/lib/src/lib_core_ops/reaction_ops.rs
+++ b/lib/src/lib_core_ops/reaction_ops.rs
@@ -54,7 +54,7 @@ impl DrasiLib {
     /// Add a reaction to a running server with additional metadata.
     ///
     /// Same as [`add_reaction`](Self::add_reaction) but merges `extra_metadata`
-    /// (e.g. `pluginId`, `pluginGeneration`) into the component graph node.
+    /// (e.g. `pluginId`) into the component graph node.
     pub async fn add_reaction_with_metadata(
         &self,
         reaction: impl Reaction + 'static,

--- a/lib/src/lib_core_ops/reaction_ops.rs
+++ b/lib/src/lib_core_ops/reaction_ops.rs
@@ -668,7 +668,7 @@ mod tests {
         core.add_reaction(reaction).await.unwrap();
 
         let status = core.get_reaction_status("r-status").await.unwrap();
-        assert_eq!(status, ComponentStatus::Stopped);
+        assert_eq!(status, ComponentStatus::Added);
     }
 
     #[tokio::test]
@@ -740,7 +740,7 @@ mod tests {
         let info = core.get_reaction_info("r-info").await.unwrap();
         assert_eq!(info.id, "r-info");
         assert_eq!(info.reaction_type, "test-log");
-        assert_eq!(info.status, ComponentStatus::Stopped);
+        assert_eq!(info.status, ComponentStatus::Added);
         assert_eq!(info.queries, vec!["q1".to_string()]);
     }
 }

--- a/lib/src/lib_core_ops/source_ops.rs
+++ b/lib/src/lib_core_ops/source_ops.rs
@@ -559,8 +559,8 @@ mod tests {
         let status = core.get_source_status("status-src").await.unwrap();
         assert_eq!(
             status,
-            ComponentStatus::Stopped,
-            "Newly added non-autostart source should be Stopped"
+            ComponentStatus::Added,
+            "Newly added non-autostart source should be Added"
         );
     }
 
@@ -589,9 +589,9 @@ mod tests {
         let source = TestMockSource::with_auto_start("lifecycle-src".to_string(), false).unwrap();
         core.add_source(source).await.unwrap();
 
-        // Initially stopped
+        // Initially in Added state
         let status = core.get_source_status("lifecycle-src").await.unwrap();
-        assert_eq!(status, ComponentStatus::Stopped);
+        assert_eq!(status, ComponentStatus::Added);
 
         // Start
         core.start_source("lifecycle-src").await.unwrap();
@@ -634,7 +634,7 @@ mod tests {
         let info = core.get_source_info("info-src").await.unwrap();
         assert_eq!(info.id, "info-src");
         assert_eq!(info.source_type, "mock");
-        assert_eq!(info.status, ComponentStatus::Stopped);
+        assert_eq!(info.status, ComponentStatus::Added);
         assert!(info.error_message.is_none());
     }
 }

--- a/lib/src/lib_core_ops/source_ops.rs
+++ b/lib/src/lib_core_ops/source_ops.rs
@@ -53,7 +53,7 @@ impl DrasiLib {
     /// Add a source to a running server with additional metadata.
     ///
     /// Same as [`add_source`](Self::add_source) but merges `extra_metadata`
-    /// (e.g. `pluginId`, `pluginGeneration`) into the component graph node.
+    /// (e.g. `pluginId`) into the component graph node.
     pub async fn add_source_with_metadata(
         &self,
         source: impl Source + 'static,

--- a/lib/src/lifecycle.rs
+++ b/lib/src/lifecycle.rs
@@ -255,9 +255,9 @@ mod tests {
 
         core.start().await.unwrap();
 
-        // Non-autostart source should remain Stopped
+        // Non-autostart source should remain Added
         let status = core.get_source_status("manual-src").await.unwrap();
-        assert_eq!(status, ComponentStatus::Stopped);
+        assert_eq!(status, ComponentStatus::Added);
     }
 
     // ========================================================================
@@ -302,13 +302,13 @@ mod tests {
 
         core.start().await.unwrap();
 
-        // Source is not auto-started, so it's already Stopped.
+        // Source is not auto-started, so it's still in Added state.
         // Stopping should succeed without errors for user components.
         // Internal components may fail, so we just verify the server marks as stopped.
         let _ = core.stop().await;
 
         let status = core.get_source_status("idle-src").await.unwrap();
-        assert_eq!(status, ComponentStatus::Stopped);
+        assert_eq!(status, ComponentStatus::Added);
     }
 
     // ========================================================================
@@ -342,8 +342,8 @@ mod tests {
             "Query 'cfg-query' should exist after build; got: {queries:?}"
         );
 
-        // Query should be in Stopped state (not yet started)
+        // Query should be in Added state (not yet started)
         let (_, status) = queries.iter().find(|(id, _)| id == "cfg-query").unwrap();
-        assert_eq!(*status, ComponentStatus::Stopped);
+        assert_eq!(*status, ComponentStatus::Added);
     }
 }

--- a/lib/src/lifecycle_events_tests.rs
+++ b/lib/src/lifecycle_events_tests.rs
@@ -157,7 +157,7 @@ mod tests {
             &events,
             "test-src",
             ComponentType::Source,
-            &[(ComponentStatus::Stopped, "added")],
+            &[(ComponentStatus::Added, "added")],
         );
 
         // Start
@@ -217,7 +217,7 @@ mod tests {
             &events,
             "test-src",
             ComponentType::Source,
-            &[(ComponentStatus::Stopped, "removed")],
+            &[(ComponentStatus::Removed, "removed")],
         );
     }
 
@@ -258,7 +258,7 @@ mod tests {
             &events,
             "test-query",
             ComponentType::Query,
-            &[(ComponentStatus::Stopped, "added")],
+            &[(ComponentStatus::Added, "added")],
         );
 
         // Start the source first (queries need running sources for bootstrap)
@@ -325,7 +325,7 @@ mod tests {
             &events,
             "test-query",
             ComponentType::Query,
-            &[(ComponentStatus::Stopped, "removed")],
+            &[(ComponentStatus::Removed, "removed")],
         );
     }
 
@@ -372,7 +372,7 @@ mod tests {
             &events,
             "test-rxn",
             ComponentType::Reaction,
-            &[(ComponentStatus::Stopped, "added")],
+            &[(ComponentStatus::Added, "added")],
         );
 
         // Start reaction
@@ -432,7 +432,7 @@ mod tests {
             &events,
             "test-rxn",
             ComponentType::Reaction,
-            &[(ComponentStatus::Stopped, "removed")],
+            &[(ComponentStatus::Removed, "removed")],
         );
     }
 
@@ -458,7 +458,7 @@ mod tests {
         )
         .await;
         assert_eq!(src_added[0].component_type, ComponentType::Source);
-        assert_eq!(src_added[0].status, ComponentStatus::Stopped);
+        assert_eq!(src_added[0].status, ComponentStatus::Added);
 
         // Add query (depends on source)
         let query_config = Query::cypher("mc-query")
@@ -475,7 +475,7 @@ mod tests {
         )
         .await;
         assert_eq!(qry_added[0].component_type, ComponentType::Query);
-        assert_eq!(qry_added[0].status, ComponentStatus::Stopped);
+        assert_eq!(qry_added[0].status, ComponentStatus::Added);
 
         // Add reaction (depends on query)
         let reaction = TestMockReaction::with_auto_start(
@@ -492,7 +492,7 @@ mod tests {
         )
         .await;
         assert_eq!(rxn_added[0].component_type, ComponentType::Reaction);
-        assert_eq!(rxn_added[0].status, ComponentStatus::Stopped);
+        assert_eq!(rxn_added[0].status, ComponentStatus::Added);
 
         // --- Start in dependency order: source → query → reaction ---
 

--- a/lib/src/managers/event_history.rs
+++ b/lib/src/managers/event_history.rs
@@ -171,6 +171,19 @@ impl ComponentEventHistory {
         (history, receiver)
     }
 
+    /// Subscribe to live events for a component (read-only).
+    ///
+    /// Returns the current history and a broadcast receiver, or `None` if the
+    /// component has no event channel yet. Unlike [`subscribe`](Self::subscribe),
+    /// this does not create a channel and therefore only requires `&self`.
+    pub fn try_subscribe(
+        &self,
+        component_id: &str,
+    ) -> Option<(Vec<ComponentEvent>, broadcast::Receiver<ComponentEvent>)> {
+        let channel = self.channels.get(component_id)?;
+        Some((channel.get_history(), channel.subscribe()))
+    }
+
     /// Get the most recent error message for a component.
     ///
     /// Searches backwards through the component's event history to find the

--- a/lib/src/managers/lifecycle_helpers.rs
+++ b/lib/src/managers/lifecycle_helpers.rs
@@ -575,7 +575,7 @@ mod tests {
         ComponentNode {
             id: id.to_string(),
             kind: ComponentKind::Source,
-            status: ComponentStatus::Stopped,
+            status: ComponentStatus::Added,
             metadata: std::collections::HashMap::new(),
         }
     }
@@ -672,7 +672,7 @@ mod tests {
         let graph = Arc::new(RwLock::new(graph));
 
         let status = get_component_status(&graph, "s1", "source").await.unwrap();
-        assert_eq!(status, ComponentStatus::Stopped);
+        assert_eq!(status, ComponentStatus::Added);
     }
 
     #[tokio::test]

--- a/lib/src/queries/joins_test.rs
+++ b/lib/src/queries/joins_test.rs
@@ -82,9 +82,8 @@ mod query_joins_tests {
 
         let mut property_map = ElementPropertyMap::new();
         for (key, value) in properties {
-            if let Ok(element_value) = convert_json_to_element_value(&value) {
-                property_map.insert(key, element_value);
-            }
+            let element_value = convert_json_to_element_value(&value);
+            property_map.insert(key, element_value);
         }
 
         let metadata = ElementMetadata {

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -1664,11 +1664,11 @@ impl QueryManager {
         Vec<ComponentEvent>,
         tokio::sync::broadcast::Receiver<ComponentEvent>,
     )> {
-        let mut graph = self.graph.write().await;
+        let graph = self.graph.read().await;
         if !graph.has_runtime(id) {
             return None;
         }
-        Some(graph.subscribe_events(id))
+        graph.subscribe_events(id)
     }
 }
 

--- a/lib/src/queries/subscription_builder.rs
+++ b/lib/src/queries/subscription_builder.rs
@@ -70,7 +70,10 @@ impl SubscriptionSettingsBuilder {
 
             match matching_indices.len() {
                 0 => {
-                    // Not found in any source config - add to first source (default)
+                    // Not found in any source config — default to the first source.
+                    // This is intentional: labels that aren't explicitly mapped in
+                    // source configuration are assumed to belong to the primary
+                    // (first) source, which is the common single-source case.
                     if let Some(first_settings) = settings_vec.first_mut() {
                         first_settings.nodes.insert(node_label.clone());
                     } else {

--- a/lib/src/queries/tests.rs
+++ b/lib/src/queries/tests.rs
@@ -574,12 +574,12 @@ mod manager_tests {
         let query_config = create_test_query_config("test-query", vec!["source1".to_string()]);
         add_query(&manager, &graph, query_config).await.unwrap();
 
-        // Verify query is in stopped state
+        // Verify query is in Added state
         let status = manager
             .get_query_status("test-query".to_string())
             .await
             .unwrap();
-        assert!(matches!(status, ComponentStatus::Stopped));
+        assert!(matches!(status, ComponentStatus::Added));
 
         // Subscribe to graph events BEFORE starting the query
         let mut event_rx = graph.read().await.subscribe();
@@ -640,14 +640,14 @@ mod manager_tests {
         let config = create_test_query_config_with_auto_start("no-auto-start-query", vec![], false);
         add_query(&manager, &graph, config).await.unwrap();
 
-        // Query should be in stopped state
+        // Query should be in Added state
         let status = manager
             .get_query_status("no-auto-start-query".to_string())
             .await
             .unwrap();
         assert!(
-            matches!(status, ComponentStatus::Stopped),
-            "Query with auto_start=false should remain stopped after add"
+            matches!(status, ComponentStatus::Added),
+            "Query with auto_start=false should remain in Added state after add"
         );
     }
 
@@ -668,14 +668,14 @@ mod manager_tests {
         );
         add_query(&manager, &graph, config).await.unwrap();
 
-        // Query should be in stopped state initially
+        // Query should be in Added state initially
         let status = manager
             .get_query_status("manual-query".to_string())
             .await
             .unwrap();
         assert!(
-            matches!(status, ComponentStatus::Stopped),
-            "Query with auto_start=false should be stopped initially"
+            matches!(status, ComponentStatus::Added),
+            "Query with auto_start=false should be in Added state initially"
         );
 
         // Subscribe to graph events BEFORE starting the query

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -428,11 +428,11 @@ impl ReactionManager {
         Vec<ComponentEvent>,
         tokio::sync::broadcast::Receiver<ComponentEvent>,
     )> {
-        let mut graph = self.graph.write().await;
+        let graph = self.graph.read().await;
         if !graph.has_runtime(id) {
             return None;
         }
-        Some(graph.subscribe_events(id))
+        graph.subscribe_events(id)
     }
 
     /// Subscribe a reaction to its configured queries and spawn forwarder tasks.

--- a/lib/src/reactions/tests.rs
+++ b/lib/src/reactions/tests.rs
@@ -308,9 +308,9 @@ pub(crate) mod manager_tests {
         let reactions = manager.list_reactions().await;
         assert_eq!(reactions.len(), 2);
 
-        // Both should be stopped initially
+        // Both should be in Added state initially
         for (_, status) in reactions {
-            assert!(matches!(status, ComponentStatus::Stopped));
+            assert!(matches!(status, ComponentStatus::Added));
         }
     }
 
@@ -325,7 +325,7 @@ pub(crate) mod manager_tests {
             .get_reaction_status("test-reaction".to_string())
             .await;
         assert!(status.is_ok());
-        assert!(matches!(status.unwrap(), ComponentStatus::Stopped));
+        assert!(matches!(status.unwrap(), ComponentStatus::Added));
     }
 
     #[tokio::test]
@@ -457,8 +457,8 @@ pub(crate) mod manager_tests {
             "Reaction with auto_start=true should be running"
         );
         assert!(
-            matches!(status2, ComponentStatus::Stopped),
-            "Reaction with auto_start=false should still be stopped"
+            matches!(status2, ComponentStatus::Added),
+            "Reaction with auto_start=false should still be in Added state"
         );
     }
 
@@ -522,7 +522,7 @@ pub(crate) mod manager_tests {
             .await
             .unwrap();
         assert!(
-            matches!(status, ComponentStatus::Stopped),
+            matches!(status, ComponentStatus::Added),
             "Reaction with auto_start=false should not be started by start_all"
         );
 

--- a/lib/src/sources/component_graph_source.rs
+++ b/lib/src/sources/component_graph_source.rs
@@ -121,6 +121,19 @@ impl Source for ComponentGraphSource {
     }
 
     async fn start(&self) -> Result<()> {
+        // Guard against double-start: if already running or starting, no-op.
+        let current = self.base.get_status().await;
+        if matches!(
+            current,
+            ComponentStatus::Running | ComponentStatus::Starting
+        ) {
+            warn!(
+                "Component graph source for instance '{}' is already {current:?}, skipping start",
+                self.instance_id
+            );
+            return Ok(());
+        }
+
         info!(
             "Starting component graph source for instance '{}'",
             self.instance_id

--- a/lib/src/sources/component_graph_source.rs
+++ b/lib/src/sources/component_graph_source.rs
@@ -233,9 +233,9 @@ async fn handle_component_event(
         return Ok(());
     }
 
-    let changes = match event.message.as_deref() {
-        Some(msg) if msg.ends_with("added") => build_added_changes(instance_id, event),
-        Some(msg) if msg.ends_with("removed") => build_removed_changes(instance_id, event),
+    let changes = match event.status {
+        ComponentStatus::Added => build_added_changes(instance_id, event),
+        ComponentStatus::Removed => build_removed_changes(instance_id, event),
         _ => build_status_update_changes(event),
     };
 

--- a/lib/src/sources/graph_elements.rs
+++ b/lib/src/sources/graph_elements.rs
@@ -91,10 +91,12 @@ pub(crate) fn now_ms() -> u64 {
 /// Human-readable string for a [`ComponentStatus`].
 pub(crate) fn status_str(status: &ComponentStatus) -> &'static str {
     match status {
+        ComponentStatus::Added => "Added",
         ComponentStatus::Stopped => "Stopped",
         ComponentStatus::Starting => "Starting",
         ComponentStatus::Running => "Running",
         ComponentStatus::Stopping => "Stopping",
+        ComponentStatus::Removed => "Removed",
         ComponentStatus::Reconfiguring => "Reconfiguring",
         ComponentStatus::Error => "Error",
     }

--- a/lib/src/sources/manager.rs
+++ b/lib/src/sources/manager.rs
@@ -33,36 +33,33 @@ use crate::sources::Source;
 use crate::state_store::StateStoreProvider;
 
 // Convert JSON value to ElementValue
-pub fn convert_json_to_element_value(value: &Value) -> Result<ElementValue> {
+pub fn convert_json_to_element_value(value: &Value) -> ElementValue {
     match value {
-        Value::String(s) => Ok(ElementValue::String(Arc::from(s.as_str()))),
+        Value::String(s) => ElementValue::String(Arc::from(s.as_str())),
         Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Ok(ElementValue::Integer(i))
+                ElementValue::Integer(i)
             } else if let Some(f) = n.as_f64() {
-                Ok(ElementValue::Float(OrderedFloat(f)))
+                ElementValue::Float(OrderedFloat(f))
             } else {
-                Ok(ElementValue::String(Arc::from(n.to_string())))
+                ElementValue::String(Arc::from(n.to_string()))
             }
         }
-        Value::Bool(b) => Ok(ElementValue::Bool(*b)),
-        Value::Null => Ok(ElementValue::Null),
+        Value::Bool(b) => ElementValue::Bool(*b),
+        Value::Null => ElementValue::Null,
         // For arrays and objects, convert to string representation
-        Value::Array(_) | Value::Object(_) => {
-            Ok(ElementValue::String(Arc::from(value.to_string())))
-        }
+        Value::Array(_) | Value::Object(_) => ElementValue::String(Arc::from(value.to_string())),
     }
 }
 
 // Convert JSON properties to ElementPropertyMap
 pub fn convert_json_to_element_properties(
     json_props: &serde_json::Map<String, Value>,
-) -> Result<ElementPropertyMap> {
+) -> ElementPropertyMap {
     let mut properties = BTreeMap::new();
 
     for (key, value) in json_props {
-        let element_value = convert_json_to_element_value(value)?;
-
+        let element_value = convert_json_to_element_value(value);
         properties.insert(Arc::from(key.as_str()), element_value);
     }
 
@@ -70,7 +67,7 @@ pub fn convert_json_to_element_properties(
     for (key, value) in properties {
         property_map.insert(&key, value);
     }
-    Ok(property_map)
+    property_map
 }
 
 pub struct SourceManager {
@@ -446,10 +443,10 @@ impl SourceManager {
         Vec<ComponentEvent>,
         tokio::sync::broadcast::Receiver<ComponentEvent>,
     )> {
-        let mut graph = self.graph.write().await;
+        let graph = self.graph.read().await;
         if !graph.has_runtime(id) {
             return None;
         }
-        Some(graph.subscribe_events(id))
+        graph.subscribe_events(id)
     }
 }

--- a/lib/src/sources/tests.rs
+++ b/lib/src/sources/tests.rs
@@ -629,7 +629,7 @@ mod manager_tests {
             .1;
 
         assert!(matches!(source1_status, ComponentStatus::Running));
-        assert!(matches!(source2_status, ComponentStatus::Stopped));
+        assert!(matches!(source2_status, ComponentStatus::Added));
     }
 
     /// Test that concurrent add_source calls with the same ID are handled atomically.
@@ -752,8 +752,8 @@ mod manager_tests {
             "Source with auto_start=true should be running"
         );
         assert!(
-            matches!(status2, ComponentStatus::Stopped),
-            "Source with auto_start=false should still be stopped"
+            matches!(status2, ComponentStatus::Added),
+            "Source with auto_start=false should still be in Added state"
         );
     }
 
@@ -818,7 +818,7 @@ mod manager_tests {
             .await
             .unwrap();
         assert!(
-            matches!(status, ComponentStatus::Stopped),
+            matches!(status, ComponentStatus::Added),
             "Source with auto_start=false should not be started by start_all"
         );
 


### PR DESCRIPTION
This pull request makes significant changes to the plugin lifecycle management system in the host SDK, primarily simplifying the plugin status model and removing support for plugin retirement, draining, and upgrade semantics at this layer. The changes also update the event system and clean up related tests and documentation. Additionally, there are minor improvements and dependency updates elsewhere in the codebase.

**Plugin Lifecycle Simplification:**

- Removed support for plugin retirement, draining, and upgrade semantics from the `PluginLifecycleManager` and related types. This includes deleting the `retire_plugin` method, the `generation` field, and all associated events and status variants. Now, the lifecycle manager only supports loading and registering plugins, with advanced lifecycle operations delegated to higher-level orchestrator components. [[1]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L18-L26) [[2]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L46-L61) [[3]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L72) [[4]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L98) [[5]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L116-R108) [[6]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L127-R119) [[7]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L138-R130) [[8]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L148) [[9]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L217-L240) [[10]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L267-L271) [[11]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L283) [[12]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L295-L303) [[13]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L318) [[14]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L339-L416) [[15]](diffhunk://#diff-849b8c42ef9bccc0c725d988c90ba8694796b465a1eb819f1d2b14197b9f7a44L438-L484)

- Simplified the `PluginStatus` enum by removing the `Draining` and `Retired` states, and updated its display implementation and related documentation. [[1]](diffhunk://#diff-2179fe26bb51744c7c48cdf238be33a3fa4def1c943ea23c778d71873ba50b72L55-L58) [[2]](diffhunk://#diff-2179fe26bb51744c7c48cdf238be33a3fa4def1c943ea23c778d71873ba50b72L68-L69) [[3]](diffhunk://#diff-2179fe26bb51744c7c48cdf238be33a3fa4def1c943ea23c778d71873ba50b72L153-L154)

- Overhauled the `PluginEvent` enum to remove all upgrade, drain, promotion, and retirement events, leaving only the basic `Loaded` and `LoadFailed` events. Documentation was updated to reflect these changes.

**Other Notable Changes:**

- Updated plugin property conversion logic in the bootstrappers and script file provider to remove unnecessary error propagation, simplifying property handling. [[1]](diffhunk://#diff-31c3a31b28a27f68ce0cdeb4b86b5b2383ca2ed727a9121da6d4bd09adda0552L410-R410) [[2]](diffhunk://#diff-9af44e05086f54e0231a5d0af258347bb74ea5909ba960faa5df1d38f202ef67L117-R117) [[3]](diffhunk://#diff-9af44e05086f54e0231a5d0af258347bb74ea5909ba960faa5df1d38f202ef67L151-R151)

- Fixed a documentation import path in the scriptfile bootstrapper example.

- Added support for new component statuses (`Added`, `Removed`) in the reaction proxy.


