### PR TITLE
fix(aws-sqs): pin AWS SDK deps below the 1.91 MSRV bump to unblock release-plz

### DIFF
--- a/components/reactions/aws-sqs/Cargo.toml
+++ b/components/reactions/aws-sqs/Cargo.toml
@@ -36,9 +36,10 @@ drasi-plugin-sdk = { workspace = true }
 utoipa = { workspace = true }
 anyhow = "1.0"
 async-trait = "0.1"
-aws-config = { version = "1", features = ["behavior-version-latest"] }
-aws-credential-types = "1"
-aws-sdk-sqs = "1"
+# Pin AWS SDK crates below the 1.91 MSRV bump (introduced late Feb 2026) so cargo publish verification works on the 1.88 toolchain.
+aws-config = { version = ">=1, <1.8.19", features = ["behavior-version-latest"] }
+aws-credential-types = ">=1, <1.2.14"
+aws-sdk-sqs = ">=1, <1.94"
 chrono = "0.4"
 handlebars = "5.1"
 log = "0.4"

--- a/components/reactions/aws-sqs/Cargo.toml
+++ b/components/reactions/aws-sqs/Cargo.toml
@@ -37,7 +37,7 @@ utoipa = { workspace = true }
 anyhow = "1.0"
 async-trait = "0.1"
 # Pin AWS SDK crates below the 1.91 MSRV bump (introduced late Feb 2026) so cargo publish verification works on the 1.88 toolchain.
-aws-config = { version = ">=1, <1.8.19", features = ["behavior-version-latest"] }
+aws-config = { version = ">=1, <1.8.18", features = ["behavior-version-latest"] }
 aws-credential-types = ">=1, <1.2.14"
 aws-sdk-sqs = ">=1, <1.94"
 chrono = "0.4"


### PR DESCRIPTION
# Description

## Summary

Constrains the AWS SDK dependencies in `drasi-reaction-aws-sqs` to versions that still compile on rustc 1.88, so `cargo publish --verify` (run by release-plz) succeeds on our CI toolchain.


The release-plz workflow has been failing during publish-verification for `drasi-reaction-aws-sqs` with:
```
   error: failed to verify package tarball
    
    Caused by:
      rustc 1.88.0 is not supported by the following packages:
        aws-config@1.8.18 requires rustc 1.91.1
        aws-credential-types@1.2.14 requires rustc 1.91.1
        aws-runtime@1.7.4 requires rustc 1.91.1
        aws-sdk-sqs@1.101.0 requires rustc 1.91.1
        aws-sdk-sso@1.101.0 requires rustc 1.91.1
        aws-sdk-ssooidc@1.103.0 requires rustc 1.91.1
        aws-sdk-sts@1.106.0 requires rustc 1.91.1
        aws-sigv4@1.4.5 requires rustc 1.91.1
        aws-smithy-async@1.2.14 requires rustc 1.91.1
        aws-smithy-http@0.63.6 requires rustc 1.91.1
        aws-smithy-http-client@1.1.13 requires rustc 1.91.1
        aws-smithy-json@0.62.7 requires rustc 1.91.1
        aws-smithy-observability@0.2.6 requires rustc 1.91.1
        aws-smithy-query@0.60.15 requires rustc 1.91.1
        aws-smithy-runtime@1.11.3 requires rustc 1.91.1
        aws-smithy-runtime-api@1.12.3 requires rustc 1.91.1
        aws-smithy-runtime-api-macros@1.0.0 requires rustc 1.91.0
        aws-smithy-schema@0.1.0 requires rustc 1.91
        aws-smithy-types@1.4.9 requires rustc 1.91.1
        aws-smithy-xml@0.60.15 requires rustc 1.91.1
        aws-types@1.3.16 requires rustc 1.91.1
        aws-types@1.3.16 requires rustc 1.91.1
        aws-types@1.3.16 requires rustc 1.91.1
    
Error: Process completed with exit code 1.
```


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
