### PR TITLE
Downgrade null-tags pagination log from warn to debug

### DIFF
--- a/components/host-sdk/src/registry/oci.rs
+++ b/components/host-sdk/src/registry/oci.rs
@@ -19,7 +19,7 @@ use crate::registry::types::{
     media_types, PluginMetadataJson, PluginReference, RegistryAuth, RegistryConfig,
 };
 use anyhow::{bail, Context, Result};
-use log::{info, warn};
+use log::{debug, info, warn};
 use oci_client::client::{ClientConfig, ClientProtocol};
 use oci_client::Reference;
 use std::path::{Path, PathBuf};
@@ -117,8 +117,10 @@ impl OciRegistryClient {
                     // Treat this as an empty tag list rather than a hard failure.
                     let err_str = format!("{e:#}");
                     if err_str.contains("invalid type: null") {
-                        warn!(
-                            "Registry returned null tags for {}; treating as empty",
+                        // GHCR returns {"tags": null} on the page after the last
+                        // real page — this is normal end-of-pagination behavior.
+                        debug!(
+                            "Registry returned null tags for {}; end of pagination",
                             oci_ref
                         );
                         break;


### PR DESCRIPTION
## Description

Follow-up to #417. The null-tags handler logs at `warn!` level, but GHCR returns `{"tags": null}` on **every** pagination page 2 — this is normal end-of-pagination behavior, not an exceptional condition. During `plugin install-all`, this produces ~20 warning lines (one per plugin), cluttering the output.

### Change

`warn!` → `debug!` with a clearer message: "end of pagination" instead of "treating as empty".

## Type of change

- Bug fix (non-breaking)