### PR TITLE
Component toml version update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,8 +102,8 @@ drasi-core = { version = "0.4.2", path = "core" }
 drasi-functions-cypher = { version = "0.4.2", path = "functions-cypher" }
 drasi-functions-gql = { version = "0.4.2", path = "functions-gql" }
 drasi-middleware = { version = "0.4.2", path = "middleware" }
-drasi-identity-azure = { version = "0.1.0", path = "components/identity/azure" }
-drasi-identity-aws = { version = "0.1.0", path = "components/identity/aws" }
+drasi-identity-azure = { version = "0.1.1", path = "components/identity/azure" }
+drasi-identity-aws = { version = "0.1.1", path = "components/identity/aws" }
 drasi-lib = { version = "0.6.0", path = "lib" }
 drasi-ffi-primitives = { version = "0.6.0", path = "components/ffi-primitives" }
 drasi-plugin-sdk = { version = "0.6.0", path = "components/plugin-sdk" }
@@ -115,15 +115,15 @@ drasi-index-rocksdb = { version = "0.3.2", path = "components/indexes/rocksdb" }
 drasi-index-garnet = { version = "0.1.9", path = "components/indexes/garnet" }
 
 # Component plugins
-drasi-source-mssql = { version = "0.1.4", path = "components/sources/mssql" }
-drasi-bootstrap-mssql = { version = "0.1.4", path = "components/bootstrappers/mssql" }
-drasi-bootstrap-postgres = { version = "0.1.14", path = "components/bootstrappers/postgres" }
-drasi-reaction-application = { version = "0.2.10", path = "components/reactions/application" }
-drasi-source-postgres = { version = "0.1.14", path = "components/sources/postgres" }
-drasi-source-application = { version = "0.1.13", path = "components/sources/application" }
-drasi-bootstrap-application = { version = "0.1.12", path = "components/bootstrappers/application" }
-drasi-reaction-http = { version = "0.1.13", path = "components/reactions/http" }
-drasi-reaction-grpc = { version = "0.2.9", path = "components/reactions/grpc" }
+drasi-source-mssql = { version = "0.1.5", path = "components/sources/mssql" }
+drasi-bootstrap-mssql = { version = "0.1.5", path = "components/bootstrappers/mssql" }
+drasi-bootstrap-postgres = { version = "0.1.15", path = "components/bootstrappers/postgres" }
+drasi-reaction-application = { version = "0.2.11", path = "components/reactions/application" }
+drasi-source-postgres = { version = "0.1.15", path = "components/sources/postgres" }
+drasi-source-application = { version = "0.1.14", path = "components/sources/application" }
+drasi-bootstrap-application = { version = "0.1.13", path = "components/bootstrappers/application" }
+drasi-reaction-http = { version = "0.1.14", path = "components/reactions/http" }
+drasi-reaction-grpc = { version = "0.2.10", path = "components/reactions/grpc" }
 drasi-mssql-common = { version = "0.1.2", path = "components/mssql-common" }
 
 [workspace.lints.rust]

--- a/components/bootstrappers/application/Cargo.toml
+++ b/components/bootstrappers/application/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-application"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Application bootstrap plugin for Drasi"

--- a/components/bootstrappers/mssql/Cargo.toml
+++ b/components/bootstrappers/mssql/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-mssql"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Microsoft SQL Server bootstrap plugin for Drasi"

--- a/components/bootstrappers/noop/Cargo.toml
+++ b/components/bootstrappers/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-bootstrap-noop"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "No-op bootstrap provider plugin for Drasi"

--- a/components/bootstrappers/platform/Cargo.toml
+++ b/components/bootstrappers/platform/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-platform"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Platform bootstrap plugin for Drasi"

--- a/components/bootstrappers/postgres/Cargo.toml
+++ b/components/bootstrappers/postgres/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-postgres"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "PostgreSQL bootstrap plugin for Drasi"

--- a/components/bootstrappers/scriptfile/Cargo.toml
+++ b/components/bootstrappers/scriptfile/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-scriptfile"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "ScriptFile bootstrap plugin for Drasi"

--- a/components/identity/aws/Cargo.toml
+++ b/components/identity/aws/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-identity-aws"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "AWS identity provider plugin for Drasi"

--- a/components/identity/azure/Cargo.toml
+++ b/components/identity/azure/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-identity-azure"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Azure identity provider plugin for Drasi"

--- a/components/reactions/application/Cargo.toml
+++ b/components/reactions/application/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-application"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Application reaction plugin for Drasi"

--- a/components/reactions/grpc-adaptive/Cargo.toml
+++ b/components/reactions/grpc-adaptive/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-grpc-adaptive"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "gRPC Adaptive reaction plugin for Drasi"

--- a/components/reactions/grpc/Cargo.toml
+++ b/components/reactions/grpc/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-grpc"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "gRPC reaction plugin for Drasi"

--- a/components/reactions/http-adaptive/Cargo.toml
+++ b/components/reactions/http-adaptive/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-http-adaptive"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "HTTP Adaptive reaction plugin for Drasi"

--- a/components/reactions/http/Cargo.toml
+++ b/components/reactions/http/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-http"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "HTTP reaction plugin for Drasi"

--- a/components/reactions/log/Cargo.toml
+++ b/components/reactions/log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-reaction-log"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Log reaction plugin for Drasi"

--- a/components/reactions/platform/Cargo.toml
+++ b/components/reactions/platform/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-platform"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Platform reaction plugin for Drasi"

--- a/components/reactions/profiler/Cargo.toml
+++ b/components/reactions/profiler/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-profiler"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Profiler reaction plugin for Drasi"

--- a/components/reactions/sse/Cargo.toml
+++ b/components/reactions/sse/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-sse"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "SSE reaction plugin for Drasi"

--- a/components/reactions/storedproc-mssql/Cargo.toml
+++ b/components/reactions/storedproc-mssql/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-storedproc-mssql"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "MS SQL Server Stored Procedure reaction plugin for Drasi"

--- a/components/reactions/storedproc-mysql/Cargo.toml
+++ b/components/reactions/storedproc-mysql/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-storedproc-mysql"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "MySQL Stored Procedure reaction plugin for Drasi"

--- a/components/reactions/storedproc-postgres/Cargo.toml
+++ b/components/reactions/storedproc-postgres/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-storedproc-postgres"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "PostgreSQL Stored Procedure reaction plugin for Drasi"

--- a/components/sources/application/Cargo.toml
+++ b/components/sources/application/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-application"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Application source plugin for Drasi"

--- a/components/sources/grpc/Cargo.toml
+++ b/components/sources/grpc/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-grpc"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "gRPC source plugin for Drasi"

--- a/components/sources/http/Cargo.toml
+++ b/components/sources/http/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-http"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "HTTP source plugin for Drasi"

--- a/components/sources/mock/Cargo.toml
+++ b/components/sources/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-source-mock"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Mock source plugin for Drasi"

--- a/components/sources/mssql/Cargo.toml
+++ b/components/sources/mssql/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-mssql"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Microsoft SQL Server CDC source plugin for Drasi"

--- a/components/sources/platform/Cargo.toml
+++ b/components/sources/platform/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-platform"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Platform source plugin for Drasi"

--- a/components/sources/postgres/Cargo.toml
+++ b/components/sources/postgres/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-postgres"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "PostgreSQL source plugin for Drasi"

--- a/components/state_stores/redb/Cargo.toml
+++ b/components/state_stores/redb/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-state-store-redb"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 license = "Apache-2.0"
 description = "Redb-based state store provider for Drasi plugins"


### PR DESCRIPTION
# Description
Some of the plugin crates published to crates.io in release #389 (e.g. drasi-reaction-application 0.2.10, drasi-state-store-redb 0.1.8) ended up with manifests that still pin drasi-plugin-sdk ^0.4.x, even though drasi-lib / drasi-plugin-sdk / drasi-host-sdk were bumped to 0.6.0 in the same release. Because crates.io manifests are immutable, these stale pins cannot be fixed in place — a downstream consumer (e.g. drasi-server) that depends on both drasi-lib 0.6.0 and any of those plugin crates gets an unresolvable graph, since Cargo sees both ^0.4 and ^0.6 of drasi-plugin-sdk and refuses to unify them.


This PR patch-bumps every plugin crate that depends on drasi-lib / drasi-plugin-sdk / drasi-host-sdk / drasi-ffi-primitives so that a fresh set of versions gets published with manifests correctly pinning the 0.6.0 line. No source changes — only version numbers.



## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
