### PR TITLE
docs: update planner/executor agents with recovery & replay guidance

### DIFF
--- a/.github/agents/reaction-plan-executor.md
+++ b/.github/agents/reaction-plan-executor.md
@@ -72,6 +72,17 @@ Implement components **exactly as specified** in the plan:
 #### Output to target system
 - Follow data format and transmission method from plan
 
+#### Recovery & Idempotency
+- If the plan specifies idempotency requirements, implement deduplication logic in the reaction (e.g., using sequence numbers, upsert operations, or target-system dedup features)
+- The framework handles outbox persistence, live-results snapshots, and sequence gap detection automatically — reactions generally don't need to implement these directly
+- Log warnings for non-idempotent operations that may be replayed after recovery
+
+#### Recovery Trait Hooks (implement as specified in plan)
+- **`is_durable()`** — Override to return `true` if the reaction needs persistent checkpoints. Default is `false`.
+- **`needs_snapshot_on_fresh_start()`** — Override to return `true` if the reaction needs full current state on first start (no prior checkpoint). Default is `false`.
+- **`default_recovery_policy()`** — Override to return the appropriate `ReactionRecoveryPolicy` variant (`Strict`, `AutoReset`, or `AutoSkipGap`). Default is `Strict`. Note: this is separate from the query-level `RecoveryPolicy` which only has `Strict` and `AutoReset`.
+- **`bootstrap(ctx: BootstrapContext)`** — Implement if the reaction needs snapshot/outbox replay during recovery. Use `ctx.fetch_snapshot()` for full state recovery and `ctx.fetch_outbox()` for incremental replay. Write checkpoints only after target-side delivery is durable.
+
 
 ### 4. Testing & Verification
 
@@ -134,6 +145,10 @@ mod integration_tests {
       .query("MATCH (n:test_table) RETURN n.id AS id, n.name AS name")
       .from_source("test-source")
       .auto_start(true)
+      // Query-level recovery options (controls source resume behavior):
+      // .with_recovery_policy(RecoveryPolicy::AutoReset)
+      // .with_outbox_capacity(1000)
+      // .with_bootstrap_timeout_secs(60)
       .build();
     
     // 4. Create the reaction under test
@@ -150,6 +165,8 @@ mod integration_tests {
       .with_source(source)
       .with_query(query)
       .with_reaction(reaction)
+      // Optional: set global query recovery policy
+      // .with_default_recovery_policy(RecoveryPolicy::AutoReset)
       .build()
       .await
       .unwrap();
@@ -218,6 +235,9 @@ mod integration_tests {
       .query("MATCH (n:test_table) RETURN n.id AS id, n.name AS name")
       .from_source("test-source")
       .auto_start(true)
+      // Query-level recovery options (use as appropriate):
+      // .with_recovery_policy(RecoveryPolicy::AutoReset)
+      // .with_outbox_capacity(1000)
       .build();
     
     // 4. Create the reaction - it will host the endpoint
@@ -390,6 +410,14 @@ Implementation is complete when ALL are true:
 - [ ] Integration test RUNS and PASSES (INSERT/UPDATE/DELETE verified)
 - [ ] For system-target: Integration test uses testcontainers
 - [ ] For protocol-target: Integration test uses client harness
+- [ ] Recovery & idempotency addressed (as per plan):
+  - [ ] Idempotency requirements implemented (if applicable)
+  - [ ] Recovery policy recommendation documented
+  - [ ] Recovery trait hooks implemented (if plan calls for durable recovery):
+    - [ ] `is_durable()` returns correct value
+    - [ ] `needs_snapshot_on_fresh_start()` returns correct value
+    - [ ] `default_recovery_policy()` returns appropriate `ReactionRecoveryPolicy`
+    - [ ] `bootstrap(ctx)` implemented (if snapshot/outbox replay needed)
 - [ ] Evidence of runtime execution documented
 - [ ] All runtime issues FIXED
 - [ ] No placeholders in core code

--- a/.github/agents/reaction-planner.md
+++ b/.github/agents/reaction-planner.md
@@ -83,6 +83,38 @@ Write a comprehensive plan in markdown format with the following sections:
 - Configuration fields
 - Strategy for failure handling
 
+## 4.5. Recovery & Delivery Guarantees
+
+The framework supports **reaction recovery** with persistent outbox and live-results tracking. The planner must evaluate:
+
+1. **Idempotency** — Can the target system handle duplicate deliveries? After a crash, the framework may replay results from the outbox. If the target is not idempotent (e.g., incrementing a counter), the reaction should implement deduplication logic.
+
+2. **Recovery policy recommendation** — There are two separate recovery policy types:
+   - **Query/source recovery** (`RecoveryPolicy`): Controls what happens when a source cannot honor a resume position.
+     - `Strict` — Fail startup, require manual intervention (default)
+     - `AutoReset` — Wipe index and re-bootstrap
+     - Configured via query builder: `.with_recovery_policy(RecoveryPolicy::AutoReset)`
+   - **Reaction recovery** (`ReactionRecoveryPolicy`): Controls what happens when the outbox has a gap or cannot satisfy the checkpoint position.
+     - `Strict` — Fail startup, require manual intervention (default)
+     - `AutoReset` — Wipe checkpoint and re-bootstrap from full snapshot
+     - `AutoSkipGap` — Skip the gap and resume from latest available outbox entry (accepts potential data loss)
+     - Configured via the `Reaction` trait: `default_recovery_policy()` method, or per-instance via `ReactionBaseParams::recovery_policy`
+   - Document which policies are appropriate for the target system.
+
+3. **Outbox capacity** — The `outbox_capacity` query builder option controls how many results are buffered for crash recovery. Recommend a size based on expected throughput and acceptable replay window.
+
+4. **Sequence gap handling** — The framework's forwarder detects sequence gaps between last-acked and incoming results. The reaction doesn't need to implement this — the framework handles it — but the planner should note whether gap detection warnings would be actionable for operators.
+
+5. **Reaction trait recovery hooks** — The `Reaction` trait provides recovery-related methods that must be evaluated:
+   - `is_durable()` → Return `true` if the reaction needs persistent checkpoints (default: `false`)
+   - `needs_snapshot_on_fresh_start()` → Return `true` if the reaction needs full current state on first start with no prior checkpoint (default: `false`)
+   - `default_recovery_policy()` → Return the appropriate `ReactionRecoveryPolicy` variant
+   - `bootstrap(ctx: BootstrapContext)` → Implement if the reaction needs snapshot/outbox replay during recovery. The `BootstrapContext` provides `fetch_snapshot()` and `fetch_outbox()` APIs, plus checkpoint read/write helpers.
+
+6. **Live results snapshot** — The query layer maintains a snapshot of the current result set via `LiveResultsWriter`. Reactions that need full-state recovery (e.g., materialized views, dashboards) should use `BootstrapContext::fetch_snapshot()` during `bootstrap()` rather than interacting with `LiveResultsWriter` directly.
+
+**Reference implementation:** See `components/reactions/sse/` for a reaction that uses the outbox and live-results snapshot for crash recovery.
+
 ## 5. Testing Strategy
 
 ### Unit Tests
@@ -177,11 +209,14 @@ Write a comprehensive plan in markdown format with the following sections:
 
 Your plan must:
 - ✅ Include POC verification with evidence
-- ✅ Specify exact Docker images (verified to exist)
+- ✅ Specify exact Docker images (verified to exist) for system-target reactions
+- ✅ Specify client harness design for protocol-target reactions
 - ✅ Define concrete test assertions
 - ✅ Reference actual library APIs (not assumptions)
 - ✅ Include all required helper scripts
 - ✅ Be actionable without additional research
+- ✅ Evaluate recovery & delivery guarantees (idempotency, recovery policy, outbox capacity)
+- ✅ Document whether the target system supports deduplication
 
 ## Red Flags to Avoid
 
@@ -191,6 +226,8 @@ Do NOT create plans that:
 - ❌ Omit integration test specification
 - ❌ Reference non-existent Docker images
 - ❌ Include placeholders like "TODO" or "TBD" in critical sections
+- ❌ Ignore idempotency requirements for the target system
+- ❌ Omit recovery policy recommendation
 
 ## Delivery
 

--- a/.github/agents/source-plan-executor.md
+++ b/.github/agents/source-plan-executor.md
@@ -57,10 +57,12 @@ If anything is missing, request clarification.
 
 Implement components **exactly as specified** in the plan:
 
-- Refer to **postgres source** (`components/sources/postgres/`) for patterns
+- Refer to **postgres source** (`components/sources/postgres/`) for patterns — especially its replay support (`ReplayState`, pause/rewind/resume in `subscribe()`, `source_position` on events)
+- Also refer to **mssql source** (`components/sources/mssql/`) for CDC-based replay patterns
 - Follow Drasi coding standards
 - Use builder pattern for configuration
 - **Error handling:** Plugin trait methods (`start`, `stop`, `bootstrap`) return `anyhow::Result` — use `.context("what failed")` to build rich error chains. **Never** use `DrasiError` inside plugin implementations; the framework converts `anyhow` errors to structured `DrasiError` at the public API boundary. See `lib/src/error.rs` for details.
+- **Structured errors:** For recoverable error conditions, use `SourceError` variants (e.g., `SourceError::PositionUnavailable`) which the orchestration layer can downcast from the `anyhow::Error`. See `lib/src/sources/traits.rs`.
 - Implement proper logging with `log::info!`/`log::error!`
 - No deviations without documenting rationale
 
@@ -77,10 +79,40 @@ Implement components **exactly as specified** in the plan:
 - Follow plan's data loading strategy
 - Implement all config fields
 - Handle errors gracefully
+- If the target system supports capturing a snapshot position (e.g., LSN, offset), set `source_position` on the `BootstrapResult` return value — this enables checkpoint seeding so recovery can resume from the bootstrap snapshot point
+
+#### Event Dispatch
+- **MUST** use `self.base.dispatch_event(event)` or `self.base.dispatch_events_batch(events)` to emit events — never use raw dispatchers directly
+- Set `source_position` on each `SourceEventWrapper` before dispatch (if `supports_replay()` is true):
+  - Encode the source's native position as `Option<Bytes>` (e.g., 8-byte big-endian `u64` for LSN/offset)
+  - `SourceBase` automatically stamps monotonic `sequence` numbers and stores `sequence → source_position` mappings
+- If `supports_replay()` is false, `source_position` can be `None` on events
+
+#### Subscribe Contract
+- The `subscribe()` implementation **MUST** call `self.base.apply_subscription_settings(&settings)` at the start of the method. Failing to do so will break sequence monotonicity after restarts.
+- Alternatively, use `self.base.subscribe_with_bootstrap()` which calls `apply_subscription_settings` automatically.
+- Check `settings.resume_from: Option<Bytes>` for a replay position:
+  - If `Some(position)`, rewind the stream to the given position
+  - If the position is no longer available (e.g., WAL vacuumed), return `SourceError::PositionUnavailable` with `earliest_available` if known
+  - If `None`, start from the configured initial cursor position
+
+#### Replay Support (if `supports_replay()` is true)
+- Override `supports_replay()` to return `true` (this is the default)
+- **Set a position comparator** during construction or initialization: call `self.base.set_position_comparator(ByteLexPositionComparator).await` if positions are byte-sortable in big-endian encoding. Without a comparator, `SourceBase` will not filter replayed events during replay and duplicates will be delivered to subscribers.
+  - Use `ByteLexPositionComparator` for big-endian u64/u128/multi-byte positions (covers Postgres LSN, MSSQL LSN, etc.)
+  - Implement a custom `PositionComparator` if positions are not lexicographically comparable
+- Override `remove_position_handle()` to delegate to `self.base.remove_position_handle(query_id).await`
+- Override `on_subscriptions_complete()` if the source needs startup fencing (e.g., hold back WAL feedback until all queries have subscribed)
+- Override `deprovision()` if the source manages external resources (e.g., replication slots, CDC cursors)
+
+#### Volatile Sources (if `supports_replay()` is false)
+- Override `supports_replay()` to return `false`
+- No need to set `source_position` on events
+- No need to handle `resume_from` in `subscribe()`
 
 #### Change Detection
 - Implement CDC mechanism from plan (no placeholders)
-- Use StateStore to persist cursor/position/offset
+- Use StateStore for source-internal state only (e.g., custom cursors, subscription metadata) — framework checkpoints handle `sequence + source_position` automatically
 - Handle reconnection and resume scenarios
 - Handle graceful shutdown and restart
 - Add debug logging for troubleshooting
@@ -352,6 +384,10 @@ mod integration_tests {
             .from_source("test-source")
             .auto_start(true)
             .enable_bootstrap(true)
+            // Recovery options (use as appropriate):
+            // .with_recovery_policy(RecoveryPolicy::AutoReset)
+            // .with_outbox_capacity(1000)
+            // .with_bootstrap_timeout_secs(60)
             .build();
         
         // 4. Create application reaction to capture results
@@ -765,8 +801,15 @@ Implementation is complete when ALL are true:
 - [ ] StateStore integration implemented:
   - [ ] Builder has `state_store` field and `with_state_store()` method
   - [ ] State passed to SourceBaseParams
-  - [ ] Cursor/position persisted to StateStore
   - [ ] Config option for initial cursor behavior
+- [ ] Replay & recovery implemented (as per plan):
+  - [ ] `supports_replay()` returns correct value
+  - [ ] Events dispatched via `self.base.dispatch_event()` (not raw dispatchers)
+  - [ ] `source_position` set on events (if supports_replay)
+  - [ ] `subscribe()` calls `apply_subscription_settings()` at start
+  - [ ] `subscribe()` handles `resume_from` parameter (if supports_replay)
+  - [ ] `SourceError::PositionUnavailable` returned when position expired (if applicable)
+  - [ ] `deprovision()` implemented (if source manages external resources)
 - [ ] Evidence of runtime execution documented
 - [ ] All runtime issues FIXED
 - [ ] No placeholders in core code
@@ -788,5 +831,8 @@ Implementation is complete when ALL are true:
 - Tests passing without actually testing change detection
 - External System source: integration test not using real Docker container
 - Protocol/Local source: integration test not using real client harness
+- Using raw dispatchers instead of `self.base.dispatch_event()`
+- Not calling `apply_subscription_settings()` in `subscribe()`
+- `supports_replay()` returns `true` but source doesn't set `source_position` or handle `resume_from`
 
 **If you encounter red flags, fix them immediately. Do not proceed until resolved.**

--- a/.github/agents/source-planner.md
+++ b/.github/agents/source-planner.md
@@ -76,18 +76,44 @@ Before designing custom authentication logic, review the shared identity abstrac
 1. Determine which `Credentials` variant the target system needs (token, password, or certificate).
 2. Check if an existing provider (e.g., `AzureIdentityProvider`) already covers the auth flow.
 3. Design the source to accept `Option<Box<dyn IdentityProvider>>` via a `with_identity_provider()` builder method.
-4. Fall back to config-based credentials (client_id/secret, connection string, etc.) when no identity provider is set.
-5. Only implement custom auth logic if no existing provider fits.
+4. Implement `set_identity_provider()` on the `Source` trait to delegate to `self.base.set_identity_provider(provider).await` — this enables DrasiLib to inject identity providers after construction.
+5. Fall back to config-based credentials (client_id/secret, connection string, etc.) when no identity provider is set.
+6. Only implement custom auth logic if no existing provider fits.
 
 **Reference implementations:** See how `storedproc-postgres` and `storedproc-mssql` reactions use `with_identity_provider()`, and how the Dataverse source (`components/sources/dataverse/src/lib.rs`) constructs an `AzureIdentityProvider` (via `with_default_credentials` or `with_client_secret`) and passes it to the HTTP client — extend `AzureIdentityProvider` rather than reimplementing OAuth2/CLI flows.
 
-### 4. Determine Data Mapping Strategies
+### 4. Evaluate Replay & Recovery Capabilities
+
+The framework now supports **checkpoint-based recovery** for continuous queries. Sources that back a persistent log can resume from a checkpointed position instead of re-bootstrapping on restart. The planner must evaluate:
+
+1. **`source_position` encoding** — Each streamed event can carry an opaque `Option<Bytes>` position (e.g., CDC LSN, Kafka offset, change-feed continuation token). Determine what the target system's native position type is and how to encode it as bytes (e.g., 8-byte big-endian `u64` for LSN).
+
+2. **`supports_replay()`** — The `Source` trait defaults to `true`. If the target system has a replayable log (WAL, CDC stream, event store), keep the default. If it is volatile/push-only (e.g., a metrics collector, pure webhook receiver), the source must override to return `false`.
+
+3. **`resume_from` handling** — When `supports_replay()` is `true`, the framework may pass a `resume_from: Option<Bytes>` position in `SourceSubscriptionSettings` during `subscribe()`. The source must be able to rewind its stream to the given position. Determine:
+   - Can the target system seek to an arbitrary position?
+   - What is the latency/cost of a rewind?
+   - Is there a "pause current stream, start new stream from position" pattern (like Postgres) or a simple seek (like Kafka)?
+
+4. **`SourceError::PositionUnavailable`** — If the target system has limited retention (e.g., WAL that gets vacuumed, CDC with a retention window), the source should return this error when the requested position has expired. Determine:
+   - How to detect whether a position is still available
+   - What the `earliest_available` position is (if the system exposes it)
+
+5. **`BootstrapResult.source_position`** — Bootstrap providers can now return a snapshot position for checkpoint seeding. Determine if the target system supports capturing a consistent snapshot position during bootstrap (e.g., `SELECT pg_current_wal_lsn()` for Postgres, snapshot LSN for MSSQL).
+
+6. **`PositionComparator`** — `SourceBase` only filters replayed events during replay when a position comparator is configured. Determine:
+   - Is the native position encoding byte-sortable in big-endian? If so, use the built-in `ByteLexPositionComparator`.
+   - If positions are not lexicographically comparable (e.g., multi-part keys), a custom `PositionComparator` implementation is needed.
+
+**Reference implementations:** See `components/sources/postgres/src/lib.rs` for full replay support (ReplayState, pause/rewind/resume in subscribe) and `components/sources/mssql/src/lib.rs` for CDC-based replay.
+
+### 5. Determine Data Mapping Strategies
 
 - Decide how to map source data to Drasi's graph data model
 - If multiple strategies are possible, outline pros/cons of each
 - Consider data types, structures, and necessary transformations
 
-### 5. Create Implementation Plan
+### 6. Create Implementation Plan
 
 Write a comprehensive plan in markdown format with the following sections:
 
@@ -130,11 +156,26 @@ Write a comprehensive plan in markdown format with the following sections:
 - Configuration fields
 - State management approach
 - Change detection implementation
+- Dispatch mode: Channel (default, backpressure, zero loss) or Broadcast (shared channel, possible loss)
 
 ### Bootstrap Component
 - Initial data loading strategy
 - Configuration requirements
 - Data retrieval approach
+- `source_position` capture: can the bootstrap capture a snapshot position? (e.g., LSN, offset)
+
+## 5.5. Replay & Recovery Design
+
+- **source_position encoding**: [e.g., 8-byte big-endian u64 LSN, Kafka offset bytes, or None for volatile sources]
+- **Position comparator**: `ByteLexPositionComparator` (if encoding is byte-sortable in big-endian) or custom `PositionComparator` implementation
+- **`supports_replay()`**: true/false (rationale — does the target system have a replayable log?)
+- **`resume_from` flow**: How `subscribe()` will handle the `resume_from: Option<Bytes>` parameter:
+  - [e.g., pause current stream → create new subscriber from requested position → resume]
+  - [e.g., seek CDC cursor to requested offset]
+- **`PositionUnavailable` handling**: How to detect expired positions and what `earliest_available` to report
+- **`BootstrapResult.source_position`**: Whether bootstrap can return a snapshot position for checkpoint seeding
+- **`on_subscriptions_complete()`**: Whether the source needs startup fencing (e.g., hold back WAL feedback until all queries have subscribed)
+- **`deprovision()`**: Whether the source manages external state that needs cleanup on removal (e.g., replication slots, CDC cursors)
 
 ## 6. Testing Strategy
 
@@ -221,17 +262,26 @@ For sources that receive data via protocol or monitor local environment:
 - How to verify changes are detected
 - Troubleshooting common issues
 
-## 7. State Management
+## 7. State Management & Recovery
+
+**Important distinction — two layers of state persistence:**
+
+1. **Framework checkpoints** (automatic): The framework automatically tracks `(sequence, source_position)` per event via `SourceBase::dispatch_event()`. Sources do NOT manage this themselves — they just set `source_position` on events and the framework handles persistence, dedup, and recovery.
+
+2. **`StateStore`** (source-internal): For source-specific state that the framework doesn't track — e.g., custom cursors, subscription metadata, configuration state, poll intervals.
 
 **StateStore Integration:**
 - Builder field: `state_store: Option<StateStoreProvider>`
 - Builder method: `with_state_store()`
-- How cursor/position will be persisted
+- What source-internal state will be persisted (if any, beyond framework checkpoints)
+
+**Initial Cursor Behavior** (source-level, not framework-level):
 - Config option for initial cursor behavior:
   - `start_from_beginning`
   - `start_from_now`
   - `start_from_timestamp(i64)`
 - Default behavior
+- Note: on recovery, `resume_from` takes precedence over initial cursor config
 
 ## 8. Implementation Phases
 
@@ -266,6 +316,9 @@ For sources that receive data via protocol or monitor local environment:
 5. ✅ **PERSONALLY VERIFIED** runtime behavior with actual output
 6. ✅ All runtime issues **FIXED** (not documented as TODO)
 7. ✅ No TODOs or placeholders in core functionality
+8. ✅ `supports_replay()` correctly reflects the source's capabilities
+9. ✅ `source_position` set on dispatched events (if `supports_replay()` is true)
+10. ✅ `subscribe()` handles `resume_from` (if `supports_replay()` is true)
 
 **⚠️ "Compiles successfully" ≠ "Works correctly"**
 
@@ -297,8 +350,10 @@ Your plan must:
 - ✅ Define concrete test assertions
 - ✅ Reference actual library APIs (not assumptions)
 - ✅ Include all required helper scripts
-- ✅ Define state management approach
+- ✅ Define state management approach (distinguish StateStore from framework checkpoints)
 - ✅ Specify initial cursor behavior options
+- ✅ Evaluate replay & recovery capabilities (`supports_replay`, `source_position` encoding, `resume_from` handling)
+- ✅ Document `BootstrapResult.source_position` capability
 - ✅ Be actionable without additional research
 - ✅ Include realistic timing estimates
 
@@ -312,6 +367,9 @@ Do NOT create plans that:
 - ❌ Skip client harness design (for Protocol/Local sources)
 - ❌ Skip state management details
 - ❌ Include placeholders like "TODO" or "TBD" in critical sections
+- ❌ Confuse StateStore (source-internal) with framework checkpoints (automatic)
+- ❌ Omit replay/recovery evaluation for sources backed by persistent logs
+- ❌ Default `supports_replay()` to `true` without verifying the source can actually replay
 
 ## Delivery
 


### PR DESCRIPTION
## Summary

Updates the source and reaction planner/executor agent documentation to reflect the checkpoint-based recovery, replay support, and reaction recovery persistence features.

### Source agents (source-planner, source-plan-executor)
- New planning step: **Evaluate Replay & Recovery Capabilities** — guides planning around `source_position`, `supports_replay()`, `resume_from`, `PositionUnavailable`, `BootstrapResult.source_position`, and `PositionComparator`
- New executor subsections: **Event Dispatch**, **Subscribe Contract**, **Replay Support**, **Volatile Sources**
- Clarified **StateStore vs framework checkpoints** distinction
- Added `SourceError::PositionUnavailable` guidance
- Updated verification checklists and red flags with replay items
- Updated reference implementations to cite both postgres and mssql replay patterns

### Reaction agents (reaction-planner, reaction-plan-executor)
- New planner section: **Recovery & Delivery Guarantees** — correctly distinguishes `RecoveryPolicy` (query/source) from `ReactionRecoveryPolicy` (reaction)
- Covers reaction trait hooks: `is_durable()`, `needs_snapshot_on_fresh_start()`, `default_recovery_policy()`, `bootstrap(ctx)`
- Clarified that reactions use `BootstrapContext::fetch_snapshot()` rather than `LiveResultsWriter` directly
- Updated test templates with query builder recovery options
- Updated verification checklist with recovery trait hooks
