### PR TITLE
fix: convert path-only deps to workspace refs for crate publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,10 @@ drasi-source-oracle = { version = "0.1.0", path = "components/sources/oracle" }
 drasi-bootstrap-oracle = { version = "0.1.0", path = "components/bootstrappers/oracle" }
 drasi-oracle-common = { version = "0.1.1", path = "components/oracle-common" }
 drasi-source-gtfs-rt = { version = "0.1.0", path = "components/sources/gtfs-rt" }
+drasi-bootstrap-gtfs-rt = { version = "0.1.0", path = "components/bootstrappers/gtfs-rt" }
+drasi-source-open511 = { version = "0.1.0", path = "components/sources/open511" }
+drasi-bootstrap-open511 = { version = "0.1.0", path = "components/bootstrappers/open511" }
+drasi-bootstrap-sqlite = { version = "0.1.1", path = "components/bootstrappers/sqlite" }
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/components/bootstrappers/gtfs-rt/Cargo.toml
+++ b/components/bootstrappers/gtfs-rt/Cargo.toml
@@ -34,7 +34,7 @@ drasi-lib.workspace = true
 drasi-core.workspace = true
 drasi-plugin-sdk = { workspace = true }
 utoipa = { workspace = true }
-drasi-source-gtfs-rt = { path = "../../sources/gtfs-rt" }
+drasi-source-gtfs-rt = { workspace = true }
 anyhow = "1.0"
 async-trait = "0.1"
 log = "0.4"

--- a/components/bootstrappers/here-traffic/Cargo.toml
+++ b/components/bootstrappers/here-traffic/Cargo.toml
@@ -33,7 +33,7 @@ workspace = true
 drasi-core.workspace = true
 drasi-lib.workspace = true
 drasi-plugin-sdk.workspace = true
-drasi-source-here-traffic = { path = "../../sources/here-traffic" }
+drasi-source-here-traffic = { workspace = true }
 utoipa.workspace = true
 anyhow = "1.0"
 async-trait = "0.1"

--- a/components/bootstrappers/open511/Cargo.toml
+++ b/components/bootstrappers/open511/Cargo.toml
@@ -33,7 +33,7 @@ workspace = true
 drasi-lib.workspace = true
 drasi-core.workspace = true
 drasi-plugin-sdk = { workspace = true }
-drasi-source-open511 = { path = "../../sources/open511" }
+drasi-source-open511 = { workspace = true }
 utoipa = { workspace = true }
 anyhow = "1.0"
 async-trait = "0.1"

--- a/components/bootstrappers/oracle/Cargo.toml
+++ b/components/bootstrappers/oracle/Cargo.toml
@@ -33,7 +33,7 @@ workspace = true
 drasi-core.workspace = true
 drasi-lib.workspace = true
 drasi-plugin-sdk = { workspace = true }
-drasi-oracle-common = { path = "../../oracle-common" }
+drasi-oracle-common = { workspace = true }
 utoipa = { workspace = true }
 anyhow = "1.0"
 async-trait = "0.1"

--- a/components/bootstrappers/sui-deepbook/Cargo.toml
+++ b/components/bootstrappers/sui-deepbook/Cargo.toml
@@ -34,7 +34,7 @@ drasi-lib.workspace = true
 drasi-core.workspace = true
 drasi-plugin-sdk = { workspace = true }
 utoipa = { workspace = true }
-drasi-source-sui-deepbook = { path = "../../sources/sui-deepbook", default-features = false }
+drasi-source-sui-deepbook = { workspace = true, default-features = false }
 anyhow = "1.0"
 async-trait = "0.1"
 log = "0.4"

--- a/components/reactions/loki/Cargo.toml
+++ b/components/reactions/loki/Cargo.toml
@@ -35,7 +35,7 @@ url = "2"
 dynamic-plugin = []
 
 [dev-dependencies]
-drasi-source-application = { path = "../../../components/sources/application" }
+drasi-source-application = { workspace = true }
 env_logger = "0.10.0"
 testcontainers = "0.27"
 tokio-test = "0.4"

--- a/components/reactions/mcp/Cargo.toml
+++ b/components/reactions/mcp/Cargo.toml
@@ -49,7 +49,7 @@ drasi-plugin-sdk = { workspace = true }
 utoipa = { workspace = true }
 
 [dev-dependencies]
-drasi-source-application = { path = "../../sources/application" }
+drasi-source-application = { workspace = true }
 eventsource-stream = "0.2"
 futures = "0.3"
 reqwest = { version = "0.11", features = ["stream", "json"] }

--- a/components/sources/cloudflare-radar/Cargo.toml
+++ b/components/sources/cloudflare-radar/Cargo.toml
@@ -48,7 +48,7 @@ url = "2"
 tokio-test = "0.4"
 testcontainers = "0.27"
 drasi-bootstrap-cloudflare-radar.workspace = true
-drasi-reaction-application = { path = "../../reactions/application" }
+drasi-reaction-application = { workspace = true }
 env_logger = "0.11"
 
 [features]

--- a/components/sources/here-traffic/Cargo.toml
+++ b/components/sources/here-traffic/Cargo.toml
@@ -50,8 +50,8 @@ tracing = "0.1"
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
-drasi-bootstrap-here-traffic = { path = "../../bootstrappers/here-traffic" }
-drasi-reaction-application = { path = "../../../components/reactions/application" }
+drasi-bootstrap-here-traffic = { workspace = true }
+drasi-reaction-application = { workspace = true }
 env_logger = "0.11"
 tokio-test = "0.4"
 wiremock = "0.6"

--- a/components/sources/http/Cargo.toml
+++ b/components/sources/http/Cargo.toml
@@ -66,7 +66,7 @@ regex = "1.10"
 
 [dev-dependencies]
 tokio-test = "0.4"
-drasi-reaction-application = { path = "../../reactions/application" }
+drasi-reaction-application = { workspace = true }
 env_logger = "0.11"
 
 

--- a/components/sources/hyperliquid/Cargo.toml
+++ b/components/sources/hyperliquid/Cargo.toml
@@ -52,7 +52,7 @@ utoipa = { workspace = true }
 [dev-dependencies]
 tokio-test = "0.4"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
-drasi-reaction-application = { path = "../../reactions/application" }
+drasi-reaction-application = { workspace = true }
 
 [features]
 # default = []

--- a/components/sources/mssql/Cargo.toml
+++ b/components/sources/mssql/Cargo.toml
@@ -55,10 +55,10 @@ bytes = "1"
 env_logger = "0.11"
 tokio-test = "0.4"
 testcontainers = "0.27"
-drasi-bootstrap-mssql = { path = "../../bootstrappers/mssql" }
-drasi-reaction-application = { path = "../../reactions/application" }
+drasi-bootstrap-mssql = { workspace = true }
+drasi-reaction-application = { workspace = true }
 drasi-index-rocksdb = { workspace = true }
-drasi-host-sdk = { path = "../../host-sdk" }
+drasi-host-sdk = { workspace = true }
 drasi-plugin-sdk = { workspace = true }
 tempfile = "3"
 bytes = "1"

--- a/components/sources/open511/Cargo.toml
+++ b/components/sources/open511/Cargo.toml
@@ -48,7 +48,7 @@ url = "2"
 
 [dev-dependencies]
 axum = "0.7"
-drasi-bootstrap-open511 = { path = "../../bootstrappers/open511" }
+drasi-bootstrap-open511 = { workspace = true }
 drasi-reaction-application.workspace = true
 env_logger = "0.11"
 reqwest = { version = "0.11", features = ["json"] }

--- a/components/sources/oracle/Cargo.toml
+++ b/components/sources/oracle/Cargo.toml
@@ -33,7 +33,7 @@ workspace = true
 drasi-core.workspace = true
 drasi-lib.workspace = true
 drasi-plugin-sdk = { workspace = true }
-drasi-oracle-common = { path = "../../oracle-common", package = "drasi-oracle-common" }
+drasi-oracle-common = { workspace = true }
 utoipa = { workspace = true }
 anyhow = "1.0"
 async-trait = "0.1"
@@ -47,9 +47,9 @@ tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 
 [dev-dependencies]
-drasi-bootstrap-oracle = { path = "../../bootstrappers/oracle" }
-drasi-index-rocksdb = { path = "../../indexes/rocksdb" }
-drasi-reaction-application = { path = "../../reactions/application" }
+drasi-bootstrap-oracle = { workspace = true }
+drasi-index-rocksdb = { workspace = true }
+drasi-reaction-application = { workspace = true }
 env_logger = "0.10.0"
 serial_test = "3.0"
 tempfile = "3.0"

--- a/components/sources/postgres/Cargo.toml
+++ b/components/sources/postgres/Cargo.toml
@@ -62,8 +62,8 @@ tokio-stream = "0.1"
 prost-types = "0.12"
 
 [dev-dependencies]
-drasi-bootstrap-postgres = { path = "../../bootstrappers/postgres" }
-drasi-reaction-application = { path = "../../reactions/application" }
+drasi-bootstrap-postgres = { workspace = true }
+drasi-reaction-application = { workspace = true }
 env_logger = "0.10.0"
 serial_test = "3.0"
 testcontainers = "0.27"

--- a/components/sources/sqlite/Cargo.toml
+++ b/components/sources/sqlite/Cargo.toml
@@ -55,7 +55,7 @@ hyper = "1.0"
 tower-http = { version = "0.5", features = ["trace"] }
 
 [dev-dependencies]
-drasi-bootstrap-sqlite = { path = "../../bootstrappers/sqlite" }
+drasi-bootstrap-sqlite = { workspace = true }
 drasi-reaction-application.workspace = true
 tokio-test = "0.4"
 tempfile = "3"


### PR DESCRIPTION
## Problem

`cargo publish` requires all dependencies to have a version specified. Several crates in the workspace use path-only references (`{ path = "..." }`) without a version, causing publish failures like:

> all dependencies must have a version specified when publishing. dependency `drasi-source-open511` does not specify a version

This affects both normal deps (bootstrappers depending on sources) and dev-deps (sources depending on reactions/bootstrappers for integration tests).

## Fix

Convert all path-only `drasi-*` dependencies to `{ workspace = true }`, which provides both:
- `path` for local development (resolves locally)
- `version` for crates.io publishing (cargo can find it on the registry)

Added missing workspace dependency entries to root `Cargo.toml` where needed.

## Affected crates

**Bootstrappers** (normal deps on source crates):
- open511, gtfs-rt, here-traffic, sui-deepbook, oracle

**Sources** (dev-deps on reaction/bootstrap crates):
- open511, here-traffic, cloudflare-radar, http, hyperliquid, mssql, oracle, postgres, sqlite

**Reactions** (dev-deps on source crates):
- loki, mcp

## Validation

- `cargo check --workspace` passes
- No remaining path-only `drasi-*` deps in the workspace