### PR TITLE
Resumable Reactions 01 - QueryResult sequence & ResultDiff row_signature (unstacked)

### DIFF
--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -291,8 +291,7 @@ impl Reaction for ReactionProxy {
         let result = std::thread::spawn(move || (stop_fn)(state.as_ptr()))
             .join()
             .map_err(|_| anyhow::anyhow!("Thread panicked"))?;
-        let r = unsafe { result.into_result().map_err(|e| anyhow::anyhow!(e)) };
-        r
+        unsafe { result.into_result().map_err(|e| anyhow::anyhow!(e)) }
     }
 
     async fn status(&self) -> ComponentStatus {

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -1800,6 +1800,7 @@ async fn test_reaction_enqueue_query_result() {
     // Build a QueryResult and enqueue it via the host-managed path
     let query_result = drasi_lib::channels::QueryResult::new(
         "test-query".to_string(),
+        0,
         chrono::Utc::now(),
         vec![],
         std::collections::HashMap::new(),
@@ -1861,6 +1862,7 @@ async fn test_reaction_enqueue_multiple_query_results() {
         let query_id = if i % 2 == 0 { "q1" } else { "q2" };
         let result = drasi_lib::channels::QueryResult::new(
             query_id.to_string(),
+            0,
             chrono::Utc::now(),
             vec![],
             std::collections::HashMap::new(),
@@ -1922,10 +1924,12 @@ async fn test_reaction_enqueue_query_result_with_data() {
 
     let result_diff = ResultDiff::Add {
         data: serde_json::json!({"id": 1, "name": "test-entity", "value": 42}),
+        row_signature: 0,
     };
 
     let query_result = drasi_lib::channels::QueryResult {
         query_id: "data-query".to_string(),
+        sequence: 0,
         timestamp: chrono::Utc::now(),
         results: vec![result_diff],
         metadata,
@@ -1994,6 +1998,7 @@ async fn test_reaction_start_stop_stress() {
         for _ in 0..ENQUEUE_PER_ITER {
             let qr = drasi_lib::channels::QueryResult::new(
                 "stress-query".to_string(),
+                0,
                 chrono::Utc::now(),
                 vec![],
                 std::collections::HashMap::new(),

--- a/components/reactions/application/src/tests.rs
+++ b/components/reactions/application/src/tests.rs
@@ -32,6 +32,7 @@ fn create_test_reaction_config(id: &str, queries: Vec<String>) -> ReactionConfig
 fn create_test_query_result(query_id: &str) -> QueryResult {
     QueryResult {
         query_id: query_id.to_string(),
+        sequence: 0,
         results: vec![],
         metadata: HashMap::new(),
         profiling: None,

--- a/components/reactions/grpc-adaptive/src/grpc_adaptive.rs
+++ b/components/reactions/grpc-adaptive/src/grpc_adaptive.rs
@@ -356,8 +356,8 @@ impl AdaptiveGrpcReaction {
                 // Convert results to proto format
                 for result in &query_result.results {
                     let (result_type, data, before, after) = match result {
-                        ResultDiff::Add { data } => ("ADD", data.clone(), None, None),
-                        ResultDiff::Delete { data } => ("DELETE", data.clone(), None, None),
+                        ResultDiff::Add { data, .. } => ("ADD", data.clone(), None, None),
+                        ResultDiff::Delete { data, .. } => ("DELETE", data.clone(), None, None),
                         ResultDiff::Update {
                             data,
                             before,
@@ -369,7 +369,7 @@ impl AdaptiveGrpcReaction {
                             Some(before.clone()),
                             Some(after.clone()),
                         ),
-                        ResultDiff::Aggregation { before, after } => (
+                        ResultDiff::Aggregation { before, after, .. } => (
                             "aggregation",
                             serde_json::to_value(result)
                                 .expect("ResultDiff serialization should succeed"),

--- a/components/reactions/grpc/src/grpc.rs
+++ b/components/reactions/grpc/src/grpc.rs
@@ -604,8 +604,8 @@ impl Reaction for GrpcReaction {
 
                 for result in &query_result.results {
                     let (result_type, data, before, after) = match result {
-                        ResultDiff::Add { data } => ("ADD", data.clone(), None, None),
-                        ResultDiff::Delete { data } => ("DELETE", data.clone(), None, None),
+                        ResultDiff::Add { data, .. } => ("ADD", data.clone(), None, None),
+                        ResultDiff::Delete { data, .. } => ("DELETE", data.clone(), None, None),
                         ResultDiff::Update {
                             data,
                             before,
@@ -617,7 +617,7 @@ impl Reaction for GrpcReaction {
                             Some(before.clone()),
                             Some(after.clone()),
                         ),
-                        ResultDiff::Aggregation { before, after } => (
+                        ResultDiff::Aggregation { before, after, .. } => (
                             "aggregation",
                             serde_json::to_value(result)
                                 .expect("ResultDiff serialization should succeed"),

--- a/components/reactions/http-adaptive/src/tests.rs
+++ b/components/reactions/http-adaptive/src/tests.rs
@@ -118,12 +118,14 @@ mod tests {
             results: vec![
                 ResultDiff::Add {
                     data: json!({"id": 1, "name": "Alice"}),
+                    row_signature: 0,
                 },
                 ResultDiff::Update {
                     data: json!({"id": 2, "name": "Bob Updated"}),
                     before: json!({"id": 2, "name": "Bob"}),
                     after: json!({"id": 2, "name": "Bob Updated"}),
                     grouping_keys: None,
+                    row_signature: 0,
                 },
             ],
             timestamp: "2025-10-19T12:34:56.789Z".to_string(),
@@ -150,6 +152,7 @@ mod tests {
                 query_id: "query1".to_string(),
                 results: vec![ResultDiff::Add {
                     data: json!({"id": 1}),
+                    row_signature: 0,
                 }],
                 timestamp: "2025-10-19T12:34:56Z".to_string(),
                 count: 1,
@@ -162,9 +165,11 @@ mod tests {
                         before: json!({"id": 2}),
                         after: json!({"id": 2}),
                         grouping_keys: None,
+                        row_signature: 0,
                     },
                     ResultDiff::Delete {
                         data: json!({"id": 3}),
+                        row_signature: 0,
                     },
                 ],
                 timestamp: "2025-10-19T12:34:57Z".to_string(),
@@ -192,15 +197,18 @@ mod tests {
             results: vec![
                 ResultDiff::Add {
                     data: json!({"id": "user_123", "name": "John Doe"}),
+                    row_signature: 0,
                 },
                 ResultDiff::Update {
                     data: json!({"id": "user_456", "name": "Jane Smith"}),
                     before: json!({"id": "user_456", "name": "Jane Doe"}),
                     after: json!({"id": "user_456", "name": "Jane Smith"}),
                     grouping_keys: None,
+                    row_signature: 0,
                 },
                 ResultDiff::Delete {
                     data: json!({"id": "user_789", "name": "Bob Wilson"}),
+                    row_signature: 0,
                 },
             ],
             timestamp: "2025-10-19T12:34:56.789Z".to_string(),
@@ -215,7 +223,7 @@ mod tests {
 
         // Verify result types and structures
         match &batch_result.results[0] {
-            ResultDiff::Add { data } => assert!(data.is_object()),
+            ResultDiff::Add { data, .. } => assert!(data.is_object()),
             _ => panic!("Expected add result"),
         }
         match &batch_result.results[1] {
@@ -232,7 +240,7 @@ mod tests {
             _ => panic!("Expected update result"),
         }
         match &batch_result.results[2] {
-            ResultDiff::Delete { data } => assert!(data.is_object()),
+            ResultDiff::Delete { data, .. } => assert!(data.is_object()),
             _ => panic!("Expected delete result"),
         }
     }
@@ -266,12 +274,15 @@ mod tests {
         let results = vec![
             ResultDiff::Add {
                 data: json!({"id": 1}),
+                row_signature: 0,
             },
             ResultDiff::Add {
                 data: json!({"id": 2}),
+                row_signature: 0,
             },
             ResultDiff::Add {
                 data: json!({"id": 3}),
+                row_signature: 0,
             },
         ];
 
@@ -398,6 +409,7 @@ mod tests {
         for i in 0..1000 {
             results.push(ResultDiff::Add {
                 data: json!({"id": i, "value": format!("item_{}", i)}),
+                row_signature: 0,
             });
         }
 

--- a/components/reactions/http/src/http.rs
+++ b/components/reactions/http/src/http.rs
@@ -442,7 +442,7 @@ impl Reaction for HttpReaction {
                 // Process each result
                 for result in &query_result.results {
                     match result {
-                        ResultDiff::Add { data } => {
+                        ResultDiff::Add { data, .. } => {
                             if let Some(spec) = query_config.added.as_ref() {
                                 if let Err(e) = Self::process_result(
                                     &client,
@@ -461,7 +461,7 @@ impl Reaction for HttpReaction {
                                 }
                             }
                         }
-                        ResultDiff::Delete { data } => {
+                        ResultDiff::Delete { data, .. } => {
                             if let Some(spec) = query_config.deleted.as_ref() {
                                 if let Err(e) = Self::process_result(
                                     &client,

--- a/components/reactions/log/src/log.rs
+++ b/components/reactions/log/src/log.rs
@@ -478,7 +478,7 @@ impl Reaction for LogReaction {
                         .or(config.default_template.as_ref());
 
                     match result {
-                        ResultDiff::Add { data } => {
+                        ResultDiff::Add { data, .. } => {
                             context.insert("operation".to_string(), Value::String("ADD".into()));
                             context.insert("after".to_string(), data.clone());
 
@@ -509,7 +509,7 @@ impl Reaction for LogReaction {
                                 }
                             }
                         }
-                        ResultDiff::Delete { data } => {
+                        ResultDiff::Delete { data, .. } => {
                             context.insert("operation".to_string(), Value::String("DELETE".into()));
                             context.insert("before".to_string(), data.clone());
 

--- a/components/reactions/platform/src/tests.rs
+++ b/components/reactions/platform/src/tests.rs
@@ -54,6 +54,7 @@ fn create_test_config() -> ReactionConfig {
 fn create_test_query_result(query_id: &str, results: Vec<ResultDiff>) -> QueryResult {
     QueryResult {
         query_id: query_id.to_string(),
+        sequence: 0,
         timestamp: chrono::Utc::now(),
         results,
         metadata: HashMap::new(),
@@ -71,6 +72,7 @@ mod transformer_integration_tests {
             "test-query",
             vec![ResultDiff::Add {
                 data: json!({"id": "1", "value": "test"}),
+                row_signature: 0,
             }],
         );
 
@@ -102,15 +104,18 @@ mod transformer_integration_tests {
             vec![
                 ResultDiff::Add {
                     data: json!({"id": "1"}),
+                    row_signature: 0,
                 },
                 ResultDiff::Update {
                     data: json!({"id": "2", "value": 20}),
                     before: json!({"id": "2", "value": 10}),
                     after: json!({"id": "2", "value": 20}),
                     grouping_keys: None,
+                    row_signature: 0,
                 },
                 ResultDiff::Delete {
                     data: json!({"id": "3"}),
+                    row_signature: 0,
                 },
             ],
         );
@@ -134,9 +139,11 @@ mod transformer_integration_tests {
 
         let query_result = QueryResult {
             query_id: "metadata-query".to_string(),
+            sequence: 0,
             timestamp: chrono::Utc::now(),
             results: vec![ResultDiff::Add {
                 data: json!({"id": "1"}),
+                row_signature: 0,
             }],
             metadata,
             profiling: None,
@@ -488,9 +495,11 @@ mod profiling_metadata_tests {
 
         let query_result = QueryResult {
             query_id: "profiling-test".to_string(),
+            sequence: 0,
             timestamp: chrono::Utc::now(),
             results: vec![ResultDiff::Add {
                 data: json!({"id": "1"}),
+                row_signature: 0,
             }],
             metadata: HashMap::new(),
             profiling: Some(profiling),
@@ -528,9 +537,11 @@ mod profiling_metadata_tests {
     fn test_no_profiling_metadata_when_not_available() {
         let query_result = QueryResult {
             query_id: "no-profiling-test".to_string(),
+            sequence: 0,
             timestamp: chrono::Utc::now(),
             results: vec![ResultDiff::Add {
                 data: json!({"id": "1"}),
+                row_signature: 0,
             }],
             metadata: HashMap::new(),
             profiling: None, // No profiling data

--- a/components/reactions/platform/src/transformer.rs
+++ b/components/reactions/platform/src/transformer.rs
@@ -117,7 +117,7 @@ pub fn transform_query_result(
     // Parse the results array
     for result_item in query_result.results {
         match result_item {
-            ResultDiff::Add { data } => {
+            ResultDiff::Add { data, .. } => {
                 let data = data
                     .as_object()
                     .ok_or_else(|| anyhow!("'data' field must be an object"))?
@@ -145,14 +145,14 @@ pub fn transform_query_result(
                     grouping_keys,
                 });
             }
-            ResultDiff::Delete { data } => {
+            ResultDiff::Delete { data, .. } => {
                 let data = data
                     .as_object()
                     .ok_or_else(|| anyhow!("'data' field must be an object"))?
                     .clone();
                 deleted_results.push(data);
             }
-            ResultDiff::Aggregation { before, after } => {
+            ResultDiff::Aggregation { before, after, .. } => {
                 let before_map = before.as_ref().and_then(|b| b.as_object()).cloned();
                 let after_map = after
                     .as_object()
@@ -227,13 +227,16 @@ mod tests {
         let timestamp = chrono::DateTime::from_timestamp_millis(1609459200000).unwrap();
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp,
             results: vec![
                 ResultDiff::Add {
                     data: json!({"id": "1", "value": "test1"}),
+                    row_signature: 0,
                 },
                 ResultDiff::Add {
                     data: json!({"id": "2", "value": "test2"}),
+                    row_signature: 0,
                 },
             ],
             metadata: HashMap::new(),
@@ -262,12 +265,14 @@ mod tests {
         let timestamp = chrono::DateTime::from_timestamp_millis(1609459200000).unwrap();
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp,
             results: vec![ResultDiff::Update {
                 data: json!({"id": "1", "value": 20}),
                 before: json!({"id": "1", "value": 10}),
                 after: json!({"id": "1", "value": 20}),
                 grouping_keys: None,
+                row_signature: 0,
             }],
             metadata: HashMap::new(),
             profiling: None,
@@ -296,12 +301,14 @@ mod tests {
     fn test_transform_update_with_grouping_keys() {
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![ResultDiff::Update {
                 data: json!({"id": "1", "value": 20}),
                 before: json!({"id": "1", "value": 10}),
                 after: json!({"id": "1", "value": 20}),
                 grouping_keys: Some(vec!["key1".to_string(), "key2".to_string()]),
+                row_signature: 0,
             }],
             metadata: HashMap::new(),
             profiling: None,
@@ -325,9 +332,11 @@ mod tests {
     fn test_transform_delete_results() {
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![ResultDiff::Delete {
                 data: json!({"id": "1"}),
+                row_signature: 0,
             }],
             metadata: HashMap::new(),
             profiling: None,
@@ -348,19 +357,23 @@ mod tests {
     fn test_transform_mixed_results() {
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![
                 ResultDiff::Add {
                     data: json!({"id": "1"}),
+                    row_signature: 0,
                 },
                 ResultDiff::Update {
                     data: json!({"id": "2", "value": 20}),
                     before: json!({"id": "2", "value": 10}),
                     after: json!({"id": "2", "value": 20}),
                     grouping_keys: None,
+                    row_signature: 0,
                 },
                 ResultDiff::Delete {
                     data: json!({"id": "3"}),
+                    row_signature: 0,
                 },
             ],
             metadata: HashMap::new(),
@@ -388,9 +401,11 @@ mod tests {
 
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![ResultDiff::Add {
                 data: json!({"id": "1"}),
+                row_signature: 0,
             }],
             metadata,
             profiling: None,
@@ -415,9 +430,11 @@ mod tests {
     fn test_transform_invalid_add_data_field() {
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![ResultDiff::Add {
                 data: json!(["not-an-object"]),
+                row_signature: 0,
             }],
             metadata: HashMap::new(),
             profiling: None,
@@ -435,12 +452,14 @@ mod tests {
     fn test_transform_invalid_update_before_field() {
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![ResultDiff::Update {
                 data: json!({"id": "1", "value": 20}),
                 before: json!(true),
                 after: json!({"id": "1", "value": 20}),
                 grouping_keys: None,
+                row_signature: 0,
             }],
             metadata: HashMap::new(),
             profiling: None,
@@ -458,12 +477,14 @@ mod tests {
     fn test_transform_invalid_update_after_field() {
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![ResultDiff::Update {
                 data: json!({"id": "1", "value": 20}),
                 before: json!({"id": "1", "value": 10}),
                 after: json!(42),
                 grouping_keys: None,
+                row_signature: 0,
             }],
             metadata: HashMap::new(),
             profiling: None,
@@ -481,14 +502,17 @@ mod tests {
     fn test_transform_unknown_type_skipped() {
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![
                 ResultDiff::Add {
                     data: json!({"id": "1"}),
+                    row_signature: 0,
                 },
                 ResultDiff::Noop,
                 ResultDiff::Delete {
                     data: json!({"id": "3"}),
+                    row_signature: 0,
                 },
             ],
             metadata: HashMap::new(),
@@ -511,9 +535,11 @@ mod tests {
     fn test_transform_empty_metadata_filtered() {
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![ResultDiff::Add {
                 data: json!({"id": "1"}),
+                row_signature: 0,
             }],
             metadata: HashMap::new(), // Empty metadata
             profiling: None,
@@ -658,9 +684,11 @@ mod tests {
 
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![ResultDiff::Add {
                 data: json!({"id": "1"}),
+                row_signature: 0,
             }],
             metadata: HashMap::new(),
             profiling: Some(profiling),
@@ -718,9 +746,11 @@ mod tests {
 
         let query_result = QueryResult {
             query_id: "test-query".to_string(),
+            sequence: 0,
             timestamp: chrono::DateTime::from_timestamp_millis(1609459200000).unwrap(),
             results: vec![ResultDiff::Add {
                 data: json!({"id": "1"}),
+                row_signature: 0,
             }],
             metadata,
             profiling: Some(profiling),

--- a/components/reactions/sse/src/sse.rs
+++ b/components/reactions/sse/src/sse.rs
@@ -350,17 +350,17 @@ impl Reaction for SseReaction {
                             let mut context = Map::new();
 
                             match result {
-                                ResultDiff::Add { data } => {
+                                ResultDiff::Add { data, .. } => {
                                     context.insert("after".to_string(), data.clone());
                                 }
                                 ResultDiff::Update { before, after, .. } => {
                                     context.insert("before".to_string(), before.clone());
                                     context.insert("after".to_string(), after.clone());
                                 }
-                                ResultDiff::Delete { data } => {
+                                ResultDiff::Delete { data, .. } => {
                                     context.insert("before".to_string(), data.clone());
                                 }
-                                ResultDiff::Aggregation { before, after } => {
+                                ResultDiff::Aggregation { before, after, .. } => {
                                     if let Some(before) = before {
                                         context.insert("before".to_string(), before.clone());
                                     }

--- a/components/reactions/storedproc-mssql/src/reaction.rs
+++ b/components/reactions/storedproc-mssql/src/reaction.rs
@@ -195,10 +195,10 @@ impl MsSqlStoredProcReaction {
                 for result_item in &query_result.results {
                     let aggregation_data;
                     let (operation, data_value, result_type) = match result_item {
-                        ResultDiff::Add { data } => (OperationType::Add, data, "ADD"),
+                        ResultDiff::Add { data, .. } => (OperationType::Add, data, "ADD"),
                         ResultDiff::Update { data, .. } => (OperationType::Update, data, "UPDATE"),
-                        ResultDiff::Delete { data } => (OperationType::Delete, data, "DELETE"),
-                        ResultDiff::Aggregation { before, after } => {
+                        ResultDiff::Delete { data, .. } => (OperationType::Delete, data, "DELETE"),
+                        ResultDiff::Aggregation { before, after, .. } => {
                             aggregation_data = json!({
                                 "before": before,
                                 "after": after,

--- a/components/reactions/storedproc-mysql/src/reaction.rs
+++ b/components/reactions/storedproc-mysql/src/reaction.rs
@@ -194,10 +194,10 @@ impl MySqlStoredProcReaction {
                 for result_item in &query_result.results {
                     let aggregation_data;
                     let (operation, data_value, result_type) = match result_item {
-                        ResultDiff::Add { data } => (OperationType::Add, data, "ADD"),
+                        ResultDiff::Add { data, .. } => (OperationType::Add, data, "ADD"),
                         ResultDiff::Update { data, .. } => (OperationType::Update, data, "UPDATE"),
-                        ResultDiff::Delete { data } => (OperationType::Delete, data, "DELETE"),
-                        ResultDiff::Aggregation { before, after } => {
+                        ResultDiff::Delete { data, .. } => (OperationType::Delete, data, "DELETE"),
+                        ResultDiff::Aggregation { before, after, .. } => {
                             aggregation_data = json!({
                                 "before": before,
                                 "after": after,

--- a/components/reactions/storedproc-postgres/src/reaction.rs
+++ b/components/reactions/storedproc-postgres/src/reaction.rs
@@ -205,10 +205,10 @@ impl PostgresStoredProcReaction {
                 for result_item in &query_result.results {
                     let aggregation_data;
                     let (operation, data_value, result_type) = match result_item {
-                        ResultDiff::Add { data } => (OperationType::Add, data, "ADD"),
+                        ResultDiff::Add { data, .. } => (OperationType::Add, data, "ADD"),
                         ResultDiff::Update { data, .. } => (OperationType::Update, data, "UPDATE"),
-                        ResultDiff::Delete { data } => (OperationType::Delete, data, "DELETE"),
-                        ResultDiff::Aggregation { before, after } => {
+                        ResultDiff::Delete { data, .. } => (OperationType::Delete, data, "DELETE"),
+                        ResultDiff::Aggregation { before, after, .. } => {
                             aggregation_data = json!({
                                 "before": before,
                                 "after": after,

--- a/components/sources/http/tests/webhook_e2e.rs
+++ b/components/sources/http/tests/webhook_e2e.rs
@@ -161,7 +161,7 @@ async fn test_webhook_event_flows_to_reaction() {
 
     // Verify the result contains our data
     match &query_result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             assert_eq!(data["name"], "Test Event");
             // Values may come as strings from template rendering
             let value = &data["value"];
@@ -268,7 +268,7 @@ async fn test_webhook_path_params_flow_to_reaction() {
 
     let query_result = result.unwrap();
     match &query_result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             assert_eq!(data["user_id"], "user-42");
             assert_eq!(data["event_type"], "click");
         }
@@ -383,7 +383,7 @@ async fn test_webhook_hmac_auth_flows_correctly() {
 
     let query_result = result.unwrap();
     match &query_result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             assert_eq!(data["data"], "confidential");
         }
         _ => panic!("Expected Add result"),
@@ -504,7 +504,7 @@ async fn test_webhook_bearer_auth_flows_correctly() {
 
     let query_result = result.unwrap();
     match &query_result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             assert_eq!(data["content"], "important info");
         }
         _ => panic!("Expected Add result"),
@@ -670,7 +670,7 @@ async fn test_webhook_condition_routing_flows_correctly() {
 
     let query_result = result.unwrap();
     match &query_result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             assert_eq!(data["type"], "Commit");
             assert_eq!(data["content"], "Fix bug");
         }
@@ -770,7 +770,7 @@ async fn test_webhook_yaml_content_flows_correctly() {
 
     let query_result = result.unwrap();
     match &query_result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             assert_eq!(data["name"], "YAML Test");
             // YAML integers may be preserved or come as strings depending on template
             let count = &data["count"];
@@ -912,7 +912,7 @@ async fn test_webhook_update_operation_flows_correctly() {
 
     let query_result = result.unwrap();
     match &query_result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             assert_eq!(data["status"], "pending");
         }
         _ => panic!("Expected Add result for insert"),
@@ -1023,7 +1023,7 @@ async fn test_standard_mode_flows_to_reaction() {
 
     let query_result = result.unwrap();
     match &query_result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             // Standard mode should preserve integer types
             let value = &data["value"];
             assert!(
@@ -1232,7 +1232,7 @@ async fn test_webhook_payload_spread_as_properties() {
 
     let query_result = result.unwrap();
     match &query_result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             // All payload fields should be available as properties
             assert_eq!(data["id"], "evt-123");
             assert_eq!(data["name"], "Test Event");

--- a/components/sources/mssql/tests/integration_test.rs
+++ b/components/sources/mssql/tests/integration_test.rs
@@ -61,8 +61,8 @@ fn matches_fields(data: &Value, fields: &[(&str, &str)]) -> bool {
 
 fn matches_change(entry: &ResultDiff, change_type: &str, fields: &[(&str, &str)]) -> bool {
     match (change_type, entry) {
-        ("ADD", ResultDiff::Add { data })
-        | ("DELETE", ResultDiff::Delete { data })
+        ("ADD", ResultDiff::Add { data, .. })
+        | ("DELETE", ResultDiff::Delete { data, .. })
         | ("UPDATE", ResultDiff::Update { data, .. }) => matches_fields(data, fields),
         _ => false,
     }

--- a/components/sources/mssql/tests/integration_test.rs
+++ b/components/sources/mssql/tests/integration_test.rs
@@ -430,7 +430,7 @@ async fn test_mssql_column_type_mapping() -> Result<()> {
         .await
         .context("Did not observe INSERT change for types test")?;
 
-        if let ResultDiff::Add { data } = &change {
+        if let ResultDiff::Add { data, .. } = &change {
             // Integers should be JSON numbers, not strings
             assert!(
                 data.get("int_val").unwrap().is_number(),

--- a/lib-integration-tests/tests/application_source_e2e.rs
+++ b/lib-integration-tests/tests/application_source_e2e.rs
@@ -209,7 +209,7 @@ async fn test_application_source_relationship_direction_e2e() -> Result<()> {
 
     // Extract the data from the ResultDiff
     let data = match row {
-        ResultDiff::Add { data } => data,
+        ResultDiff::Add { data, .. } => data,
         _ => panic!("Expected Add result, got {row:?}"),
     };
 
@@ -256,7 +256,7 @@ async fn test_application_source_relationship_direction_e2e() -> Result<()> {
     // For updates, we should get either an Update or Add
     let updated_data = match updated_row {
         ResultDiff::Update { after, .. } => after,
-        ResultDiff::Add { data } => data,
+        ResultDiff::Add { data, .. } => data,
         _ => panic!("Expected Update or Add result, got {updated_row:?}"),
     };
 
@@ -421,7 +421,7 @@ async fn test_application_source_multiple_relationships() -> Result<()> {
 
             if let Some(row) = result.results.first() {
                 let data = match row {
-                    ResultDiff::Add { data } => data,
+                    ResultDiff::Add { data, .. } => data,
                     ResultDiff::Aggregation { after, .. } => after,
                     _ => continue,
                 };

--- a/lib-integration-tests/tests/source_query_reaction_e2e.rs
+++ b/lib-integration-tests/tests/source_query_reaction_e2e.rs
@@ -340,7 +340,7 @@ async fn test_source_to_query_to_reaction_data_flow() {
     assert_eq!(result.results.len(), 1, "Should have one result diff");
 
     match &result.results[0] {
-        ResultDiff::Add { data } => {
+        ResultDiff::Add { data, .. } => {
             assert!(
                 data.get("s").is_some(),
                 "Result should contain variable 's' from RETURN clause"

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -370,13 +370,26 @@ pub struct QuerySubscriptionResponse {
 }
 
 /// Typed result diff emitted by continuous queries.
+///
+/// Each non-`Noop` variant carries a `row_signature` stamped by the core engine:
+/// the path-solver binding hash for non-aggregating rows, and the grouping-key hash
+/// for aggregations. Downstream consumers use it as the row identity in place of
+/// JSON-equality matching.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum ResultDiff {
     #[serde(rename = "ADD")]
-    Add { data: serde_json::Value },
+    Add {
+        data: serde_json::Value,
+        #[serde(default)]
+        row_signature: u64,
+    },
     #[serde(rename = "DELETE")]
-    Delete { data: serde_json::Value },
+    Delete {
+        data: serde_json::Value,
+        #[serde(default)]
+        row_signature: u64,
+    },
     #[serde(rename = "UPDATE")]
     Update {
         data: serde_json::Value,
@@ -384,11 +397,15 @@ pub enum ResultDiff {
         after: serde_json::Value,
         #[serde(skip_serializing_if = "Option::is_none")]
         grouping_keys: Option<Vec<String>>,
+        #[serde(default)]
+        row_signature: u64,
     },
     #[serde(rename = "aggregation")]
     Aggregation {
         before: Option<serde_json::Value>,
         after: serde_json::Value,
+        #[serde(default)]
+        row_signature: u64,
     },
     #[serde(rename = "noop")]
     Noop,
@@ -401,6 +418,11 @@ pub enum ResultDiff {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryResult {
     pub query_id: String,
+    /// Monotonic per-query sequence number identifying this emission.
+    /// Reactions persist this in their checkpoint, the outbox is keyed by it,
+    /// and the bootstrap APIs return it as `as_of_sequence`.
+    #[serde(default)]
+    pub sequence: u64,
     pub timestamp: chrono::DateTime<chrono::Utc>,
     pub results: Vec<ResultDiff>,
     pub metadata: HashMap<String, serde_json::Value>,
@@ -413,12 +435,14 @@ impl QueryResult {
     /// Create a new QueryResult without profiling
     pub fn new(
         query_id: String,
+        sequence: u64,
         timestamp: chrono::DateTime<chrono::Utc>,
         results: Vec<ResultDiff>,
         metadata: HashMap<String, serde_json::Value>,
     ) -> Self {
         Self {
             query_id,
+            sequence,
             timestamp,
             results,
             metadata,
@@ -429,6 +453,7 @@ impl QueryResult {
     /// Create a new QueryResult with profiling metadata
     pub fn with_profiling(
         query_id: String,
+        sequence: u64,
         timestamp: chrono::DateTime<chrono::Utc>,
         results: Vec<ResultDiff>,
         metadata: HashMap<String, serde_json::Value>,
@@ -436,6 +461,7 @@ impl QueryResult {
     ) -> Self {
         Self {
             query_id,
+            sequence,
             timestamp,
             results,
             metadata,

--- a/lib/src/channels/events_test.rs
+++ b/lib/src/channels/events_test.rs
@@ -106,6 +106,7 @@ mod tests {
 
         let result = QueryResult {
             query_id: "query-1".to_string(),
+            sequence: 0,
             results: vec![],
             metadata: HashMap::new(),
             profiling: None,
@@ -125,6 +126,7 @@ mod tests {
 
         let result = QueryResult {
             query_id: "query-1".to_string(),
+            sequence: 0,
             results: vec![],
             metadata: metadata.clone(),
             profiling: None,
@@ -205,6 +207,7 @@ mod tests {
 
         let result = QueryResult {
             query_id: "query-1".to_string(),
+            sequence: 0,
             results: vec![],
             metadata: HashMap::new(),
             profiling: None,

--- a/lib/src/queries/base.rs
+++ b/lib/src/queries/base.rs
@@ -539,6 +539,7 @@ mod tests {
         // Dispatch a result
         let result = QueryResult {
             query_id: "test_query".to_string(),
+            sequence: 0,
             timestamp: chrono::Utc::now(),
             results: vec![],
             metadata: HashMap::new(),
@@ -586,6 +587,7 @@ mod tests {
         // Dispatch a result
         let result = QueryResult {
             query_id: "test_query".to_string(),
+            sequence: 0,
             timestamp: chrono::Utc::now(),
             results: vec![],
             metadata: HashMap::new(),

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -156,24 +156,47 @@ async fn dispatch_query_results(
     let converted_results: Vec<ResultDiff> = results
         .iter()
         .map(|ctx| match ctx {
-            QueryPartEvaluationContext::Adding { after, .. } => ResultDiff::Add {
+            QueryPartEvaluationContext::Adding {
+                after,
+                row_signature,
+            } => ResultDiff::Add {
                 data: convert_query_variables_to_json(after),
+                row_signature: *row_signature,
             },
-            QueryPartEvaluationContext::Removing { before, .. } => ResultDiff::Delete {
+            QueryPartEvaluationContext::Removing {
+                before,
+                row_signature,
+            } => ResultDiff::Delete {
                 data: convert_query_variables_to_json(before),
+                row_signature: *row_signature,
             },
-            QueryPartEvaluationContext::Updating { before, after, .. } => ResultDiff::Update {
+            QueryPartEvaluationContext::Updating {
+                before,
+                after,
+                row_signature,
+            } => ResultDiff::Update {
                 data: convert_query_variables_to_json(after),
                 before: convert_query_variables_to_json(before),
                 after: convert_query_variables_to_json(after),
                 grouping_keys: None,
+                row_signature: *row_signature,
             },
-            QueryPartEvaluationContext::Aggregation { before, after, .. } => {
-                ResultDiff::Aggregation {
-                    before: before.as_ref().map(convert_query_variables_to_json),
-                    after: convert_query_variables_to_json(after),
-                }
-            }
+            // NOTE: When a group empties (last contributor removed), core emits
+            // Aggregation { default_after: true, .. } with identity values (count:0,
+            // sum:0, etc.) rather than Removing. Proper empty-group → Delete detection
+            // requires core-level `is_at_identity()` on each accumulator (see PR #409).
+            // Without that infrastructure, this conversion preserves current behavior:
+            // the row stays in the result set with zeroed-out values.
+            QueryPartEvaluationContext::Aggregation {
+                before,
+                after,
+                row_signature,
+                ..
+            } => ResultDiff::Aggregation {
+                before: before.as_ref().map(convert_query_variables_to_json),
+                after: convert_query_variables_to_json(after),
+                row_signature: *row_signature,
+            },
             QueryPartEvaluationContext::Noop => ResultDiff::Noop,
         })
         .collect();
@@ -182,10 +205,10 @@ async fn dispatch_query_results(
     let mut result_set = current_results.write().await;
     for result in &converted_results {
         match result {
-            ResultDiff::Add { data } => {
+            ResultDiff::Add { data, .. } => {
                 result_set.push(data.clone());
             }
-            ResultDiff::Delete { data } => {
+            ResultDiff::Delete { data, .. } => {
                 result_set.retain(|item| item != data);
             }
             ResultDiff::Update { before, after, .. } => {
@@ -197,7 +220,7 @@ async fn dispatch_query_results(
                     result_set.push(after.clone());
                 }
             }
-            ResultDiff::Aggregation { before, after } => {
+            ResultDiff::Aggregation { before, after, .. } => {
                 if let Some(before) = before {
                     if let Some(pos) = result_set.iter().position(|item| item == before) {
                         result_set[pos] = after.clone();
@@ -214,8 +237,12 @@ async fn dispatch_query_results(
     }
     drop(result_set);
 
+    // sequence is set to 0 here. The result-sequence counter that increments
+    // per emission lands in a follow-up issue (see #396 / Reaction Recovery
+    // doc 01 section 1).
     let query_result = QueryResult::with_profiling(
         query_id.to_string(),
+        0,
         chrono::Utc::now(),
         converted_results,
         {
@@ -708,6 +735,7 @@ impl Query for DrasiQuery {
 
             let control_result = QueryResult::new(
                 self.base.config.id.clone(),
+                0,
                 chrono::Utc::now(),
                 vec![],
                 metadata,
@@ -854,6 +882,7 @@ impl Query for DrasiQuery {
 
                             let control_result = QueryResult::new(
                                 query_id_clone.clone(),
+                                0,
                                 chrono::Utc::now(),
                                 vec![],
                                 metadata,

--- a/lib/src/reactions/common/base.rs
+++ b/lib/src/reactions/common/base.rs
@@ -433,6 +433,7 @@ mod tests {
         // Create a test query result
         let query_result = QueryResult::new(
             "test-query".to_string(),
+            0,
             chrono::Utc::now(),
             vec![],
             Default::default(),


### PR DESCRIPTION
Closes #395.

Equivalent to the lib-layer changes from #410 but **without the dependency on #409**. This PR cherry-picks the `row_signature` and `sequence` plumbing onto `main` directly, proving the two PRs are independent.

## What this PR does

`QueryResult` gains a `sequence: u64` field. Every non-`Noop` `ResultDiff` variant gains a `row_signature: u64` field. Core already stamps a stable per-row hash on each `QueryPartEvaluationContext`, but the lib's core-to-lib conversion was discarding it. This PR propagates it through to downstream consumers.

The `sequence` field is initialized to `0` for now; the per-emission counter lands in #396.

## Why this is NOT stacked on #409

Analysis showed the stacking in #410 was a development convenience, not a technical necessity:

1. **Zero merge conflicts** — the cherry-pick applies cleanly onto `main`
2. **Pattern match compatibility** — Rust `...` wildcards handle the extra `default_after` field that #409 removes
3. **Orthogonal concerns** — #410 adds new fields (structural); #409 changes which variant is emitted (behavioral)
4. **No detection logic needed** — lib-side empty-group detection is impractical without core-level accumulator access (`is_at_identity()`)

## Empty-group behavior note

Without #409, when an aggregation group empties, reactions still see an `Aggregation` update to identity values (count:0, sum:0) rather than a `Delete`. This matches current `main` behavior. Proper detection requires #409's `is_at_identity()` infrastructure at the core level — naive lib-side heuristics (checking `default_after`) would incorrectly delete rows from non-empty groups.

A clarifying comment has been added to `lib/src/queries/manager.rs` documenting this.

## Test plan

- `cargo test -p drasi-lib` — 92 passed, 0 failed
- `cargo test -p drasi-reaction-platform --tests` — 25 passed, 0 failed
- `cargo clippy -p drasi-lib --all-targets -- -D warnings` — no warnings
