### PR TITLE
fix: add manual single-crate publish workflow

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,43 @@
+name: Publish single crate
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Crate name to publish (e.g. drasi-reaction-application)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.package }}
+    runs-on: ubuntu-latest-8-cores
+    environment: drasi-core-release
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq libjq-dev protobuf-compiler
+
+      - name: Set JQ_LIB_DIR
+        run: echo "JQ_LIB_DIR=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Publish ${{ inputs.package }}
+        run: cargo publish -p "${{ inputs.package }}" --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -88,25 +88,7 @@ jobs:
 
       - name: Publish crates
         if: ${{ (steps.check_release.outputs.is_release == 'true' || inputs.force_publish == true) && inputs.dry_run != true }}
-        run: |
-          # Retry up to 3 times to handle transient failures and dependency ordering issues.
-          # release-plz skips already-published crates (via git tags), so retries are safe
-          # and allow dependent crates to publish after their dependencies land on crates.io.
-          for attempt in 1 2 3; do
-            echo "=== Publish attempt $attempt/3 ==="
-            if release-plz release --git-token "$GITHUB_TOKEN" --backend github; then
-              echo "All crates published successfully."
-              break
-            else
-              if [ $attempt -lt 3 ]; then
-                echo "Some crates failed to publish. Waiting 30s for crates.io index to update before retrying..."
-                sleep 30
-              else
-                echo "::error::Publish failed after 3 attempts"
-                exit 1
-              fi
-            fi
-          done
+        run: release-plz release --git-token "$GITHUB_TOKEN" --backend github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,10 +12,6 @@ git_release_type = "prod"
 
 # Publishing settings
 publish = true
-# Skip cargo publish verification (build check) since CI already validates builds.
-# This prevents publish failures due to dev-dependency ordering issues where
-# release-plz may try to publish a crate before its dev-deps are on crates.io.
-publish_no_verify = true
 
 # PR settings
 pr_labels = ["release"]


### PR DESCRIPTION
## Problem

release-plz doesn't consider dev-dependencies when determining publish order. When it tries to publish `drasi-source-open511` before `drasi-reaction-application`, cargo fails during packaging because it can't resolve the dev-dep version on crates.io.

The previous fix (#468) tried `publish_no_verify` and retry loops, but neither works:
- `--no-verify` only skips the build step, not dependency resolution during packaging
- Retries don't help because release-plz always iterates the same (wrong) order

## Fix

Adds a **manual workflow** (`publish-crate.yml`) that publishes a single crate via `workflow_dispatch`. When release-plz fails due to ordering:

1. Run the manual workflow for the blocking dependency (e.g. `drasi-reaction-application`)
2. Wait for it to land on crates.io (~30s)
3. Re-run the release workflow with `force_publish: true`

release-plz will skip the already-published crate (detects it on crates.io) and still create its git tag and GitHub release.

Also reverts the ineffective `publish_no_verify` and retry loop from #468.