### PR TITLE
fix(sui-deepbook): correct workspace default-features inheritance (#481)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ drasi-bootstrap-mysql = { version = "0.2.3", path = "components/bootstrappers/my
 drasi-source-mysql = { version = "0.2.0", path = "components/sources/mysql" }
 drasi-source-ris-live = { version = "0.1.1", path = "components/sources/ris-live" }
 drasi-bootstrap-sui-deepbook = { version = "0.1.0", path = "components/bootstrappers/sui-deepbook" }
-drasi-source-sui-deepbook = { version = "0.1.0", path = "components/sources/sui-deepbook" }
+drasi-source-sui-deepbook = { version = "0.1.0", path = "components/sources/sui-deepbook", default-features = false }
 drasi-kubernetes-common = { version = "0.1.2", path = "components/kubernetes-common" }
 drasi-source-kubernetes = { version = "0.1.0", path = "components/sources/kubernetes" }
 drasi-bootstrap-kubernetes = { version = "0.1.0", path = "components/bootstrappers/kubernetes" }

--- a/components/bootstrappers/sui-deepbook/Cargo.toml
+++ b/components/bootstrappers/sui-deepbook/Cargo.toml
@@ -34,7 +34,7 @@ drasi-lib.workspace = true
 drasi-core.workspace = true
 drasi-plugin-sdk = { workspace = true }
 utoipa = { workspace = true }
-drasi-source-sui-deepbook = { workspace = true, default-features = false }
+drasi-source-sui-deepbook = { workspace = true }
 anyhow = "1.0"
 async-trait = "0.1"
 log = "0.4"

--- a/components/sources/source-documentation-standards.md
+++ b/components/sources/source-documentation-standards.md
@@ -625,3 +625,26 @@ When reviewing a source plugin, verify:
 - [ ] Tests pass with `cargo test -p drasi-plugin-{name}`
 - [ ] No clippy warnings with `cargo clippy -p drasi-plugin-{name}`
 - [ ] Code is formatted with `cargo fmt`
+
+## Workspace Dependency Conventions
+
+When a component declares a workspace-inherited dependency and needs `default-features = false`,
+the **workspace root** entry (`[workspace.dependencies]` in the top-level `Cargo.toml`) must also set
+`default-features = false`. Cargo silently ignores a member-level `default-features` override when the
+workspace entry does not declare it, and has announced this will become a hard error in a future release.
+
+```toml
+# Cargo.toml (workspace root) — declare default-features so members can opt out reliably
+drasi-source-foo = { version = "0.1.0", path = "components/sources/foo", default-features = false }
+```
+
+```toml
+# components/bootstrappers/foo/Cargo.toml — inherits cleanly, no ignored override
+drasi-source-foo = { workspace = true }
+```
+
+Any consumer that needs the default feature set should opt back in explicitly:
+
+```toml
+drasi-source-foo = { workspace = true, features = ["default"] }
+```


### PR DESCRIPTION
Fixes #481

## Problem

`cargo build` printed a warning on every invocation:

```
warning: .../components/bootstrappers/sui-deepbook/Cargo.toml: `default-features` is ignored for drasi-source-sui-deepbook, since `default-features` was not specified for `workspace.dependencies.drasi-source-sui-deepbook`, this could become a hard error in the future
```

The bootstrapper inherited the source dependency with `default-features = false`, but the workspace root entry did not declare `default-features`, so Cargo silently ignored the override (and announced it will become a hard error).

`sui-deepbook` was the only bootstrapper carrying this override — gtfs-rt, here-traffic, and open511 all inherit cleanly with `{ workspace = true }`.

## Fix (Option A from the issue)

- Set `default-features = false` on the workspace root entry for `drasi-source-sui-deepbook`.
- Drop the now-redundant override in `components/bootstrappers/sui-deepbook/Cargo.toml`, bringing it in line with the other bootstrappers.

**No feature behavior change:** `components/sources/sui-deepbook` defines no `default` feature (only `dynamic-plugin`), so there were never any default features to disable. The example (`examples/lib/sui-deepbook-getting-started`) uses a direct path dependency in its own workspace and is unaffected.

## Documentation

Added a 'Workspace Dependency Conventions' section to `components/sources/source-documentation-standards.md` documenting the rule that the workspace root entry must declare `default-features` for members to opt out reliably.

## Validation

- [x] `cargo build -p drasi-bootstrap-sui-deepbook` — warning gone.
- [x] `cargo check --workspace` — no `default-features is ignored` warning.
- [x] `cargo tree -p drasi-bootstrap-sui-deepbook -e features` — confirms `drasi-source-sui-deepbook` builds with no extra features, matching the original intent.