### PR TITLE
Add cross-repo trigger for centralized agentic PR reviewers 

### DIFF
--- a/.github/workflows/pr-reviewers.yml
+++ b/.github/workflows/pr-reviewers.yml
@@ -14,9 +14,11 @@
 
 # Caller workflow that triggers the centralized Drasi agentic PR reviewers
 # in drasi-project/.github via workflow_dispatch (cross-repo API call).
-# The reviewer runs in the target repo's context, where the org-level
-# secrets (COPILOT_GITHUB_TOKEN, ISSUE_UPDATE_TOKEN) are available, and
-# posts its comment back to this PR using its own configured token.
+# The reviewer workflows execute in the centralized drasi-project/.github
+# repository context, so any secrets or tokens they use (e.g.
+# COPILOT_GITHUB_TOKEN, ISSUE_UPDATE_TOKEN) must be configured there.
+# They receive this PR URL as input and post comments back to the
+# target PR using their own configured token.
 #
 # Required org-level secret (must grant access to this repository):
 #   ORG_DISPATCH_TOKEN - PAT or GitHub App token with `actions: write`
@@ -26,12 +28,10 @@
 name: Trigger PR Reviewers
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 env:
   REVIEWER_REPO: drasi-project/.github

--- a/.github/workflows/pr-reviewers.yml
+++ b/.github/workflows/pr-reviewers.yml
@@ -18,9 +18,10 @@
 # secrets (COPILOT_GITHUB_TOKEN, ISSUE_UPDATE_TOKEN) are available, and
 # posts its comment back to this PR using its own configured token.
 #
-# Required caller-repo secret:
-#   DISPATCH_TOKEN - PAT or GitHub App token with `actions: write` (or
-#                    classic `workflow` scope) on drasi-project/.github.
+# Required org-level secret (must grant access to this repository):
+#   ORG_DISPATCH_TOKEN - PAT or GitHub App token with `actions: write`
+#                        (or classic `workflow` scope) on
+#                        drasi-project/.github.
 
 name: Trigger PR Reviewers
 
@@ -60,9 +61,13 @@ jobs:
       - name: Dispatch reviewers
         if: steps.reviewers.outputs.workflows != ''
         env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORG_DISPATCH_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::ORG_DISPATCH_TOKEN is not set or not accessible to this repository."
+            exit 1
+          fi
           for wf in ${{ steps.reviewers.outputs.workflows }}; do
             echo "Dispatching $wf for $PR_URL"
             gh workflow run "$wf" \

--- a/.github/workflows/pr-reviewers.yml
+++ b/.github/workflows/pr-reviewers.yml
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Caller workflow that forwards PR review requests to the centralized
-# Drasi agentic reviewers in drasi-project/.github. Each job is gated by
-# the same label conditions used by the original reviewers and forwards
-# the PR URL to the reusable workflow.
+# Caller workflow that triggers the centralized Drasi agentic PR reviewers
+# in drasi-project/.github via workflow_dispatch (cross-repo API call).
+# The reviewer runs in the target repo's context, where the org-level
+# secrets (COPILOT_GITHUB_TOKEN, ISSUE_UPDATE_TOKEN) are available, and
+# posts its comment back to this PR using its own configured token.
 #
-# Required org-level secrets: COPILOT_GITHUB_TOKEN, ISSUE_UPDATE_TOKEN
+# Required caller-repo secret:
+#   DISPATCH_TOKEN - PAT or GitHub App token with `actions: write` (or
+#                    classic `workflow` scope) on drasi-project/.github.
 
 name: Trigger PR Reviewers
 
@@ -27,49 +30,43 @@ on:
 
 permissions:
   contents: read
-  actions: read
-  issues: write
-  pull-requests: write
+  pull-requests: read
+
+env:
+  REVIEWER_REPO: drasi-project/.github
+  REVIEWER_REF: main
 
 jobs:
-  correctness:
-    if: github.event.label.name == 'review:correctness' || github.event.label.name == 'review:all'
-    uses: drasi-project/.github/.github/workflows/pr-correctness-reviewer.lock.yml@main
-    with:
-      pr_url: ${{ github.event.pull_request.html_url }}
-    secrets: inherit
+  dispatch:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.label.name, 'review:')
+    steps:
+      - name: Determine reviewers
+        id: reviewers
+        run: |
+          label='${{ github.event.label.name }}'
+          case "$label" in
+            review:correctness) workflows="pr-correctness-reviewer.lock.yml" ;;
+            review:security)    workflows="pr-security-reviewer.lock.yml" ;;
+            review:design)      workflows="pr-design-reviewer.lock.yml" ;;
+            review:docs)        workflows="pr-docs-reviewer.lock.yml" ;;
+            review:testing)     workflows="pr-testing-reviewer.lock.yml" ;;
+            review:prior-art)   workflows="pr-prior-art-reviewer.lock.yml" ;;
+            review:all)         workflows="pr-correctness-reviewer.lock.yml pr-security-reviewer.lock.yml pr-design-reviewer.lock.yml pr-docs-reviewer.lock.yml pr-testing-reviewer.lock.yml pr-prior-art-reviewer.lock.yml" ;;
+            *)                  workflows="" ;;
+          esac
+          echo "workflows=$workflows" >> "$GITHUB_OUTPUT"
 
-  security:
-    if: github.event.label.name == 'review:security' || github.event.label.name == 'review:all'
-    uses: drasi-project/.github/.github/workflows/pr-security-reviewer.lock.yml@main
-    with:
-      pr_url: ${{ github.event.pull_request.html_url }}
-    secrets: inherit
-
-  design:
-    if: github.event.label.name == 'review:design' || github.event.label.name == 'review:all'
-    uses: drasi-project/.github/.github/workflows/pr-design-reviewer.lock.yml@main
-    with:
-      pr_url: ${{ github.event.pull_request.html_url }}
-    secrets: inherit
-
-  docs:
-    if: github.event.label.name == 'review:docs' || github.event.label.name == 'review:all'
-    uses: drasi-project/.github/.github/workflows/pr-docs-reviewer.lock.yml@main
-    with:
-      pr_url: ${{ github.event.pull_request.html_url }}
-    secrets: inherit
-
-  testing:
-    if: github.event.label.name == 'review:testing' || github.event.label.name == 'review:all'
-    uses: drasi-project/.github/.github/workflows/pr-testing-reviewer.lock.yml@main
-    with:
-      pr_url: ${{ github.event.pull_request.html_url }}
-    secrets: inherit
-
-  prior-art:
-    if: github.event.label.name == 'review:prior-art' || github.event.label.name == 'review:all'
-    uses: drasi-project/.github/.github/workflows/pr-prior-art-reviewer.lock.yml@main
-    with:
-      pr_url: ${{ github.event.pull_request.html_url }}
-    secrets: inherit
+      - name: Dispatch reviewers
+        if: steps.reviewers.outputs.workflows != ''
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          for wf in ${{ steps.reviewers.outputs.workflows }}; do
+            echo "Dispatching $wf for $PR_URL"
+            gh workflow run "$wf" \
+              --repo "$REVIEWER_REPO" \
+              --ref "$REVIEWER_REF" \
+              -f pr_url="$PR_URL"
+          done

--- a/.github/workflows/pr-reviewers.yml
+++ b/.github/workflows/pr-reviewers.yml
@@ -1,0 +1,75 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Caller workflow that forwards PR review requests to the centralized
+# Drasi agentic reviewers in drasi-project/.github. Each job is gated by
+# the same label conditions used by the original reviewers and forwards
+# the PR URL to the reusable workflow.
+#
+# Required org-level secrets: COPILOT_GITHUB_TOKEN, ISSUE_UPDATE_TOKEN
+
+name: Trigger PR Reviewers
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  correctness:
+    if: github.event.label.name == 'review:correctness' || github.event.label.name == 'review:all'
+    uses: drasi-project/.github/.github/workflows/pr-correctness-reviewer.lock.yml@main
+    with:
+      pr_url: ${{ github.event.pull_request.html_url }}
+    secrets: inherit
+
+  security:
+    if: github.event.label.name == 'review:security' || github.event.label.name == 'review:all'
+    uses: drasi-project/.github/.github/workflows/pr-security-reviewer.lock.yml@main
+    with:
+      pr_url: ${{ github.event.pull_request.html_url }}
+    secrets: inherit
+
+  design:
+    if: github.event.label.name == 'review:design' || github.event.label.name == 'review:all'
+    uses: drasi-project/.github/.github/workflows/pr-design-reviewer.lock.yml@main
+    with:
+      pr_url: ${{ github.event.pull_request.html_url }}
+    secrets: inherit
+
+  docs:
+    if: github.event.label.name == 'review:docs' || github.event.label.name == 'review:all'
+    uses: drasi-project/.github/.github/workflows/pr-docs-reviewer.lock.yml@main
+    with:
+      pr_url: ${{ github.event.pull_request.html_url }}
+    secrets: inherit
+
+  testing:
+    if: github.event.label.name == 'review:testing' || github.event.label.name == 'review:all'
+    uses: drasi-project/.github/.github/workflows/pr-testing-reviewer.lock.yml@main
+    with:
+      pr_url: ${{ github.event.pull_request.html_url }}
+    secrets: inherit
+
+  prior-art:
+    if: github.event.label.name == 'review:prior-art' || github.event.label.name == 'review:all'
+    uses: drasi-project/.github/.github/workflows/pr-prior-art-reviewer.lock.yml@main
+    with:
+      pr_url: ${{ github.event.pull_request.html_url }}
+    secrets: inherit

--- a/.github/workflows/pr-reviewers.yml
+++ b/.github/workflows/pr-reviewers.yml
@@ -44,8 +44,10 @@ jobs:
     steps:
       - name: Determine reviewers
         id: reviewers
+        env:
+          LABEL: ${{ github.event.label.name }}
         run: |
-          label='${{ github.event.label.name }}'
+          label="$LABEL"
           case "$label" in
             review:correctness) workflows="pr-correctness-reviewer.lock.yml" ;;
             review:security)    workflows="pr-security-reviewer.lock.yml" ;;


### PR DESCRIPTION
# Description

Adds `.github/workflows/pr-reviewers.yml`, a label-driven caller workflow
that dispatches the centralized Drasi agentic PR reviewers hosted in
`drasi-project/.github`.

When a PR is labeled with one of:
- `review:correctness`
- `review:security`
- `review:design`
- `review:docs`
- `review:testing`
- `review:prior-art`
- `review:all` (runs all six)

the workflow invokes the corresponding `pr-*-reviewer.lock.yml` in
`drasi-project/.github` via `gh workflow run` (cross-repo
`workflow_dispatch`). Each reviewer executes in the `.github` repo
context, fetches the PR, and posts its review back as a comment on
this PR.

For reference, here is a test PR: https://github.com/drasi-project/drasi-core/pull/429

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
