### PR TITLE
fix(ffi): bound bootstrap channels to propagate backpressure

### DIFF
--- a/components/host-sdk/src/proxies/bootstrap_provider.rs
+++ b/components/host-sdk/src/proxies/bootstrap_provider.rs
@@ -171,8 +171,15 @@ impl Drop for BootstrapProviderProxy {
 /// Uses a std::sync::mpsc channel + forwarding thread to avoid blocking the plugin's
 /// tokio runtime (the same pattern proven in the PoC's cross-plugin bootstrap).
 fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSender {
-    // Create a std::sync channel for the plugin to send on (sync-safe)
-    let (std_tx, std_rx) = std::sync::mpsc::channel::<BootstrapEvent>();
+    // Create a *bounded* std::sync channel so the plugin's `send_fn` blocks
+    // when the forwarding thread is itself blocked on the bounded tokio
+    // channel downstream. With an unbounded channel, the plugin could keep
+    // pushing events past whatever rate the query consumes, which on large
+    // bootstraps quietly burns memory.
+    // The capacity matches the downstream tokio channel capacity (1000) so
+    // the buffer is at most ~2x downstream capacity in flight.
+    // See https://github.com/drasi-project/drasi-core/issues/454
+    let (std_tx, std_rx) = std::sync::mpsc::sync_channel::<BootstrapEvent>(1000);
 
     // Spawn a thread that forwards from std channel → tokio channel
     std::thread::spawn(move || {
@@ -191,7 +198,7 @@ fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSen
 
     extern "C" fn send_fn(state: *mut c_void, event: *mut FfiBootstrapEvent) -> i32 {
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let tx = unsafe { &*(state as *const std::sync::mpsc::Sender<BootstrapEvent>) };
+            let tx = unsafe { &*(state as *const std::sync::mpsc::SyncSender<BootstrapEvent>) };
             if event.is_null() {
                 return -1;
             }
@@ -211,7 +218,7 @@ fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSen
     extern "C" fn drop_fn(state: *mut c_void) {
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
             drop(Box::from_raw(
-                state as *mut std::sync::mpsc::Sender<BootstrapEvent>,
+                state as *mut std::sync::mpsc::SyncSender<BootstrapEvent>,
             ))
         }));
     }

--- a/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
+++ b/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
@@ -59,7 +59,7 @@ impl BootstrapProvider for FfiBootstrapProviderProxy {
 
         // FFI sender callback — wraps tokio sender, called from the bootstrap thread
         struct SenderState {
-            tx: std::sync::mpsc::Sender<drasi_lib::channels::events::BootstrapEvent>,
+            tx: std::sync::mpsc::SyncSender<drasi_lib::channels::events::BootstrapEvent>,
         }
 
         extern "C" fn send_fn(state: *mut c_void, event: *mut FfiBootstrapEvent) -> i32 {
@@ -82,9 +82,14 @@ impl BootstrapProvider for FfiBootstrapProviderProxy {
             unsafe { drop(Box::from_raw(state as *mut SenderState)) };
         }
 
-        // Use std::sync::mpsc so the vtable thread can send without async
+        // Use a *bounded* std::sync::mpsc so the vtable thread (the plugin
+        // bootstrap sender) blocks when downstream backpressure takes hold,
+        // rather than buffering events without limit. The capacity matches
+        // the host's forwarding channel (1000) so the buffer in flight is
+        // bounded.
+        // See https://github.com/drasi-project/drasi-core/issues/454
         let (std_tx, std_rx) =
-            std::sync::mpsc::channel::<drasi_lib::channels::events::BootstrapEvent>();
+            std::sync::mpsc::sync_channel::<drasi_lib::channels::events::BootstrapEvent>(1000);
 
         let sender_state = Box::new(SenderState { tx: std_tx });
         let ffi_sender = Box::new(FfiBootstrapSender {


### PR DESCRIPTION
Closes #454.

## Problem

The FFI bootstrap bridge had unbounded \`std::sync::mpsc\` channels at two points:

- \`host-sdk/src/proxies/bootstrap_provider.rs::build_ffi_bootstrap_sender\` (line ~175)
- \`plugin-sdk/src/ffi/bootstrap_proxy.rs\` (line ~87)

Both feed a forwarding thread that blocks on a bounded tokio mpsc (capacity 1000) into the query. When the query falls behind: forwarding thread blocks → tokio channel applies backpressure to it → but the unbounded \`std::sync::mpsc\` upstream of it accepts events from the plugin without limit. On large bootstraps (millions of rows) this quietly grows memory.

## Fix

Replace both \`std::sync::mpsc::channel()\` with \`std::sync::mpsc::sync_channel(1000)\` (matching the downstream tokio channel capacity). \`Sender<_>\` becomes \`SyncSender<_>\` at the type sites that touch the raw pointer. Now when downstream is saturated, the plugin's \`send_fn\` blocks, propagating backpressure all the way back to the bootstrap provider's row generator.

Net diff: 19 lines added, 7 removed. No public API changes.

\`\`\`
$ cargo build -p drasi-host-sdk -p drasi-plugin-sdk        # OK
$ cargo test -p drasi-host-sdk --lib
test result: ok. 83 passed; 0 failed
\`\`\`

(\`cargo clippy --all-targets -- -D warnings\` flags some pre-existing \`uninlined-format-args\` issues outside this PR's scope; \`cargo clippy --no-deps\` on the affected crates is clean.)

## Capacity choice

1000 matches the downstream tokio channel capacity, so the in-flight buffer is bounded by ~2× downstream capacity. Easy to retune as constants if a different shape proves better in practice.