### PR TITLE
docs: clarify properties() persistence contract on Source and Reaction traits

### DIFF
--- a/lib/src/config/snapshot.rs
+++ b/lib/src/config/snapshot.rs
@@ -78,7 +78,11 @@ pub struct SourceSnapshot {
     pub status: ComponentStatus,
     /// Whether the source was configured to auto-start
     pub auto_start: bool,
-    /// Configuration properties reported by the source plugin
+    /// Configuration properties from [`Source::properties()`], including secrets.
+    ///
+    /// This is the authoritative config used to persist and recreate the source.
+    /// It intentionally contains sensitive values — see the persistence contract
+    /// on [`Source::properties()`] for details.
     pub properties: HashMap<String, serde_json::Value>,
     /// Bootstrap provider configuration, if one is attached to this source
     pub bootstrap_provider: Option<BootstrapSnapshot>,
@@ -89,7 +93,7 @@ pub struct SourceSnapshot {
 pub struct BootstrapSnapshot {
     /// Bootstrap provider kind (e.g., "postgres", "scriptfile", "noop")
     pub kind: String,
-    /// Configuration properties for the bootstrap provider
+    /// Configuration properties for the bootstrap provider, including secrets.
     pub properties: HashMap<String, serde_json::Value>,
 }
 
@@ -117,6 +121,10 @@ pub struct ReactionSnapshot {
     pub auto_start: bool,
     /// Query IDs this reaction subscribes to
     pub queries: Vec<String>,
-    /// Configuration properties reported by the reaction plugin
+    /// Configuration properties from [`Reaction::properties()`], including secrets.
+    ///
+    /// This is the authoritative config used to persist and recreate the reaction.
+    /// It intentionally contains sensitive values — see the persistence contract
+    /// on [`Reaction::properties()`] for details.
     pub properties: HashMap<String, serde_json::Value>,
 }

--- a/lib/src/reactions/traits.rs
+++ b/lib/src/reactions/traits.rs
@@ -138,11 +138,26 @@ pub trait Reaction: Send + Sync {
     /// Get the reaction type name (e.g., "http", "log", "sse")
     fn type_name(&self) -> &str;
 
-    /// Get the reaction's configuration properties for inspection
+    /// Return **all** configuration properties for this reaction, including secrets.
     ///
-    /// This returns a HashMap representation of the reaction's configuration
-    /// for use in APIs and inspection. The actual typed configuration is
-    /// owned by the plugin - this is just for external visibility.
+    /// # Persistence contract
+    ///
+    /// This method is the **serialization hook** used by the host to persist
+    /// configuration to disk. When the server saves its config file it calls
+    /// `snapshot_configuration()`, which in turn calls `properties()` on every
+    /// reaction. The returned map is written to the YAML config so the component
+    /// can be recreated on the next startup.
+    ///
+    /// Because there is no separate config cache — the live component is the
+    /// single source of truth — any key/value omitted here will be **lost** on
+    /// the next save and the component will fail to start after a restart.
+    ///
+    /// # ⚠ Do not filter secrets
+    ///
+    /// Implementations **must** include sensitive values (passwords, tokens,
+    /// connection strings, etc.). Removing them makes the persistence round-trip
+    /// lossy and breaks restart. The host is responsible for protecting the
+    /// config file on disk; this method is not an external-facing API.
     fn properties(&self) -> std::collections::HashMap<String, serde_json::Value>;
 
     /// Get the list of query IDs this reaction subscribes to

--- a/lib/src/sources/traits.rs
+++ b/lib/src/sources/traits.rs
@@ -125,11 +125,26 @@ pub trait Source: Send + Sync {
     /// Get the source type name (e.g., "postgres", "http", "mock")
     fn type_name(&self) -> &str;
 
-    /// Get the source's configuration properties for inspection
+    /// Return **all** configuration properties for this source, including secrets.
     ///
-    /// This returns a HashMap representation of the source's configuration
-    /// for use in APIs and inspection. The actual typed configuration is
-    /// owned by the plugin - this is just for external visibility.
+    /// # Persistence contract
+    ///
+    /// This method is the **serialization hook** used by the host to persist
+    /// configuration to disk. When the server saves its config file it calls
+    /// `snapshot_configuration()`, which in turn calls `properties()` on every
+    /// source. The returned map is written to the YAML config so the component
+    /// can be recreated on the next startup.
+    ///
+    /// Because there is no separate config cache — the live component is the
+    /// single source of truth — any key/value omitted here will be **lost** on
+    /// the next save and the component will fail to start after a restart.
+    ///
+    /// # ⚠ Do not filter secrets
+    ///
+    /// Implementations **must** include sensitive values (passwords, tokens,
+    /// connection strings, etc.). Removing them makes the persistence round-trip
+    /// lossy and breaks restart. The host is responsible for protecting the
+    /// config file on disk; this method is not an external-facing API.
     fn properties(&self) -> std::collections::HashMap<String, serde_json::Value>;
 
     /// Get the dispatch mode for this source (Channel or Broadcast)


### PR DESCRIPTION
## Summary

The `properties()` method on the `Source` and `Reaction` traits is the serialization hook used by the host (drasi-server) to persist component configuration to disk via `snapshot_configuration()`. The existing doc comments described it as being "for inspection," which misleads AI coding agents (and potentially human contributors) into filtering out sensitive values like passwords and tokens — making the config round-trip lossy and breaking server restart.

## Changes

- **`Source::properties()`** and **`Reaction::properties()`** — replaced the doc comments with a clear explanation of the persistence contract and an explicit warning not to filter secrets.
- **`SourceSnapshot::properties`**, **`ReactionSnapshot::properties`**, and **`BootstrapSnapshot::properties`** — updated field docs to note they intentionally contain sensitive values and link back to the trait method docs.

## Motivation

AI coding agents repeatedly suggest removing passwords/secrets from `properties()` implementations because:
1. The old doc comment said "for inspection" — implying a display/API surface
2. General security training biases agents toward redacting secrets from getters

The new docs make the persistence contract unmistakable, which should prevent these incorrect suggestions.