### PR TITLE
Cascade workspace minor bumps to unblock release-plz publish of drasi-lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/drasi-project/drasi-core"
@@ -104,33 +104,33 @@ drasi-query-ast = { version = "0.3.4", path = "query-ast" }
 drasi-query-cypher = { version = "0.3.4", path = "query-cypher" }
 drasi-query-gql = { version = "0.3.4", path = "query-gql" }
 drasi-core = { version = "0.5.0", path = "core" }
-drasi-functions-cypher = { version = "0.4.3", path = "functions-cypher" }
-drasi-functions-gql = { version = "0.4.3", path = "functions-gql" }
-drasi-middleware = { version = "0.4.3", path = "middleware" }
-drasi-identity-azure = { version = "0.1.4", path = "components/identity/azure" }
-drasi-identity-aws = { version = "0.1.3", path = "components/identity/aws" }
-drasi-lib = { version = "0.7.0", path = "lib" }
-drasi-ffi-primitives = { version = "0.7.0", path = "components/ffi-primitives" }
-drasi-plugin-sdk = { version = "0.7.0", path = "components/plugin-sdk" }
-drasi-host-sdk = { version = "0.7.0", path = "components/host-sdk" }
+drasi-functions-cypher = { version = "0.5.0", path = "functions-cypher" }
+drasi-functions-gql = { version = "0.5.0", path = "functions-gql" }
+drasi-middleware = { version = "0.5.0", path = "middleware" }
+drasi-identity-azure = { version = "0.2.0", path = "components/identity/azure" }
+drasi-identity-aws = { version = "0.2.0", path = "components/identity/aws" }
+drasi-lib = { version = "0.8.0", path = "lib" }
+drasi-ffi-primitives = { version = "0.8.0", path = "components/ffi-primitives" }
+drasi-plugin-sdk = { version = "0.8.0", path = "components/plugin-sdk" }
+drasi-host-sdk = { version = "0.8.0", path = "components/host-sdk" }
 
 # Common dependencies
 im = "15"
 utoipa = { version = "4", features = ["chrono"] }
-drasi-index-rocksdb = { version = "0.4.0", path = "components/indexes/rocksdb" }
-drasi-index-garnet = { version = "0.2.0", path = "components/indexes/garnet" }
+drasi-index-rocksdb = { version = "0.5.0", path = "components/indexes/rocksdb" }
+drasi-index-garnet = { version = "0.3.0", path = "components/indexes/garnet" }
 
 # Component plugins
-drasi-source-mssql = { version = "0.1.8", path = "components/sources/mssql" }
-drasi-bootstrap-mssql = { version = "0.1.7", path = "components/bootstrappers/mssql" }
-drasi-bootstrap-postgres = { version = "0.1.17", path = "components/bootstrappers/postgres" }
-drasi-reaction-application = { version = "0.2.14", path = "components/reactions/application" }
-drasi-source-postgres = { version = "0.1.18", path = "components/sources/postgres" }
-drasi-source-application = { version = "0.1.15", path = "components/sources/application" }
-drasi-bootstrap-application = { version = "0.1.15", path = "components/bootstrappers/application" }
-drasi-reaction-http = { version = "0.1.17", path = "components/reactions/http" }
-drasi-reaction-grpc = { version = "0.2.13", path = "components/reactions/grpc" }
-drasi-mssql-common = { version = "0.1.3", path = "components/mssql-common" }
+drasi-source-mssql = { version = "0.2.0", path = "components/sources/mssql" }
+drasi-bootstrap-mssql = { version = "0.2.0", path = "components/bootstrappers/mssql" }
+drasi-bootstrap-postgres = { version = "0.2.0", path = "components/bootstrappers/postgres" }
+drasi-reaction-application = { version = "0.3.0", path = "components/reactions/application" }
+drasi-source-postgres = { version = "0.2.0", path = "components/sources/postgres" }
+drasi-source-application = { version = "0.2.0", path = "components/sources/application" }
+drasi-bootstrap-application = { version = "0.2.0", path = "components/bootstrappers/application" }
+drasi-reaction-http = { version = "0.2.0", path = "components/reactions/http" }
+drasi-reaction-grpc = { version = "0.3.0", path = "components/reactions/grpc" }
+drasi-mssql-common = { version = "0.2.0", path = "components/mssql-common" }
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/components/bootstrappers/application/Cargo.toml
+++ b/components/bootstrappers/application/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-application"
-version = "0.1.15"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Application bootstrap plugin for Drasi"

--- a/components/bootstrappers/dataverse/Cargo.toml
+++ b/components/bootstrappers/dataverse/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-dataverse"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 authors = ["Drasi Project"]

--- a/components/bootstrappers/mssql/Cargo.toml
+++ b/components/bootstrappers/mssql/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-mssql"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Microsoft SQL Server bootstrap plugin for Drasi"

--- a/components/bootstrappers/noop/Cargo.toml
+++ b/components/bootstrappers/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-bootstrap-noop"
-version = "0.1.14"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "No-op bootstrap provider plugin for Drasi"

--- a/components/bootstrappers/platform/Cargo.toml
+++ b/components/bootstrappers/platform/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-platform"
-version = "0.1.15"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Platform bootstrap plugin for Drasi"

--- a/components/bootstrappers/postgres/Cargo.toml
+++ b/components/bootstrappers/postgres/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-postgres"
-version = "0.1.17"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "PostgreSQL bootstrap plugin for Drasi"

--- a/components/bootstrappers/scriptfile/Cargo.toml
+++ b/components/bootstrappers/scriptfile/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-bootstrap-scriptfile"
-version = "0.1.15"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "ScriptFile bootstrap plugin for Drasi"

--- a/components/identity/aws/Cargo.toml
+++ b/components/identity/aws/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-identity-aws"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "AWS identity provider plugin for Drasi"

--- a/components/identity/azure/Cargo.toml
+++ b/components/identity/azure/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-identity-azure"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Azure identity provider plugin for Drasi"

--- a/components/indexes/garnet/Cargo.toml
+++ b/components/indexes/garnet/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-index-garnet"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Drasi Core Garnet/Redis Index Plugin"

--- a/components/indexes/rocksdb/Cargo.toml
+++ b/components/indexes/rocksdb/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-index-rocksdb"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Drasi Core RocksDb Index Plugin"

--- a/components/mssql-common/Cargo.toml
+++ b/components/mssql-common/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-mssql-common"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Shared types for MS SQL source and bootstrap plugins"

--- a/components/reactions/application/Cargo.toml
+++ b/components/reactions/application/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-application"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Application reaction plugin for Drasi"

--- a/components/reactions/grpc-adaptive/Cargo.toml
+++ b/components/reactions/grpc-adaptive/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-grpc-adaptive"
-version = "0.1.15"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "gRPC Adaptive reaction plugin for Drasi"

--- a/components/reactions/grpc/Cargo.toml
+++ b/components/reactions/grpc/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-grpc"
-version = "0.2.13"
+version = "0.3.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "gRPC reaction plugin for Drasi"

--- a/components/reactions/http-adaptive/Cargo.toml
+++ b/components/reactions/http-adaptive/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-http-adaptive"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "HTTP Adaptive reaction plugin for Drasi"

--- a/components/reactions/http/Cargo.toml
+++ b/components/reactions/http/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-http"
-version = "0.1.17"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "HTTP reaction plugin for Drasi"

--- a/components/reactions/log/Cargo.toml
+++ b/components/reactions/log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-reaction-log"
-version = "0.1.16"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Log reaction plugin for Drasi"

--- a/components/reactions/platform/Cargo.toml
+++ b/components/reactions/platform/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-platform"
-version = "0.2.15"
+version = "0.3.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Platform reaction plugin for Drasi"

--- a/components/reactions/profiler/Cargo.toml
+++ b/components/reactions/profiler/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-profiler"
-version = "0.2.12"
+version = "0.3.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Profiler reaction plugin for Drasi"

--- a/components/reactions/sse/Cargo.toml
+++ b/components/reactions/sse/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-sse"
-version = "0.2.15"
+version = "0.3.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "SSE reaction plugin for Drasi"

--- a/components/reactions/storedproc-mssql/Cargo.toml
+++ b/components/reactions/storedproc-mssql/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-storedproc-mssql"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "MS SQL Server Stored Procedure reaction plugin for Drasi"

--- a/components/reactions/storedproc-mysql/Cargo.toml
+++ b/components/reactions/storedproc-mysql/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-storedproc-mysql"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "MySQL Stored Procedure reaction plugin for Drasi"

--- a/components/reactions/storedproc-postgres/Cargo.toml
+++ b/components/reactions/storedproc-postgres/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-reaction-storedproc-postgres"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "PostgreSQL Stored Procedure reaction plugin for Drasi"

--- a/components/sources/application/Cargo.toml
+++ b/components/sources/application/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-application"
-version = "0.1.15"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Application source plugin for Drasi"

--- a/components/sources/dataverse/Cargo.toml
+++ b/components/sources/dataverse/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-dataverse"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 authors = ["Drasi Project"]

--- a/components/sources/grpc/Cargo.toml
+++ b/components/sources/grpc/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-grpc"
-version = "0.1.17"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "gRPC source plugin for Drasi"

--- a/components/sources/http/Cargo.toml
+++ b/components/sources/http/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-http"
-version = "0.1.17"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "HTTP source plugin for Drasi"

--- a/components/sources/mock/Cargo.toml
+++ b/components/sources/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-source-mock"
-version = "0.1.17"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Mock source plugin for Drasi"

--- a/components/sources/mssql/Cargo.toml
+++ b/components/sources/mssql/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-mssql"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Microsoft SQL Server CDC source plugin for Drasi"

--- a/components/sources/platform/Cargo.toml
+++ b/components/sources/platform/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-platform"
-version = "0.1.16"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "Platform source plugin for Drasi"

--- a/components/sources/postgres/Cargo.toml
+++ b/components/sources/postgres/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-source-postgres"
-version = "0.1.18"
+version = "0.2.0"
 edition = "2021"
 authors = ["Drasi Project"]
 description = "PostgreSQL source plugin for Drasi"

--- a/components/state_stores/redb/Cargo.toml
+++ b/components/state_stores/redb/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-state-store-redb"
-version = "0.1.10"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Redb-based state store provider for Drasi plugins"

--- a/components/wals/redb/Cargo.toml
+++ b/components/wals/redb/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-wal-redb"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Redb-based Write-Ahead Log implementation for Drasi transient sources"

--- a/functions-cypher/Cargo.toml
+++ b/functions-cypher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-functions-cypher"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Cypher function implementations for Drasi"

--- a/functions-gql/Cargo.toml
+++ b/functions-gql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-functions-gql"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "GraphQL function implementations for Drasi"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-lib"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 authors = ["Drasi Project"]
 description = "Embedded Drasi for in-process data change processing using continuous queries"

--- a/middleware/Cargo.toml
+++ b/middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drasi-middleware"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 description = "Drasi Core Middleware"


### PR DESCRIPTION
# Description


The previous release-plz [run](https://github.com/drasi-project/drasi-core/actions/runs/25696327186/job/75445374865) failed verifying the `drasi-lib 0.7.0` tarball:

```
error[E0599]: no method named `with_cypher_function_set` found for struct `Arc<FunctionRegistry>`
error[E0599]: no method named `with_gql_function_set` found for struct `Arc<FunctionRegistry>`
```

**Root cause:** `drasi-core` was bumped `0.4.3 → 0.5.0` (a SemVer-incompatible change on `0.x`) without cascading bumps to the crates that depend on it. The already-published `drasi-functions-cypher 0.4.3`, `drasi-functions-gql 0.4.3`, and `drasi-middleware 0.4.3` still pin `drasi-core ^0.4`, so when cargo verified the tarball it pulled in **both** `drasi-core 0.5.0` (path dep) and `drasi-core 0.4.3` (transitive). The `CypherFunctionSet` / `GQLFunctionSet` impls live in the 0.4.3 crates and are implemented for the 0.4.3 `FunctionRegistry`, but `drasi-lib` constructs a 0.5.0 `FunctionRegistry`. Two distinct types → trait method not found.

### What

Cascading minor bump of every workspace crate that transitively depends on `drasi-core`, so the next publish re-publishes them against `drasi-core ^0.5`.

**Workspace `Cargo.toml`:**
- `[workspace.package]` `0.7.0 → 0.8.0` (cascades via `version.workspace = true` to `drasi-ffi-primitives`, `drasi-plugin-sdk`, `drasi-host-sdk`)
- `drasi-functions-cypher`, `drasi-functions-gql`, `drasi-middleware`: `0.4.3 → 0.5.0`
- `drasi-lib`, `drasi-ffi-primitives`, `drasi-plugin-sdk`, `drasi-host-sdk`: `0.7.0 → 0.8.0`
- `drasi-index-rocksdb`: `0.4.0 → 0.5.0`
- `drasi-index-garnet`: `0.2.0 → 0.3.0`
- `drasi-mssql-common`: `0.1.3 → 0.2.0`
- `drasi-identity-azure`: `0.1.4 → 0.2.0`, `drasi-identity-aws`: `0.1.3 → 0.2.0`
- All sources, reactions, and bootstrappers bumped one minor (`0.1.x → 0.2.0`, `0.2.x → 0.3.0`)

**Per-crate `Cargo.toml`:** matching `version = "..."` updated for `lib`, `middleware`, `functions-cypher`, `functions-gql`, and every component crate.

`drasi-core` stays at `0.5.0` (already published).

### Verification

- `cargo update --workspace` resolves cleanly with a single `drasi-core 0.5.0`.
- `cargo check -p drasi-lib` builds successfully against the bumped path deps — confirms the 0.5.0 `FunctionRegistry` trait methods resolve.
- `cargo publish --dry-run -p drasi-lib` cannot fully run locally because the new `0.5.0` / `0.8.0` deps aren't on crates.io yet; the real verification will happen during the release-plz run after the cascaded crates are published.


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
