### PR TITLE
Dashboard snapshot

### DIFF
--- a/components/reactions/dashboard/Cargo.toml
+++ b/components/reactions/dashboard/Cargo.toml
@@ -47,10 +47,10 @@ uuid = { version = "1.0", features = ["v4"] }
 rust-embed = { version = "8", features = ["axum", "mime-guess"] }
 drasi-plugin-sdk = { workspace = true }
 utoipa = { workspace = true }
-reqwest = { version = "0.12", features = ["json"] }
 
 [dev-dependencies]
 drasi-core.workspace = true
+reqwest = { version = "0.12", features = ["json"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 env_logger = "0.11"
 tokio-test = "0.4"

--- a/components/reactions/dashboard/README.md
+++ b/components/reactions/dashboard/README.md
@@ -20,7 +20,6 @@ let reaction = DashboardReaction::builder("my-dashboard")
     .with_host("0.0.0.0")
     .with_port(3000)
     .with_heartbeat_interval_ms(30_000)
-    .with_results_api_url("http://localhost:8080")
     .build()?;
 ```
 
@@ -31,9 +30,15 @@ let reaction = DashboardReaction::builder("my-dashboard")
 | `host` | `String` | `"0.0.0.0"` | Bind host for HTTP + WebSocket server |
 | `port` | `u16` | `3000` | Bind port |
 | `heartbeat_interval_ms` | `u64` | `30000` | WebSocket heartbeat interval |
-| `results_api_url` | `Option<String>` | `None` | Optional results API URL for snapshot bootstrap |
 | `priority_queue_capacity` | `Option<usize>` | `None` | Maximum pending change events in the priority queue; unbounded if not set |
 | `queries` | `Vec<String>` | `[]` | Subscribed query IDs |
+
+### Snapshot Fallback
+
+When a client requests the current state of a query via `/api/queries/:id/snapshot` and
+the dashboard's in-memory snapshot is empty (e.g. before any diffs have arrived), the
+dashboard automatically falls back to the host-provided `SnapshotFetcher` API to retrieve
+the query's current result set. This happens transparently — no configuration is needed.
 
 ## Predefined Dashboards
 

--- a/components/reactions/dashboard/README.md
+++ b/components/reactions/dashboard/README.md
@@ -25,12 +25,14 @@ let reaction = DashboardReaction::builder("my-dashboard")
 
 ### Fields
 
+Configuration fields use **camelCase** in JSON/YAML:
+
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `host` | `String` | `"0.0.0.0"` | Bind host for HTTP + WebSocket server |
 | `port` | `u16` | `3000` | Bind port |
-| `heartbeat_interval_ms` | `u64` | `30000` | WebSocket heartbeat interval |
-| `priority_queue_capacity` | `Option<usize>` | `None` | Maximum pending change events in the priority queue; unbounded if not set |
+| `heartbeatIntervalMs` | `u64` | `30000` | WebSocket heartbeat interval |
+| `priorityQueueCapacity` | `Option<usize>` | `None` | Maximum pending change events in the priority queue; unbounded if not set |
 | `queries` | `Vec<String>` | `[]` | Subscribed query IDs |
 
 ### Snapshot Fallback

--- a/components/reactions/dashboard/README.md
+++ b/components/reactions/dashboard/README.md
@@ -35,13 +35,6 @@ Configuration fields use **camelCase** in JSON/YAML:
 | `priorityQueueCapacity` | `Option<usize>` | `None` | Maximum pending change events in the priority queue; unbounded if not set |
 | `queries` | `Vec<String>` | `[]` | Subscribed query IDs |
 
-### Snapshot Fallback
-
-When a client requests the current state of a query via `/api/queries/:id/snapshot` and
-the dashboard's in-memory snapshot is empty (e.g. before any diffs have arrived), the
-dashboard automatically falls back to the host-provided `SnapshotFetcher` API to retrieve
-the query's current result set. This happens transparently — no configuration is needed.
-
 ## Predefined Dashboards
 
 You can ship dashboards as part of your reaction configuration using `.with_dashboard()`.

--- a/components/reactions/dashboard/src/api.rs
+++ b/components/reactions/dashboard/src/api.rs
@@ -24,6 +24,7 @@ use axum::{
     routing::get,
     Json, Router,
 };
+use drasi_lib::reactions::SnapshotFetcher;
 use drasi_lib::StateStoreProvider;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -36,8 +37,7 @@ pub struct ApiState {
     query_ids: Arc<Vec<String>>,
     state_store: Option<Arc<dyn StateStoreProvider>>,
     snapshot_store: QuerySnapshotStore,
-    results_api_url: Option<String>,
-    results_api_client: Option<reqwest::Client>,
+    snapshot_fetcher: Option<Arc<dyn SnapshotFetcher>>,
 }
 
 impl ApiState {
@@ -46,28 +46,15 @@ impl ApiState {
         query_ids: Vec<String>,
         state_store: Option<Arc<dyn StateStoreProvider>>,
         snapshot_store: QuerySnapshotStore,
+        snapshot_fetcher: Option<Arc<dyn SnapshotFetcher>>,
     ) -> Self {
         Self {
             reaction_id: reaction_id.into(),
             query_ids: Arc::new(query_ids),
             state_store,
             snapshot_store,
-            results_api_url: None,
-            results_api_client: None,
+            snapshot_fetcher,
         }
-    }
-
-    pub fn with_results_api_url(mut self, url: Option<String>) -> Self {
-        if url.is_some() {
-            self.results_api_client = Some(
-                reqwest::Client::builder()
-                    .timeout(std::time::Duration::from_secs(5))
-                    .build()
-                    .expect("failed to build reqwest client"),
-            );
-        }
-        self.results_api_url = url;
-        self
     }
 
     fn storage(&self) -> anyhow::Result<DashboardStorage> {
@@ -289,15 +276,11 @@ async fn get_query_snapshot(
         return Ok(Json(snapshot));
     }
 
-    // Fall back to the results API if configured and local snapshot is empty.
-    if let (Some(base_url), Some(client)) = (&state.results_api_url, &state.results_api_client) {
-        let url = format!(
-            "{}/queries/{}/results",
-            base_url.trim_end_matches('/'),
-            query_id
-        );
-        if let Ok(response) = client.get(&url).send().await {
-            if let Ok(rows) = response.json::<Vec<serde_json::Value>>().await {
+    // Fall back to the internal snapshot fetcher if configured and local snapshot is empty.
+    if let Some(ref fetcher) = state.snapshot_fetcher {
+        if let Ok(stream) = fetcher.fetch_snapshot(&query_id).await {
+            let rows = stream.collect_vec().await;
+            if !rows.is_empty() {
                 return Ok(Json(QuerySnapshot {
                     rows,
                     aggregation: None,
@@ -321,6 +304,7 @@ mod tests {
             vec!["query-1".to_string()],
             Some(store),
             QuerySnapshotStore::new(),
+            None,
         )
     }
 

--- a/components/reactions/dashboard/src/config.rs
+++ b/components/reactions/dashboard/src/config.rs
@@ -42,12 +42,6 @@ pub struct DashboardReactionConfig {
     /// WebSocket heartbeat interval in milliseconds.
     #[serde(default = "default_heartbeat_interval_ms")]
     pub heartbeat_interval_ms: u64,
-
-    /// Optional base URL for the DrasiLib results API (e.g., "http://localhost:8080").
-    /// When set, the dashboard proxies initial query data from this API
-    /// so widgets populate immediately with bootstrap data.
-    #[serde(default)]
-    pub results_api_url: Option<String>,
 }
 
 impl Default for DashboardReactionConfig {
@@ -56,7 +50,6 @@ impl Default for DashboardReactionConfig {
             host: default_dashboard_host(),
             port: default_dashboard_port(),
             heartbeat_interval_ms: default_heartbeat_interval_ms(),
-            results_api_url: None,
         }
     }
 }

--- a/components/reactions/dashboard/src/config.rs
+++ b/components/reactions/dashboard/src/config.rs
@@ -30,6 +30,7 @@ fn default_heartbeat_interval_ms() -> u64 {
 
 /// Dashboard reaction configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct DashboardReactionConfig {
     /// Host to bind the dashboard server.
     #[serde(default = "default_dashboard_host")]

--- a/components/reactions/dashboard/src/dashboard.rs
+++ b/components/reactions/dashboard/src/dashboard.rs
@@ -277,13 +277,19 @@ impl Reaction for DashboardReaction {
         });
         self.task_handles.lock().await.push(heartbeat_handle);
 
+        let snapshot_fetcher = self
+            .base
+            .context()
+            .await
+            .and_then(|ctx| ctx.snapshot_fetcher.clone());
+
         let api_state = ApiState::new(
             self.base.id.clone(),
             self.base.queries.clone(),
             self.base.state_store().await,
             self.snapshot_store.clone(),
-        )
-        .with_results_api_url(self.config.results_api_url.clone());
+            snapshot_fetcher,
+        );
         let websocket_hub = self.websocket_hub.clone();
         let query_ids = self.base.queries.clone();
         let server_status_handle = self.base.status_handle();

--- a/components/reactions/dashboard/src/descriptor.rs
+++ b/components/reactions/dashboard/src/descriptor.rs
@@ -182,13 +182,6 @@ pub struct DashboardReactionConfigDto {
     #[schema(value_type = Option<ConfigValueU64>)]
     pub heartbeat_interval_ms: Option<ConfigValue<u64>>,
 
-    /// Deprecated: previously used for HTTP-based results API fallback.
-    /// The dashboard now uses the internal SnapshotFetcher API automatically.
-    /// Retained for backwards-compatible deserialization only.
-    #[serde(skip_serializing, default)]
-    #[schema(ignore)]
-    pub results_api_url: Option<ConfigValue<String>>,
-
     /// Optional priority queue capacity for change event processing.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<ConfigValueU64>)]
@@ -262,7 +255,6 @@ impl From<&crate::config::DashboardReactionConfig> for DashboardReactionConfigDt
             host: Some(ConfigValue::Static(config.host.clone())),
             port: Some(ConfigValue::Static(config.port)),
             heartbeat_interval_ms: Some(ConfigValue::Static(config.heartbeat_interval_ms)),
-            results_api_url: None,
             priority_queue_capacity: None,
             predefined_dashboards: Vec::new(),
         }

--- a/components/reactions/dashboard/src/descriptor.rs
+++ b/components/reactions/dashboard/src/descriptor.rs
@@ -182,11 +182,11 @@ pub struct DashboardReactionConfigDto {
     #[schema(value_type = Option<ConfigValueU64>)]
     pub heartbeat_interval_ms: Option<ConfigValue<u64>>,
 
-    /// Optional base URL for the DrasiLib results API (e.g., "http://localhost:8080").
-    /// When set, the dashboard proxies initial query data from this API
-    /// so widgets populate immediately with bootstrap data.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<ConfigValueString>)]
+    /// Deprecated: previously used for HTTP-based results API fallback.
+    /// The dashboard now uses the internal SnapshotFetcher API automatically.
+    /// Retained for backwards-compatible deserialization only.
+    #[serde(skip_serializing, default)]
+    #[schema(ignore)]
     pub results_api_url: Option<ConfigValue<String>>,
 
     /// Optional priority queue capacity for change event processing.
@@ -262,10 +262,7 @@ impl From<&crate::config::DashboardReactionConfig> for DashboardReactionConfigDt
             host: Some(ConfigValue::Static(config.host.clone())),
             port: Some(ConfigValue::Static(config.port)),
             heartbeat_interval_ms: Some(ConfigValue::Static(config.heartbeat_interval_ms)),
-            results_api_url: config
-                .results_api_url
-                .as_ref()
-                .map(|u| ConfigValue::Static(u.clone())),
+            results_api_url: None,
             priority_queue_capacity: None,
             predefined_dashboards: Vec::new(),
         }
@@ -343,9 +340,6 @@ impl ReactionPluginDescriptor for DashboardReactionDescriptor {
         if let Some(ref heartbeat_interval_ms) = dto.heartbeat_interval_ms {
             builder = builder
                 .with_heartbeat_interval_ms(mapper.resolve_typed(heartbeat_interval_ms).await?);
-        }
-        if let Some(ref results_api_url) = dto.results_api_url {
-            builder = builder.with_results_api_url(mapper.resolve_string(results_api_url).await?);
         }
         if let Some(ref priority_queue_capacity) = dto.priority_queue_capacity {
             let capacity: u64 = mapper.resolve_typed(priority_queue_capacity).await?;

--- a/components/reactions/dashboard/src/lib.rs
+++ b/components/reactions/dashboard/src/lib.rs
@@ -97,12 +97,6 @@ impl DashboardReactionBuilder {
         self
     }
 
-    /// Set the results API base URL for proxying initial query data.
-    #[deprecated(note = "The dashboard now uses the internal SnapshotFetcher API automatically")]
-    pub fn with_results_api_url(self, _url: impl Into<String>) -> Self {
-        self
-    }
-
     /// Add a predefined dashboard that will be seeded on startup.
     /// Predefined dashboards are only seeded if they don't already exist in the state store,
     /// so user edits made via the UI are preserved across restarts.

--- a/components/reactions/dashboard/src/lib.rs
+++ b/components/reactions/dashboard/src/lib.rs
@@ -34,7 +34,6 @@ pub struct DashboardReactionBuilder {
     host: String,
     port: u16,
     heartbeat_interval_ms: u64,
-    results_api_url: Option<String>,
     priority_queue_capacity: Option<usize>,
     auto_start: bool,
     predefined_dashboards: Vec<DashboardConfig>,
@@ -50,7 +49,6 @@ impl DashboardReactionBuilder {
             host: config.host,
             port: config.port,
             heartbeat_interval_ms: config.heartbeat_interval_ms,
-            results_api_url: None,
             priority_queue_capacity: None,
             auto_start: true,
             predefined_dashboards: Vec::new(),
@@ -100,8 +98,8 @@ impl DashboardReactionBuilder {
     }
 
     /// Set the results API base URL for proxying initial query data.
-    pub fn with_results_api_url(mut self, url: impl Into<String>) -> Self {
-        self.results_api_url = Some(url.into());
+    #[deprecated(note = "The dashboard now uses the internal SnapshotFetcher API automatically")]
+    pub fn with_results_api_url(self, _url: impl Into<String>) -> Self {
         self
     }
 
@@ -118,7 +116,6 @@ impl DashboardReactionBuilder {
         self.host = config.host;
         self.port = config.port;
         self.heartbeat_interval_ms = config.heartbeat_interval_ms;
-        self.results_api_url = config.results_api_url;
         self
     }
 
@@ -128,7 +125,6 @@ impl DashboardReactionBuilder {
             host: self.host,
             port: self.port,
             heartbeat_interval_ms: self.heartbeat_interval_ms,
-            results_api_url: self.results_api_url,
         };
 
         Ok(DashboardReaction::from_builder(

--- a/components/reactions/dashboard/src/tests.rs
+++ b/components/reactions/dashboard/src/tests.rs
@@ -80,7 +80,6 @@ fn test_dashboard_config_serialization() {
         host: "localhost".to_string(),
         port: 5050,
         heartbeat_interval_ms: 15_000,
-        results_api_url: None,
     };
 
     let serialized = serde_json::to_string(&config).expect("config should serialize");
@@ -166,7 +165,6 @@ fn test_schema_config_has_all_properties() {
         "host",
         "port",
         "heartbeatIntervalMs",
-        "resultsApiUrl",
         "priorityQueueCapacity",
         "predefinedDashboards",
     ];
@@ -229,7 +227,6 @@ fn test_dto_deserialize_minimal_config() {
     assert!(dto.host.is_none());
     assert!(dto.port.is_none());
     assert!(dto.heartbeat_interval_ms.is_none());
-    assert!(dto.results_api_url.is_none());
     assert!(dto.priority_queue_capacity.is_none());
     assert!(dto.predefined_dashboards.is_empty());
 }
@@ -276,7 +273,6 @@ fn test_dto_deserialize_full_config() {
     assert!(dto.host.is_some());
     assert!(dto.port.is_some());
     assert!(dto.heartbeat_interval_ms.is_some());
-    assert!(dto.results_api_url.is_some());
     assert!(dto.priority_queue_capacity.is_some());
     assert_eq!(dto.predefined_dashboards.len(), 1);
 


### PR DESCRIPTION
This pull request refactors the Dashboard Reaction's configuration and snapshot fallback logic to remove the legacy HTTP-based results API fallback in favor of a new, internal `SnapshotFetcher` API. The configuration now uses camelCase for JSON/YAML fields, and the results API URL is deprecated and no longer used for fetching snapshots. The snapshot fallback logic is now handled transparently and internally, simplifying both configuration and code.
