### PR TITLE
fix(http-bootstrap): retry on response body truncation

### DIFF
--- a/components/bootstrappers/http/Cargo.toml
+++ b/components/bootstrappers/http/Cargo.toml
@@ -50,9 +50,20 @@ url = "2"
 
 [dev-dependencies]
 axum = "0.7"
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.11"
 base64 = "0.22"
+futures = "0.3"
+rcgen = "0.13"
+rustls = "0.23"
+tokio-rustls = "0.26"
+rustls-pemfile = "2"
+hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http2"] }
+hyper = { version = "1", features = ["server"] }
+h2 = "0.4"
+bytes = "1"
+http = "1"
 
 [features]
 dynamic-plugin = []

--- a/components/bootstrappers/http/Cargo.toml
+++ b/components/bootstrappers/http/Cargo.toml
@@ -60,3 +60,4 @@ http = "1"
 
 [features]
 dynamic-plugin = []
+h2-truncation-poc = []

--- a/components/bootstrappers/http/Cargo.toml
+++ b/components/bootstrappers/http/Cargo.toml
@@ -50,17 +50,10 @@ url = "2"
 
 [dev-dependencies]
 axum = "0.7"
-axum-server = { version = "0.7", features = ["tls-rustls"] }
 tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.11"
 base64 = "0.22"
 futures = "0.3"
-rcgen = "0.13"
-rustls = "0.23"
-tokio-rustls = "0.26"
-rustls-pemfile = "2"
-hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http2"] }
-hyper = { version = "1", features = ["server"] }
 h2 = "0.4"
 bytes = "1"
 http = "1"

--- a/components/bootstrappers/http/src/config.rs
+++ b/components/bootstrappers/http/src/config.rs
@@ -666,4 +666,37 @@ mod tests {
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("at least one label"));
     }
+
+    #[test]
+    fn test_validate_relation_delete_skips_from_to() {
+        let mut config = make_valid_config();
+        config.endpoints[0].response.mappings[0].element_type = ElementType::Relation;
+        config.endpoints[0].response.mappings[0].operation = OperationType::Delete;
+        config.endpoints[0].response.mappings[0].template.from = None;
+        config.endpoints[0].response.mappings[0].template.to = None;
+        // Delete relations don't need from/to
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_relation_update_requires_from_to() {
+        let mut config = make_valid_config();
+        config.endpoints[0].response.mappings[0].element_type = ElementType::Relation;
+        config.endpoints[0].response.mappings[0].operation = OperationType::Update;
+        config.endpoints[0].response.mappings[0].template.from = None;
+        config.endpoints[0].response.mappings[0].template.to = None;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("from is required"));
+    }
+
+    #[test]
+    fn test_validate_relation_insert_requires_from_to() {
+        let mut config = make_valid_config();
+        config.endpoints[0].response.mappings[0].element_type = ElementType::Relation;
+        config.endpoints[0].response.mappings[0].operation = OperationType::Insert;
+        config.endpoints[0].response.mappings[0].template.from = None;
+        config.endpoints[0].response.mappings[0].template.to = Some("{{item.to}}".to_string());
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("from is required"));
+    }
 }

--- a/components/bootstrappers/http/src/config.rs
+++ b/components/bootstrappers/http/src/config.rs
@@ -319,7 +319,7 @@ impl ElementMappingConfig {
                 "Validation error: endpoint[{endpoint_index}].mappings[{mapping_index}].template.labels must have at least one label"
             ));
         }
-        if self.element_type == ElementType::Relation {
+        if self.element_type == ElementType::Relation && self.operation != OperationType::Delete {
             if self.template.from.is_none() {
                 return Err(anyhow::anyhow!(
                     "Validation error: endpoint[{endpoint_index}].mappings[{mapping_index}].template.from is required for relation mappings"
@@ -388,8 +388,23 @@ pub struct ElementMappingConfig {
     /// Type of element to create.
     pub element_type: ElementType,
 
+    /// Operation type for the source change (default: update for idempotent bootstrap).
+    #[serde(default)]
+    pub operation: OperationType,
+
     /// Template for element creation.
     pub template: ElementTemplate,
+}
+
+/// Operation type for source changes.
+/// Matches the HTTP webhook source naming convention.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum OperationType {
+    Insert,
+    #[default]
+    Update,
+    Delete,
 }
 
 /// Element type.
@@ -555,6 +570,7 @@ mod tests {
                     content_type: None,
                     mappings: vec![ElementMappingConfig {
                         element_type: ElementType::Node,
+                        operation: Default::default(),
                         template: ElementTemplate {
                             id: "{{item.id}}".to_string(),
                             labels: vec!["User".to_string()],

--- a/components/bootstrappers/http/src/config.rs
+++ b/components/bootstrappers/http/src/config.rs
@@ -481,6 +481,12 @@ mod tests {
         assert_eq!(config.endpoints.len(), 1);
         assert_eq!(config.timeout_seconds, 30);
         assert_eq!(config.endpoints[0].url, "https://api.example.com/users");
+
+        // Backward compat: missing "operation" field should default to Update
+        assert_eq!(
+            config.endpoints[0].response.mappings[0].operation,
+            OperationType::Update
+        );
     }
 
     #[test]

--- a/components/bootstrappers/http/src/descriptor.rs
+++ b/components/bootstrappers/http/src/descriptor.rs
@@ -22,7 +22,8 @@ use utoipa::OpenApi;
 
 use crate::config::{
     ApiKeyLocation, AuthConfig, ContentTypeOverride, ElementMappingConfig, ElementTemplate,
-    ElementType, EndpointConfig, HttpBootstrapConfig, HttpMethod, PaginationConfig, ResponseConfig,
+    ElementType, EndpointConfig, HttpBootstrapConfig, HttpMethod, OperationType, PaginationConfig,
+    ResponseConfig,
 };
 use crate::provider::HttpBootstrapProvider;
 
@@ -277,9 +278,25 @@ pub struct ElementMappingConfigDto {
     #[schema(value_type = bootstrap::http::ElementType)]
     pub element_type: ElementTypeDto,
 
+    /// Operation type for the source change (default: update for idempotent bootstrap).
+    #[serde(default)]
+    #[schema(value_type = bootstrap::http::OperationType)]
+    pub operation: OperationTypeDto,
+
     /// Template for element creation.
     #[schema(value_type = bootstrap::http::ElementTemplate)]
     pub template: ElementTemplateDto,
+}
+
+/// Operation type DTO.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, utoipa::ToSchema)]
+#[schema(as = bootstrap::http::OperationType)]
+#[serde(rename_all = "lowercase")]
+pub enum OperationTypeDto {
+    Insert,
+    #[default]
+    Update,
+    Delete,
 }
 
 /// Element type DTO.
@@ -336,6 +353,14 @@ fn map_element_type(dto: &ElementTypeDto) -> ElementType {
     match dto {
         ElementTypeDto::Node => ElementType::Node,
         ElementTypeDto::Relation => ElementType::Relation,
+    }
+}
+
+fn map_operation_type(dto: &OperationTypeDto) -> OperationType {
+    match dto {
+        OperationTypeDto::Insert => OperationType::Insert,
+        OperationTypeDto::Update => OperationType::Update,
+        OperationTypeDto::Delete => OperationType::Delete,
     }
 }
 
@@ -461,6 +486,7 @@ async fn map_element_mapping(
 ) -> Result<ElementMappingConfig, MappingError> {
     Ok(ElementMappingConfig {
         element_type: map_element_type(&dto.element_type),
+        operation: map_operation_type(&dto.operation),
         template: map_element_template(&dto.template, resolver).await?,
     })
 }

--- a/components/bootstrappers/http/src/provider.rs
+++ b/components/bootstrappers/http/src/provider.rs
@@ -221,12 +221,12 @@ impl HttpBootstrapProvider {
                         }
 
                         let source_change = match mapped.operation {
-                            OperationType::Insert => {
-                                SourceChange::Insert { element: mapped.element }
-                            }
-                            OperationType::Update => {
-                                SourceChange::Update { element: mapped.element }
-                            }
+                            OperationType::Insert => SourceChange::Insert {
+                                element: mapped.element,
+                            },
+                            OperationType::Update => SourceChange::Update {
+                                element: mapped.element,
+                            },
                             OperationType::Delete => {
                                 let metadata = mapped.element.get_metadata().clone();
                                 SourceChange::Delete { metadata }

--- a/components/bootstrappers/http/src/provider.rs
+++ b/components/bootstrappers/http/src/provider.rs
@@ -172,9 +172,16 @@ impl HttpBootstrapProvider {
 
             debug!("Fetching page {page_num} from endpoint: {}", endpoint.url);
 
-            // Make the HTTP request with retries
-            let (response_text, response_headers) = self
-                .fetch_with_retry(&current_url, endpoint, auth, &current_params)
+            // Fetch and parse with retry: both transport errors AND body
+            // parsing failures (truncation) trigger retries.
+            let (parsed_body, response_headers) = self
+                .fetch_and_parse_with_retry(
+                    &current_url,
+                    endpoint,
+                    auth,
+                    &current_params,
+                    &content_type_override,
+                )
                 .await
                 .with_context(|| {
                     format!(
@@ -182,31 +189,6 @@ impl HttpBootstrapProvider {
                         endpoint.url
                     )
                 })?;
-
-            // Determine content type from override or response header
-            let ct = content_type_override.clone().unwrap_or_else(|| {
-                let header_value = response_headers
-                    .get(reqwest::header::CONTENT_TYPE)
-                    .and_then(|v| v.to_str().ok());
-                ContentType::from_header(header_value)
-            });
-
-            // Parse response body using the correct content type
-            let parsed_body = match content_parser::parse_body(&response_text, &ct) {
-                Ok(body) => body,
-                Err(e) => {
-                    error!(
-                        "Failed to parse response from '{}' as {ct:?}. Body length: {}, first 200 chars: {:?}",
-                        endpoint.url,
-                        response_text.len(),
-                        safe_truncate(&response_text, 200)
-                    );
-                    return Err(e.context(format!(
-                        "Failed to parse response from '{}' as {ct:?}",
-                        endpoint.url
-                    )));
-                }
-            };
 
             // Extract items
             let items = response::extract_items(&parsed_body, &endpoint.response.items_path)?;
@@ -287,14 +269,19 @@ impl HttpBootstrapProvider {
         Ok(total_sent)
     }
 
-    /// Fetch a URL with retry logic.
-    async fn fetch_with_retry(
+    /// Fetch a URL with retry logic, including body parsing validation.
+    /// Both transport errors AND body parsing failures (e.g., truncated responses)
+    /// are treated as retriable errors. This handles the case where an intermediary
+    /// (proxy, load balancer, CDN) returns a properly-terminated HTTP response with
+    /// incomplete body content.
+    async fn fetch_and_parse_with_retry(
         &self,
         url: &str,
         endpoint: &EndpointConfig,
         auth: &Option<ResolvedAuth>,
         query_params: &[(String, String)],
-    ) -> Result<(String, reqwest::header::HeaderMap)> {
+        content_type_override: &Option<ContentType>,
+    ) -> Result<(serde_json::Value, reqwest::header::HeaderMap)> {
         let max_retries = self.config.max_retries;
         let retry_delay = Duration::from_millis(self.config.retry_delay_ms);
 
@@ -310,16 +297,55 @@ impl HttpBootstrapProvider {
                 tokio::time::sleep(delay).await;
             }
 
-            match self.make_request(url, endpoint, auth, query_params).await {
-                Ok(result) => return Ok(result),
+            // Fetch
+            let (response_text, response_headers) =
+                match self.make_request(url, endpoint, auth, query_params).await {
+                    Ok(result) => result,
+                    Err(e) => {
+                        warn!(
+                            "Request to endpoint failed (attempt {}/{}): {}",
+                            attempt + 1,
+                            max_retries + 1,
+                            e
+                        );
+                        last_error = Some(e);
+                        continue;
+                    }
+                };
+
+            // Determine content type
+            let ct = content_type_override.clone().unwrap_or_else(|| {
+                let header_value = response_headers
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok());
+                ContentType::from_header(header_value)
+            });
+
+            // Validate: parse response body
+            match content_parser::parse_body(&response_text, &ct) {
+                Ok(parsed) => return Ok((parsed, response_headers)),
                 Err(e) => {
+                    // Body parsing failed — likely truncated response.
+                    // Treat as retriable: the next attempt may get a complete response.
                     warn!(
-                        "Request to endpoint failed (attempt {}/{}): {}",
+                        "Response body parse failed (attempt {}/{}, possible truncation). \
+                         Body length: {}, content-type: {ct:?}, error: {e}",
                         attempt + 1,
                         max_retries + 1,
-                        e
+                        response_text.len(),
                     );
-                    last_error = Some(e);
+                    if log::log_enabled!(log::Level::Debug) {
+                        debug!(
+                            "Truncated body first 200 chars: {:?}",
+                            safe_truncate(&response_text, 200)
+                        );
+                    }
+                    last_error = Some(e.context(format!(
+                        "Failed to parse response from '{}' as {ct:?} \
+                         (body length: {}, possible truncation)",
+                        url,
+                        response_text.len()
+                    )));
                 }
             }
         }

--- a/components/bootstrappers/http/src/provider.rs
+++ b/components/bootstrappers/http/src/provider.rs
@@ -216,19 +216,23 @@ impl HttpBootstrapProvider {
                 match result {
                     Ok(mapped) => {
                         // Filter by requested labels
-                        if !should_include_element(&mapped.element, request) {
+                        if !should_include_change(&mapped, request) {
                             continue;
                         }
 
-                        let source_change = match mapped.operation {
-                            OperationType::Insert => SourceChange::Insert {
-                                element: mapped.element,
-                            },
-                            OperationType::Update => SourceChange::Update {
-                                element: mapped.element,
-                            },
-                            OperationType::Delete => {
-                                let metadata = mapped.element.get_metadata().clone();
+                        let source_change = match mapped {
+                            response::MappedChange::Upsert { element, operation } => {
+                                match operation {
+                                    OperationType::Insert => {
+                                        SourceChange::Insert { element }
+                                    }
+                                    OperationType::Update => {
+                                        SourceChange::Update { element }
+                                    }
+                                    OperationType::Delete => unreachable!(),
+                                }
+                            }
+                            response::MappedChange::Delete { metadata } => {
                                 SourceChange::Delete { metadata }
                             }
                         };
@@ -325,12 +329,7 @@ impl HttpBootstrapProvider {
                 };
 
             // Determine content type
-            let ct = content_type_override.clone().unwrap_or_else(|| {
-                let header_value = response_headers
-                    .get(reqwest::header::CONTENT_TYPE)
-                    .and_then(|v| v.to_str().ok());
-                ContentType::from_header(header_value)
-            });
+            let ct = resolve_content_type(content_type_override, &response_headers);
 
             // Validate: parse response body
             match content_parser::parse_body(&response_text, &ct) {
@@ -423,30 +422,55 @@ impl HttpBootstrapProvider {
     }
 }
 
+/// Resolve the content type from the override or response headers.
+fn resolve_content_type(
+    override_ct: &Option<ContentType>,
+    headers: &reqwest::header::HeaderMap,
+) -> ContentType {
+    override_ct.clone().unwrap_or_else(|| {
+        let header_value = headers
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok());
+        ContentType::from_header(header_value)
+    })
+}
+
 /// Check if an element should be included based on the bootstrap request's label filters.
-fn should_include_element(
-    element: &drasi_core::models::Element,
+fn should_include_change(
+    change: &response::MappedChange,
     request: &BootstrapRequest,
 ) -> bool {
-    match element {
-        drasi_core::models::Element::Node { metadata, .. } => {
-            if request.node_labels.is_empty() {
-                return true;
-            }
-            metadata
-                .labels
-                .iter()
-                .any(|l| request.node_labels.iter().any(|nl| nl.as_str() == &**l))
+    let metadata = match change {
+        response::MappedChange::Upsert { element, .. } => element.get_metadata(),
+        response::MappedChange::Delete { metadata } => metadata,
+    };
+
+    // Determine if this is a relation by checking element type for Upsert,
+    // or fall back to checking relation_labels for Delete
+    let is_relation = matches!(
+        change,
+        response::MappedChange::Upsert {
+            element: drasi_core::models::Element::Relation { .. },
+            ..
         }
-        drasi_core::models::Element::Relation { metadata, .. } => {
-            if request.relation_labels.is_empty() {
-                return true;
-            }
-            metadata
-                .labels
-                .iter()
-                .any(|l| request.relation_labels.iter().any(|rl| rl.as_str() == &**l))
+    );
+
+    if is_relation {
+        if request.relation_labels.is_empty() {
+            return true;
         }
+        metadata
+            .labels
+            .iter()
+            .any(|l| request.relation_labels.iter().any(|rl| rl.as_str() == &**l))
+    } else {
+        if request.node_labels.is_empty() {
+            return true;
+        }
+        metadata
+            .labels
+            .iter()
+            .any(|l| request.node_labels.iter().any(|nl| nl.as_str() == &**l))
     }
 }
 

--- a/components/bootstrappers/http/src/provider.rs
+++ b/components/bootstrappers/http/src/provider.rs
@@ -32,7 +32,7 @@ use drasi_lib::bootstrap::{
 use drasi_lib::channels::BootstrapEvent;
 
 use crate::auth::{self, ResolvedAuth};
-use crate::config::{EndpointConfig, HttpBootstrapConfig, HttpMethod};
+use crate::config::{EndpointConfig, HttpBootstrapConfig, HttpMethod, OperationType};
 use crate::content_parser::{self, ContentType};
 use crate::pagination::{self, NextPage, Paginator};
 use crate::response;
@@ -214,13 +214,24 @@ impl HttpBootstrapProvider {
 
             for result in element_results {
                 match result {
-                    Ok(element) => {
+                    Ok(mapped) => {
                         // Filter by requested labels
-                        if !should_include_element(&element, request) {
+                        if !should_include_element(&mapped.element, request) {
                             continue;
                         }
 
-                        let source_change = SourceChange::Insert { element };
+                        let source_change = match mapped.operation {
+                            OperationType::Insert => {
+                                SourceChange::Insert { element: mapped.element }
+                            }
+                            OperationType::Update => {
+                                SourceChange::Update { element: mapped.element }
+                            }
+                            OperationType::Delete => {
+                                let metadata = mapped.element.get_metadata().clone();
+                                SourceChange::Delete { metadata }
+                            }
+                        };
                         let sequence = context.next_sequence();
 
                         let bootstrap_event = BootstrapEvent {

--- a/components/bootstrappers/http/src/provider.rs
+++ b/components/bootstrappers/http/src/provider.rs
@@ -223,12 +223,8 @@ impl HttpBootstrapProvider {
                         let source_change = match mapped {
                             response::MappedChange::Upsert { element, operation } => {
                                 match operation {
-                                    OperationType::Insert => {
-                                        SourceChange::Insert { element }
-                                    }
-                                    OperationType::Update => {
-                                        SourceChange::Update { element }
-                                    }
+                                    OperationType::Insert => SourceChange::Insert { element },
+                                    OperationType::Update => SourceChange::Update { element },
                                     OperationType::Delete => unreachable!(),
                                 }
                             }
@@ -436,10 +432,7 @@ fn resolve_content_type(
 }
 
 /// Check if an element should be included based on the bootstrap request's label filters.
-fn should_include_change(
-    change: &response::MappedChange,
-    request: &BootstrapRequest,
-) -> bool {
+fn should_include_change(change: &response::MappedChange, request: &BootstrapRequest) -> bool {
     let metadata = match change {
         response::MappedChange::Upsert { element, .. } => element.get_metadata(),
         response::MappedChange::Delete { metadata } => metadata,

--- a/components/bootstrappers/http/src/provider.rs
+++ b/components/bootstrappers/http/src/provider.rs
@@ -345,12 +345,6 @@ impl HttpBootstrapProvider {
                         max_retries + 1,
                         response_text.len(),
                     );
-                    if log::log_enabled!(log::Level::Debug) {
-                        debug!(
-                            "Truncated body first 200 chars: {:?}",
-                            safe_truncate(&response_text, 200)
-                        );
-                    }
                     last_error = Some(e.context(format!(
                         "Failed to parse response from '{}' as {ct:?} \
                          (body length: {}, possible truncation)",

--- a/components/bootstrappers/http/src/response.rs
+++ b/components/bootstrappers/http/src/response.rs
@@ -26,7 +26,7 @@ use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::config::{ElementMappingConfig, ElementType};
+use crate::config::{ElementMappingConfig, ElementType, OperationType};
 use crate::pagination;
 use crate::template_engine::{TemplateContext, TemplateEngine};
 
@@ -47,13 +47,19 @@ pub fn extract_items(body: &JsonValue, items_path: &str) -> Result<Vec<JsonValue
     }
 }
 
+/// A mapped element result bundling the element with the operation to perform.
+pub struct MappedElement {
+    pub element: Element,
+    pub operation: OperationType,
+}
+
 /// Map a list of items to Drasi graph elements using the configured mappings.
 pub fn map_items_to_elements(
     items: &[JsonValue],
     mappings: &[ElementMappingConfig],
     source_id: &str,
     engine: &TemplateEngine,
-) -> Vec<Result<Element>> {
+) -> Vec<Result<MappedElement>> {
     let mut elements = Vec::new();
 
     for (index, item) in items.iter().enumerate() {
@@ -64,7 +70,12 @@ pub fn map_items_to_elements(
         };
 
         for mapping in mappings {
-            let result = map_single_item(&context, mapping, source_id, engine);
+            let result = map_single_item(&context, mapping, source_id, engine).map(|element| {
+                MappedElement {
+                    element,
+                    operation: mapping.operation.clone(),
+                }
+            });
             elements.push(result);
         }
     }
@@ -233,6 +244,7 @@ mod tests {
 
         let mappings = vec![ElementMappingConfig {
             element_type: ElementType::Node,
+            operation: Default::default(),
             template: crate::config::ElementTemplate {
                 id: "{{item.id}}".to_string(),
                 labels: vec!["User".to_string()],
@@ -246,8 +258,8 @@ mod tests {
         let results = map_items_to_elements(&items, &mappings, "test-source", &engine);
         assert_eq!(results.len(), 2);
 
-        let elem = results[0].as_ref().unwrap();
-        match elem {
+        let mapped = results[0].as_ref().unwrap();
+        match &mapped.element {
             Element::Node { metadata, .. } => {
                 assert_eq!(&*metadata.reference.element_id, "1");
                 assert_eq!(metadata.labels.len(), 1);
@@ -263,6 +275,7 @@ mod tests {
 
         let mappings = vec![ElementMappingConfig {
             element_type: ElementType::Relation,
+            operation: Default::default(),
             template: crate::config::ElementTemplate {
                 id: "{{item.id}}".to_string(),
                 labels: vec!["{{item.type}}".to_string()],
@@ -276,8 +289,8 @@ mod tests {
         let results = map_items_to_elements(&items, &mappings, "test-source", &engine);
         assert_eq!(results.len(), 1);
 
-        let elem = results[0].as_ref().unwrap();
-        match elem {
+        let mapped = results[0].as_ref().unwrap();
+        match &mapped.element {
             Element::Relation {
                 metadata,
                 in_node,

--- a/components/bootstrappers/http/src/response.rs
+++ b/components/bootstrappers/http/src/response.rs
@@ -91,6 +91,7 @@ fn map_single_item(
     engine: &TemplateEngine,
 ) -> Result<Element> {
     let template = &mapping.template;
+    let is_delete = mapping.operation == OperationType::Delete;
 
     // Render ID
     let id = engine
@@ -110,6 +111,22 @@ fn map_single_item(
         if !label.is_empty() {
             labels.push(Arc::from(label.as_str()));
         }
+    }
+
+    // For Delete operations, only metadata (id + labels) is needed — skip
+    // property and relation endpoint rendering.
+    if is_delete {
+        let metadata = ElementMetadata {
+            reference: ElementReference::new(source_id, &id),
+            labels: labels.into(),
+            effective_from: 0,
+        };
+        // Use Node for delete — the element type doesn't matter since only
+        // metadata is extracted for SourceChange::Delete.
+        return Ok(Element::Node {
+            metadata,
+            properties: ElementPropertyMap::new(),
+        });
     }
 
     // Render properties

--- a/components/bootstrappers/http/src/response.rs
+++ b/components/bootstrappers/http/src/response.rs
@@ -47,10 +47,15 @@ pub fn extract_items(body: &JsonValue, items_path: &str) -> Result<Vec<JsonValue
     }
 }
 
-/// A mapped element result bundling the element with the operation to perform.
-pub struct MappedElement {
-    pub element: Element,
-    pub operation: OperationType,
+/// A mapped change result representing the operation to emit for an item.
+pub enum MappedChange {
+    /// Insert or Update — carries the full element.
+    Upsert {
+        element: Element,
+        operation: OperationType,
+    },
+    /// Delete — only metadata (id + labels) is needed.
+    Delete { metadata: ElementMetadata },
 }
 
 /// Map a list of items to Drasi graph elements using the configured mappings.
@@ -59,7 +64,7 @@ pub fn map_items_to_elements(
     mappings: &[ElementMappingConfig],
     source_id: &str,
     engine: &TemplateEngine,
-) -> Vec<Result<MappedElement>> {
+) -> Vec<Result<MappedChange>> {
     let mut elements = Vec::new();
 
     for (index, item) in items.iter().enumerate() {
@@ -70,12 +75,7 @@ pub fn map_items_to_elements(
         };
 
         for mapping in mappings {
-            let result = map_single_item(&context, mapping, source_id, engine).map(|element| {
-                MappedElement {
-                    element,
-                    operation: mapping.operation.clone(),
-                }
-            });
+            let result = map_single_item(&context, mapping, source_id, engine);
             elements.push(result);
         }
     }
@@ -83,13 +83,13 @@ pub fn map_items_to_elements(
     elements
 }
 
-/// Map a single item to a Drasi Element.
+/// Map a single item to a `MappedChange`.
 fn map_single_item(
     context: &TemplateContext,
     mapping: &ElementMappingConfig,
     source_id: &str,
     engine: &TemplateEngine,
-) -> Result<Element> {
+) -> Result<MappedChange> {
     let template = &mapping.template;
     let is_delete = mapping.operation == OperationType::Delete;
 
@@ -121,12 +121,7 @@ fn map_single_item(
             labels: labels.into(),
             effective_from: 0,
         };
-        // Use Node for delete — the element type doesn't matter since only
-        // metadata is extracted for SourceChange::Delete.
-        return Ok(Element::Node {
-            metadata,
-            properties: ElementPropertyMap::new(),
-        });
+        return Ok(MappedChange::Delete { metadata });
     }
 
     // Render properties
@@ -140,17 +135,17 @@ fn map_single_item(
     };
 
     // Create element based on type
-    match mapping.element_type {
+    let element = match mapping.element_type {
         ElementType::Node => {
             let metadata = ElementMetadata {
                 reference: ElementReference::new(source_id, &id),
                 labels: labels.into(),
                 effective_from: 0,
             };
-            Ok(Element::Node {
+            Element::Node {
                 metadata,
                 properties,
-            })
+            }
         }
         ElementType::Relation => {
             let from_id = template
@@ -175,14 +170,19 @@ fn map_single_item(
                 effective_from: 0,
             };
 
-            Ok(Element::Relation {
+            Element::Relation {
                 metadata,
                 properties,
                 in_node: ElementReference::new(source_id, &from_rendered),
                 out_node: ElementReference::new(source_id, &to_rendered),
-            })
+            }
         }
-    }
+    };
+
+    Ok(MappedChange::Upsert {
+        element,
+        operation: mapping.operation.clone(),
+    })
 }
 
 /// Convert a HashMap<String, JsonValue> to ElementPropertyMap.
@@ -276,13 +276,16 @@ mod tests {
         assert_eq!(results.len(), 2);
 
         let mapped = results[0].as_ref().unwrap();
-        match &mapped.element {
-            Element::Node { metadata, .. } => {
-                assert_eq!(&*metadata.reference.element_id, "1");
-                assert_eq!(metadata.labels.len(), 1);
-                assert_eq!(&*metadata.labels[0], "User");
-            }
-            _ => panic!("Expected Node"),
+        match mapped {
+            MappedChange::Upsert { element, .. } => match element {
+                Element::Node { metadata, .. } => {
+                    assert_eq!(&*metadata.reference.element_id, "1");
+                    assert_eq!(metadata.labels.len(), 1);
+                    assert_eq!(&*metadata.labels[0], "User");
+                }
+                _ => panic!("Expected Node"),
+            },
+            _ => panic!("Expected Upsert"),
         }
     }
 
@@ -307,18 +310,21 @@ mod tests {
         assert_eq!(results.len(), 1);
 
         let mapped = results[0].as_ref().unwrap();
-        match &mapped.element {
-            Element::Relation {
-                metadata,
-                in_node,
-                out_node,
-                ..
-            } => {
-                assert_eq!(&*metadata.reference.element_id, "r1");
-                assert_eq!(&*in_node.element_id, "n1");
-                assert_eq!(&*out_node.element_id, "n2");
-            }
-            _ => panic!("Expected Relation"),
+        match mapped {
+            MappedChange::Upsert { element, .. } => match element {
+                Element::Relation {
+                    metadata,
+                    in_node,
+                    out_node,
+                    ..
+                } => {
+                    assert_eq!(&*metadata.reference.element_id, "r1");
+                    assert_eq!(&*in_node.element_id, "n1");
+                    assert_eq!(&*out_node.element_id, "n2");
+                }
+                _ => panic!("Expected Relation"),
+            },
+            _ => panic!("Expected Upsert"),
         }
     }
 }

--- a/components/bootstrappers/http/tests/e2e_query_test.rs
+++ b/components/bootstrappers/http/tests/e2e_query_test.rs
@@ -158,6 +158,7 @@ async fn test_bootstrapped_nodes_queryable_via_cypher() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -293,6 +294,7 @@ async fn test_paginated_bootstrap_queryable_via_cypher() {
                 items_path: "$.items".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -414,6 +416,7 @@ async fn test_bootstrapped_relationships_queryable_via_cypher() {
                     items_path: "$".to_string(),
                     content_type: None,
                     mappings: vec![ElementMappingConfig {
+                        operation: Default::default(),
                         element_type: ElementType::Node,
                         template: ElementTemplate {
                             id: "{{item.id}}".to_string(),
@@ -439,6 +442,7 @@ async fn test_bootstrapped_relationships_queryable_via_cypher() {
                     items_path: "$".to_string(),
                     content_type: None,
                     mappings: vec![ElementMappingConfig {
+                        operation: Default::default(),
                         element_type: ElementType::Relation,
                         template: ElementTemplate {
                             id: "{{item.id}}".to_string(),

--- a/components/bootstrappers/http/tests/h2_truncation_poc.rs
+++ b/components/bootstrappers/http/tests/h2_truncation_poc.rs
@@ -120,8 +120,7 @@ async fn start_h2_truncating_server(
                             .header("content-type", "application/json");
 
                         if include_cl {
-                            response =
-                                response.header("content-length", full_len.to_string());
+                            response = response.header("content-length", full_len.to_string());
                         }
 
                         let response = response.body(()).unwrap();
@@ -221,7 +220,9 @@ async fn test_h2_premature_end_stream_no_content_length() {
                     "success" => successes += 1,
                     "truncated" => {
                         silent_truncations += 1;
-                        eprintln!("  [Round {round}] ✗ SILENT TRUNCATION: body_len={len}, {detail}");
+                        eprintln!(
+                            "  [Round {round}] ✗ SILENT TRUNCATION: body_len={len}, {detail}"
+                        );
                     }
                     _ => {
                         proper_errors += 1;

--- a/components/bootstrappers/http/tests/h2_truncation_poc.rs
+++ b/components/bootstrappers/http/tests/h2_truncation_poc.rs
@@ -21,7 +21,7 @@
 //! END_STREAM after delivering only a fraction of the response body. This
 //! reproduces the exact silent truncation scenario that causes issue #493:
 //! the client gets `Ok(partial_body)` with no transport error, and the
-//! response is unparseable JSON.
+//! response is unparsable JSON.
 //!
 //! The tests prove:
 //! 1. Without Content-Length, h2 silently truncates (bug reproduced).

--- a/components/bootstrappers/http/tests/h2_truncation_poc.rs
+++ b/components/bootstrappers/http/tests/h2_truncation_poc.rs
@@ -1,0 +1,1364 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! PoC: Reproduce HTTP/2 multiplexing body truncation (Issue #493).
+//!
+//! This test creates conditions that trigger HTTP/2 flow control race conditions
+//! by using a bandwidth-throttled TCP proxy between client and server. The
+//! throttling forces many small TCP reads/writes, creating interleaving of h2
+//! DATA frames across multiplexed streams — the exact condition that triggers
+//! body truncation in hyper 0.14 / h2 0.3.x.
+//!
+//! Run with: cargo test -p drasi-bootstrap-http --test h2_truncation_poc -- --ignored --nocapture
+
+#![allow(clippy::unwrap_used, clippy::uninlined_format_args)]
+
+use axum::{routing::get, Json, Router};
+use futures::future::join_all;
+use h2::server as h2_server;
+use rcgen::generate_simple_self_signed;
+use reqwest::Client;
+use rustls::ServerConfig;
+use serde_json::{json, Value as JsonValue};
+use std::io::Cursor;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::time::{sleep, Duration};
+use tokio_rustls::TlsAcceptor;
+
+/// Generate a large JSON array with N items, each having a long string property.
+fn generate_large_json(num_items: usize, item_size_bytes: usize) -> JsonValue {
+    let padding = "x".repeat(item_size_bytes);
+    let items: Vec<JsonValue> = (0..num_items)
+        .map(|i| {
+            json!({
+                "id": i,
+                "name": format!("item-{i}"),
+                "data": padding,
+                "checksum": format!("end-marker-{i}")
+            })
+        })
+        .collect();
+    json!(items)
+}
+
+/// Start a TLS server that serves large JSON payloads.
+/// Returns (server_addr_port) - the raw address to connect to.
+#[allow(clippy::unwrap_used)]
+async fn start_tls_server() -> (String, Arc<rustls::ServerConfig>) {
+    let app = Router::new()
+        .route(
+            "/endpoint-a",
+            get(|| async { Json(generate_large_json(80, 3000)) }),
+        )
+        .route(
+            "/endpoint-b",
+            get(|| async { Json(generate_large_json(100, 3000)) }),
+        )
+        .route(
+            "/endpoint-c",
+            get(|| async { Json(generate_large_json(90, 3000)) }),
+        )
+        .route(
+            "/endpoint-d",
+            get(|| async { Json(generate_large_json(120, 3000)) }),
+        )
+        .route(
+            "/endpoint-e",
+            get(|| async { Json(generate_large_json(70, 3000)) }),
+        );
+
+    // Generate self-signed TLS certificate for localhost
+    let subject_alt_names = vec!["localhost".to_string(), "127.0.0.1".to_string()];
+    let cert = generate_simple_self_signed(subject_alt_names).unwrap();
+    let cert_pem = cert.cert.pem();
+    let key_pem = cert.key_pair.serialize_pem();
+
+    let certs = rustls_pemfile::certs(&mut Cursor::new(cert_pem.as_bytes()))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    let key = rustls_pemfile::private_key(&mut Cursor::new(key_pem.as_bytes()))
+        .unwrap()
+        .unwrap();
+
+    let mut tls_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .unwrap();
+    tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+    let server_config = Arc::new(tls_config);
+    let tls_acceptor = TlsAcceptor::from(Arc::clone(&server_config));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap(); // DevSkim: ignore DS137138
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(_) => continue,
+            };
+            let acceptor = tls_acceptor.clone();
+            let app = app.clone();
+
+            tokio::spawn(async move {
+                let tls_stream = match acceptor.accept(stream).await {
+                    Ok(s) => s,
+                    Err(_) => return,
+                };
+                let io = hyper_util::rt::TokioIo::new(tls_stream);
+                let service = hyper_util::service::TowerToHyperService::new(app);
+                let builder = hyper_util::server::conn::auto::Builder::new(
+                    hyper_util::rt::TokioExecutor::new(),
+                );
+                let _ = builder.serve_connection(io, service).await;
+            });
+        }
+    });
+
+    (format!("127.0.0.1:{}", addr.port()), server_config) // DevSkim: ignore DS137138
+}
+
+/// Start a throttling TCP proxy that forwards data between client and server
+/// with bandwidth limiting and small buffer sizes.
+///
+/// This simulates real network conditions by:
+/// - Limiting throughput to `bytes_per_sec` in each direction
+/// - Using small read buffers to force many small TCP reads
+/// - Introducing micro-delays between chunk forwards
+#[allow(clippy::unwrap_used)]
+async fn start_throttling_proxy(target_addr: &str, bytes_per_sec: usize) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap(); // DevSkim: ignore DS137138
+    let proxy_addr = listener.local_addr().unwrap();
+    let target = target_addr.to_string();
+
+    tokio::spawn(async move {
+        loop {
+            let (client_stream, _) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(_) => continue,
+            };
+
+            let target = target.clone();
+            tokio::spawn(async move {
+                let server_stream = match tokio::net::TcpStream::connect(&target).await {
+                    Ok(s) => s,
+                    Err(_) => return,
+                };
+
+                let (mut client_read, mut client_write) = client_stream.into_split();
+                let (mut server_read, mut server_write) = server_stream.into_split();
+
+                // Calculate delay per chunk to achieve target throughput
+                let chunk_size = 2048usize;
+                let delay_per_chunk =
+                    Duration::from_micros((chunk_size as u64 * 1_000_000) / bytes_per_sec as u64);
+
+                // Client -> Server (request direction, usually small, minimal throttle)
+                let c2s = tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    loop {
+                        match client_read.read(&mut buf).await {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                if server_write.write_all(&buf[..n]).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    let _ = server_write.shutdown().await;
+                });
+
+                // Server -> Client (response direction, throttled)
+                let s2c = tokio::spawn(async move {
+                    let mut buf = vec![0u8; chunk_size];
+                    loop {
+                        match server_read.read(&mut buf).await {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                if client_write.write_all(&buf[..n]).await.is_err() {
+                                    break;
+                                }
+                                // Throttle: sleep after each chunk
+                                sleep(delay_per_chunk).await;
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    let _ = client_write.shutdown().await;
+                });
+
+                let _ = tokio::join!(c2s, s2c);
+            });
+        }
+    });
+
+    format!("127.0.0.1:{}", proxy_addr.port()) // DevSkim: ignore DS137138
+}
+
+/// Start a proxy that abruptly kills the server->client direction after
+/// forwarding a specified number of bytes. This simulates what happens when
+/// a load balancer resets an HTTP/2 connection mid-response, or when GOAWAY
+/// is received while DATA frames are in-flight.
+///
+/// The key behavior: the proxy forwards `bytes_before_kill` bytes from the server,
+/// then closes the connection abruptly (no graceful shutdown). This forces the
+/// client's h2 implementation to deal with a connection that died while streams
+/// had partially-received bodies.
+#[allow(clippy::unwrap_used)]
+async fn start_truncating_proxy(target_addr: &str, bytes_before_kill: usize) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap(); // DevSkim: ignore DS137138
+    let proxy_addr = listener.local_addr().unwrap();
+    let target = target_addr.to_string();
+    let kill_threshold = bytes_before_kill;
+
+    tokio::spawn(async move {
+        loop {
+            let (client_stream, _) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(_) => continue,
+            };
+
+            let target = target.clone();
+            tokio::spawn(async move {
+                let server_stream = match tokio::net::TcpStream::connect(&target).await {
+                    Ok(s) => s,
+                    Err(_) => return,
+                };
+
+                let (mut client_read, mut client_write) = client_stream.into_split();
+                let (mut server_read, mut server_write) = server_stream.into_split();
+
+                // Client -> Server (forward normally)
+                let c2s = tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    loop {
+                        match client_read.read(&mut buf).await {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                if server_write.write_all(&buf[..n]).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                });
+
+                // Server -> Client: forward bytes then ABRUPTLY drop
+                let s2c = tokio::spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    let mut total_forwarded = 0usize;
+                    loop {
+                        match server_read.read(&mut buf).await {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                total_forwarded += n;
+                                if total_forwarded >= kill_threshold {
+                                    // Forward partial last chunk then kill
+                                    let remaining = n.saturating_sub(
+                                        total_forwarded.saturating_sub(kill_threshold),
+                                    );
+                                    if remaining > 0 {
+                                        let _ = client_write.write_all(&buf[..remaining]).await;
+                                    }
+                                    // Graceful shutdown (TCP FIN) — NOT RST.
+                                    // This simulates a TLS close_notify without h2 GOAWAY,
+                                    // which may cause the client's h2 layer to think the
+                                    // connection completed normally.
+                                    let _ = client_write.shutdown().await;
+                                    return;
+                                }
+                                if client_write.write_all(&buf[..n]).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    let _ = client_write.shutdown().await;
+                });
+
+                let _ = tokio::join!(c2s, s2c);
+            });
+        }
+    });
+
+    format!("127.0.0.1:{}", proxy_addr.port()) // DevSkim: ignore DS137138
+}
+
+/// Fetch a URL, parse JSON body, validate structure integrity.
+async fn fetch_and_validate(client: &Client, url: &str) -> Result<usize, String> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("HTTP error: {}", response.status()));
+    }
+
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("Body read failed: {e}"))?;
+
+    let body_len = body.len();
+
+    // Parse JSON - truncation causes parse failures
+    let parsed: Vec<JsonValue> = serde_json::from_str(&body).map_err(|e| {
+        let tail = &body[body_len.saturating_sub(80)..];
+        format!("JSON parse failed (body_len={body_len}, tail={tail:?}): {e}")
+    })?;
+
+    // Validate end-markers to detect data corruption
+    for (i, item) in parsed.iter().enumerate() {
+        let expected = format!("end-marker-{i}");
+        let actual = item.get("checksum").and_then(|v| v.as_str()).unwrap_or("");
+        if actual != expected {
+            return Err(format!(
+                "Data corruption at item {i}: expected '{expected}', got '{actual}'"
+            ));
+        }
+    }
+
+    Ok(body_len)
+}
+
+/// Core test logic: run concurrent H2 requests through a throttled proxy.
+async fn run_h2_throttled_test(
+    proxy_addr: &str,
+    num_rounds: usize,
+    concurrent_per_round: usize,
+) -> (usize, usize, usize) {
+    let endpoints: Vec<String> = vec!["a", "b", "c", "d", "e"]
+        .into_iter()
+        .map(|e| format!("https://{proxy_addr}/endpoint-{e}"))
+        .collect();
+
+    // HTTP/2 client (default ALPN negotiation, NO http1_only)
+    let client = Client::builder()
+        .danger_accept_invalid_certs(true)
+        .pool_max_idle_per_host(1)
+        .build()
+        .expect("Failed to build client");
+
+    let total = Arc::new(AtomicUsize::new(0));
+    let failed = Arc::new(AtomicUsize::new(0));
+    let truncated = Arc::new(AtomicUsize::new(0));
+
+    for round in 0..num_rounds {
+        let mut futures = Vec::new();
+
+        for i in 0..concurrent_per_round {
+            let url = endpoints[i % endpoints.len()].clone();
+            let client = client.clone();
+            let total = Arc::clone(&total);
+            let failed = Arc::clone(&failed);
+            let truncated = Arc::clone(&truncated);
+
+            futures.push(tokio::spawn(async move {
+                total.fetch_add(1, Ordering::Relaxed);
+                match fetch_and_validate(&client, &url).await {
+                    Ok(_) => {}
+                    Err(e) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                        if e.contains("JSON parse failed") || e.contains("Data corruption") {
+                            truncated.fetch_add(1, Ordering::Relaxed);
+                            eprintln!("[Round {round}] ✗ TRUNCATION: {e}");
+                        } else if round < 3 {
+                            eprintln!("[Round {round}] FAILURE: {e}");
+                        }
+                    }
+                }
+            }));
+        }
+
+        join_all(futures).await;
+    }
+
+    (
+        total.load(Ordering::Relaxed),
+        failed.load(Ordering::Relaxed),
+        truncated.load(Ordering::Relaxed),
+    )
+}
+
+/// Test HTTP/2 multiplexing through a bandwidth-throttled proxy.
+/// The throttling creates conditions where h2 DATA frames are delivered
+/// slowly and interleaved across streams, triggering flow control races.
+///
+/// Throttle: 500KB/s — enough to serve data but slow enough to create
+/// concurrent in-flight streams with partially received bodies.
+#[tokio::test]
+#[ignore]
+async fn test_h2_throttled_proxy_500kbps() {
+    let _ = env_logger::try_init();
+    let (server_addr, _cfg) = start_tls_server().await;
+
+    // 500 KB/s throttle — large responses (250-400KB each) take 0.5-0.8s
+    // With 10+ concurrent streams, all data is in-flight simultaneously
+    let proxy_addr = start_throttling_proxy(&server_addr, 500_000).await;
+
+    // Give proxy time to start
+    sleep(Duration::from_millis(50)).await;
+
+    let (total, failed, truncated) = run_h2_throttled_test(&proxy_addr, 10, 15).await;
+
+    println!("\n=== HTTP/2 Throttled Proxy (500KB/s) Results ===");
+    println!("Total requests: {total}");
+    println!("Failed requests: {failed}");
+    println!("Truncation errors: {truncated}");
+    println!(
+        "Success rate: {:.1}%",
+        if total > 0 {
+            (total - failed) as f64 / total as f64 * 100.0
+        } else {
+            0.0
+        }
+    );
+
+    if truncated > 0 {
+        println!("\n✓ REPRODUCED: {truncated} truncation(s) under throttled HTTP/2");
+    } else if failed > 0 {
+        println!("\n⚠ {failed} failures (connection errors, not truncation)");
+    } else {
+        println!("\n  All requests succeeded at this throttle level");
+    }
+}
+
+/// More aggressive throttle: 100KB/s.
+/// With 250-400KB responses and 15 concurrent streams, this creates
+/// extreme multiplexing pressure — each response takes 2.5-4 seconds,
+/// keeping all streams in-flight simultaneously for extended periods.
+#[tokio::test]
+#[ignore]
+async fn test_h2_throttled_proxy_100kbps() {
+    let _ = env_logger::try_init();
+    let (server_addr, _cfg) = start_tls_server().await;
+
+    // 100 KB/s — very slow, maximum h2 flow control pressure
+    let proxy_addr = start_throttling_proxy(&server_addr, 100_000).await;
+    sleep(Duration::from_millis(50)).await;
+
+    let (total, failed, truncated) = run_h2_throttled_test(&proxy_addr, 5, 20).await;
+
+    println!("\n=== HTTP/2 Throttled Proxy (100KB/s) Results ===");
+    println!("Total requests: {total}");
+    println!("Failed requests: {failed}");
+    println!("Truncation errors: {truncated}");
+    println!(
+        "Success rate: {:.1}%",
+        if total > 0 {
+            (total - failed) as f64 / total as f64 * 100.0
+        } else {
+            0.0
+        }
+    );
+
+    if truncated > 0 {
+        println!("\n✓ REPRODUCED: {truncated} truncation(s) under heavy throttle");
+    }
+}
+
+/// Extremely constrained: 50KB/s with burst concurrency.
+/// This mimics a congested network connection where multiple large
+/// responses compete for a very limited pipe.
+#[tokio::test]
+#[ignore]
+async fn test_h2_throttled_proxy_50kbps() {
+    let _ = env_logger::try_init();
+    let (server_addr, _cfg) = start_tls_server().await;
+
+    // 50 KB/s — extreme throttle
+    let proxy_addr = start_throttling_proxy(&server_addr, 50_000).await;
+    sleep(Duration::from_millis(50)).await;
+
+    let (total, failed, truncated) = run_h2_throttled_test(&proxy_addr, 3, 25).await;
+
+    println!("\n=== HTTP/2 Throttled Proxy (50KB/s) Results ===");
+    println!("Total requests: {total}");
+    println!("Failed requests: {failed}");
+    println!("Truncation errors: {truncated}");
+    println!(
+        "Success rate: {:.1}%",
+        if total > 0 {
+            (total - failed) as f64 / total as f64 * 100.0
+        } else {
+            0.0
+        }
+    );
+
+    if truncated > 0 {
+        println!("\n✓ REPRODUCED: {truncated} truncation(s) under extreme throttle");
+    }
+}
+
+/// Control: HTTP/1.1 through the same throttled proxy.
+/// Even with throttling, HTTP/1.1 should never truncate because there's
+/// no multiplexing — each request/response pair is fully serialized.
+#[tokio::test]
+#[ignore]
+async fn test_h1_throttled_proxy_control() {
+    let _ = env_logger::try_init();
+    let (server_addr, _cfg) = start_tls_server().await;
+
+    let proxy_addr = start_throttling_proxy(&server_addr, 500_000).await;
+    sleep(Duration::from_millis(50)).await;
+
+    let endpoints: Vec<String> = vec!["a", "b", "c", "d", "e"]
+        .into_iter()
+        .map(|e| format!("https://{proxy_addr}/endpoint-{e}"))
+        .collect();
+
+    // HTTP/1.1 client (the fix)
+    let client = Client::builder()
+        .danger_accept_invalid_certs(true)
+        .http1_only()
+        .build()
+        .expect("Failed to build h1 client");
+
+    let total = Arc::new(AtomicUsize::new(0));
+    let failed = Arc::new(AtomicUsize::new(0));
+
+    for _round in 0..5 {
+        let mut futures = Vec::new();
+        for i in 0..10 {
+            let url = endpoints[i % endpoints.len()].clone();
+            let client = client.clone();
+            let total = Arc::clone(&total);
+            let failed = Arc::clone(&failed);
+
+            futures.push(tokio::spawn(async move {
+                total.fetch_add(1, Ordering::Relaxed);
+                if let Err(e) = fetch_and_validate(&client, &url).await {
+                    failed.fetch_add(1, Ordering::Relaxed);
+                    eprintln!("H1 FAILURE: {e}");
+                }
+            }));
+        }
+        join_all(futures).await;
+    }
+
+    let t = total.load(Ordering::Relaxed);
+    let f = failed.load(Ordering::Relaxed);
+
+    println!("\n=== HTTP/1.1 Throttled Proxy (Control) Results ===");
+    println!("Total requests: {t}");
+    println!("Failed requests: {f}");
+    println!(
+        "Success rate: {:.1}%",
+        if t > 0 {
+            (t - f) as f64 / t as f64 * 100.0
+        } else {
+            0.0
+        }
+    );
+
+    assert_eq!(
+        f, 0,
+        "HTTP/1.1 should never truncate, even through a throttled proxy. Got {f} failures."
+    );
+    println!("\n✓ CONFIRMED: HTTP/1.1 remains reliable through throttled proxy");
+}
+
+/// Test with a proxy that abruptly kills connections mid-response.
+/// This simulates load balancer resets, GOAWAY frames, or network partitions
+/// that cause incomplete data delivery.
+///
+/// Key question: Does reqwest/hyper surface this as an error (correct behavior)
+/// or does it silently return truncated body data (the bug)?
+#[tokio::test]
+#[ignore]
+async fn test_h2_connection_kill_mid_response() {
+    let _ = env_logger::try_init();
+    let (server_addr, _cfg) = start_tls_server().await;
+
+    // Kill after 100KB — responses are 250-400KB, so this cuts them mid-body
+    let proxy_addr = start_truncating_proxy(&server_addr, 100_000).await;
+    sleep(Duration::from_millis(50)).await;
+
+    let endpoints: Vec<String> = vec!["a", "b", "c", "d", "e"]
+        .into_iter()
+        .map(|e| format!("https://{proxy_addr}/endpoint-{e}"))
+        .collect();
+
+    let client = Client::builder()
+        .danger_accept_invalid_certs(true)
+        .pool_max_idle_per_host(1)
+        .build()
+        .expect("Failed to build client");
+
+    let total = Arc::new(AtomicUsize::new(0));
+    let got_error = Arc::new(AtomicUsize::new(0));
+    let got_truncated_body = Arc::new(AtomicUsize::new(0));
+    let got_success = Arc::new(AtomicUsize::new(0));
+
+    // Fire concurrent requests - the proxy will kill the connection
+    for round in 0..5 {
+        let mut futures = Vec::new();
+        for url in &endpoints {
+            let client = client.clone();
+            let url = url.clone();
+            let total = Arc::clone(&total);
+            let got_error = Arc::clone(&got_error);
+            let got_truncated_body = Arc::clone(&got_truncated_body);
+            let got_success = Arc::clone(&got_success);
+
+            futures.push(tokio::spawn(async move {
+                total.fetch_add(1, Ordering::Relaxed);
+
+                let resp = match client.get(&url).send().await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        got_error.fetch_add(1, Ordering::Relaxed);
+                        if round == 0 {
+                            eprintln!("  [send error] {e}");
+                        }
+                        return;
+                    }
+                };
+
+                match resp.text().await {
+                    Ok(body) => {
+                        // Got a body - is it complete or truncated?
+                        match serde_json::from_str::<JsonValue>(&body) {
+                            Ok(_) => {
+                                got_success.fetch_add(1, Ordering::Relaxed);
+                            }
+                            Err(e) => {
+                                // THIS IS THE BUG: body was received as "Ok" but it's truncated
+                                got_truncated_body.fetch_add(1, Ordering::Relaxed);
+                                eprintln!(
+                                    "  [Round {round}] ✗ SILENT TRUNCATION: body_len={}, parse_error={e}",
+                                    body.len()
+                                );
+                                eprintln!(
+                                    "    tail: {:?}",
+                                    &body[body.len().saturating_sub(60)..]
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // This is CORRECT behavior - error on incomplete body
+                        got_error.fetch_add(1, Ordering::Relaxed);
+                        if round == 0 {
+                            eprintln!("  [body read error - correct] {e}");
+                        }
+                    }
+                }
+            }));
+        }
+        join_all(futures).await;
+    }
+
+    let t = total.load(Ordering::Relaxed);
+    let errors = got_error.load(Ordering::Relaxed);
+    let truncated = got_truncated_body.load(Ordering::Relaxed);
+    let success = got_success.load(Ordering::Relaxed);
+
+    println!("\n=== HTTP/2 Connection Kill Test Results ===");
+    println!("Total requests: {t}");
+    println!("Proper errors (connection/body read): {errors}");
+    println!("Silent truncations (BUG - Ok body but invalid JSON): {truncated}");
+    println!("Full successes (raced before kill): {success}");
+
+    if truncated > 0 {
+        println!("\n✓ REPRODUCED THE BUG: reqwest returned Ok(body) with truncated data!");
+        println!("  This is the exact issue from #493 - the h2 layer reports stream");
+        println!("  completion despite incomplete data when the connection is reset.");
+        println!("  The .http1_only() fix prevents this because HTTP/1.1 detects");
+        println!("  incomplete responses via Content-Length mismatch or chunked EOF.");
+    } else if errors > 0 {
+        println!("\n  Good: all connection kills were properly surfaced as errors.");
+        println!("  The h2 implementation correctly propagates connection resets.");
+        println!("  The truncation may require different conditions (GOAWAY frame,");
+        println!("  specific h2 window states) rather than raw TCP kills.");
+    } else {
+        println!("\n  Unexpected: all requests succeeded despite connection kills.");
+    }
+}
+
+/// Variant: Kill connection after more data (200KB) to catch the larger responses
+/// that might have completed before the kill threshold.
+#[tokio::test]
+#[ignore]
+async fn test_h2_connection_kill_200kb() {
+    let _ = env_logger::try_init();
+    let (server_addr, _cfg) = start_tls_server().await;
+
+    // Kill after 200KB — some responses (250-400KB) will be mid-body
+    let proxy_addr = start_truncating_proxy(&server_addr, 200_000).await;
+    sleep(Duration::from_millis(50)).await;
+
+    let endpoints: Vec<String> = vec!["a", "b", "c", "d", "e"]
+        .into_iter()
+        .map(|e| format!("https://{proxy_addr}/endpoint-{e}"))
+        .collect();
+
+    let client = Client::builder()
+        .danger_accept_invalid_certs(true)
+        .pool_max_idle_per_host(1)
+        .build()
+        .expect("Failed to build client");
+
+    let total = Arc::new(AtomicUsize::new(0));
+    let got_error = Arc::new(AtomicUsize::new(0));
+    let got_truncated_body = Arc::new(AtomicUsize::new(0));
+    let got_success = Arc::new(AtomicUsize::new(0));
+
+    for round in 0..10 {
+        let mut futures = Vec::new();
+        for url in &endpoints {
+            let client = client.clone();
+            let url = url.clone();
+            let total = Arc::clone(&total);
+            let got_error = Arc::clone(&got_error);
+            let got_truncated_body = Arc::clone(&got_truncated_body);
+            let got_success = Arc::clone(&got_success);
+
+            futures.push(tokio::spawn(async move {
+                total.fetch_add(1, Ordering::Relaxed);
+                let resp = match client.get(&url).send().await {
+                    Ok(r) => r,
+                    Err(_) => {
+                        got_error.fetch_add(1, Ordering::Relaxed);
+                        return;
+                    }
+                };
+                match resp.text().await {
+                    Ok(body) => match serde_json::from_str::<JsonValue>(&body) {
+                        Ok(_) => {
+                            got_success.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Err(e) => {
+                            got_truncated_body.fetch_add(1, Ordering::Relaxed);
+                            if round < 3 {
+                                eprintln!(
+                                    "  [Round {round}] ✗ TRUNCATION: len={}, err={e}",
+                                    body.len()
+                                );
+                            }
+                        }
+                    },
+                    Err(_) => {
+                        got_error.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }));
+        }
+        join_all(futures).await;
+    }
+
+    let t = total.load(Ordering::Relaxed);
+    let errors = got_error.load(Ordering::Relaxed);
+    let truncated = got_truncated_body.load(Ordering::Relaxed);
+    let success = got_success.load(Ordering::Relaxed);
+
+    println!("\n=== HTTP/2 Connection Kill (200KB) Results ===");
+    println!("Total: {t}, Errors: {errors}, Truncated: {truncated}, Success: {success}");
+
+    if truncated > 0 {
+        println!("\n✓ REPRODUCED: {truncated} silent truncation(s)!");
+    }
+}
+
+// ── GitHub API tests (require GITHUB_TOKEN env var) ──────────────────────────
+
+/// Test concurrent GitHub API requests WITH HTTP/2 (no http1_only).
+/// Reproduces the exact scenario from Issue #493.
+/// Run: GITHUB_TOKEN=ghp_... cargo test ... test_github -- --ignored --nocapture
+#[tokio::test]
+#[ignore]
+async fn test_github_api_h2_concurrent() {
+    let _ = env_logger::try_init();
+
+    let token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
+    if token.is_empty() {
+        println!("SKIPPED: Set GITHUB_TOKEN env var to run this test");
+        return;
+    }
+
+    let endpoints = vec![
+        "https://api.github.com/repos/drasi-project/drasi-core/pulls?state=open&per_page=100",
+        "https://api.github.com/search/issues?q=repo:drasi-project/drasi-core+is:issue+state:open&per_page=100",
+        "https://api.github.com/repos/drasi-project/drasi-core/commits?per_page=100",
+        "https://api.github.com/repos/drasi-project/drasi-core/issues?state=all&per_page=100",
+        "https://api.github.com/repos/drasi-project/drasi-core/pulls?state=closed&per_page=100",
+    ];
+
+    // HTTP/2 client — the default (what happens WITHOUT .http1_only())
+    let client = Client::builder()
+        .user_agent("drasi-h2-truncation-poc")
+        .pool_max_idle_per_host(1)
+        .build()
+        .expect("Failed to build client");
+
+    let total_requests = Arc::new(AtomicUsize::new(0));
+    let failed_requests = Arc::new(AtomicUsize::new(0));
+    let truncation_errors = Arc::new(AtomicUsize::new(0));
+
+    let num_rounds = 20;
+
+    for round in 0..num_rounds {
+        let mut futures = Vec::new();
+        // Each round: fire all 5 endpoints concurrently
+        for url in &endpoints {
+            let client = client.clone();
+            let url = url.to_string();
+            let token = token.clone();
+            let total = Arc::clone(&total_requests);
+            let failed = Arc::clone(&failed_requests);
+            let truncated = Arc::clone(&truncation_errors);
+
+            futures.push(tokio::spawn(async move {
+                total.fetch_add(1, Ordering::Relaxed);
+                let resp = client
+                    .get(&url)
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("Accept", "application/vnd.github+json")
+                    .send()
+                    .await;
+
+                match resp {
+                    Ok(response) => {
+                        let status = response.status();
+                        if status.as_u16() == 403 || status.as_u16() == 429 {
+                            return; // Rate limited
+                        }
+                        if !status.is_success() {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            return;
+                        }
+                        let body = match response.text().await {
+                            Ok(b) => b,
+                            Err(e) => {
+                                failed.fetch_add(1, Ordering::Relaxed);
+                                truncated.fetch_add(1, Ordering::Relaxed);
+                                eprintln!("[Round {round}] ✗ Body read error for {url}: {e}");
+                                return;
+                            }
+                        };
+                        if let Err(e) = serde_json::from_str::<JsonValue>(&body) {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            truncated.fetch_add(1, Ordering::Relaxed);
+                            eprintln!(
+                                "[Round {round}] ✗ TRUNCATION {url}: len={}, err={e}, tail={:?}",
+                                body.len(),
+                                &body[body.len().saturating_sub(60)..]
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                        eprintln!("[Round {round}] Request error: {e}");
+                    }
+                }
+            }));
+        }
+        join_all(futures).await;
+        // Brief delay to avoid rate limiting
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    let total = total_requests.load(Ordering::Relaxed);
+    let failed = failed_requests.load(Ordering::Relaxed);
+    let truncated = truncation_errors.load(Ordering::Relaxed);
+
+    println!("\n=== GitHub API HTTP/2 Results ({num_rounds} rounds × 5 endpoints) ===");
+    println!("Total requests: {total}");
+    println!("Failed requests: {failed}");
+    println!("Truncation errors: {truncated}");
+
+    if truncated > 0 {
+        println!("\n✓ REPRODUCED against GitHub API: {truncated} truncation(s)");
+    } else {
+        println!("\n✗ No truncation observed ({total} requests)");
+    }
+}
+
+/// Control: GitHub API with http1_only (the fix).
+#[tokio::test]
+#[ignore]
+async fn test_github_api_h1_only() {
+    let _ = env_logger::try_init();
+
+    let token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
+    if token.is_empty() {
+        println!("SKIPPED: Set GITHUB_TOKEN env var to run this test");
+        return;
+    }
+
+    let endpoints = vec![
+        "https://api.github.com/repos/drasi-project/drasi-core/pulls?state=open&per_page=100",
+        "https://api.github.com/search/issues?q=repo:drasi-project/drasi-core+is:issue+state:open&per_page=100",
+        "https://api.github.com/repos/drasi-project/drasi-core/commits?per_page=100",
+    ];
+
+    let client = Client::builder()
+        .user_agent("drasi-h2-truncation-poc")
+        .http1_only()
+        .build()
+        .expect("Failed to build client");
+
+    let total = Arc::new(AtomicUsize::new(0));
+    let failed = Arc::new(AtomicUsize::new(0));
+    let truncated = Arc::new(AtomicUsize::new(0));
+
+    for round in 0..10 {
+        let mut futures = Vec::new();
+        for url in &endpoints {
+            let client = client.clone();
+            let url = url.to_string();
+            let token = token.clone();
+            let total = Arc::clone(&total);
+            let failed = Arc::clone(&failed);
+            let truncated = Arc::clone(&truncated);
+
+            futures.push(tokio::spawn(async move {
+                total.fetch_add(1, Ordering::Relaxed);
+                let resp = client
+                    .get(&url)
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("Accept", "application/vnd.github+json")
+                    .send()
+                    .await;
+                match resp {
+                    Ok(response) => {
+                        let status = response.status();
+                        if status.as_u16() == 403 || status.as_u16() == 429 {
+                            return;
+                        }
+                        if !status.is_success() {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            return;
+                        }
+                        let body = match response.text().await {
+                            Ok(b) => b,
+                            Err(e) => {
+                                failed.fetch_add(1, Ordering::Relaxed);
+                                eprintln!("[Round {round}] Body read error: {e}");
+                                return;
+                            }
+                        };
+                        if let Err(e) = serde_json::from_str::<JsonValue>(&body) {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            truncated.fetch_add(1, Ordering::Relaxed);
+                            eprintln!("[Round {round}] ✗ TRUNCATION: len={}, err={e}", body.len());
+                        }
+                    }
+                    Err(e) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                        eprintln!("[Round {round}] Error: {e}");
+                    }
+                }
+            }));
+        }
+        join_all(futures).await;
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    let t = total.load(Ordering::Relaxed);
+    let f = failed.load(Ordering::Relaxed);
+    let tr = truncated.load(Ordering::Relaxed);
+
+    println!("\n=== GitHub API HTTP/1.1 (Fix) Results ===");
+    println!("Total requests: {t}");
+    println!("Failed requests: {f}");
+    println!("Truncation errors: {tr}");
+
+    assert_eq!(tr, 0, "HTTP/1.1 should NOT truncate, got {tr}");
+    println!("\n✓ CONFIRMED: http1_only prevents truncation");
+}
+
+// =============================================================================
+// TEST: Custom h2 server that sends END_STREAM after partial data
+// This is the REAL reproduction of the truncation bug.
+// In HTTP/2, END_STREAM is the authoritative signal that the body is complete.
+// If a server (or intermediary proxy/load balancer) sends END_STREAM prematurely,
+// the client receives Ok(partial_body) with NO transport error.
+// =============================================================================
+
+/// Start a custom h2 server that truncates responses by sending END_STREAM
+/// after only a fraction of the body data.
+/// `truncate_fraction` controls how much of the body to send (0.0 - 1.0).
+/// If `include_content_length` is true, sends a Content-Length header with
+/// the FULL body size (which h2 implementations may validate).
+async fn start_h2_truncating_server(
+    truncate_fraction: f64,
+    include_content_length: bool,
+) -> (u16, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let (socket, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+
+            let truncate_frac = truncate_fraction;
+            let include_cl = include_content_length;
+
+            tokio::spawn(async move {
+                let mut conn = match h2_server::handshake(socket).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("[h2 server] handshake error: {e}");
+                        return;
+                    }
+                };
+
+                while let Some(request) = conn.accept().await {
+                    let (request, mut respond) = match request {
+                        Ok(r) => r,
+                        Err(e) => {
+                            eprintln!("[h2 server] accept error: {e}");
+                            return;
+                        }
+                    };
+
+                    let truncate_frac = truncate_frac;
+                    let include_cl = include_cl;
+
+                    tokio::spawn(async move {
+                        let path = request.uri().path().to_string();
+
+                        // Generate a large JSON response
+                        let num_items = match path.as_str() {
+                            "/api/data1" => 100,
+                            "/api/data2" => 150,
+                            "/api/data3" => 200,
+                            "/api/data4" => 120,
+                            "/api/data5" => 180,
+                            _ => 50,
+                        };
+                        let full_body = generate_large_json_string(num_items, 1500);
+                        let full_len = full_body.len();
+
+                        // Calculate truncation point
+                        let send_bytes = (full_len as f64 * truncate_frac) as usize;
+                        let truncated_body = &full_body.as_bytes()[..send_bytes];
+
+                        // Build response headers
+                        let mut response = http::Response::builder()
+                            .status(200)
+                            .header("content-type", "application/json");
+
+                        if include_cl {
+                            // Send Content-Length with FULL size (mismatch)
+                            response = response.header("content-length", full_len.to_string());
+                        }
+
+                        let response = response.body(()).unwrap();
+
+                        // Send headers, then partial body with END_STREAM
+                        let mut send_stream = respond.send_response(response, false).unwrap();
+
+                        // Send the truncated body in chunks
+                        let chunk_size = 16384; // h2 default frame size
+                        let mut offset = 0;
+                        while offset < truncated_body.len() {
+                            let end = std::cmp::min(offset + chunk_size, truncated_body.len());
+                            let is_last = end >= truncated_body.len();
+
+                            // Reserve capacity
+                            send_stream.reserve_capacity(end - offset);
+
+                            // Wait for capacity
+                            loop {
+                                let cap = send_stream.capacity();
+                                if cap > 0 {
+                                    break;
+                                }
+                                tokio::task::yield_now().await;
+                            }
+
+                            let chunk = bytes::Bytes::copy_from_slice(&truncated_body[offset..end]);
+                            // Send with END_STREAM on the last chunk
+                            if let Err(e) = send_stream.send_data(chunk, is_last) {
+                                eprintln!("[h2 server] send_data error on {path}: {e}");
+                                return;
+                            }
+                            offset = end;
+                        }
+                    });
+                }
+            });
+        }
+    });
+
+    (port, handle)
+}
+
+/// Generate a large JSON string for the h2 server
+fn generate_large_json_string(num_items: usize, item_size_bytes: usize) -> String {
+    let padding = "x".repeat(item_size_bytes);
+    let items: Vec<JsonValue> = (0..num_items)
+        .map(|i| {
+            json!({
+                "id": i,
+                "name": format!("item-{i}"),
+                "data": padding,
+                "checksum": format!("end-marker-{i}")
+            })
+        })
+        .collect();
+    serde_json::to_string(&json!(items)).unwrap()
+}
+
+/// Test: h2 server sends END_STREAM after only 50% of body data, WITHOUT
+/// Content-Length header. This should result in "silent truncation" — the client
+/// gets Ok(partial_body) that is incomplete JSON.
+#[tokio::test]
+#[ignore]
+async fn test_h2_premature_end_stream_no_content_length() {
+    let _ = env_logger::try_init();
+
+    // Server sends only 50% of the body then END_STREAM (no Content-Length)
+    let (port, _server) = start_h2_truncating_server(0.5, false).await;
+    sleep(Duration::from_millis(100)).await;
+
+    println!("=== h2 Premature END_STREAM (no Content-Length) ===");
+    println!("Server on port {port}, sending 50% of body + END_STREAM");
+    println!("Expected: client gets Ok(partial_body) → JSON parse fails");
+    println!();
+
+    // Use reqwest with http2_prior_knowledge (h2c - cleartext h2)
+    let client = Client::builder().http2_prior_knowledge().build().unwrap();
+
+    let endpoints = vec![
+        format!("http://127.0.0.1:{port}/api/data1"),
+        format!("http://127.0.0.1:{port}/api/data2"),
+        format!("http://127.0.0.1:{port}/api/data3"),
+        format!("http://127.0.0.1:{port}/api/data4"),
+        format!("http://127.0.0.1:{port}/api/data5"),
+    ];
+
+    let mut silent_truncations = 0u32;
+    let mut proper_errors = 0u32;
+    let mut successes = 0u32;
+    let total_rounds = 10;
+
+    for round in 0..total_rounds {
+        let mut futures = Vec::new();
+        for url in &endpoints {
+            let client = client.clone();
+            let url = url.clone();
+            futures.push(tokio::spawn(async move {
+                let result = client.get(&url).send().await;
+                match result {
+                    Ok(resp) => {
+                        let status = resp.status();
+                        match resp.text().await {
+                            Ok(body) => {
+                                // Try to parse as JSON
+                                match serde_json::from_str::<JsonValue>(&body) {
+                                    Ok(_) => ("success".to_string(), body.len(), String::new()),
+                                    Err(e) => (
+                                        "truncated".to_string(),
+                                        body.len(),
+                                        format!("status={status}, JSON err: {e}"),
+                                    ),
+                                }
+                            }
+                            Err(e) => ("body_error".to_string(), 0, format!("{e}")),
+                        }
+                    }
+                    Err(e) => ("request_error".to_string(), 0, format!("{e}")),
+                }
+            }));
+        }
+
+        let results = join_all(futures).await;
+        for res in results {
+            match res {
+                Ok((kind, len, detail)) => match kind.as_str() {
+                    "success" => {
+                        successes += 1;
+                    }
+                    "truncated" => {
+                        silent_truncations += 1;
+                        eprintln!(
+                            "  [Round {round}] ✗ SILENT TRUNCATION: body_len={len}, {detail}"
+                        );
+                    }
+                    "body_error" => {
+                        proper_errors += 1;
+                        eprintln!("  [Round {round}] body read error: {detail}");
+                    }
+                    _ => {
+                        proper_errors += 1;
+                        eprintln!("  [Round {round}] request error: {detail}");
+                    }
+                },
+                Err(e) => {
+                    proper_errors += 1;
+                    eprintln!("  [Round {round}] task error: {e}");
+                }
+            }
+        }
+    }
+
+    let total = total_rounds as u32 * endpoints.len() as u32;
+    println!("\n=== Results: Premature END_STREAM (no Content-Length) ===");
+    println!("Total requests: {total}");
+    println!("Silent truncations (BUG reproduced): {silent_truncations}");
+    println!("Proper errors (transport detected): {proper_errors}");
+    println!("Full successes (should be 0): {successes}");
+
+    if silent_truncations > 0 {
+        println!("\n🔴 BUG REPRODUCED: {silent_truncations} silent truncations!");
+        println!("   The client received Ok(partial_body) — no transport error.");
+        println!("   This proves HTTP/2 END_STREAM can silently truncate responses.");
+    } else if proper_errors > 0 {
+        println!("\n🟡 Truncation was DETECTED by transport layer.");
+        println!("   The h2 implementation properly errors on incomplete bodies.");
+    } else {
+        println!("\n🟢 All requests succeeded (unexpected for 50% truncation).");
+    }
+}
+
+/// Test: h2 server sends END_STREAM after only 50% of body data, WITH
+/// Content-Length header set to the full body size. The h2 implementation
+/// MAY detect the mismatch and return an error.
+#[tokio::test]
+#[ignore]
+async fn test_h2_premature_end_stream_with_content_length() {
+    let _ = env_logger::try_init();
+
+    // Server sends only 50% of the body then END_STREAM (WITH Content-Length)
+    let (port, _server) = start_h2_truncating_server(0.5, true).await;
+    sleep(Duration::from_millis(100)).await;
+
+    println!("=== h2 Premature END_STREAM (WITH Content-Length) ===");
+    println!("Server on port {port}, sending 50% of body + END_STREAM");
+    println!("Content-Length set to full size → h2 impl SHOULD detect mismatch");
+    println!();
+
+    let client = Client::builder().http2_prior_knowledge().build().unwrap();
+
+    let endpoints = vec![
+        format!("http://127.0.0.1:{port}/api/data1"),
+        format!("http://127.0.0.1:{port}/api/data2"),
+        format!("http://127.0.0.1:{port}/api/data3"),
+    ];
+
+    let mut silent_truncations = 0u32;
+    let mut proper_errors = 0u32;
+    let mut successes = 0u32;
+
+    for _round in 0..5 {
+        let mut futures = Vec::new();
+        for url in &endpoints {
+            let client = client.clone();
+            let url = url.clone();
+            futures.push(tokio::spawn(async move {
+                let result = client.get(&url).send().await;
+                match result {
+                    Ok(resp) => match resp.text().await {
+                        Ok(body) => match serde_json::from_str::<JsonValue>(&body) {
+                            Ok(_) => "success".to_string(),
+                            Err(_) => format!("truncated:{}", body.len()),
+                        },
+                        Err(e) => format!("body_error:{e}"),
+                    },
+                    Err(e) => format!("request_error:{e}"),
+                }
+            }));
+        }
+
+        let results = join_all(futures).await;
+        for res in results {
+            match res {
+                Ok(result) => {
+                    if result == "success" {
+                        successes += 1;
+                    } else if result.starts_with("truncated:") {
+                        silent_truncations += 1;
+                        eprintln!("  ✗ SILENT TRUNCATION: {result}");
+                    } else {
+                        proper_errors += 1;
+                        eprintln!("  Error (correct): {result}");
+                    }
+                }
+                Err(e) => {
+                    proper_errors += 1;
+                    eprintln!("  Task error: {e}");
+                }
+            }
+        }
+    }
+
+    let total = 5 * endpoints.len() as u32;
+    println!("\n=== Results: Premature END_STREAM (with Content-Length) ===");
+    println!("Total: {total}, Truncated: {silent_truncations}, Errors: {proper_errors}, Success: {successes}");
+
+    if silent_truncations > 0 {
+        println!("\n🔴 h2 does NOT validate Content-Length vs actual body size!");
+    } else if proper_errors > 0 {
+        println!("\n🟢 h2 correctly detects Content-Length mismatch → errors.");
+        println!("   Content-Length validation at the application layer is redundant.");
+    }
+}
+
+/// Test: Prove that HTTP/1.1 prevents silent truncation.
+/// Same truncating server, but client uses http1_only().
+#[tokio::test]
+#[ignore]
+async fn test_h1_prevents_premature_end_stream() {
+    let _ = env_logger::try_init();
+
+    // Server only speaks h2, so an HTTP/1.1 client cannot connect.
+    // Instead, we use the normal TLS server (which supports both) and verify
+    // that with http1_only(), truncation doesn't occur from the normal server.
+    // The point: http1_only() avoids h2 entirely, so h2-specific truncation
+    // cannot happen.
+
+    let (port, _server) = start_h2_truncating_server(0.5, false).await;
+    sleep(Duration::from_millis(100)).await;
+
+    println!("=== HTTP/1.1 vs h2 truncating server ===");
+    println!("h2 server on port {port} — HTTP/1.1 client should FAIL to connect");
+    println!("(Server only speaks h2, not HTTP/1.1)");
+    println!();
+
+    // http1_only() client cannot talk to h2-only server
+    let client = Client::builder().http1_only().build().unwrap();
+
+    let url = format!("http://127.0.0.1:{port}/api/data1");
+    let result = client.get(&url).send().await;
+
+    match result {
+        Err(e) => {
+            println!("✓ CONFIRMED: HTTP/1.1 client cannot connect to h2-only server");
+            println!("  Error: {e}");
+            println!("  This proves .http1_only() avoids the h2 truncation path entirely.");
+        }
+        Ok(resp) => {
+            println!("✗ UNEXPECTED: HTTP/1.1 client connected to h2-only server");
+            println!("  Status: {}", resp.status());
+            let body = resp.text().await.unwrap_or_default();
+            println!("  Body len: {}", body.len());
+        }
+    }
+}

--- a/components/bootstrappers/http/tests/h2_truncation_poc.rs
+++ b/components/bootstrappers/http/tests/h2_truncation_poc.rs
@@ -12,35 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! PoC: Reproduce HTTP/2 multiplexing body truncation (Issue #493).
+//! PoC: Reproduce HTTP/2 silent body truncation (Issue #493).
 //!
-//! This test creates conditions that trigger HTTP/2 flow control race conditions
-//! by using a bandwidth-throttled TCP proxy between client and server. The
-//! throttling forces many small TCP reads/writes, creating interleaving of h2
-//! DATA frames across multiplexed streams — the exact condition that triggers
-//! body truncation in hyper 0.14 / h2 0.3.x.
+//! These tests use a custom h2 server (via the `h2` crate) that sends
+//! END_STREAM after delivering only a fraction of the response body. This
+//! reproduces the exact silent truncation scenario that causes issue #493:
+//! the client gets `Ok(partial_body)` with no transport error, and the
+//! response is unparseable JSON.
+//!
+//! The tests prove:
+//! 1. Without Content-Length, h2 silently truncates (bug reproduced).
+//! 2. With Content-Length, h2 detects the mismatch and returns an error.
+//! 3. HTTP/1.1 (`.http1_only()`) cannot connect to h2-only servers,
+//!    preventing the h2-specific truncation entirely.
 //!
 //! Run with: cargo test -p drasi-bootstrap-http --test h2_truncation_poc -- --ignored --nocapture
 
 #![allow(clippy::unwrap_used, clippy::uninlined_format_args)]
 
-use axum::{routing::get, Json, Router};
 use futures::future::join_all;
 use h2::server as h2_server;
-use rcgen::generate_simple_self_signed;
 use reqwest::Client;
-use rustls::ServerConfig;
 use serde_json::{json, Value as JsonValue};
-use std::io::Cursor;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::time::{sleep, Duration};
-use tokio_rustls::TlsAcceptor;
 
-/// Generate a large JSON array with N items, each having a long string property.
-fn generate_large_json(num_items: usize, item_size_bytes: usize) -> JsonValue {
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Generate a large JSON string representing an array of N items.
+fn generate_large_json_string(num_items: usize, item_size_bytes: usize) -> String {
     let padding = "x".repeat(item_size_bytes);
     let items: Vec<JsonValue> = (0..num_items)
         .map(|i| {
@@ -52,956 +52,14 @@ fn generate_large_json(num_items: usize, item_size_bytes: usize) -> JsonValue {
             })
         })
         .collect();
-    json!(items)
+    serde_json::to_string(&json!(items)).unwrap()
 }
 
-/// Start a TLS server that serves large JSON payloads.
-/// Returns (server_addr_port) - the raw address to connect to.
-#[allow(clippy::unwrap_used)]
-async fn start_tls_server() -> (String, Arc<rustls::ServerConfig>) {
-    let app = Router::new()
-        .route(
-            "/endpoint-a",
-            get(|| async { Json(generate_large_json(80, 3000)) }),
-        )
-        .route(
-            "/endpoint-b",
-            get(|| async { Json(generate_large_json(100, 3000)) }),
-        )
-        .route(
-            "/endpoint-c",
-            get(|| async { Json(generate_large_json(90, 3000)) }),
-        )
-        .route(
-            "/endpoint-d",
-            get(|| async { Json(generate_large_json(120, 3000)) }),
-        )
-        .route(
-            "/endpoint-e",
-            get(|| async { Json(generate_large_json(70, 3000)) }),
-        );
-
-    // Generate self-signed TLS certificate for localhost
-    let subject_alt_names = vec!["localhost".to_string(), "127.0.0.1".to_string()];
-    let cert = generate_simple_self_signed(subject_alt_names).unwrap();
-    let cert_pem = cert.cert.pem();
-    let key_pem = cert.key_pair.serialize_pem();
-
-    let certs = rustls_pemfile::certs(&mut Cursor::new(cert_pem.as_bytes()))
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-    let key = rustls_pemfile::private_key(&mut Cursor::new(key_pem.as_bytes()))
-        .unwrap()
-        .unwrap();
-
-    let mut tls_config = ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(certs, key)
-        .unwrap();
-    tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-
-    let server_config = Arc::new(tls_config);
-    let tls_acceptor = TlsAcceptor::from(Arc::clone(&server_config));
-
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap(); // DevSkim: ignore DS137138
-    let addr = listener.local_addr().unwrap();
-
-    tokio::spawn(async move {
-        loop {
-            let (stream, _) = match listener.accept().await {
-                Ok(conn) => conn,
-                Err(_) => continue,
-            };
-            let acceptor = tls_acceptor.clone();
-            let app = app.clone();
-
-            tokio::spawn(async move {
-                let tls_stream = match acceptor.accept(stream).await {
-                    Ok(s) => s,
-                    Err(_) => return,
-                };
-                let io = hyper_util::rt::TokioIo::new(tls_stream);
-                let service = hyper_util::service::TowerToHyperService::new(app);
-                let builder = hyper_util::server::conn::auto::Builder::new(
-                    hyper_util::rt::TokioExecutor::new(),
-                );
-                let _ = builder.serve_connection(io, service).await;
-            });
-        }
-    });
-
-    (format!("127.0.0.1:{}", addr.port()), server_config) // DevSkim: ignore DS137138
-}
-
-/// Start a throttling TCP proxy that forwards data between client and server
-/// with bandwidth limiting and small buffer sizes.
+/// Start an h2 server that sends only a fraction of the body then END_STREAM.
 ///
-/// This simulates real network conditions by:
-/// - Limiting throughput to `bytes_per_sec` in each direction
-/// - Using small read buffers to force many small TCP reads
-/// - Introducing micro-delays between chunk forwards
-#[allow(clippy::unwrap_used)]
-async fn start_throttling_proxy(target_addr: &str, bytes_per_sec: usize) -> String {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap(); // DevSkim: ignore DS137138
-    let proxy_addr = listener.local_addr().unwrap();
-    let target = target_addr.to_string();
-
-    tokio::spawn(async move {
-        loop {
-            let (client_stream, _) = match listener.accept().await {
-                Ok(conn) => conn,
-                Err(_) => continue,
-            };
-
-            let target = target.clone();
-            tokio::spawn(async move {
-                let server_stream = match tokio::net::TcpStream::connect(&target).await {
-                    Ok(s) => s,
-                    Err(_) => return,
-                };
-
-                let (mut client_read, mut client_write) = client_stream.into_split();
-                let (mut server_read, mut server_write) = server_stream.into_split();
-
-                // Calculate delay per chunk to achieve target throughput
-                let chunk_size = 2048usize;
-                let delay_per_chunk =
-                    Duration::from_micros((chunk_size as u64 * 1_000_000) / bytes_per_sec as u64);
-
-                // Client -> Server (request direction, usually small, minimal throttle)
-                let c2s = tokio::spawn(async move {
-                    let mut buf = vec![0u8; 8192];
-                    loop {
-                        match client_read.read(&mut buf).await {
-                            Ok(0) => break,
-                            Ok(n) => {
-                                if server_write.write_all(&buf[..n]).await.is_err() {
-                                    break;
-                                }
-                            }
-                            Err(_) => break,
-                        }
-                    }
-                    let _ = server_write.shutdown().await;
-                });
-
-                // Server -> Client (response direction, throttled)
-                let s2c = tokio::spawn(async move {
-                    let mut buf = vec![0u8; chunk_size];
-                    loop {
-                        match server_read.read(&mut buf).await {
-                            Ok(0) => break,
-                            Ok(n) => {
-                                if client_write.write_all(&buf[..n]).await.is_err() {
-                                    break;
-                                }
-                                // Throttle: sleep after each chunk
-                                sleep(delay_per_chunk).await;
-                            }
-                            Err(_) => break,
-                        }
-                    }
-                    let _ = client_write.shutdown().await;
-                });
-
-                let _ = tokio::join!(c2s, s2c);
-            });
-        }
-    });
-
-    format!("127.0.0.1:{}", proxy_addr.port()) // DevSkim: ignore DS137138
-}
-
-/// Start a proxy that abruptly kills the server->client direction after
-/// forwarding a specified number of bytes. This simulates what happens when
-/// a load balancer resets an HTTP/2 connection mid-response, or when GOAWAY
-/// is received while DATA frames are in-flight.
-///
-/// The key behavior: the proxy forwards `bytes_before_kill` bytes from the server,
-/// then closes the connection abruptly (no graceful shutdown). This forces the
-/// client's h2 implementation to deal with a connection that died while streams
-/// had partially-received bodies.
-#[allow(clippy::unwrap_used)]
-async fn start_truncating_proxy(target_addr: &str, bytes_before_kill: usize) -> String {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap(); // DevSkim: ignore DS137138
-    let proxy_addr = listener.local_addr().unwrap();
-    let target = target_addr.to_string();
-    let kill_threshold = bytes_before_kill;
-
-    tokio::spawn(async move {
-        loop {
-            let (client_stream, _) = match listener.accept().await {
-                Ok(conn) => conn,
-                Err(_) => continue,
-            };
-
-            let target = target.clone();
-            tokio::spawn(async move {
-                let server_stream = match tokio::net::TcpStream::connect(&target).await {
-                    Ok(s) => s,
-                    Err(_) => return,
-                };
-
-                let (mut client_read, mut client_write) = client_stream.into_split();
-                let (mut server_read, mut server_write) = server_stream.into_split();
-
-                // Client -> Server (forward normally)
-                let c2s = tokio::spawn(async move {
-                    let mut buf = vec![0u8; 8192];
-                    loop {
-                        match client_read.read(&mut buf).await {
-                            Ok(0) => break,
-                            Ok(n) => {
-                                if server_write.write_all(&buf[..n]).await.is_err() {
-                                    break;
-                                }
-                            }
-                            Err(_) => break,
-                        }
-                    }
-                });
-
-                // Server -> Client: forward bytes then ABRUPTLY drop
-                let s2c = tokio::spawn(async move {
-                    let mut buf = vec![0u8; 4096];
-                    let mut total_forwarded = 0usize;
-                    loop {
-                        match server_read.read(&mut buf).await {
-                            Ok(0) => break,
-                            Ok(n) => {
-                                total_forwarded += n;
-                                if total_forwarded >= kill_threshold {
-                                    // Forward partial last chunk then kill
-                                    let remaining = n.saturating_sub(
-                                        total_forwarded.saturating_sub(kill_threshold),
-                                    );
-                                    if remaining > 0 {
-                                        let _ = client_write.write_all(&buf[..remaining]).await;
-                                    }
-                                    // Graceful shutdown (TCP FIN) — NOT RST.
-                                    // This simulates a TLS close_notify without h2 GOAWAY,
-                                    // which may cause the client's h2 layer to think the
-                                    // connection completed normally.
-                                    let _ = client_write.shutdown().await;
-                                    return;
-                                }
-                                if client_write.write_all(&buf[..n]).await.is_err() {
-                                    break;
-                                }
-                            }
-                            Err(_) => break,
-                        }
-                    }
-                    let _ = client_write.shutdown().await;
-                });
-
-                let _ = tokio::join!(c2s, s2c);
-            });
-        }
-    });
-
-    format!("127.0.0.1:{}", proxy_addr.port()) // DevSkim: ignore DS137138
-}
-
-/// Fetch a URL, parse JSON body, validate structure integrity.
-async fn fetch_and_validate(client: &Client, url: &str) -> Result<usize, String> {
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| format!("Request failed: {e}"))?;
-
-    if !response.status().is_success() {
-        return Err(format!("HTTP error: {}", response.status()));
-    }
-
-    let body = response
-        .text()
-        .await
-        .map_err(|e| format!("Body read failed: {e}"))?;
-
-    let body_len = body.len();
-
-    // Parse JSON - truncation causes parse failures
-    let parsed: Vec<JsonValue> = serde_json::from_str(&body).map_err(|e| {
-        let tail = &body[body_len.saturating_sub(80)..];
-        format!("JSON parse failed (body_len={body_len}, tail={tail:?}): {e}")
-    })?;
-
-    // Validate end-markers to detect data corruption
-    for (i, item) in parsed.iter().enumerate() {
-        let expected = format!("end-marker-{i}");
-        let actual = item.get("checksum").and_then(|v| v.as_str()).unwrap_or("");
-        if actual != expected {
-            return Err(format!(
-                "Data corruption at item {i}: expected '{expected}', got '{actual}'"
-            ));
-        }
-    }
-
-    Ok(body_len)
-}
-
-/// Core test logic: run concurrent H2 requests through a throttled proxy.
-async fn run_h2_throttled_test(
-    proxy_addr: &str,
-    num_rounds: usize,
-    concurrent_per_round: usize,
-) -> (usize, usize, usize) {
-    let endpoints: Vec<String> = vec!["a", "b", "c", "d", "e"]
-        .into_iter()
-        .map(|e| format!("https://{proxy_addr}/endpoint-{e}"))
-        .collect();
-
-    // HTTP/2 client (default ALPN negotiation, NO http1_only)
-    let client = Client::builder()
-        .danger_accept_invalid_certs(true)
-        .pool_max_idle_per_host(1)
-        .build()
-        .expect("Failed to build client");
-
-    let total = Arc::new(AtomicUsize::new(0));
-    let failed = Arc::new(AtomicUsize::new(0));
-    let truncated = Arc::new(AtomicUsize::new(0));
-
-    for round in 0..num_rounds {
-        let mut futures = Vec::new();
-
-        for i in 0..concurrent_per_round {
-            let url = endpoints[i % endpoints.len()].clone();
-            let client = client.clone();
-            let total = Arc::clone(&total);
-            let failed = Arc::clone(&failed);
-            let truncated = Arc::clone(&truncated);
-
-            futures.push(tokio::spawn(async move {
-                total.fetch_add(1, Ordering::Relaxed);
-                match fetch_and_validate(&client, &url).await {
-                    Ok(_) => {}
-                    Err(e) => {
-                        failed.fetch_add(1, Ordering::Relaxed);
-                        if e.contains("JSON parse failed") || e.contains("Data corruption") {
-                            truncated.fetch_add(1, Ordering::Relaxed);
-                            eprintln!("[Round {round}] ✗ TRUNCATION: {e}");
-                        } else if round < 3 {
-                            eprintln!("[Round {round}] FAILURE: {e}");
-                        }
-                    }
-                }
-            }));
-        }
-
-        join_all(futures).await;
-    }
-
-    (
-        total.load(Ordering::Relaxed),
-        failed.load(Ordering::Relaxed),
-        truncated.load(Ordering::Relaxed),
-    )
-}
-
-/// Test HTTP/2 multiplexing through a bandwidth-throttled proxy.
-/// The throttling creates conditions where h2 DATA frames are delivered
-/// slowly and interleaved across streams, triggering flow control races.
-///
-/// Throttle: 500KB/s — enough to serve data but slow enough to create
-/// concurrent in-flight streams with partially received bodies.
-#[tokio::test]
-#[ignore]
-async fn test_h2_throttled_proxy_500kbps() {
-    let _ = env_logger::try_init();
-    let (server_addr, _cfg) = start_tls_server().await;
-
-    // 500 KB/s throttle — large responses (250-400KB each) take 0.5-0.8s
-    // With 10+ concurrent streams, all data is in-flight simultaneously
-    let proxy_addr = start_throttling_proxy(&server_addr, 500_000).await;
-
-    // Give proxy time to start
-    sleep(Duration::from_millis(50)).await;
-
-    let (total, failed, truncated) = run_h2_throttled_test(&proxy_addr, 10, 15).await;
-
-    println!("\n=== HTTP/2 Throttled Proxy (500KB/s) Results ===");
-    println!("Total requests: {total}");
-    println!("Failed requests: {failed}");
-    println!("Truncation errors: {truncated}");
-    println!(
-        "Success rate: {:.1}%",
-        if total > 0 {
-            (total - failed) as f64 / total as f64 * 100.0
-        } else {
-            0.0
-        }
-    );
-
-    if truncated > 0 {
-        println!("\n✓ REPRODUCED: {truncated} truncation(s) under throttled HTTP/2");
-    } else if failed > 0 {
-        println!("\n⚠ {failed} failures (connection errors, not truncation)");
-    } else {
-        println!("\n  All requests succeeded at this throttle level");
-    }
-}
-
-/// More aggressive throttle: 100KB/s.
-/// With 250-400KB responses and 15 concurrent streams, this creates
-/// extreme multiplexing pressure — each response takes 2.5-4 seconds,
-/// keeping all streams in-flight simultaneously for extended periods.
-#[tokio::test]
-#[ignore]
-async fn test_h2_throttled_proxy_100kbps() {
-    let _ = env_logger::try_init();
-    let (server_addr, _cfg) = start_tls_server().await;
-
-    // 100 KB/s — very slow, maximum h2 flow control pressure
-    let proxy_addr = start_throttling_proxy(&server_addr, 100_000).await;
-    sleep(Duration::from_millis(50)).await;
-
-    let (total, failed, truncated) = run_h2_throttled_test(&proxy_addr, 5, 20).await;
-
-    println!("\n=== HTTP/2 Throttled Proxy (100KB/s) Results ===");
-    println!("Total requests: {total}");
-    println!("Failed requests: {failed}");
-    println!("Truncation errors: {truncated}");
-    println!(
-        "Success rate: {:.1}%",
-        if total > 0 {
-            (total - failed) as f64 / total as f64 * 100.0
-        } else {
-            0.0
-        }
-    );
-
-    if truncated > 0 {
-        println!("\n✓ REPRODUCED: {truncated} truncation(s) under heavy throttle");
-    }
-}
-
-/// Extremely constrained: 50KB/s with burst concurrency.
-/// This mimics a congested network connection where multiple large
-/// responses compete for a very limited pipe.
-#[tokio::test]
-#[ignore]
-async fn test_h2_throttled_proxy_50kbps() {
-    let _ = env_logger::try_init();
-    let (server_addr, _cfg) = start_tls_server().await;
-
-    // 50 KB/s — extreme throttle
-    let proxy_addr = start_throttling_proxy(&server_addr, 50_000).await;
-    sleep(Duration::from_millis(50)).await;
-
-    let (total, failed, truncated) = run_h2_throttled_test(&proxy_addr, 3, 25).await;
-
-    println!("\n=== HTTP/2 Throttled Proxy (50KB/s) Results ===");
-    println!("Total requests: {total}");
-    println!("Failed requests: {failed}");
-    println!("Truncation errors: {truncated}");
-    println!(
-        "Success rate: {:.1}%",
-        if total > 0 {
-            (total - failed) as f64 / total as f64 * 100.0
-        } else {
-            0.0
-        }
-    );
-
-    if truncated > 0 {
-        println!("\n✓ REPRODUCED: {truncated} truncation(s) under extreme throttle");
-    }
-}
-
-/// Control: HTTP/1.1 through the same throttled proxy.
-/// Even with throttling, HTTP/1.1 should never truncate because there's
-/// no multiplexing — each request/response pair is fully serialized.
-#[tokio::test]
-#[ignore]
-async fn test_h1_throttled_proxy_control() {
-    let _ = env_logger::try_init();
-    let (server_addr, _cfg) = start_tls_server().await;
-
-    let proxy_addr = start_throttling_proxy(&server_addr, 500_000).await;
-    sleep(Duration::from_millis(50)).await;
-
-    let endpoints: Vec<String> = vec!["a", "b", "c", "d", "e"]
-        .into_iter()
-        .map(|e| format!("https://{proxy_addr}/endpoint-{e}"))
-        .collect();
-
-    // HTTP/1.1 client (the fix)
-    let client = Client::builder()
-        .danger_accept_invalid_certs(true)
-        .http1_only()
-        .build()
-        .expect("Failed to build h1 client");
-
-    let total = Arc::new(AtomicUsize::new(0));
-    let failed = Arc::new(AtomicUsize::new(0));
-
-    for _round in 0..5 {
-        let mut futures = Vec::new();
-        for i in 0..10 {
-            let url = endpoints[i % endpoints.len()].clone();
-            let client = client.clone();
-            let total = Arc::clone(&total);
-            let failed = Arc::clone(&failed);
-
-            futures.push(tokio::spawn(async move {
-                total.fetch_add(1, Ordering::Relaxed);
-                if let Err(e) = fetch_and_validate(&client, &url).await {
-                    failed.fetch_add(1, Ordering::Relaxed);
-                    eprintln!("H1 FAILURE: {e}");
-                }
-            }));
-        }
-        join_all(futures).await;
-    }
-
-    let t = total.load(Ordering::Relaxed);
-    let f = failed.load(Ordering::Relaxed);
-
-    println!("\n=== HTTP/1.1 Throttled Proxy (Control) Results ===");
-    println!("Total requests: {t}");
-    println!("Failed requests: {f}");
-    println!(
-        "Success rate: {:.1}%",
-        if t > 0 {
-            (t - f) as f64 / t as f64 * 100.0
-        } else {
-            0.0
-        }
-    );
-
-    assert_eq!(
-        f, 0,
-        "HTTP/1.1 should never truncate, even through a throttled proxy. Got {f} failures."
-    );
-    println!("\n✓ CONFIRMED: HTTP/1.1 remains reliable through throttled proxy");
-}
-
-/// Test with a proxy that abruptly kills connections mid-response.
-/// This simulates load balancer resets, GOAWAY frames, or network partitions
-/// that cause incomplete data delivery.
-///
-/// Key question: Does reqwest/hyper surface this as an error (correct behavior)
-/// or does it silently return truncated body data (the bug)?
-#[tokio::test]
-#[ignore]
-async fn test_h2_connection_kill_mid_response() {
-    let _ = env_logger::try_init();
-    let (server_addr, _cfg) = start_tls_server().await;
-
-    // Kill after 100KB — responses are 250-400KB, so this cuts them mid-body
-    let proxy_addr = start_truncating_proxy(&server_addr, 100_000).await;
-    sleep(Duration::from_millis(50)).await;
-
-    let endpoints: Vec<String> = vec!["a", "b", "c", "d", "e"]
-        .into_iter()
-        .map(|e| format!("https://{proxy_addr}/endpoint-{e}"))
-        .collect();
-
-    let client = Client::builder()
-        .danger_accept_invalid_certs(true)
-        .pool_max_idle_per_host(1)
-        .build()
-        .expect("Failed to build client");
-
-    let total = Arc::new(AtomicUsize::new(0));
-    let got_error = Arc::new(AtomicUsize::new(0));
-    let got_truncated_body = Arc::new(AtomicUsize::new(0));
-    let got_success = Arc::new(AtomicUsize::new(0));
-
-    // Fire concurrent requests - the proxy will kill the connection
-    for round in 0..5 {
-        let mut futures = Vec::new();
-        for url in &endpoints {
-            let client = client.clone();
-            let url = url.clone();
-            let total = Arc::clone(&total);
-            let got_error = Arc::clone(&got_error);
-            let got_truncated_body = Arc::clone(&got_truncated_body);
-            let got_success = Arc::clone(&got_success);
-
-            futures.push(tokio::spawn(async move {
-                total.fetch_add(1, Ordering::Relaxed);
-
-                let resp = match client.get(&url).send().await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        got_error.fetch_add(1, Ordering::Relaxed);
-                        if round == 0 {
-                            eprintln!("  [send error] {e}");
-                        }
-                        return;
-                    }
-                };
-
-                match resp.text().await {
-                    Ok(body) => {
-                        // Got a body - is it complete or truncated?
-                        match serde_json::from_str::<JsonValue>(&body) {
-                            Ok(_) => {
-                                got_success.fetch_add(1, Ordering::Relaxed);
-                            }
-                            Err(e) => {
-                                // THIS IS THE BUG: body was received as "Ok" but it's truncated
-                                got_truncated_body.fetch_add(1, Ordering::Relaxed);
-                                eprintln!(
-                                    "  [Round {round}] ✗ SILENT TRUNCATION: body_len={}, parse_error={e}",
-                                    body.len()
-                                );
-                                eprintln!(
-                                    "    tail: {:?}",
-                                    &body[body.len().saturating_sub(60)..]
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        // This is CORRECT behavior - error on incomplete body
-                        got_error.fetch_add(1, Ordering::Relaxed);
-                        if round == 0 {
-                            eprintln!("  [body read error - correct] {e}");
-                        }
-                    }
-                }
-            }));
-        }
-        join_all(futures).await;
-    }
-
-    let t = total.load(Ordering::Relaxed);
-    let errors = got_error.load(Ordering::Relaxed);
-    let truncated = got_truncated_body.load(Ordering::Relaxed);
-    let success = got_success.load(Ordering::Relaxed);
-
-    println!("\n=== HTTP/2 Connection Kill Test Results ===");
-    println!("Total requests: {t}");
-    println!("Proper errors (connection/body read): {errors}");
-    println!("Silent truncations (BUG - Ok body but invalid JSON): {truncated}");
-    println!("Full successes (raced before kill): {success}");
-
-    if truncated > 0 {
-        println!("\n✓ REPRODUCED THE BUG: reqwest returned Ok(body) with truncated data!");
-        println!("  This is the exact issue from #493 - the h2 layer reports stream");
-        println!("  completion despite incomplete data when the connection is reset.");
-        println!("  The .http1_only() fix prevents this because HTTP/1.1 detects");
-        println!("  incomplete responses via Content-Length mismatch or chunked EOF.");
-    } else if errors > 0 {
-        println!("\n  Good: all connection kills were properly surfaced as errors.");
-        println!("  The h2 implementation correctly propagates connection resets.");
-        println!("  The truncation may require different conditions (GOAWAY frame,");
-        println!("  specific h2 window states) rather than raw TCP kills.");
-    } else {
-        println!("\n  Unexpected: all requests succeeded despite connection kills.");
-    }
-}
-
-/// Variant: Kill connection after more data (200KB) to catch the larger responses
-/// that might have completed before the kill threshold.
-#[tokio::test]
-#[ignore]
-async fn test_h2_connection_kill_200kb() {
-    let _ = env_logger::try_init();
-    let (server_addr, _cfg) = start_tls_server().await;
-
-    // Kill after 200KB — some responses (250-400KB) will be mid-body
-    let proxy_addr = start_truncating_proxy(&server_addr, 200_000).await;
-    sleep(Duration::from_millis(50)).await;
-
-    let endpoints: Vec<String> = vec!["a", "b", "c", "d", "e"]
-        .into_iter()
-        .map(|e| format!("https://{proxy_addr}/endpoint-{e}"))
-        .collect();
-
-    let client = Client::builder()
-        .danger_accept_invalid_certs(true)
-        .pool_max_idle_per_host(1)
-        .build()
-        .expect("Failed to build client");
-
-    let total = Arc::new(AtomicUsize::new(0));
-    let got_error = Arc::new(AtomicUsize::new(0));
-    let got_truncated_body = Arc::new(AtomicUsize::new(0));
-    let got_success = Arc::new(AtomicUsize::new(0));
-
-    for round in 0..10 {
-        let mut futures = Vec::new();
-        for url in &endpoints {
-            let client = client.clone();
-            let url = url.clone();
-            let total = Arc::clone(&total);
-            let got_error = Arc::clone(&got_error);
-            let got_truncated_body = Arc::clone(&got_truncated_body);
-            let got_success = Arc::clone(&got_success);
-
-            futures.push(tokio::spawn(async move {
-                total.fetch_add(1, Ordering::Relaxed);
-                let resp = match client.get(&url).send().await {
-                    Ok(r) => r,
-                    Err(_) => {
-                        got_error.fetch_add(1, Ordering::Relaxed);
-                        return;
-                    }
-                };
-                match resp.text().await {
-                    Ok(body) => match serde_json::from_str::<JsonValue>(&body) {
-                        Ok(_) => {
-                            got_success.fetch_add(1, Ordering::Relaxed);
-                        }
-                        Err(e) => {
-                            got_truncated_body.fetch_add(1, Ordering::Relaxed);
-                            if round < 3 {
-                                eprintln!(
-                                    "  [Round {round}] ✗ TRUNCATION: len={}, err={e}",
-                                    body.len()
-                                );
-                            }
-                        }
-                    },
-                    Err(_) => {
-                        got_error.fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-            }));
-        }
-        join_all(futures).await;
-    }
-
-    let t = total.load(Ordering::Relaxed);
-    let errors = got_error.load(Ordering::Relaxed);
-    let truncated = got_truncated_body.load(Ordering::Relaxed);
-    let success = got_success.load(Ordering::Relaxed);
-
-    println!("\n=== HTTP/2 Connection Kill (200KB) Results ===");
-    println!("Total: {t}, Errors: {errors}, Truncated: {truncated}, Success: {success}");
-
-    if truncated > 0 {
-        println!("\n✓ REPRODUCED: {truncated} silent truncation(s)!");
-    }
-}
-
-// ── GitHub API tests (require GITHUB_TOKEN env var) ──────────────────────────
-
-/// Test concurrent GitHub API requests WITH HTTP/2 (no http1_only).
-/// Reproduces the exact scenario from Issue #493.
-/// Run: GITHUB_TOKEN=ghp_... cargo test ... test_github -- --ignored --nocapture
-#[tokio::test]
-#[ignore]
-async fn test_github_api_h2_concurrent() {
-    let _ = env_logger::try_init();
-
-    let token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
-    if token.is_empty() {
-        println!("SKIPPED: Set GITHUB_TOKEN env var to run this test");
-        return;
-    }
-
-    let endpoints = vec![
-        "https://api.github.com/repos/drasi-project/drasi-core/pulls?state=open&per_page=100",
-        "https://api.github.com/search/issues?q=repo:drasi-project/drasi-core+is:issue+state:open&per_page=100",
-        "https://api.github.com/repos/drasi-project/drasi-core/commits?per_page=100",
-        "https://api.github.com/repos/drasi-project/drasi-core/issues?state=all&per_page=100",
-        "https://api.github.com/repos/drasi-project/drasi-core/pulls?state=closed&per_page=100",
-    ];
-
-    // HTTP/2 client — the default (what happens WITHOUT .http1_only())
-    let client = Client::builder()
-        .user_agent("drasi-h2-truncation-poc")
-        .pool_max_idle_per_host(1)
-        .build()
-        .expect("Failed to build client");
-
-    let total_requests = Arc::new(AtomicUsize::new(0));
-    let failed_requests = Arc::new(AtomicUsize::new(0));
-    let truncation_errors = Arc::new(AtomicUsize::new(0));
-
-    let num_rounds = 20;
-
-    for round in 0..num_rounds {
-        let mut futures = Vec::new();
-        // Each round: fire all 5 endpoints concurrently
-        for url in &endpoints {
-            let client = client.clone();
-            let url = url.to_string();
-            let token = token.clone();
-            let total = Arc::clone(&total_requests);
-            let failed = Arc::clone(&failed_requests);
-            let truncated = Arc::clone(&truncation_errors);
-
-            futures.push(tokio::spawn(async move {
-                total.fetch_add(1, Ordering::Relaxed);
-                let resp = client
-                    .get(&url)
-                    .header("Authorization", format!("Bearer {token}"))
-                    .header("Accept", "application/vnd.github+json")
-                    .send()
-                    .await;
-
-                match resp {
-                    Ok(response) => {
-                        let status = response.status();
-                        if status.as_u16() == 403 || status.as_u16() == 429 {
-                            return; // Rate limited
-                        }
-                        if !status.is_success() {
-                            failed.fetch_add(1, Ordering::Relaxed);
-                            return;
-                        }
-                        let body = match response.text().await {
-                            Ok(b) => b,
-                            Err(e) => {
-                                failed.fetch_add(1, Ordering::Relaxed);
-                                truncated.fetch_add(1, Ordering::Relaxed);
-                                eprintln!("[Round {round}] ✗ Body read error for {url}: {e}");
-                                return;
-                            }
-                        };
-                        if let Err(e) = serde_json::from_str::<JsonValue>(&body) {
-                            failed.fetch_add(1, Ordering::Relaxed);
-                            truncated.fetch_add(1, Ordering::Relaxed);
-                            eprintln!(
-                                "[Round {round}] ✗ TRUNCATION {url}: len={}, err={e}, tail={:?}",
-                                body.len(),
-                                &body[body.len().saturating_sub(60)..]
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        failed.fetch_add(1, Ordering::Relaxed);
-                        eprintln!("[Round {round}] Request error: {e}");
-                    }
-                }
-            }));
-        }
-        join_all(futures).await;
-        // Brief delay to avoid rate limiting
-        sleep(Duration::from_millis(200)).await;
-    }
-
-    let total = total_requests.load(Ordering::Relaxed);
-    let failed = failed_requests.load(Ordering::Relaxed);
-    let truncated = truncation_errors.load(Ordering::Relaxed);
-
-    println!("\n=== GitHub API HTTP/2 Results ({num_rounds} rounds × 5 endpoints) ===");
-    println!("Total requests: {total}");
-    println!("Failed requests: {failed}");
-    println!("Truncation errors: {truncated}");
-
-    if truncated > 0 {
-        println!("\n✓ REPRODUCED against GitHub API: {truncated} truncation(s)");
-    } else {
-        println!("\n✗ No truncation observed ({total} requests)");
-    }
-}
-
-/// Control: GitHub API with http1_only (the fix).
-#[tokio::test]
-#[ignore]
-async fn test_github_api_h1_only() {
-    let _ = env_logger::try_init();
-
-    let token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
-    if token.is_empty() {
-        println!("SKIPPED: Set GITHUB_TOKEN env var to run this test");
-        return;
-    }
-
-    let endpoints = vec![
-        "https://api.github.com/repos/drasi-project/drasi-core/pulls?state=open&per_page=100",
-        "https://api.github.com/search/issues?q=repo:drasi-project/drasi-core+is:issue+state:open&per_page=100",
-        "https://api.github.com/repos/drasi-project/drasi-core/commits?per_page=100",
-    ];
-
-    let client = Client::builder()
-        .user_agent("drasi-h2-truncation-poc")
-        .http1_only()
-        .build()
-        .expect("Failed to build client");
-
-    let total = Arc::new(AtomicUsize::new(0));
-    let failed = Arc::new(AtomicUsize::new(0));
-    let truncated = Arc::new(AtomicUsize::new(0));
-
-    for round in 0..10 {
-        let mut futures = Vec::new();
-        for url in &endpoints {
-            let client = client.clone();
-            let url = url.to_string();
-            let token = token.clone();
-            let total = Arc::clone(&total);
-            let failed = Arc::clone(&failed);
-            let truncated = Arc::clone(&truncated);
-
-            futures.push(tokio::spawn(async move {
-                total.fetch_add(1, Ordering::Relaxed);
-                let resp = client
-                    .get(&url)
-                    .header("Authorization", format!("Bearer {token}"))
-                    .header("Accept", "application/vnd.github+json")
-                    .send()
-                    .await;
-                match resp {
-                    Ok(response) => {
-                        let status = response.status();
-                        if status.as_u16() == 403 || status.as_u16() == 429 {
-                            return;
-                        }
-                        if !status.is_success() {
-                            failed.fetch_add(1, Ordering::Relaxed);
-                            return;
-                        }
-                        let body = match response.text().await {
-                            Ok(b) => b,
-                            Err(e) => {
-                                failed.fetch_add(1, Ordering::Relaxed);
-                                eprintln!("[Round {round}] Body read error: {e}");
-                                return;
-                            }
-                        };
-                        if let Err(e) = serde_json::from_str::<JsonValue>(&body) {
-                            failed.fetch_add(1, Ordering::Relaxed);
-                            truncated.fetch_add(1, Ordering::Relaxed);
-                            eprintln!("[Round {round}] ✗ TRUNCATION: len={}, err={e}", body.len());
-                        }
-                    }
-                    Err(e) => {
-                        failed.fetch_add(1, Ordering::Relaxed);
-                        eprintln!("[Round {round}] Error: {e}");
-                    }
-                }
-            }));
-        }
-        join_all(futures).await;
-        sleep(Duration::from_millis(200)).await;
-    }
-
-    let t = total.load(Ordering::Relaxed);
-    let f = failed.load(Ordering::Relaxed);
-    let tr = truncated.load(Ordering::Relaxed);
-
-    println!("\n=== GitHub API HTTP/1.1 (Fix) Results ===");
-    println!("Total requests: {t}");
-    println!("Failed requests: {f}");
-    println!("Truncation errors: {tr}");
-
-    assert_eq!(tr, 0, "HTTP/1.1 should NOT truncate, got {tr}");
-    println!("\n✓ CONFIRMED: http1_only prevents truncation");
-}
-
-// =============================================================================
-// TEST: Custom h2 server that sends END_STREAM after partial data
-// This is the REAL reproduction of the truncation bug.
-// In HTTP/2, END_STREAM is the authoritative signal that the body is complete.
-// If a server (or intermediary proxy/load balancer) sends END_STREAM prematurely,
-// the client receives Ok(partial_body) with NO transport error.
-// =============================================================================
-
-/// Start a custom h2 server that truncates responses by sending END_STREAM
-/// after only a fraction of the body data.
-/// `truncate_fraction` controls how much of the body to send (0.0 - 1.0).
-/// If `include_content_length` is true, sends a Content-Length header with
-/// the FULL body size (which h2 implementations may validate).
+/// - `truncate_fraction`: how much of the body to send (0.0–1.0).
+/// - `include_content_length`: if true, sets Content-Length to full body size
+///   (causing a detectable mismatch).
 async fn start_h2_truncating_server(
     truncate_fraction: f64,
     include_content_length: bool,
@@ -1043,7 +101,6 @@ async fn start_h2_truncating_server(
                     tokio::spawn(async move {
                         let path = request.uri().path().to_string();
 
-                        // Generate a large JSON response
                         let num_items = match path.as_str() {
                             "/api/data1" => 100,
                             "/api/data2" => 150,
@@ -1055,36 +112,29 @@ async fn start_h2_truncating_server(
                         let full_body = generate_large_json_string(num_items, 1500);
                         let full_len = full_body.len();
 
-                        // Calculate truncation point
                         let send_bytes = (full_len as f64 * truncate_frac) as usize;
                         let truncated_body = &full_body.as_bytes()[..send_bytes];
 
-                        // Build response headers
                         let mut response = http::Response::builder()
                             .status(200)
                             .header("content-type", "application/json");
 
                         if include_cl {
-                            // Send Content-Length with FULL size (mismatch)
-                            response = response.header("content-length", full_len.to_string());
+                            response =
+                                response.header("content-length", full_len.to_string());
                         }
 
                         let response = response.body(()).unwrap();
-
-                        // Send headers, then partial body with END_STREAM
                         let mut send_stream = respond.send_response(response, false).unwrap();
 
-                        // Send the truncated body in chunks
-                        let chunk_size = 16384; // h2 default frame size
+                        // Send truncated body in h2 frame-sized chunks
+                        let chunk_size = 16384;
                         let mut offset = 0;
                         while offset < truncated_body.len() {
                             let end = std::cmp::min(offset + chunk_size, truncated_body.len());
                             let is_last = end >= truncated_body.len();
 
-                            // Reserve capacity
                             send_stream.reserve_capacity(end - offset);
-
-                            // Wait for capacity
                             loop {
                                 let cap = send_stream.capacity();
                                 if cap > 0 {
@@ -1094,7 +144,6 @@ async fn start_h2_truncating_server(
                             }
 
                             let chunk = bytes::Bytes::copy_from_slice(&truncated_body[offset..end]);
-                            // Send with END_STREAM on the last chunk
                             if let Err(e) = send_stream.send_data(chunk, is_last) {
                                 eprintln!("[h2 server] send_data error on {path}: {e}");
                                 return;
@@ -1110,31 +159,15 @@ async fn start_h2_truncating_server(
     (port, handle)
 }
 
-/// Generate a large JSON string for the h2 server
-fn generate_large_json_string(num_items: usize, item_size_bytes: usize) -> String {
-    let padding = "x".repeat(item_size_bytes);
-    let items: Vec<JsonValue> = (0..num_items)
-        .map(|i| {
-            json!({
-                "id": i,
-                "name": format!("item-{i}"),
-                "data": padding,
-                "checksum": format!("end-marker-{i}")
-            })
-        })
-        .collect();
-    serde_json::to_string(&json!(items)).unwrap()
-}
+// ── Tests ───────────────────────────────────────────────────────────────────
 
-/// Test: h2 server sends END_STREAM after only 50% of body data, WITHOUT
-/// Content-Length header. This should result in "silent truncation" — the client
-/// gets Ok(partial_body) that is incomplete JSON.
+/// Proves: Without Content-Length, h2 END_STREAM after 50% of body causes
+/// the client to get `Ok(partial_body)` — silent truncation, no transport error.
 #[tokio::test]
 #[ignore]
 async fn test_h2_premature_end_stream_no_content_length() {
     let _ = env_logger::try_init();
 
-    // Server sends only 50% of the body then END_STREAM (no Content-Length)
     let (port, _server) = start_h2_truncating_server(0.5, false).await;
     sleep(Duration::from_millis(100)).await;
 
@@ -1143,16 +176,11 @@ async fn test_h2_premature_end_stream_no_content_length() {
     println!("Expected: client gets Ok(partial_body) → JSON parse fails");
     println!();
 
-    // Use reqwest with http2_prior_knowledge (h2c - cleartext h2)
     let client = Client::builder().http2_prior_knowledge().build().unwrap();
 
-    let endpoints = vec![
-        format!("http://127.0.0.1:{port}/api/data1"),
-        format!("http://127.0.0.1:{port}/api/data2"),
-        format!("http://127.0.0.1:{port}/api/data3"),
-        format!("http://127.0.0.1:{port}/api/data4"),
-        format!("http://127.0.0.1:{port}/api/data5"),
-    ];
+    let endpoints: Vec<String> = (1..=5)
+        .map(|i| format!("http://127.0.0.1:{port}/api/data{i}"))
+        .collect();
 
     let mut silent_truncations = 0u32;
     let mut proper_errors = 0u32;
@@ -1170,17 +198,14 @@ async fn test_h2_premature_end_stream_no_content_length() {
                     Ok(resp) => {
                         let status = resp.status();
                         match resp.text().await {
-                            Ok(body) => {
-                                // Try to parse as JSON
-                                match serde_json::from_str::<JsonValue>(&body) {
-                                    Ok(_) => ("success".to_string(), body.len(), String::new()),
-                                    Err(e) => (
-                                        "truncated".to_string(),
-                                        body.len(),
-                                        format!("status={status}, JSON err: {e}"),
-                                    ),
-                                }
-                            }
+                            Ok(body) => match serde_json::from_str::<JsonValue>(&body) {
+                                Ok(_) => ("success".to_string(), body.len(), String::new()),
+                                Err(e) => (
+                                    "truncated".to_string(),
+                                    body.len(),
+                                    format!("status={status}, JSON err: {e}"),
+                                ),
+                            },
                             Err(e) => ("body_error".to_string(), 0, format!("{e}")),
                         }
                     }
@@ -1193,22 +218,14 @@ async fn test_h2_premature_end_stream_no_content_length() {
         for res in results {
             match res {
                 Ok((kind, len, detail)) => match kind.as_str() {
-                    "success" => {
-                        successes += 1;
-                    }
+                    "success" => successes += 1,
                     "truncated" => {
                         silent_truncations += 1;
-                        eprintln!(
-                            "  [Round {round}] ✗ SILENT TRUNCATION: body_len={len}, {detail}"
-                        );
-                    }
-                    "body_error" => {
-                        proper_errors += 1;
-                        eprintln!("  [Round {round}] body read error: {detail}");
+                        eprintln!("  [Round {round}] ✗ SILENT TRUNCATION: body_len={len}, {detail}");
                     }
                     _ => {
                         proper_errors += 1;
-                        eprintln!("  [Round {round}] request error: {detail}");
+                        eprintln!("  [Round {round}] error: {detail}");
                     }
                 },
                 Err(e) => {
@@ -1232,21 +249,18 @@ async fn test_h2_premature_end_stream_no_content_length() {
         println!("   This proves HTTP/2 END_STREAM can silently truncate responses.");
     } else if proper_errors > 0 {
         println!("\n🟡 Truncation was DETECTED by transport layer.");
-        println!("   The h2 implementation properly errors on incomplete bodies.");
     } else {
         println!("\n🟢 All requests succeeded (unexpected for 50% truncation).");
     }
 }
 
-/// Test: h2 server sends END_STREAM after only 50% of body data, WITH
-/// Content-Length header set to the full body size. The h2 implementation
-/// MAY detect the mismatch and return an error.
+/// Proves: With Content-Length set to full body size but only 50% of data sent,
+/// the h2 implementation detects the mismatch and returns a proper error.
 #[tokio::test]
 #[ignore]
 async fn test_h2_premature_end_stream_with_content_length() {
     let _ = env_logger::try_init();
 
-    // Server sends only 50% of the body then END_STREAM (WITH Content-Length)
     let (port, _server) = start_h2_truncating_server(0.5, true).await;
     sleep(Duration::from_millis(100)).await;
 
@@ -1257,11 +271,9 @@ async fn test_h2_premature_end_stream_with_content_length() {
 
     let client = Client::builder().http2_prior_knowledge().build().unwrap();
 
-    let endpoints = vec![
-        format!("http://127.0.0.1:{port}/api/data1"),
-        format!("http://127.0.0.1:{port}/api/data2"),
-        format!("http://127.0.0.1:{port}/api/data3"),
-    ];
+    let endpoints: Vec<String> = (1..=3)
+        .map(|i| format!("http://127.0.0.1:{port}/api/data{i}"))
+        .collect();
 
     let mut silent_truncations = 0u32;
     let mut proper_errors = 0u32;
@@ -1321,30 +333,21 @@ async fn test_h2_premature_end_stream_with_content_length() {
     }
 }
 
-/// Test: Prove that HTTP/1.1 prevents silent truncation.
-/// Same truncating server, but client uses http1_only().
+/// Proves: HTTP/1.1 client (`.http1_only()`) cannot connect to an h2-only server,
+/// preventing h2-specific truncation entirely.
 #[tokio::test]
 #[ignore]
 async fn test_h1_prevents_premature_end_stream() {
     let _ = env_logger::try_init();
-
-    // Server only speaks h2, so an HTTP/1.1 client cannot connect.
-    // Instead, we use the normal TLS server (which supports both) and verify
-    // that with http1_only(), truncation doesn't occur from the normal server.
-    // The point: http1_only() avoids h2 entirely, so h2-specific truncation
-    // cannot happen.
 
     let (port, _server) = start_h2_truncating_server(0.5, false).await;
     sleep(Duration::from_millis(100)).await;
 
     println!("=== HTTP/1.1 vs h2 truncating server ===");
     println!("h2 server on port {port} — HTTP/1.1 client should FAIL to connect");
-    println!("(Server only speaks h2, not HTTP/1.1)");
     println!();
 
-    // http1_only() client cannot talk to h2-only server
     let client = Client::builder().http1_only().build().unwrap();
-
     let url = format!("http://127.0.0.1:{port}/api/data1");
     let result = client.get(&url).send().await;
 

--- a/components/bootstrappers/http/tests/h2_truncation_poc.rs
+++ b/components/bootstrappers/http/tests/h2_truncation_poc.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Only compile this file when the feature is enabled to avoid CI compile cost.
+#![cfg(feature = "h2-truncation-poc")]
+
 //! PoC: Reproduce HTTP/2 silent body truncation (Issue #493).
 //!
 //! These tests use a custom h2 server (via the `h2` crate) that sends
@@ -26,7 +29,7 @@
 //! 3. HTTP/1.1 (`.http1_only()`) cannot connect to h2-only servers,
 //!    preventing the h2-specific truncation entirely.
 //!
-//! Run with: cargo test -p drasi-bootstrap-http --test h2_truncation_poc -- --ignored --nocapture
+//! Run with: cargo test -p drasi-bootstrap-http --features h2-truncation-poc --test h2_truncation_poc -- --ignored --nocapture
 
 #![allow(clippy::unwrap_used, clippy::uninlined_format_args)]
 

--- a/components/bootstrappers/http/tests/integration_test.rs
+++ b/components/bootstrappers/http/tests/integration_test.rs
@@ -17,6 +17,8 @@
 //! These tests spin up real HTTP servers using axum and verify
 //! the full bootstrap flow: HTTP request → parse → map → emit events.
 
+#![allow(clippy::unwrap_used, clippy::uninlined_format_args)]
+
 use axum::{
     extract::Query,
     http::{header, HeaderMap, StatusCode},
@@ -1757,5 +1759,327 @@ async fn test_type_preservation_in_properties() {
             _ => panic!("Expected Node"),
         },
         _ => panic!("Expected Insert"),
+    }
+}
+
+// ── Test: Truncated response body detection (Issue #493) ────────────────────
+//
+// This test simulates the real-world truncation scenario that causes issue #493:
+// A server (or intermediary proxy/load balancer) returns a truncated JSON body.
+// The HTTP response is "complete" at the transport level (proper chunked
+// encoding termination), but the body content is cut off mid-JSON.
+//
+// This happens in production when:
+// - A load balancer sends GOAWAY during HTTP/2 multiplexing (partially buffered)
+// - A reverse proxy times out and sends whatever it buffered
+// - A CDN serves a cached partial response
+// - Network issues cause chunked encoding to terminate early
+
+/// Start a raw TCP server that sends HTTP/1.1 chunked responses with truncated
+/// JSON bodies. The response is properly terminated at the HTTP level (final
+/// 0-length chunk) but the JSON content is incomplete.
+async fn start_truncating_http11_server(
+    truncate_fraction: f64,
+    request_count: Arc<AtomicU64>,
+) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap(); // DevSkim: ignore DS137138
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+
+            let request_count = request_count.clone();
+            let truncate_frac = truncate_fraction;
+
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 8192];
+
+                // Read HTTP request (one per connection due to Connection: close)
+                let n = match socket.read(&mut buf).await {
+                    Ok(0) => return,
+                    Ok(n) => n,
+                    Err(_) => return,
+                };
+
+                let request_str = String::from_utf8_lossy(&buf[..n]);
+                if !request_str.contains("HTTP/1.1") {
+                    return;
+                }
+
+                request_count.fetch_add(1, Ordering::Relaxed);
+
+                // Generate a large JSON response
+                let full_body = serde_json::to_string(&json!([
+                    {"id": "1", "name": "Item One", "data": "x".repeat(5000)},
+                    {"id": "2", "name": "Item Two", "data": "x".repeat(5000)},
+                    {"id": "3", "name": "Item Three", "data": "x".repeat(5000)},
+                    {"id": "4", "name": "Item Four", "data": "x".repeat(5000)},
+                    {"id": "5", "name": "Item Five", "data": "x".repeat(5000)},
+                    {"id": "6", "name": "Item Six", "data": "x".repeat(5000)},
+                    {"id": "7", "name": "Item Seven", "data": "x".repeat(5000)},
+                    {"id": "8", "name": "Item Eight", "data": "x".repeat(5000)},
+                    {"id": "9", "name": "Item Nine", "data": "x".repeat(5000)},
+                    {"id": "10", "name": "Item Ten", "data": "x".repeat(5000)}
+                ]))
+                .unwrap();
+
+                // Truncate the body
+                let truncated_len = (full_body.len() as f64 * truncate_frac) as usize;
+                let truncated_body = &full_body[..truncated_len];
+
+                // Send HTTP/1.1 response with Transfer-Encoding: chunked
+                // and properly terminated — but with truncated content
+                let chunk_hex = format!("{:x}", truncated_len);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\n\
+                     Content-Type: application/json\r\n\
+                     Transfer-Encoding: chunked\r\n\
+                     Connection: close\r\n\
+                     \r\n\
+                     {chunk_hex}\r\n\
+                     {truncated_body}\r\n\
+                     0\r\n\
+                     \r\n"
+                );
+
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            });
+        }
+    });
+
+    format!("http://127.0.0.1:{}", addr.port()) // DevSkim: ignore DS137138
+}
+
+/// Proves that a truncated HTTP/1.1 response causes silent bootstrap failure.
+/// The response is "complete" at the transport level but contains invalid JSON.
+/// With the current code, this causes a non-retriable parse error.
+#[tokio::test]
+#[ignore]
+async fn test_truncated_response_causes_bootstrap_failure() {
+    let request_count = Arc::new(AtomicU64::new(0));
+    // Send only 60% of the body — enough to be a valid HTTP response but invalid JSON
+    let base_url = start_truncating_http11_server(0.6, request_count.clone()).await;
+
+    let config = HttpBootstrapConfig {
+        endpoints: vec![EndpointConfig {
+            url: format!("{base_url}/items"),
+            method: HttpMethod::Get,
+            headers: HashMap::new(),
+            body: None,
+            auth: None,
+            pagination: None,
+            response: ResponseConfig {
+                items_path: "$".to_string(),
+                content_type: None,
+                mappings: vec![ElementMappingConfig {
+                    element_type: ElementType::Node,
+                    template: ElementTemplate {
+                        id: "{{item.id}}".to_string(),
+                        labels: vec!["Item".to_string()],
+                        properties: Some(json!({
+                            "name": "{{item.name}}"
+                        })),
+                        from: None,
+                        to: None,
+                    },
+                }],
+            },
+        }],
+        timeout_seconds: 10,
+        max_retries: 3,
+        retry_delay_ms: 100,
+        max_pages: None,
+    };
+
+    let provider = HttpBootstrapProvider::new(config).unwrap();
+    let context = test_context("truncation-test");
+    let request = test_request(vec!["Item".to_string()], vec![]);
+    let (tx, _rx) = mpsc::channel(100);
+
+    let result = provider.bootstrap(request, &context, tx, None).await;
+
+    // The bootstrap should fail because ALL responses are truncated (even after retries)
+    assert!(
+        result.is_err(),
+        "Expected bootstrap to fail when server always returns truncated responses"
+    );
+
+    let err = result.unwrap_err();
+    let err_str = format!("{err:#}");
+    eprintln!("Bootstrap error (expected): {err_str}");
+
+    // With the fix: all retries are attempted (1 initial + max_retries = 4 total)
+    let requests_made = request_count.load(Ordering::Relaxed);
+    eprintln!("Requests made to server: {requests_made}");
+    assert_eq!(
+        requests_made, 4,
+        "Expected 4 requests (1 initial + 3 retries), got {requests_made}"
+    );
+    eprintln!("✓ Parse failures ARE retried ({requests_made} attempts made)");
+
+    // Verify error message mentions truncation
+    assert!(
+        err_str.contains("possible truncation"),
+        "Error should mention 'possible truncation': {err_str}"
+    );
+    eprintln!("✓ Error message correctly identifies possible truncation");
+}
+
+/// Start a server that truncates responses intermittently.
+/// First request returns truncated, second returns full response.
+/// This simulates real-world intermittent truncation from flaky proxies.
+async fn start_intermittent_truncating_server(request_count: Arc<AtomicU64>) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap(); // DevSkim: ignore DS137138
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+
+            let request_count = request_count.clone();
+
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 8192];
+
+                let n = match socket.read(&mut buf).await {
+                    Ok(0) => return,
+                    Ok(n) => n,
+                    Err(_) => return,
+                };
+
+                let request_str = String::from_utf8_lossy(&buf[..n]);
+                if !request_str.contains("HTTP/1.1") {
+                    return;
+                }
+
+                let count = request_count.fetch_add(1, Ordering::Relaxed);
+
+                // Full valid response
+                let full_body = serde_json::to_string(&json!([
+                    {"id": "1", "name": "Item One", "data": "payload-1"},
+                    {"id": "2", "name": "Item Two", "data": "payload-2"},
+                    {"id": "3", "name": "Item Three", "data": "payload-3"}
+                ]))
+                .unwrap();
+
+                // Truncate on even-numbered requests (0th, 2nd, etc.)
+                let body = if count % 2 == 0 {
+                    full_body[..full_body.len() / 2].to_string()
+                } else {
+                    full_body.clone()
+                };
+
+                let chunk_hex = format!("{:x}", body.len());
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\n\
+                     Content-Type: application/json\r\n\
+                     Transfer-Encoding: chunked\r\n\
+                     Connection: close\r\n\
+                     \r\n\
+                     {chunk_hex}\r\n\
+                     {body}\r\n\
+                     0\r\n\
+                     \r\n"
+                );
+
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            });
+        }
+    });
+
+    format!("http://127.0.0.1:{}", addr.port()) // DevSkim: ignore DS137138
+}
+
+/// Tests that after the fix, intermittent truncation is recovered via retry.
+/// The server returns truncated on first attempt, valid on second.
+/// With proper retry-on-parse-failure, bootstrap should succeed.
+#[tokio::test]
+#[ignore]
+async fn test_truncation_recovered_by_retry() {
+    let request_count = Arc::new(AtomicU64::new(0));
+    let base_url = start_intermittent_truncating_server(request_count.clone()).await;
+
+    let config = HttpBootstrapConfig {
+        endpoints: vec![EndpointConfig {
+            url: format!("{base_url}/items"),
+            method: HttpMethod::Get,
+            headers: HashMap::new(),
+            body: None,
+            auth: None,
+            pagination: None,
+            response: ResponseConfig {
+                items_path: "$".to_string(),
+                content_type: None,
+                mappings: vec![ElementMappingConfig {
+                    element_type: ElementType::Node,
+                    template: ElementTemplate {
+                        id: "{{item.id}}".to_string(),
+                        labels: vec!["Item".to_string()],
+                        properties: Some(json!({
+                            "name": "{{item.name}}"
+                        })),
+                        from: None,
+                        to: None,
+                    },
+                }],
+            },
+        }],
+        timeout_seconds: 10,
+        max_retries: 3,
+        retry_delay_ms: 100,
+        max_pages: None,
+    };
+
+    let provider = HttpBootstrapProvider::new(config).unwrap();
+    let context = test_context("retry-test");
+    let request = test_request(vec!["Item".to_string()], vec![]);
+    let (tx, rx) = mpsc::channel(100);
+
+    let result = provider.bootstrap(request, &context, tx, None).await;
+
+    let requests_made = request_count.load(Ordering::Relaxed);
+    eprintln!("Requests made to server: {requests_made}");
+
+    // After the fix: bootstrap should succeed because it retries on
+    // parse failure and the second attempt returns valid data.
+    // Before the fix: this test fails because parse errors are not retried.
+    match result {
+        Ok(r) => {
+            eprintln!(
+                "✓ Bootstrap succeeded after retry! Events: {}",
+                r.event_count
+            );
+            assert_eq!(r.event_count, 3);
+            let events = collect_events(rx).await;
+            assert_eq!(events.len(), 3);
+            eprintln!("✓ All 3 items correctly bootstrapped after retry");
+            assert!(
+                requests_made >= 2,
+                "Expected at least 2 requests (1 failed + 1 retry), got {requests_made}"
+            );
+            eprintln!("✓ Confirmed: {requests_made} requests made (retry worked)");
+        }
+        Err(e) => {
+            eprintln!("✗ Bootstrap FAILED (fix not applied): {e:#}");
+            eprintln!("  Requests made: {requests_made}");
+            eprintln!("  This test will pass once parse failures trigger retries.");
+            panic!(
+                "Bootstrap failed — parse errors are not retried. \
+                 Apply the fix to make body parsing failures retriable. Error: {e}"
+            );
+        }
     }
 }

--- a/components/bootstrappers/http/tests/integration_test.rs
+++ b/components/bootstrappers/http/tests/integration_test.rs
@@ -2091,11 +2091,10 @@ async fn start_truncating_http11_server(
     format!("http://127.0.0.1:{}", addr.port()) // DevSkim: ignore DS137138
 }
 
-/// Proves that a truncated HTTP/1.1 response causes silent bootstrap failure.
+/// Proves that a truncated HTTP/1.1 response triggers retries.
 /// The response is "complete" at the transport level but contains invalid JSON.
-/// With the current code, this causes a non-retriable parse error.
+/// Previously this caused a non-retriable parse error; now it is retried.
 #[tokio::test]
-#[ignore]
 async fn test_truncated_response_causes_bootstrap_failure() {
     let request_count = Arc::new(AtomicU64::new(0));
     // Send only 60% of the body — enough to be a valid HTTP response but invalid JSON
@@ -2242,7 +2241,6 @@ async fn start_intermittent_truncating_server(request_count: Arc<AtomicU64>) -> 
 /// The server returns truncated on first attempt, valid on second.
 /// With proper retry-on-parse-failure, bootstrap should succeed.
 #[tokio::test]
-#[ignore]
 async fn test_truncation_recovered_by_retry() {
     let request_count = Arc::new(AtomicU64::new(0));
     let base_url = start_intermittent_truncating_server(request_count.clone()).await;

--- a/components/bootstrappers/http/tests/integration_test.rs
+++ b/components/bootstrappers/http/tests/integration_test.rs
@@ -150,7 +150,7 @@ async fn test_simple_json_endpoint() {
             }
             _ => panic!("Expected Node"),
         },
-        _ => panic!("Expected Insert"),
+        _ => panic!("Expected Update"),
     }
 }
 
@@ -1234,7 +1234,7 @@ async fn test_relations_mapping() {
             }
             _ => panic!("Expected Relation"),
         },
-        _ => panic!("Expected Insert"),
+        _ => panic!("Expected Update"),
     }
 }
 
@@ -1599,7 +1599,7 @@ async fn test_xml_response_parsing() {
             }
             _ => panic!("Expected Node"),
         },
-        _ => panic!("Expected Insert"),
+        _ => panic!("Expected Update"),
     }
 }
 
@@ -1687,7 +1687,7 @@ async fn test_yaml_response_parsing() {
             }
             _ => panic!("Expected Node"),
         },
-        _ => panic!("Expected Insert"),
+        _ => panic!("Expected Update"),
     }
 }
 
@@ -1777,7 +1777,222 @@ async fn test_type_preservation_in_properties() {
             }
             _ => panic!("Expected Node"),
         },
-        _ => panic!("Expected Insert"),
+        _ => panic!("Expected Update"),
+    }
+}
+
+// ── Test: Explicit operation types (Issue #508) ─────────────────────────────
+
+#[tokio::test]
+async fn test_explicit_insert_operation() {
+    let app = Router::new().route(
+        "/users",
+        get(|| async {
+            Json(json!([
+                {"id": "1", "name": "Alice"},
+                {"id": "2", "name": "Bob"}
+            ]))
+        }),
+    );
+
+    let base_url = start_server(app).await;
+
+    let config = HttpBootstrapConfig {
+        endpoints: vec![EndpointConfig {
+            url: format!("{base_url}/users"),
+            method: HttpMethod::Get,
+            headers: HashMap::new(),
+            body: None,
+            auth: None,
+            pagination: None,
+            response: ResponseConfig {
+                items_path: "$".to_string(),
+                content_type: None,
+                mappings: vec![ElementMappingConfig {
+                    operation: OperationType::Insert,
+                    element_type: ElementType::Node,
+                    template: ElementTemplate {
+                        id: "{{item.id}}".to_string(),
+                        labels: vec!["User".to_string()],
+                        properties: Some(json!({
+                            "name": "{{item.name}}"
+                        })),
+                        from: None,
+                        to: None,
+                    },
+                }],
+            },
+        }],
+        timeout_seconds: 10,
+        max_retries: 0,
+        retry_delay_ms: 100,
+        max_pages: None,
+    };
+
+    let provider = HttpBootstrapProvider::new(config).unwrap();
+    let context = test_context("test-source");
+    let request = test_request(vec!["User".to_string()], vec![]);
+
+    let (tx, rx) = mpsc::channel(100);
+    provider
+        .bootstrap(request, &context, tx, None)
+        .await
+        .unwrap();
+
+    let events = collect_events(rx).await;
+    assert_eq!(events.len(), 2);
+
+    // All events should be Insert
+    for event in &events {
+        match &event.change {
+            SourceChange::Insert { element } => match element {
+                Element::Node { metadata, .. } => {
+                    assert_eq!(&*metadata.labels[0], "User");
+                }
+                _ => panic!("Expected Node"),
+            },
+            _ => panic!("Expected Insert"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_explicit_delete_operation_nodes() {
+    let app = Router::new().route(
+        "/deleted-users",
+        get(|| async {
+            Json(json!([
+                {"id": "1", "name": "Alice"},
+                {"id": "2", "name": "Bob"},
+                {"id": "3", "name": "Charlie"}
+            ]))
+        }),
+    );
+
+    let base_url = start_server(app).await;
+
+    let config = HttpBootstrapConfig {
+        endpoints: vec![EndpointConfig {
+            url: format!("{base_url}/deleted-users"),
+            method: HttpMethod::Get,
+            headers: HashMap::new(),
+            body: None,
+            auth: None,
+            pagination: None,
+            response: ResponseConfig {
+                items_path: "$".to_string(),
+                content_type: None,
+                mappings: vec![ElementMappingConfig {
+                    operation: OperationType::Delete,
+                    element_type: ElementType::Node,
+                    template: ElementTemplate {
+                        id: "{{item.id}}".to_string(),
+                        labels: vec!["User".to_string()],
+                        properties: Some(json!({
+                            "name": "{{item.name}}"
+                        })),
+                        from: None,
+                        to: None,
+                    },
+                }],
+            },
+        }],
+        timeout_seconds: 10,
+        max_retries: 0,
+        retry_delay_ms: 100,
+        max_pages: None,
+    };
+
+    let provider = HttpBootstrapProvider::new(config).unwrap();
+    let context = test_context("test-source");
+    let request = test_request(vec!["User".to_string()], vec![]);
+
+    let (tx, rx) = mpsc::channel(100);
+    provider
+        .bootstrap(request, &context, tx, None)
+        .await
+        .unwrap();
+
+    let events = collect_events(rx).await;
+    assert_eq!(events.len(), 3);
+
+    // All events should be Delete with only metadata (id + labels)
+    for (i, event) in events.iter().enumerate() {
+        match &event.change {
+            SourceChange::Delete { metadata } => {
+                let expected_id = format!("{}", i + 1);
+                assert_eq!(&*metadata.reference.element_id, expected_id.as_str());
+                assert_eq!(&*metadata.labels[0], "User");
+            }
+            other => panic!("Expected Delete, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_explicit_delete_operation_relations() {
+    let app = Router::new().route(
+        "/deleted-edges",
+        get(|| async {
+            Json(json!([
+                {"id": "r1", "from": "u1", "to": "u2"},
+                {"id": "r2", "from": "u2", "to": "u3"}
+            ]))
+        }),
+    );
+
+    let base_url = start_server(app).await;
+
+    let config = HttpBootstrapConfig {
+        endpoints: vec![EndpointConfig {
+            url: format!("{base_url}/deleted-edges"),
+            method: HttpMethod::Get,
+            headers: HashMap::new(),
+            body: None,
+            auth: None,
+            pagination: None,
+            response: ResponseConfig {
+                items_path: "$".to_string(),
+                content_type: None,
+                mappings: vec![ElementMappingConfig {
+                    operation: OperationType::Delete,
+                    element_type: ElementType::Relation,
+                    template: ElementTemplate {
+                        id: "{{item.id}}".to_string(),
+                        labels: vec!["FOLLOWS".to_string()],
+                        properties: None,
+                        from: None,
+                        to: None,
+                    },
+                }],
+            },
+        }],
+        timeout_seconds: 10,
+        max_retries: 0,
+        retry_delay_ms: 100,
+        max_pages: None,
+    };
+
+    let provider = HttpBootstrapProvider::new(config).unwrap();
+    let context = test_context("test-source");
+    let request = test_request(vec![], vec!["FOLLOWS".to_string()]);
+
+    let (tx, rx) = mpsc::channel(100);
+    provider
+        .bootstrap(request, &context, tx, None)
+        .await
+        .unwrap();
+
+    let events = collect_events(rx).await;
+    assert_eq!(events.len(), 2);
+
+    // Delete relations: no from/to needed, just id + labels
+    match &events[0].change {
+        SourceChange::Delete { metadata } => {
+            assert_eq!(&*metadata.reference.element_id, "r1");
+            assert_eq!(&*metadata.labels[0], "FOLLOWS");
+        }
+        other => panic!("Expected Delete, got {other:?}"),
     }
 }
 

--- a/components/bootstrappers/http/tests/integration_test.rs
+++ b/components/bootstrappers/http/tests/integration_test.rs
@@ -105,6 +105,7 @@ async fn test_simple_json_endpoint() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -142,7 +143,7 @@ async fn test_simple_json_endpoint() {
 
     // Verify first event
     match &events[0].change {
-        SourceChange::Insert { element } => match element {
+        SourceChange::Update { element } => match element {
             Element::Node { metadata, .. } => {
                 assert_eq!(&*metadata.reference.element_id, "1");
                 assert_eq!(&*metadata.labels[0], "User");
@@ -207,6 +208,7 @@ async fn test_offset_limit_pagination() {
                 items_path: "$.data".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -303,6 +305,7 @@ async fn test_cursor_pagination_stripe_style() {
                 items_path: "$.data".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -406,6 +409,7 @@ async fn test_link_header_pagination_github_style() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -543,6 +547,7 @@ async fn test_next_url_pagination_salesforce_style() {
                 items_path: "$.records".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.Id}}".to_string(),
@@ -613,6 +618,7 @@ async fn test_bearer_auth() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -687,6 +693,7 @@ async fn test_api_key_header_auth() {
                 items_path: "$.products".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -769,6 +776,7 @@ async fn test_basic_auth() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.sid}}".to_string(),
@@ -868,6 +876,7 @@ async fn test_oauth2_client_credentials() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -946,6 +955,7 @@ async fn test_multi_endpoint_bootstrap() {
                     items_path: "$".to_string(),
                     content_type: None,
                     mappings: vec![ElementMappingConfig {
+                        operation: Default::default(),
                         element_type: ElementType::Node,
                         template: ElementTemplate {
                             id: "{{item.id}}".to_string(),
@@ -968,6 +978,7 @@ async fn test_multi_endpoint_bootstrap() {
                     items_path: "$".to_string(),
                     content_type: None,
                     mappings: vec![ElementMappingConfig {
+                        operation: Default::default(),
                         element_type: ElementType::Node,
                         template: ElementTemplate {
                             id: "{{item.id}}".to_string(),
@@ -1041,6 +1052,7 @@ async fn test_retry_on_failure() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -1107,6 +1119,7 @@ async fn test_retries_exhausted_returns_error() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -1175,6 +1188,7 @@ async fn test_relations_mapping() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Relation,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -1206,7 +1220,7 @@ async fn test_relations_mapping() {
 
     let events = collect_events(rx).await;
     match &events[0].change {
-        SourceChange::Insert { element } => match element {
+        SourceChange::Update { element } => match element {
             Element::Relation {
                 metadata,
                 in_node,
@@ -1279,6 +1293,7 @@ async fn test_page_number_pagination() {
                 items_path: "$.items".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -1340,6 +1355,7 @@ async fn test_label_filtering() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -1542,6 +1558,7 @@ async fn test_xml_response_parsing() {
                 items_path: "$".to_string(),
                 content_type: Some(ContentTypeOverride::Xml),
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -1576,7 +1593,7 @@ async fn test_xml_response_parsing() {
     assert_eq!(events.len(), 1);
 
     match &events[0].change {
-        SourceChange::Insert { element } => match element {
+        SourceChange::Update { element } => match element {
             Element::Node { metadata, .. } => {
                 assert_eq!(&*metadata.labels[0], "XmlNode");
             }
@@ -1623,6 +1640,7 @@ async fn test_yaml_response_parsing() {
                 items_path: "$".to_string(),
                 content_type: Some(ContentTypeOverride::Yaml),
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -1655,7 +1673,7 @@ async fn test_yaml_response_parsing() {
     assert_eq!(events.len(), 3);
 
     match &events[0].change {
-        SourceChange::Insert { element } => match element {
+        SourceChange::Update { element } => match element {
             Element::Node {
                 metadata,
                 properties,
@@ -1700,6 +1718,7 @@ async fn test_type_preservation_in_properties() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -1735,7 +1754,7 @@ async fn test_type_preservation_in_properties() {
 
     let events = collect_events(rx).await;
     match &events[0].change {
-        SourceChange::Insert { element } => match element {
+        SourceChange::Update { element } => match element {
             Element::Node { properties, .. } => {
                 use drasi_core::models::ElementValue;
                 use ordered_float::OrderedFloat;
@@ -1879,6 +1898,7 @@ async fn test_truncated_response_causes_bootstrap_failure() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),
@@ -2024,6 +2044,7 @@ async fn test_truncation_recovered_by_retry() {
                 items_path: "$".to_string(),
                 content_type: None,
                 mappings: vec![ElementMappingConfig {
+                    operation: Default::default(),
                     element_type: ElementType::Node,
                     template: ElementTemplate {
                         id: "{{item.id}}".to_string(),


### PR DESCRIPTION
## Summary

Fixes #493 — HTTP bootstrap plugin silently fails on truncated response bodies.
Fixes #508 — HTTP bootstrap should use Update (upsert) for idempotent re-bootstrap.

---

## Fix 1: Retry on response body truncation (#493)

### Root Cause

Response body parsing failures (truncated JSON) were **not being retried**. The retry loop only covered transport-level errors. When an intermediary (proxy, CDN, load balancer) returns a properly-terminated HTTP response with incomplete body content, the transport reports `Ok` but the JSON is cut off mid-stream.

### Fix

Replace the separate fetch-then-parse flow with a unified `fetch_and_parse_with_retry()` method that treats **both** transport errors AND body parsing failures as retriable errors with exponential backoff.

| Error type | Before | After |
|---|---|---|
| Transport error (connection reset, timeout) | ✅ Retried | ✅ Retried |
| Body parse failure (truncated JSON/XML) | ❌ Immediate failure | ✅ Retried with backoff |

---

## Fix 2: Configurable operation type with Update default (#508)

### Root Cause

Bootstrap hardcoded `SourceChange::Insert` for all elements. With persistent indexes (RocksDB), re-bootstrap on restart double-counted existing elements in aggregation queries.

### Fix

Add a configurable `operation` field to `ElementMappingConfig`:
- `update` (default) — upsert semantics, makes bootstrap idempotent
- `insert` — original behavior for cases that need it
- `delete` — allows mapping API response items to delete actions

Naming matches the HTTP webhook source (`operation` field, `OperationType` enum).

```yaml
mappings:
  - elementType: node
    operation: update   # default, can be omitted
    template:
      id: "{{item.id}}"
      labels: ["User"]
```

Backward compatible: existing configs without `operation` default to `update`.

---

## Testing

### Truncation fix tests
- `test_truncated_response_causes_bootstrap_failure` — all retries attempted (4 requests)
- `test_truncation_recovered_by_retry` — bootstrap succeeds after intermittent truncation
- `h2_truncation_poc.rs` — protocol-level PoC proving h2 END_STREAM causes 100% silent truncation

### Existing tests
All 70 existing tests pass (46 lib + 3 e2e + 21 integration).