### PR TITLE
fix: lossless config persistence — preserve ConfigValue envelopes, camelCase keys, and passwords

### DIFF
--- a/components/reactions/grpc/src/descriptor.rs
+++ b/components/reactions/grpc/src/descriptor.rs
@@ -135,7 +135,9 @@ impl ReactionPluginDescriptor for GrpcReactionDescriptor {
             builder = builder.with_metadata(key, value);
         }
 
-        let reaction = builder.build()?;
+        let mut reaction = builder.build()?;
+        reaction.base.set_raw_config(config_json.clone());
+
         Ok(Box::new(reaction))
     }
 }

--- a/components/reactions/grpc/src/grpc.rs
+++ b/components/reactions/grpc/src/grpc.rs
@@ -37,7 +37,7 @@ use crate::proto::{
 
 /// gRPC reaction that sends query results to an external gRPC service
 pub struct GrpcReaction {
-    base: ReactionBase,
+    pub(crate) base: ReactionBase,
     config: GrpcReactionConfig,
 }
 
@@ -356,6 +356,10 @@ impl Reaction for GrpcReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
         use crate::descriptor::GrpcReactionConfigDto;
         use drasi_plugin_sdk::ConfigValue;
 

--- a/components/reactions/grpc/src/grpc.rs
+++ b/components/reactions/grpc/src/grpc.rs
@@ -356,10 +356,6 @@ impl Reaction for GrpcReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
-
         use crate::descriptor::GrpcReactionConfigDto;
         use drasi_plugin_sdk::ConfigValue;
 
@@ -378,10 +374,7 @@ impl Reaction for GrpcReaction {
             metadata: self.config.metadata.clone(),
         };
 
-        match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base.properties_or_serialize(&dto)
     }
 
     fn query_ids(&self) -> Vec<String> {

--- a/components/reactions/http/src/descriptor.rs
+++ b/components/reactions/http/src/descriptor.rs
@@ -159,7 +159,9 @@ impl ReactionPluginDescriptor for HttpReactionDescriptor {
             builder = builder.with_route(query_id, map_query_config(config));
         }
 
-        let reaction = builder.build()?;
+        let mut reaction = builder.build()?;
+        reaction.base.set_raw_config(config_json.clone());
+
         Ok(Box::new(reaction))
     }
 }

--- a/components/reactions/http/src/http.rs
+++ b/components/reactions/http/src/http.rs
@@ -33,7 +33,7 @@ use drasi_lib::Reaction;
 use super::HttpReactionBuilder;
 
 pub struct HttpReaction {
-    base: ReactionBase,
+    pub(crate) base: ReactionBase,
     config: HttpReactionConfig,
 }
 
@@ -242,6 +242,10 @@ impl Reaction for HttpReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
         use crate::descriptor::{CallSpecDto, HttpQueryConfigDto, HttpReactionConfigDto};
         use drasi_plugin_sdk::ConfigValue;
 

--- a/components/reactions/http/src/http.rs
+++ b/components/reactions/http/src/http.rs
@@ -242,10 +242,6 @@ impl Reaction for HttpReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
-
         use crate::descriptor::{CallSpecDto, HttpQueryConfigDto, HttpReactionConfigDto};
         use drasi_plugin_sdk::ConfigValue;
 
@@ -282,10 +278,7 @@ impl Reaction for HttpReaction {
                 .collect(),
         };
 
-        match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base.properties_or_serialize(&dto)
     }
 
     fn query_ids(&self) -> Vec<String> {

--- a/components/reactions/log/src/descriptor.rs
+++ b/components/reactions/log/src/descriptor.rs
@@ -128,7 +128,9 @@ impl ReactionPluginDescriptor for LogReactionDescriptor {
             builder = builder.with_route(query_id, map_query_config(config));
         }
 
-        let reaction = builder.build()?;
+        let mut reaction = builder.build()?;
+        reaction.base.set_raw_config(config_json.clone());
+
         Ok(Box::new(reaction))
     }
 }

--- a/components/reactions/log/src/log.rs
+++ b/components/reactions/log/src/log.rs
@@ -26,7 +26,7 @@ use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
 use drasi_lib::Reaction;
 
 pub struct LogReaction {
-    base: ReactionBase,
+    pub(crate) base: ReactionBase,
     config: LogReactionConfig,
 }
 
@@ -328,6 +328,10 @@ impl Reaction for LogReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
         use crate::descriptor::{LogReactionConfigDto, QueryConfigDto, TemplateSpecDto};
 
         fn map_spec_to_dto(spec: &crate::TemplateSpec) -> TemplateSpecDto {

--- a/components/reactions/log/src/log.rs
+++ b/components/reactions/log/src/log.rs
@@ -328,10 +328,6 @@ impl Reaction for LogReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
-
         use crate::descriptor::{LogReactionConfigDto, QueryConfigDto, TemplateSpecDto};
 
         fn map_spec_to_dto(spec: &crate::TemplateSpec) -> TemplateSpecDto {
@@ -358,10 +354,7 @@ impl Reaction for LogReaction {
             default_template: self.config.default_template.as_ref().map(map_qc_to_dto),
         };
 
-        match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base.properties_or_serialize(&dto)
     }
 
     fn query_ids(&self) -> Vec<String> {

--- a/components/reactions/sse/src/descriptor.rs
+++ b/components/reactions/sse/src/descriptor.rs
@@ -172,7 +172,9 @@ impl ReactionPluginDescriptor for SseReactionDescriptor {
             builder = builder.with_route(query_id, map_query_config(config));
         }
 
-        let reaction = builder.build()?;
+        let mut reaction = builder.build()?;
+        reaction.base.set_raw_config(config_json.clone());
+
         Ok(Box::new(reaction))
     }
 }

--- a/components/reactions/sse/src/descriptor.rs
+++ b/components/reactions/sse/src/descriptor.rs
@@ -105,6 +105,45 @@ fn map_query_config(dto: &SseQueryConfigDto) -> crate::QueryConfig {
     }
 }
 
+impl From<&crate::TemplateSpec> for SseTemplateSpecDto {
+    fn from(spec: &crate::TemplateSpec) -> Self {
+        Self {
+            template: spec.template.clone(),
+            path: spec.extension.path.clone(),
+        }
+    }
+}
+
+impl From<&crate::QueryConfig> for SseQueryConfigDto {
+    fn from(config: &crate::QueryConfig) -> Self {
+        Self {
+            added: config.added.as_ref().map(SseTemplateSpecDto::from),
+            updated: config.updated.as_ref().map(SseTemplateSpecDto::from),
+            deleted: config.deleted.as_ref().map(SseTemplateSpecDto::from),
+        }
+    }
+}
+
+impl From<&crate::SseReactionConfig> for SseReactionConfigDto {
+    fn from(config: &crate::SseReactionConfig) -> Self {
+        Self {
+            host: Some(ConfigValue::Static(config.host.clone())),
+            port: Some(ConfigValue::Static(config.port)),
+            sse_path: Some(ConfigValue::Static(config.sse_path.clone())),
+            heartbeat_interval_ms: Some(ConfigValue::Static(config.heartbeat_interval_ms)),
+            routes: config
+                .routes
+                .iter()
+                .map(|(k, v)| (k.clone(), SseQueryConfigDto::from(v)))
+                .collect(),
+            default_template: config
+                .default_template
+                .as_ref()
+                .map(SseQueryConfigDto::from),
+        }
+    }
+}
+
 #[derive(OpenApi)]
 #[openapi(components(schemas(SseReactionConfigDto, SseQueryConfigDto, SseTemplateSpecDto,)))]
 struct SseReactionSchemas;

--- a/components/reactions/sse/src/sse.rs
+++ b/components/reactions/sse/src/sse.rs
@@ -78,7 +78,7 @@ fn pre_create_broadcasters_for_query_config(
 
 /// SSE reaction exposes query results to browser clients via Server-Sent Events.
 pub struct SseReaction {
-    base: ReactionBase,
+    pub(crate) base: ReactionBase,
     config: SseReactionConfig,
     broadcasters: Arc<tokio::sync::RwLock<HashMap<String, broadcast::Sender<String>>>>,
     task_handles: Arc<tokio::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>>,
@@ -228,6 +228,11 @@ impl Reaction for SseReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
+        // Fallback for builder-created components (no descriptor / no raw_config).
         match serde_json::to_value(&self.config) {
             Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
             _ => HashMap::new(),

--- a/components/reactions/sse/src/sse.rs
+++ b/components/reactions/sse/src/sse.rs
@@ -228,15 +228,10 @@ impl Reaction for SseReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
+        use crate::descriptor::SseReactionConfigDto;
 
-        // Fallback for builder-created components (no descriptor / no raw_config).
-        match serde_json::to_value(&self.config) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base
+            .properties_or_serialize(&SseReactionConfigDto::from(&self.config))
     }
 
     fn query_ids(&self) -> Vec<String> {

--- a/components/reactions/sse/src/tests.rs
+++ b/components/reactions/sse/src/tests.rs
@@ -62,7 +62,7 @@ fn test_sse_builder_with_heartbeat() {
     let props = reaction.properties();
     assert_eq!(reaction.id(), "test-reaction");
     assert_eq!(
-        props.get("sse_path"),
+        props.get("ssePath"),
         Some(&serde_json::Value::String("/events".to_string()))
     );
 }
@@ -104,7 +104,7 @@ fn test_sse_builder_chaining() {
         Some(&serde_json::Value::Number(3000.into()))
     );
     assert_eq!(
-        props.get("sse_path"),
+        props.get("ssePath"),
         Some(&serde_json::Value::String("/events/stream".to_string()))
     );
 }
@@ -352,4 +352,54 @@ fn test_config_with_default_template_serialization() {
     let deserialized: SseReactionConfig = serde_json::from_str(&serialized).unwrap();
 
     assert_eq!(config, deserialized);
+}
+
+#[test]
+fn test_builder_fallback_produces_camel_case() {
+    let reaction = SseReactionBuilder::new("sse-fallback")
+        .with_host("127.0.0.1")
+        .with_port(9090)
+        .with_sse_path("/custom-events")
+        .with_heartbeat_interval_ms(15000)
+        .with_queries(vec!["q1".to_string()])
+        .build()
+        .unwrap();
+
+    let props = reaction.properties();
+
+    // Must use camelCase keys (DTO serialization)
+    assert!(
+        props.contains_key("ssePath"),
+        "expected camelCase 'ssePath', got keys: {:?}",
+        props.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        props.contains_key("heartbeatIntervalMs"),
+        "expected camelCase 'heartbeatIntervalMs'"
+    );
+
+    // Must NOT have snake_case keys
+    assert!(
+        !props.contains_key("sse_path"),
+        "should not have snake_case 'sse_path'"
+    );
+    assert!(
+        !props.contains_key("heartbeat_interval_ms"),
+        "should not have snake_case 'heartbeat_interval_ms'"
+    );
+
+    // Values should be correct
+    assert_eq!(
+        props.get("host").and_then(|v| v.as_str()),
+        Some("127.0.0.1")
+    );
+    assert_eq!(props.get("port").and_then(|v| v.as_u64()), Some(9090));
+    assert_eq!(
+        props.get("ssePath").and_then(|v| v.as_str()),
+        Some("/custom-events")
+    );
+    assert_eq!(
+        props.get("heartbeatIntervalMs").and_then(|v| v.as_u64()),
+        Some(15000)
+    );
 }

--- a/components/reactions/storedproc-mssql/src/descriptor.rs
+++ b/components/reactions/storedproc-mssql/src/descriptor.rs
@@ -188,7 +188,9 @@ impl ReactionPluginDescriptor for MsSqlStoredProcReactionDescriptor {
             builder = builder.with_route(query_id, map_query_config(config));
         }
 
-        let reaction = builder.build().await?;
+        let mut reaction = builder.build().await?;
+        reaction.base.set_raw_config(config_json.clone());
+
         Ok(Box::new(reaction))
     }
 }

--- a/components/reactions/storedproc-mssql/src/reaction.rs
+++ b/components/reactions/storedproc-mssql/src/reaction.rs
@@ -38,7 +38,7 @@ use crate::parser::ParameterParser;
 /// Invokes MS SQL Server stored procedures when continuous query results change.
 /// Supports different procedures for ADD, UPDATE, and DELETE operations.
 pub struct MsSqlStoredProcReaction {
-    base: ReactionBase,
+    pub(crate) base: ReactionBase,
     config: MsSqlStoredProcReactionConfig,
     executor: RwLock<Option<Arc<MsSqlExecutor>>>,
     parser: ParameterParser,
@@ -269,6 +269,10 @@ impl Reaction for MsSqlStoredProcReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
         use crate::descriptor::{
             MsSqlStoredProcReactionConfigDto, StoredProcQueryConfigDto, StoredProcTemplateSpecDto,
         };
@@ -307,11 +311,7 @@ impl Reaction for MsSqlStoredProcReaction {
         };
 
         match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(mut map)) => {
-                // Don't expose password
-                map.remove("password");
-                map.into_iter().collect()
-            }
+            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
             _ => HashMap::new(),
         }
     }

--- a/components/reactions/storedproc-mssql/src/reaction.rs
+++ b/components/reactions/storedproc-mssql/src/reaction.rs
@@ -269,10 +269,6 @@ impl Reaction for MsSqlStoredProcReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
-
         use crate::descriptor::{
             MsSqlStoredProcReactionConfigDto, StoredProcQueryConfigDto, StoredProcTemplateSpecDto,
         };
@@ -310,10 +306,7 @@ impl Reaction for MsSqlStoredProcReaction {
             retry_attempts: Some(ConfigValue::Static(self.config.retry_attempts)),
         };
 
-        match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base.properties_or_serialize(&dto)
     }
 
     fn query_ids(&self) -> Vec<String> {

--- a/components/reactions/storedproc-mysql/src/descriptor.rs
+++ b/components/reactions/storedproc-mysql/src/descriptor.rs
@@ -188,7 +188,9 @@ impl ReactionPluginDescriptor for MySqlStoredProcReactionDescriptor {
             builder = builder.with_route(query_id, map_query_config(config));
         }
 
-        let reaction = builder.build().await?;
+        let mut reaction = builder.build().await?;
+        reaction.base.set_raw_config(config_json.clone());
+
         Ok(Box::new(reaction))
     }
 }

--- a/components/reactions/storedproc-mysql/src/reaction.rs
+++ b/components/reactions/storedproc-mysql/src/reaction.rs
@@ -38,7 +38,7 @@ use drasi_lib::reactions::common::OperationType;
 /// Invokes MySQL stored procedures when continuous query results change.
 /// Supports different procedures for ADD, UPDATE, and DELETE operations.
 pub struct MySqlStoredProcReaction {
-    base: ReactionBase,
+    pub(crate) base: ReactionBase,
     config: MySqlStoredProcReactionConfig,
     executor: RwLock<Option<Arc<MySqlExecutor>>>,
     parser: ParameterParser,
@@ -268,6 +268,10 @@ impl Reaction for MySqlStoredProcReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
         use crate::descriptor::{
             MySqlStoredProcReactionConfigDto, StoredProcQueryConfigDto, StoredProcTemplateSpecDto,
         };
@@ -306,11 +310,7 @@ impl Reaction for MySqlStoredProcReaction {
         };
 
         match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(mut map)) => {
-                // Don't expose password
-                map.remove("password");
-                map.into_iter().collect()
-            }
+            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
             _ => HashMap::new(),
         }
     }

--- a/components/reactions/storedproc-mysql/src/reaction.rs
+++ b/components/reactions/storedproc-mysql/src/reaction.rs
@@ -268,10 +268,6 @@ impl Reaction for MySqlStoredProcReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
-
         use crate::descriptor::{
             MySqlStoredProcReactionConfigDto, StoredProcQueryConfigDto, StoredProcTemplateSpecDto,
         };
@@ -309,10 +305,7 @@ impl Reaction for MySqlStoredProcReaction {
             retry_attempts: Some(ConfigValue::Static(self.config.retry_attempts)),
         };
 
-        match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base.properties_or_serialize(&dto)
     }
 
     fn query_ids(&self) -> Vec<String> {

--- a/components/reactions/storedproc-postgres/src/descriptor.rs
+++ b/components/reactions/storedproc-postgres/src/descriptor.rs
@@ -188,7 +188,9 @@ impl ReactionPluginDescriptor for PostgresStoredProcReactionDescriptor {
             builder = builder.with_route(query_id, map_query_config(config));
         }
 
-        let reaction = builder.build().await?;
+        let mut reaction = builder.build().await?;
+        reaction.base.set_raw_config(config_json.clone());
+
         Ok(Box::new(reaction))
     }
 }

--- a/components/reactions/storedproc-postgres/src/reaction.rs
+++ b/components/reactions/storedproc-postgres/src/reaction.rs
@@ -38,7 +38,7 @@ use drasi_lib::reactions::common::OperationType;
 /// Invokes PostgreSQL stored procedures when continuous query results change.
 /// Supports different procedures for ADD, UPDATE, and DELETE operations.
 pub struct PostgresStoredProcReaction {
-    base: ReactionBase,
+    pub(crate) base: ReactionBase,
     config: PostgresStoredProcReactionConfig,
     executor: RwLock<Option<Arc<PostgresExecutor>>>,
     parser: ParameterParser,
@@ -279,6 +279,10 @@ impl Reaction for PostgresStoredProcReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
         use crate::descriptor::{
             PostgresStoredProcReactionConfigDto, StoredProcQueryConfigDto,
             StoredProcTemplateSpecDto,
@@ -318,11 +322,7 @@ impl Reaction for PostgresStoredProcReaction {
         };
 
         match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(mut map)) => {
-                // Don't expose password
-                map.remove("password");
-                map.into_iter().collect()
-            }
+            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
             _ => HashMap::new(),
         }
     }

--- a/components/reactions/storedproc-postgres/src/reaction.rs
+++ b/components/reactions/storedproc-postgres/src/reaction.rs
@@ -279,10 +279,6 @@ impl Reaction for PostgresStoredProcReaction {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
-
         use crate::descriptor::{
             PostgresStoredProcReactionConfigDto, StoredProcQueryConfigDto,
             StoredProcTemplateSpecDto,
@@ -321,10 +317,7 @@ impl Reaction for PostgresStoredProcReaction {
             retry_attempts: Some(ConfigValue::Static(self.config.retry_attempts)),
         };
 
-        match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base.properties_or_serialize(&dto)
     }
 
     fn query_ids(&self) -> Vec<String> {

--- a/components/sources/grpc/src/descriptor.rs
+++ b/components/sources/grpc/src/descriptor.rs
@@ -93,10 +93,12 @@ impl SourcePluginDescriptor for GrpcSourceDescriptor {
             timeout_ms: mapper.resolve_typed(&dto.timeout_ms)?,
         };
 
-        let source = GrpcSourceBuilder::new(id)
+        let mut source = GrpcSourceBuilder::new(id)
             .with_config(config)
             .with_auto_start(auto_start)
             .build()?;
+
+        source.base.set_raw_config(config_json.clone());
 
         Ok(Box::new(source))
     }

--- a/components/sources/grpc/src/lib.rs
+++ b/components/sources/grpc/src/lib.rs
@@ -246,6 +246,10 @@ impl Source for GrpcSource {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
         use crate::descriptor::GrpcSourceConfigDto;
         use drasi_plugin_sdk::ConfigValue;
 

--- a/components/sources/grpc/src/lib.rs
+++ b/components/sources/grpc/src/lib.rs
@@ -246,10 +246,6 @@ impl Source for GrpcSource {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
-
         use crate::descriptor::GrpcSourceConfigDto;
         use drasi_plugin_sdk::ConfigValue;
 
@@ -264,10 +260,7 @@ impl Source for GrpcSource {
             timeout_ms: ConfigValue::Static(self.config.timeout_ms),
         };
 
-        match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base.properties_or_serialize(&dto)
     }
 
     fn auto_start(&self) -> bool {

--- a/components/sources/http/src/descriptor.rs
+++ b/components/sources/http/src/descriptor.rs
@@ -602,10 +602,12 @@ impl SourcePluginDescriptor for HttpSourceDescriptor {
                 .transpose()?,
         };
 
-        let source = HttpSourceBuilder::new(id)
+        let mut source = HttpSourceBuilder::new(id)
             .with_config(config)
             .with_auto_start(auto_start)
             .build()?;
+
+        source.base.set_raw_config(config_json.clone());
 
         Ok(Box::new(source))
     }

--- a/components/sources/http/src/descriptor.rs
+++ b/components/sources/http/src/descriptor.rs
@@ -524,6 +524,243 @@ fn map_element_template(
     })
 }
 
+// --- Reverse mapping: internal config → DTO ---
+
+impl From<&ErrorBehavior> for ErrorBehaviorDto {
+    fn from(eb: &ErrorBehavior) -> Self {
+        match eb {
+            ErrorBehavior::AcceptAndLog => ErrorBehaviorDto::AcceptAndLog,
+            ErrorBehavior::AcceptAndSkip => ErrorBehaviorDto::AcceptAndSkip,
+            ErrorBehavior::Reject => ErrorBehaviorDto::Reject,
+        }
+    }
+}
+
+impl From<&HttpMethod> for HttpMethodDto {
+    fn from(m: &HttpMethod) -> Self {
+        match m {
+            HttpMethod::Get => HttpMethodDto::Get,
+            HttpMethod::Post => HttpMethodDto::Post,
+            HttpMethod::Put => HttpMethodDto::Put,
+            HttpMethod::Patch => HttpMethodDto::Patch,
+            HttpMethod::Delete => HttpMethodDto::Delete,
+        }
+    }
+}
+
+impl From<&SignatureAlgorithm> for SignatureAlgorithmDto {
+    fn from(a: &SignatureAlgorithm) -> Self {
+        match a {
+            SignatureAlgorithm::HmacSha1 => SignatureAlgorithmDto::HmacSha1,
+            SignatureAlgorithm::HmacSha256 => SignatureAlgorithmDto::HmacSha256,
+        }
+    }
+}
+
+impl From<&SignatureEncoding> for SignatureEncodingDto {
+    fn from(e: &SignatureEncoding) -> Self {
+        match e {
+            SignatureEncoding::Hex => SignatureEncodingDto::Hex,
+            SignatureEncoding::Base64 => SignatureEncodingDto::Base64,
+        }
+    }
+}
+
+impl From<&OperationType> for OperationTypeDto {
+    fn from(op: &OperationType) -> Self {
+        match op {
+            OperationType::Insert => OperationTypeDto::Insert,
+            OperationType::Update => OperationTypeDto::Update,
+            OperationType::Delete => OperationTypeDto::Delete,
+        }
+    }
+}
+
+impl From<&ElementType> for ElementTypeDto {
+    fn from(et: &ElementType) -> Self {
+        match et {
+            ElementType::Node => ElementTypeDto::Node,
+            ElementType::Relation => ElementTypeDto::Relation,
+        }
+    }
+}
+
+impl From<&TimestampFormat> for TimestampFormatDto {
+    fn from(f: &TimestampFormat) -> Self {
+        match f {
+            TimestampFormat::Iso8601 => TimestampFormatDto::Iso8601,
+            TimestampFormat::UnixSeconds => TimestampFormatDto::UnixSeconds,
+            TimestampFormat::UnixMillis => TimestampFormatDto::UnixMillis,
+            TimestampFormat::UnixNanos => TimestampFormatDto::UnixNanos,
+        }
+    }
+}
+
+impl From<&MappingCondition> for MappingConditionDto {
+    fn from(c: &MappingCondition) -> Self {
+        Self {
+            header: c.header.as_ref().map(|v| ConfigValue::Static(v.clone())),
+            field: c.field.as_ref().map(|v| ConfigValue::Static(v.clone())),
+            equals: c.equals.as_ref().map(|v| ConfigValue::Static(v.clone())),
+            contains: c.contains.as_ref().map(|v| ConfigValue::Static(v.clone())),
+            regex: c.regex.as_ref().map(|v| ConfigValue::Static(v.clone())),
+        }
+    }
+}
+
+impl From<&EffectiveFromConfig> for EffectiveFromConfigDto {
+    fn from(e: &EffectiveFromConfig) -> Self {
+        match e {
+            EffectiveFromConfig::Simple(v) => {
+                EffectiveFromConfigDto::Simple(ConfigValue::Static(v.clone()))
+            }
+            EffectiveFromConfig::Explicit { value, format } => EffectiveFromConfigDto::Explicit {
+                value: ConfigValue::Static(value.clone()),
+                format: TimestampFormatDto::from(format),
+            },
+        }
+    }
+}
+
+impl From<&ElementTemplate> for ElementTemplateDto {
+    fn from(t: &ElementTemplate) -> Self {
+        Self {
+            id: ConfigValue::Static(t.id.clone()),
+            labels: t
+                .labels
+                .iter()
+                .map(|l| ConfigValue::Static(l.clone()))
+                .collect(),
+            properties: t.properties.clone(),
+            from: t.from.as_ref().map(|v| ConfigValue::Static(v.clone())),
+            to: t.to.as_ref().map(|v| ConfigValue::Static(v.clone())),
+        }
+    }
+}
+
+impl From<&WebhookMapping> for WebhookMappingDto {
+    fn from(m: &WebhookMapping) -> Self {
+        Self {
+            when: m.when.as_ref().map(MappingConditionDto::from),
+            operation: m.operation.as_ref().map(OperationTypeDto::from),
+            operation_from: m
+                .operation_from
+                .as_ref()
+                .map(|v| ConfigValue::Static(v.clone())),
+            operation_map: m.operation_map.as_ref().map(|om| {
+                om.iter()
+                    .map(|(k, v)| (k.clone(), OperationTypeDto::from(v)))
+                    .collect()
+            }),
+            element_type: ElementTypeDto::from(&m.element_type),
+            effective_from: m.effective_from.as_ref().map(EffectiveFromConfigDto::from),
+            template: ElementTemplateDto::from(&m.template),
+        }
+    }
+}
+
+impl From<&SignatureConfig> for SignatureConfigDto {
+    fn from(s: &SignatureConfig) -> Self {
+        Self {
+            algorithm: SignatureAlgorithmDto::from(&s.algorithm),
+            secret_env: ConfigValue::Static(s.secret_env.clone()),
+            header: ConfigValue::Static(s.header.clone()),
+            prefix: s.prefix.as_ref().map(|v| ConfigValue::Static(v.clone())),
+            encoding: SignatureEncodingDto::from(&s.encoding),
+        }
+    }
+}
+
+impl From<&BearerConfig> for BearerConfigDto {
+    fn from(b: &BearerConfig) -> Self {
+        Self {
+            token_env: ConfigValue::Static(b.token_env.clone()),
+        }
+    }
+}
+
+impl From<&AuthConfig> for AuthConfigDto {
+    fn from(a: &AuthConfig) -> Self {
+        Self {
+            signature: a.signature.as_ref().map(SignatureConfigDto::from),
+            bearer: a.bearer.as_ref().map(BearerConfigDto::from),
+        }
+    }
+}
+
+impl From<&WebhookRoute> for WebhookRouteDto {
+    fn from(r: &WebhookRoute) -> Self {
+        Self {
+            path: ConfigValue::Static(r.path.clone()),
+            methods: r.methods.iter().map(HttpMethodDto::from).collect(),
+            auth: r.auth.as_ref().map(AuthConfigDto::from),
+            error_behavior: r.error_behavior.as_ref().map(ErrorBehaviorDto::from),
+            mappings: r.mappings.iter().map(WebhookMappingDto::from).collect(),
+        }
+    }
+}
+
+impl From<&CorsConfig> for CorsConfigDto {
+    fn from(c: &CorsConfig) -> Self {
+        Self {
+            enabled: c.enabled,
+            allow_origins: c
+                .allow_origins
+                .iter()
+                .map(|v| ConfigValue::Static(v.clone()))
+                .collect(),
+            allow_methods: c
+                .allow_methods
+                .iter()
+                .map(|v| ConfigValue::Static(v.clone()))
+                .collect(),
+            allow_headers: c
+                .allow_headers
+                .iter()
+                .map(|v| ConfigValue::Static(v.clone()))
+                .collect(),
+            expose_headers: c
+                .expose_headers
+                .iter()
+                .map(|v| ConfigValue::Static(v.clone()))
+                .collect(),
+            allow_credentials: c.allow_credentials,
+            max_age: c.max_age,
+        }
+    }
+}
+
+impl From<&WebhookConfig> for WebhookConfigDto {
+    fn from(w: &WebhookConfig) -> Self {
+        Self {
+            error_behavior: ErrorBehaviorDto::from(&w.error_behavior),
+            cors: w.cors.as_ref().map(CorsConfigDto::from),
+            routes: w.routes.iter().map(WebhookRouteDto::from).collect(),
+        }
+    }
+}
+
+impl From<&HttpSourceConfig> for HttpSourceConfigDto {
+    fn from(config: &HttpSourceConfig) -> Self {
+        Self {
+            host: ConfigValue::Static(config.host.clone()),
+            port: ConfigValue::Static(config.port),
+            endpoint: config
+                .endpoint
+                .as_ref()
+                .map(|v| ConfigValue::Static(v.clone())),
+            timeout_ms: ConfigValue::Static(config.timeout_ms),
+            adaptive_max_batch_size: config.adaptive_max_batch_size.map(ConfigValue::Static),
+            adaptive_min_batch_size: config.adaptive_min_batch_size.map(ConfigValue::Static),
+            adaptive_max_wait_ms: config.adaptive_max_wait_ms.map(ConfigValue::Static),
+            adaptive_min_wait_ms: config.adaptive_min_wait_ms.map(ConfigValue::Static),
+            adaptive_window_secs: config.adaptive_window_secs.map(ConfigValue::Static),
+            adaptive_enabled: config.adaptive_enabled.map(ConfigValue::Static),
+            webhooks: config.webhooks.as_ref().map(WebhookConfigDto::from),
+        }
+    }
+}
+
 #[derive(OpenApi)]
 #[openapi(components(schemas(
     HttpSourceConfigDto,

--- a/components/sources/http/src/lib.rs
+++ b/components/sources/http/src/lib.rs
@@ -899,6 +899,11 @@ impl Source for HttpSource {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
+        // Fallback for builder-created components (no descriptor / no raw_config).
         match serde_json::to_value(&self.config) {
             Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
             _ => HashMap::new(),

--- a/components/sources/http/src/lib.rs
+++ b/components/sources/http/src/lib.rs
@@ -899,15 +899,10 @@ impl Source for HttpSource {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
+        use crate::descriptor::HttpSourceConfigDto;
 
-        // Fallback for builder-created components (no descriptor / no raw_config).
-        match serde_json::to_value(&self.config) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base
+            .properties_or_serialize(&HttpSourceConfigDto::from(&self.config))
     }
 
     fn auto_start(&self) -> bool {
@@ -1922,6 +1917,75 @@ mod tests {
                 default_config.min_batch_size
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod fallback_tests {
+    use super::*;
+    use drasi_lib::sources::Source;
+
+    #[test]
+    fn test_builder_fallback_produces_camel_case() {
+        let source = HttpSourceBuilder::new("http-fallback")
+            .with_host("0.0.0.0")
+            .with_port(9090)
+            .with_endpoint("/ingest")
+            .with_timeout_ms(5000)
+            .with_adaptive_max_batch_size(500)
+            .with_adaptive_min_batch_size(10)
+            .with_adaptive_max_wait_ms(2000)
+            .with_adaptive_min_wait_ms(100)
+            .build()
+            .unwrap();
+
+        let props = source.properties();
+
+        // Must use camelCase keys (DTO serialization)
+        assert!(
+            props.contains_key("timeoutMs"),
+            "expected camelCase 'timeoutMs', got keys: {:?}",
+            props.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            props.contains_key("adaptiveMaxBatchSize"),
+            "expected camelCase 'adaptiveMaxBatchSize'"
+        );
+        assert!(
+            props.contains_key("adaptiveMinBatchSize"),
+            "expected camelCase 'adaptiveMinBatchSize'"
+        );
+        assert!(
+            props.contains_key("adaptiveMaxWaitMs"),
+            "expected camelCase 'adaptiveMaxWaitMs'"
+        );
+        assert!(
+            props.contains_key("adaptiveMinWaitMs"),
+            "expected camelCase 'adaptiveMinWaitMs'"
+        );
+
+        // Must NOT have snake_case keys
+        assert!(
+            !props.contains_key("timeout_ms"),
+            "should not have snake_case 'timeout_ms'"
+        );
+        assert!(
+            !props.contains_key("adaptive_max_batch_size"),
+            "should not have snake_case 'adaptive_max_batch_size'"
+        );
+
+        // Values should be correct
+        assert_eq!(props.get("host").and_then(|v| v.as_str()), Some("0.0.0.0"));
+        assert_eq!(props.get("port").and_then(|v| v.as_u64()), Some(9090));
+        assert_eq!(
+            props.get("endpoint").and_then(|v| v.as_str()),
+            Some("/ingest")
+        );
+        assert_eq!(props.get("timeoutMs").and_then(|v| v.as_u64()), Some(5000));
+        assert_eq!(
+            props.get("adaptiveMaxBatchSize").and_then(|v| v.as_u64()),
+            Some(500)
+        );
     }
 }
 

--- a/components/sources/mock/src/descriptor.rs
+++ b/components/sources/mock/src/descriptor.rs
@@ -103,11 +103,13 @@ impl SourcePluginDescriptor for MockSourceDescriptor {
 
         let interval_ms: u64 = mapper.resolve_typed(&dto.interval_ms)?;
 
-        let source = MockSourceBuilder::new(id)
+        let mut source = MockSourceBuilder::new(id)
             .with_data_type(data_type)
             .with_interval_ms(interval_ms)
             .with_auto_start(auto_start)
             .build()?;
+
+        source.base.set_raw_config(config_json.clone());
 
         Ok(Box::new(source))
     }

--- a/components/sources/mock/src/mock.rs
+++ b/components/sources/mock/src/mock.rs
@@ -48,7 +48,7 @@ use tracing::Instrument;
 /// Internal state is protected by `RwLock`.
 pub struct MockSource {
     /// Base source implementation providing dispatchers, status tracking, and lifecycle management.
-    base: SourceBase,
+    pub(crate) base: SourceBase,
 
     /// Configuration specifying data type and generation interval.
     config: MockSourceConfig,
@@ -154,6 +154,10 @@ impl Source for MockSource {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
         // Serialize through the DTO to get camelCase naming and structured output
         // matching the creation schema and config file format
         use crate::descriptor::{DataTypeDto, MockSourceConfigDto};

--- a/components/sources/mock/src/mock.rs
+++ b/components/sources/mock/src/mock.rs
@@ -154,10 +154,6 @@ impl Source for MockSource {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
-
         // Serialize through the DTO to get camelCase naming and structured output
         // matching the creation schema and config file format
         use crate::descriptor::{DataTypeDto, MockSourceConfigDto};
@@ -176,10 +172,7 @@ impl Source for MockSource {
             interval_ms: ConfigValue::Static(self.config.interval_ms),
         };
 
-        match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base.properties_or_serialize(&dto)
     }
 
     fn auto_start(&self) -> bool {

--- a/components/sources/mssql/src/descriptor.rs
+++ b/components/sources/mssql/src/descriptor.rs
@@ -254,7 +254,9 @@ impl SourcePluginDescriptor for MsSqlSourceDescriptor {
             builder = builder.with_table_key(tk.table.clone(), tk.key_columns.clone());
         }
 
-        let source = builder.build()?;
+        let mut source = builder.build()?;
+        source.base.set_raw_config(config_json.clone());
+
         Ok(Box::new(source))
     }
 }

--- a/components/sources/mssql/src/lib.rs
+++ b/components/sources/mssql/src/lib.rs
@@ -185,6 +185,10 @@ impl Source for MsSqlSource {
     }
 
     fn properties(&self) -> std::collections::HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
         use crate::descriptor::{
             AuthModeDto, EncryptionModeDto, MsSqlSourceConfigDto, StartPositionDto,
             TableKeyConfigDto,
@@ -234,11 +238,7 @@ impl Source for MsSqlSource {
         };
 
         match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(mut map)) => {
-                // Don't expose password
-                map.remove("password");
-                map.into_iter().collect()
-            }
+            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
             _ => std::collections::HashMap::new(),
         }
     }

--- a/components/sources/mssql/src/lib.rs
+++ b/components/sources/mssql/src/lib.rs
@@ -185,10 +185,6 @@ impl Source for MsSqlSource {
     }
 
     fn properties(&self) -> std::collections::HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
-
         use crate::descriptor::{
             AuthModeDto, EncryptionModeDto, MsSqlSourceConfigDto, StartPositionDto,
             TableKeyConfigDto,
@@ -237,10 +233,7 @@ impl Source for MsSqlSource {
             start_position: ConfigValue::Static(start_position_dto),
         };
 
-        match serde_json::to_value(&dto) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => std::collections::HashMap::new(),
-        }
+        self.base.properties_or_serialize(&dto)
     }
 
     fn auto_start(&self) -> bool {

--- a/components/sources/postgres/src/descriptor.rs
+++ b/components/sources/postgres/src/descriptor.rs
@@ -173,10 +173,12 @@ impl SourcePluginDescriptor for PostgresSourceDescriptor {
                 .collect(),
         };
 
-        let source = crate::PostgresSourceBuilder::new(id)
+        let mut source = crate::PostgresSourceBuilder::new(id)
             .with_config(config)
             .with_auto_start(auto_start)
             .build()?;
+
+        source.base.set_raw_config(config_json.clone());
 
         Ok(Box::new(source))
     }

--- a/components/sources/postgres/src/descriptor.rs
+++ b/components/sources/postgres/src/descriptor.rs
@@ -80,6 +80,46 @@ impl From<SslModeDto> for SslMode {
     }
 }
 
+impl From<&SslMode> for SslModeDto {
+    fn from(mode: &SslMode) -> Self {
+        match mode {
+            SslMode::Disable => SslModeDto::Disable,
+            SslMode::Prefer => SslModeDto::Prefer,
+            SslMode::Require => SslModeDto::Require,
+        }
+    }
+}
+
+impl From<&TableKeyConfig> for TableKeyConfigDto {
+    fn from(tk: &TableKeyConfig) -> Self {
+        Self {
+            table: tk.table.clone(),
+            key_columns: tk.key_columns.clone(),
+        }
+    }
+}
+
+impl From<&PostgresSourceConfig> for PostgresSourceConfigDto {
+    fn from(config: &PostgresSourceConfig) -> Self {
+        Self {
+            host: ConfigValue::Static(config.host.clone()),
+            port: ConfigValue::Static(config.port),
+            database: ConfigValue::Static(config.database.clone()),
+            user: ConfigValue::Static(config.user.clone()),
+            password: ConfigValue::Static(config.password.clone()),
+            tables: config.tables.clone(),
+            slot_name: config.slot_name.clone(),
+            publication_name: config.publication_name.clone(),
+            ssl_mode: ConfigValue::Static(SslModeDto::from(&config.ssl_mode)),
+            table_keys: config
+                .table_keys
+                .iter()
+                .map(TableKeyConfigDto::from)
+                .collect(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
 #[schema(as = source::postgres::TableKeyConfig)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/components/sources/postgres/src/lib.rs
+++ b/components/sources/postgres/src/lib.rs
@@ -305,11 +305,13 @@ impl Source for PostgresReplicationSource {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
+        // Fallback for builder-created components (no descriptor / no raw_config).
         match serde_json::to_value(&self.config) {
-            Ok(serde_json::Value::Object(mut map)) => {
-                map.remove("password");
-                map.into_iter().collect()
-            }
+            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
             _ => HashMap::new(),
         }
     }
@@ -768,7 +770,7 @@ mod tests {
         }
 
         #[test]
-        fn test_properties_does_not_expose_password() {
+        fn test_properties_includes_password() {
             let source = PostgresSourceBuilder::new("test")
                 .with_database("db")
                 .with_user("user")
@@ -777,8 +779,13 @@ mod tests {
                 .unwrap();
             let props = source.properties();
 
-            // Password should not be exposed in properties
-            assert!(!props.contains_key("password"));
+            // Password must be preserved for config persistence roundtrip
+            assert_eq!(
+                props.get("password"),
+                Some(&serde_json::Value::String(
+                    "super_secret_password".to_string()
+                ))
+            );
         }
 
         #[test]

--- a/components/sources/postgres/src/lib.rs
+++ b/components/sources/postgres/src/lib.rs
@@ -305,15 +305,10 @@ impl Source for PostgresReplicationSource {
     }
 
     fn properties(&self) -> HashMap<String, serde_json::Value> {
-        if let Some(serde_json::Value::Object(map)) = self.base.raw_config() {
-            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-        }
+        use crate::descriptor::PostgresSourceConfigDto;
 
-        // Fallback for builder-created components (no descriptor / no raw_config).
-        match serde_json::to_value(&self.config) {
-            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
-            _ => HashMap::new(),
-        }
+        self.base
+            .properties_or_serialize(&PostgresSourceConfigDto::from(&self.config))
     }
 
     fn auto_start(&self) -> bool {
@@ -826,9 +821,9 @@ mod tests {
         }
 
         fn ensure_test_secret_resolver() {
-            let _ = drasi_plugin_sdk::resolver::register_secret_resolver(
-                std::sync::Arc::new(TestSecretResolver),
-            );
+            let _ = drasi_plugin_sdk::resolver::register_secret_resolver(std::sync::Arc::new(
+                TestSecretResolver,
+            ));
         }
 
         #[tokio::test]
@@ -905,6 +900,62 @@ mod tests {
                 .build()
                 .unwrap();
             assert_eq!(source.status().await, ComponentStatus::Stopped);
+        }
+
+        #[test]
+        fn test_builder_fallback_produces_camel_case() {
+            use drasi_lib::sources::Source;
+
+            let source = PostgresSourceBuilder::new("pg-fallback")
+                .with_host("myhost.example.com")
+                .with_port(5433)
+                .with_database("mydb")
+                .with_user("admin")
+                .with_password("secret123")
+                .with_ssl_mode(SslMode::Require)
+                .with_slot_name("custom_slot")
+                .with_publication_name("custom_pub")
+                .build()
+                .unwrap();
+
+            let props = source.properties();
+
+            // Must use camelCase keys (DTO serialization)
+            assert!(
+                props.contains_key("slotName"),
+                "expected camelCase 'slotName', got keys: {:?}",
+                props.keys().collect::<Vec<_>>()
+            );
+            assert!(
+                props.contains_key("publicationName"),
+                "expected camelCase 'publicationName'"
+            );
+            assert!(
+                props.contains_key("sslMode"),
+                "expected camelCase 'sslMode'"
+            );
+
+            // Must NOT have snake_case keys
+            assert!(
+                !props.contains_key("slot_name"),
+                "should not have snake_case 'slot_name'"
+            );
+            assert!(
+                !props.contains_key("publication_name"),
+                "should not have snake_case 'publication_name'"
+            );
+
+            // Values should be correct
+            assert_eq!(
+                props.get("host").and_then(|v| v.as_str()),
+                Some("myhost.example.com")
+            );
+            assert_eq!(props.get("port").and_then(|v| v.as_u64()), Some(5433));
+            assert_eq!(props.get("database").and_then(|v| v.as_str()), Some("mydb"));
+            assert_eq!(
+                props.get("password").and_then(|v| v.as_str()),
+                Some("secret123")
+            );
         }
     }
 

--- a/components/sources/postgres/src/lib.rs
+++ b/components/sources/postgres/src/lib.rs
@@ -808,6 +808,95 @@ mod tests {
     mod lifecycle {
         use super::*;
 
+        /// A test secret resolver that returns a fixed value for any secret name.
+        struct TestSecretResolver;
+
+        impl drasi_plugin_sdk::resolver::ValueResolver for TestSecretResolver {
+            fn resolve_to_string(
+                &self,
+                value: &drasi_plugin_sdk::ConfigValue<String>,
+            ) -> Result<String, drasi_plugin_sdk::resolver::ResolverError> {
+                match value {
+                    drasi_plugin_sdk::ConfigValue::Secret { name } => {
+                        Ok(format!("resolved-secret-{name}"))
+                    }
+                    _ => Err(drasi_plugin_sdk::resolver::ResolverError::WrongResolverType),
+                }
+            }
+        }
+
+        fn ensure_test_secret_resolver() {
+            let _ = drasi_plugin_sdk::resolver::register_secret_resolver(
+                std::sync::Arc::new(TestSecretResolver),
+            );
+        }
+
+        #[tokio::test]
+        async fn test_descriptor_preserves_secret_envelope() {
+            use crate::descriptor::PostgresSourceDescriptor;
+            use drasi_lib::sources::Source;
+            use drasi_plugin_sdk::descriptor::SourcePluginDescriptor;
+
+            ensure_test_secret_resolver();
+
+            let config_json = serde_json::json!({
+                "host": "db.example.com",
+                "port": 5432,
+                "database": "mydb",
+                "user": "app_user",
+                "password": {
+                    "kind": "Secret",
+                    "name": "db-password"
+                },
+                "tables": ["users"],
+                "slotName": "drasi_slot",
+                "publicationName": "drasi_pub"
+            });
+
+            let descriptor = PostgresSourceDescriptor;
+            let source = descriptor
+                .create_source("pg-secret-test", &config_json, true)
+                .await
+                .expect("descriptor should create source");
+
+            let props = source.properties();
+
+            // Password must be the Secret envelope, NOT the resolved value
+            let password = props.get("password").expect("password must be present");
+            assert!(
+                password.is_object(),
+                "password should be Secret envelope, got: {password}"
+            );
+            assert_eq!(
+                password.get("kind").and_then(|v| v.as_str()),
+                Some("Secret"),
+                "envelope kind must be Secret"
+            );
+            assert_eq!(
+                password.get("name").and_then(|v| v.as_str()),
+                Some("db-password"),
+                "secret name must be preserved"
+            );
+
+            // Resolved value must NOT leak into persisted properties
+            let props_str = serde_json::to_string(&props).unwrap();
+            assert!(
+                !props_str.contains("resolved-secret-db-password"),
+                "resolved secret must not appear in properties"
+            );
+
+            // Keys must be camelCase (from raw_config)
+            assert!(
+                props.contains_key("slotName"),
+                "expected camelCase 'slotName', got keys: {:?}",
+                props.keys().collect::<Vec<_>>()
+            );
+            assert!(
+                props.contains_key("publicationName"),
+                "expected camelCase 'publicationName'"
+            );
+        }
+
         #[tokio::test]
         async fn test_initial_status_is_stopped() {
             let source = PostgresSourceBuilder::new("test")

--- a/lib/src/lib_core.rs
+++ b/lib/src/lib_core.rs
@@ -1805,6 +1805,412 @@ mod tests {
             assert!(bp.properties.contains_key("file_paths"));
         }
 
+        // -- Mock source with raw_config (simulates descriptor-created source) --
+
+        struct RawConfigSource {
+            id: String,
+            raw_config: serde_json::Value,
+            status_handle: crate::component_graph::ComponentStatusHandle,
+            dispatchers: Arc<
+                RwLock<
+                    Vec<
+                        Box<
+                            dyn crate::channels::ChangeDispatcher<
+                                crate::channels::SourceEventWrapper,
+                            >,
+                        >,
+                    >,
+                >,
+            >,
+        }
+
+        impl RawConfigSource {
+            fn new(id: &str, raw_config: serde_json::Value) -> Self {
+                Self {
+                    id: id.to_string(),
+                    raw_config,
+                    status_handle: crate::component_graph::ComponentStatusHandle::new(id),
+                    dispatchers: Arc::new(RwLock::new(Vec::new())),
+                }
+            }
+        }
+
+        #[async_trait]
+        impl crate::sources::Source for RawConfigSource {
+            fn id(&self) -> &str {
+                &self.id
+            }
+            fn type_name(&self) -> &str {
+                "test-postgres"
+            }
+            fn properties(&self) -> HashMap<String, serde_json::Value> {
+                // Return raw_config if set (simulates the pattern in real plugins)
+                if let serde_json::Value::Object(map) = &self.raw_config {
+                    return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                }
+                HashMap::new()
+            }
+            fn auto_start(&self) -> bool {
+                false
+            }
+            async fn start(&self) -> anyhow::Result<()> {
+                self.status_handle
+                    .set_status(
+                        crate::channels::ComponentStatus::Running,
+                        Some("Running".into()),
+                    )
+                    .await;
+                Ok(())
+            }
+            async fn stop(&self) -> anyhow::Result<()> {
+                self.status_handle
+                    .set_status(
+                        crate::channels::ComponentStatus::Stopped,
+                        Some("Stopped".into()),
+                    )
+                    .await;
+                Ok(())
+            }
+            async fn status(&self) -> crate::channels::ComponentStatus {
+                self.status_handle.get_status().await
+            }
+            async fn subscribe(
+                &self,
+                settings: crate::config::SourceSubscriptionSettings,
+            ) -> anyhow::Result<crate::channels::SubscriptionResponse> {
+                use crate::channels::ChannelChangeDispatcher;
+                let dispatcher =
+                    ChannelChangeDispatcher::<crate::channels::SourceEventWrapper>::new(100);
+                let receiver = dispatcher.create_receiver().await?;
+                self.dispatchers.write().await.push(Box::new(dispatcher));
+                Ok(crate::channels::SubscriptionResponse {
+                    query_id: settings.query_id,
+                    source_id: self.id.clone(),
+                    receiver,
+                    bootstrap_receiver: None,
+                    position_handle: None,
+                })
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            async fn initialize(&self, ctx: crate::context::SourceRuntimeContext) {
+                self.status_handle.wire(ctx.update_tx.clone()).await;
+            }
+        }
+
+        // -- Mock reaction with raw_config --
+
+        struct RawConfigReaction {
+            id: String,
+            queries: Vec<String>,
+            raw_config: serde_json::Value,
+            status_handle: crate::component_graph::ComponentStatusHandle,
+        }
+
+        impl RawConfigReaction {
+            fn new(id: &str, queries: Vec<String>, raw_config: serde_json::Value) -> Self {
+                Self {
+                    id: id.to_string(),
+                    queries,
+                    raw_config,
+                    status_handle: crate::component_graph::ComponentStatusHandle::new(id),
+                }
+            }
+        }
+
+        #[async_trait]
+        impl Reaction for RawConfigReaction {
+            fn id(&self) -> &str {
+                &self.id
+            }
+            fn type_name(&self) -> &str {
+                "test-http"
+            }
+            fn properties(&self) -> HashMap<String, serde_json::Value> {
+                if let serde_json::Value::Object(map) = &self.raw_config {
+                    return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                }
+                HashMap::new()
+            }
+            fn query_ids(&self) -> Vec<String> {
+                self.queries.clone()
+            }
+            fn auto_start(&self) -> bool {
+                false
+            }
+            async fn initialize(&self, ctx: crate::context::ReactionRuntimeContext) {
+                self.status_handle.wire(ctx.update_tx.clone()).await;
+            }
+            async fn start(&self) -> anyhow::Result<()> {
+                self.status_handle
+                    .set_status(
+                        crate::channels::ComponentStatus::Running,
+                        Some("Running".into()),
+                    )
+                    .await;
+                Ok(())
+            }
+            async fn stop(&self) -> anyhow::Result<()> {
+                self.status_handle
+                    .set_status(
+                        crate::channels::ComponentStatus::Stopped,
+                        Some("Stopped".into()),
+                    )
+                    .await;
+                Ok(())
+            }
+            async fn status(&self) -> crate::channels::ComponentStatus {
+                self.status_handle.get_status().await
+            }
+            async fn enqueue_query_result(
+                &self,
+                _result: crate::channels::QueryResult,
+            ) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+
+        // -- Tests for raw_config preservation --
+
+        #[tokio::test]
+        async fn snapshot_preserves_secret_references_in_source_properties() {
+            let raw_config = serde_json::json!({
+                "host": "db.example.com",
+                "port": 5432,
+                "password": { "kind": "secret", "name": "DB_PASSWORD" },
+                "sslMode": { "kind": "EnvironmentVariable", "name": "SSL_MODE", "default": "prefer" }
+            });
+
+            let source = RawConfigSource::new("pg-source", raw_config.clone());
+            let core = DrasiLib::builder()
+                .with_id("raw-config-test")
+                .with_source(source)
+                .with_query(
+                    Query::cypher("q1")
+                        .query("MATCH (n) RETURN n")
+                        .from_source("pg-source")
+                        .auto_start(false)
+                        .build(),
+                )
+                .build()
+                .await
+                .unwrap();
+            core.start().await.unwrap();
+
+            let snapshot = core.snapshot_configuration().await.unwrap();
+            let src = snapshot
+                .sources
+                .iter()
+                .find(|s| s.id == "pg-source")
+                .expect("pg-source should be in snapshot");
+
+            // Static values preserved
+            assert_eq!(
+                src.properties.get("host"),
+                Some(&serde_json::json!("db.example.com"))
+            );
+            assert_eq!(src.properties.get("port"), Some(&serde_json::json!(5432)));
+
+            // Secret reference preserved (not resolved to plaintext)
+            assert_eq!(
+                src.properties.get("password"),
+                Some(&serde_json::json!({"kind": "secret", "name": "DB_PASSWORD"}))
+            );
+
+            // Environment variable reference preserved (not resolved)
+            assert_eq!(
+                src.properties.get("sslMode"),
+                Some(
+                    &serde_json::json!({"kind": "EnvironmentVariable", "name": "SSL_MODE", "default": "prefer"})
+                )
+            );
+        }
+
+        #[tokio::test]
+        async fn snapshot_preserves_secret_references_in_reaction_properties() {
+            // First, create a source so the query has something to reference
+            let source = PropertiedSource::new("pg-source");
+
+            let raw_config = serde_json::json!({
+                "endpoint": "https://api.example.com/webhook",
+                "apiKey": { "kind": "secret", "name": "API_KEY" },
+                "retryCount": 3,
+                "timeout": { "kind": "EnvironmentVariable", "name": "TIMEOUT_MS", "default": "5000" }
+            });
+
+            let reaction =
+                RawConfigReaction::new("http-reaction", vec!["q1".to_string()], raw_config);
+
+            let core = DrasiLib::builder()
+                .with_id("raw-config-reaction-test")
+                .with_source(source)
+                .with_query(
+                    Query::cypher("q1")
+                        .query("MATCH (n) RETURN n")
+                        .from_source("pg-source")
+                        .auto_start(false)
+                        .build(),
+                )
+                .build()
+                .await
+                .unwrap();
+            core.start().await.unwrap();
+            core.add_reaction(reaction).await.unwrap();
+
+            let snapshot = core.snapshot_configuration().await.unwrap();
+            let rxn = snapshot
+                .reactions
+                .iter()
+                .find(|r| r.id == "http-reaction")
+                .expect("http-reaction should be in snapshot");
+
+            // Secret reference preserved
+            assert_eq!(
+                rxn.properties.get("apiKey"),
+                Some(&serde_json::json!({"kind": "secret", "name": "API_KEY"}))
+            );
+
+            // Env var reference preserved
+            assert_eq!(
+                rxn.properties.get("timeout"),
+                Some(
+                    &serde_json::json!({"kind": "EnvironmentVariable", "name": "TIMEOUT_MS", "default": "5000"})
+                )
+            );
+
+            // Static values preserved
+            assert_eq!(
+                rxn.properties.get("endpoint"),
+                Some(&serde_json::json!("https://api.example.com/webhook"))
+            );
+            assert_eq!(
+                rxn.properties.get("retryCount"),
+                Some(&serde_json::json!(3))
+            );
+        }
+
+        #[tokio::test]
+        async fn snapshot_preserves_camelcase_keys_from_raw_config() {
+            let raw_config = serde_json::json!({
+                "host": "localhost",
+                "port": 5432,
+                "slotName": "my_slot",
+                "publicationName": "my_pub",
+                "sslMode": "prefer"
+            });
+
+            let source = RawConfigSource::new("pg-source", raw_config);
+            let core = DrasiLib::builder()
+                .with_id("camelcase-test")
+                .with_source(source)
+                .with_query(
+                    Query::cypher("q1")
+                        .query("MATCH (n) RETURN n")
+                        .from_source("pg-source")
+                        .auto_start(false)
+                        .build(),
+                )
+                .build()
+                .await
+                .unwrap();
+            core.start().await.unwrap();
+
+            let snapshot = core.snapshot_configuration().await.unwrap();
+            let src = snapshot
+                .sources
+                .iter()
+                .find(|s| s.id == "pg-source")
+                .unwrap();
+
+            // Verify camelCase keys are preserved (not converted to snake_case)
+            assert!(
+                src.properties.contains_key("slotName"),
+                "Should have camelCase key 'slotName', got: {:?}",
+                src.properties.keys().collect::<Vec<_>>()
+            );
+            assert!(
+                src.properties.contains_key("publicationName"),
+                "Should have camelCase key 'publicationName'"
+            );
+            assert!(
+                src.properties.contains_key("sslMode"),
+                "Should have camelCase key 'sslMode'"
+            );
+        }
+
+        #[tokio::test]
+        async fn snapshot_mixed_config_values_roundtrip() {
+            let raw_config = serde_json::json!({
+                "host": "db.example.com",
+                "port": 5432,
+                "database": "${DB_NAME:-mydb}",
+                "password": { "kind": "secret", "name": "DB_PASSWORD" },
+                "sslMode": { "kind": "EnvironmentVariable", "name": "SSL_MODE", "default": "prefer" },
+                "tables": [
+                    { "name": "users", "keys": ["id"] },
+                    { "name": "orders", "keys": ["order_id"] }
+                ]
+            });
+
+            let source = RawConfigSource::new("pg-source", raw_config);
+            let core = DrasiLib::builder()
+                .with_id("mixed-config-test")
+                .with_source(source)
+                .with_query(
+                    Query::cypher("q1")
+                        .query("MATCH (n) RETURN n")
+                        .from_source("pg-source")
+                        .auto_start(false)
+                        .build(),
+                )
+                .build()
+                .await
+                .unwrap();
+            core.start().await.unwrap();
+
+            let snapshot = core.snapshot_configuration().await.unwrap();
+
+            // Serialize to JSON and back (simulates persistence roundtrip)
+            let json = serde_json::to_string_pretty(&snapshot).expect("Should serialize to JSON");
+            let restored: ConfigurationSnapshot =
+                serde_json::from_str(&json).expect("Should deserialize from JSON");
+
+            let src = restored
+                .sources
+                .iter()
+                .find(|s| s.id == "pg-source")
+                .unwrap();
+
+            // All value types survive JSON roundtrip
+            assert_eq!(
+                src.properties.get("host"),
+                Some(&serde_json::json!("db.example.com"))
+            );
+            assert_eq!(src.properties.get("port"), Some(&serde_json::json!(5432)));
+            assert_eq!(
+                src.properties.get("database"),
+                Some(&serde_json::json!("${DB_NAME:-mydb}"))
+            );
+            assert_eq!(
+                src.properties.get("password"),
+                Some(&serde_json::json!({"kind": "secret", "name": "DB_PASSWORD"}))
+            );
+            assert_eq!(
+                src.properties.get("sslMode"),
+                Some(
+                    &serde_json::json!({"kind": "EnvironmentVariable", "name": "SSL_MODE", "default": "prefer"})
+                )
+            );
+            assert_eq!(
+                src.properties.get("tables"),
+                Some(&serde_json::json!([
+                    {"name": "users", "keys": ["id"]},
+                    {"name": "orders", "keys": ["order_id"]}
+                ]))
+            );
+        }
+
         #[tokio::test]
         async fn snapshot_excludes_introspection_source() {
             let core = build_core_with_components().await;

--- a/lib/src/reactions/common/base.rs
+++ b/lib/src/reactions/common/base.rs
@@ -120,6 +120,9 @@ pub struct ReactionBase {
     /// Set either programmatically (via `set_identity_provider`) or automatically
     /// from the runtime context during `initialize()`.
     identity_provider: Arc<RwLock<Option<Arc<dyn IdentityProvider>>>>,
+    /// Original raw config JSON from the descriptor, preserving ConfigValue
+    /// envelopes (secrets, env vars) for lossless persistence roundtrips.
+    raw_config: Option<serde_json::Value>,
 }
 
 impl ReactionBase {
@@ -140,6 +143,7 @@ impl ReactionBase {
             processing_task: Arc::new(RwLock::new(None)),
             shutdown_tx: Arc::new(RwLock::new(None)),
             identity_provider: Arc::new(RwLock::new(None)),
+            raw_config: None,
         }
     }
 
@@ -209,6 +213,16 @@ impl ReactionBase {
         self.auto_start
     }
 
+    /// Set the original raw config JSON for lossless persistence roundtrips.
+    pub fn set_raw_config(&mut self, config: serde_json::Value) {
+        self.raw_config = Some(config);
+    }
+
+    /// Get the original raw config JSON, if set by a descriptor.
+    pub fn raw_config(&self) -> Option<&serde_json::Value> {
+        self.raw_config.as_ref()
+    }
+
     /// Clone the ReactionBase with shared Arc references
     ///
     /// This creates a new ReactionBase that shares the same underlying
@@ -226,6 +240,7 @@ impl ReactionBase {
             processing_task: self.processing_task.clone(),
             shutdown_tx: self.shutdown_tx.clone(),
             identity_provider: self.identity_provider.clone(),
+            raw_config: self.raw_config.clone(),
         }
     }
 

--- a/lib/src/reactions/common/base.rs
+++ b/lib/src/reactions/common/base.rs
@@ -223,6 +223,27 @@ impl ReactionBase {
         self.raw_config.as_ref()
     }
 
+    /// Build the properties map for this reaction.
+    ///
+    /// If `raw_config` was set (descriptor path), returns its top-level keys.
+    /// Otherwise, serializes `fallback_dto` (the DTO reconstructed from typed
+    /// config) to produce camelCase output.
+    ///
+    /// This eliminates the duplicated if-let + serialize pattern from plugins.
+    pub fn properties_or_serialize<D: serde::Serialize>(
+        &self,
+        fallback_dto: &D,
+    ) -> std::collections::HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.raw_config.as_ref() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
+        match serde_json::to_value(fallback_dto) {
+            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
+            _ => std::collections::HashMap::new(),
+        }
+    }
+
     /// Clone the ReactionBase with shared Arc references
     ///
     /// This creates a new ReactionBase that shares the same underlying

--- a/lib/src/sources/base.rs
+++ b/lib/src/sources/base.rs
@@ -175,6 +175,9 @@ pub struct SourceBase {
     /// ("no position confirmed yet"). Only populated when
     /// `request_position_handle == true`.
     position_handles: Arc<RwLock<HashMap<String, Arc<AtomicU64>>>>,
+    /// Original raw config JSON from the descriptor, preserving ConfigValue
+    /// envelopes (secrets, env vars) for lossless persistence roundtrips.
+    raw_config: Option<serde_json::Value>,
 }
 
 impl SourceBase {
@@ -221,12 +224,30 @@ impl SourceBase {
             bootstrap_provider: Arc::new(RwLock::new(bootstrap_provider)),
             identity_provider: Arc::new(RwLock::new(None)),
             position_handles: Arc::new(RwLock::new(HashMap::new())),
+            raw_config: None,
         })
     }
 
     /// Get whether this source should auto-start
     pub fn get_auto_start(&self) -> bool {
         self.auto_start
+    }
+
+    /// Set the original raw config JSON for lossless persistence roundtrips.
+    ///
+    /// Called by plugin descriptors to preserve the original config JSON
+    /// (including `ConfigValue` envelopes for secrets and env vars) before
+    /// resolution to plain values.
+    pub fn set_raw_config(&mut self, config: serde_json::Value) {
+        self.raw_config = Some(config);
+    }
+
+    /// Get the original raw config JSON, if set by a descriptor.
+    ///
+    /// Returns `None` for builder-created components that don't have
+    /// a raw config JSON (they use DTO reconstruction in `properties()`).
+    pub fn raw_config(&self) -> Option<&serde_json::Value> {
+        self.raw_config.as_ref()
     }
 
     /// Initialize the source with runtime context.
@@ -385,6 +406,7 @@ impl SourceBase {
             bootstrap_provider: self.bootstrap_provider.clone(),
             identity_provider: self.identity_provider.clone(),
             position_handles: self.position_handles.clone(),
+            raw_config: self.raw_config.clone(),
         }
     }
 

--- a/lib/src/sources/base.rs
+++ b/lib/src/sources/base.rs
@@ -250,6 +250,27 @@ impl SourceBase {
         self.raw_config.as_ref()
     }
 
+    /// Build the properties map for this source.
+    ///
+    /// If `raw_config` was set (descriptor path), returns its top-level keys.
+    /// Otherwise, serializes `fallback_dto` (the DTO reconstructed from typed
+    /// config) to produce camelCase output.
+    ///
+    /// This eliminates the duplicated if-let + serialize pattern from plugins.
+    pub fn properties_or_serialize<D: serde::Serialize>(
+        &self,
+        fallback_dto: &D,
+    ) -> HashMap<String, serde_json::Value> {
+        if let Some(serde_json::Value::Object(map)) = self.raw_config.as_ref() {
+            return map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        }
+
+        match serde_json::to_value(fallback_dto) {
+            Ok(serde_json::Value::Object(map)) => map.into_iter().collect(),
+            _ => HashMap::new(),
+        }
+    }
+
     /// Initialize the source with runtime context.
     ///
     /// This method is called automatically by DrasiLib's `add_source()` method.


### PR DESCRIPTION
## Problem

When `drasi-server` persists configuration via `snapshot_configuration()` → `properties()`, three issues caused data loss:

1. **ConfigValue envelopes flattened** — Secret references (`{kind: secret, name: DB_PASSWORD}`) and environment variable references were resolved to plaintext, losing the original envelope structure
2. **camelCase keys converted to snake_case** — Properties like `slotName` became `slot_name` because `properties()` was serializing internal config structs (which lack `#[serde(rename_all = "camelCase")]`)
3. **Passwords stripped** — Five plugins actively removed password fields in `properties()` (a display-safety measure that became destructive when persistence started using `properties()` as data source)

## Root Cause

PR #349 changed `properties()` from hand-built HashMaps to `serde_json::to_value(&self.config)`, introducing the snake_case issue. When drasi-server PR #84 then replaced its shadow-cache persistence with `snapshot_configuration()` → `properties()` roundtripping, all three issues became data loss bugs.

## Solution

Store the original raw config JSON in each component so `properties()` can return it with ConfigValue envelopes intact:

- **`SourceBase` / `ReactionBase`**: Added `raw_config: Option<serde_json::Value>` field with `set_raw_config()` / `raw_config()` accessors
- **All 12 plugin descriptors**: Call `set_raw_config(config_json.clone())` during construction, preserving the original JSON before resolution
- **All 12 plugin `properties()` methods**: Return `raw_config` when available; fall back to DTO reconstruction for builder-created components (backward compatible)
- **Password fields**: Removed `map.remove("password")` from 5 plugins (postgres, mssql, storedproc-*)
- **camelCase fixes**: Added DTO reconstruction fallback in postgres, http, sse plugins

## Testing

- 4 new snapshot tests verifying secret/env-var/camelCase/mixed-value preservation
- All 710 drasi-lib tests pass
- All 123 plugin unit tests pass (across all 12 plugins)
- `cargo fmt` and `cargo clippy` clean

## Dependencies

drasi-server will have a companion PR adding persistence roundtrip tests.