### PR TITLE
fix parsing in publish plugins

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -167,23 +167,47 @@ jobs:
 
       - name: Set packages to public
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The default GITHUB_TOKEN cannot administer org-level container
+          # package visibility (those endpoints return 404). A PAT (classic)
+          # with write:packages, or a GitHub App token with org packages:write,
+          # is required. Configure a PACKAGES_ADMIN_TOKEN secret; we fall back
+          # to GITHUB_TOKEN only so the step doesn't fail to start.
+          GH_TOKEN: ${{ secrets.PACKAGES_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           REGISTRY="${{ inputs.registry }}"
           ORG="${REGISTRY#*/}"
+
+          FAILED=0
+
+          set_public() {
+            local pkg="$1"
+            local encoded
+            encoded=$(printf '%s' "$pkg" | sed 's|/|%2F|g')
+            echo "Setting ${ORG}/${pkg} to public..."
+            if ! gh api --method PATCH \
+              "/orgs/${ORG}/packages/container/${encoded}" \
+              -f visibility=public; then
+              echo "::error::Failed to set ${ORG}/${pkg} to public"
+              FAILED=1
+            fi
+          }
+
           # Set plugin directory to public
-          echo "Setting ${ORG}/drasi-plugin-directory to public..."
-          gh api --method PATCH \
-            "/orgs/${ORG}/packages/container/drasi-plugin-directory" \
-            -f visibility=public \
-            2>/dev/null || echo "  (skipped — may already be public or insufficient permissions)"
-          # Set each plugin package to public
-          PLUGINS=$(cargo run -p xtask -- list-plugins 2>/dev/null | grep '^\s' | awk '{print $1}')
+          set_public "drasi-plugin-directory"
+
+          # Set each plugin package to public. list-plugins prints plugin lines
+          # as "  <type>/<kind> v<version> (<path>)"; match only those so the
+          # indented "SDK: ..." summary line is excluded.
+          PLUGINS=$(cargo run -p xtask -- list-plugins 2>/dev/null \
+            | grep -E '^[[:space:]]+[a-z-]+/[^[:space:]]+ v[0-9]' \
+            | awk '{print $1}')
           for PLUGIN in $PLUGINS; do
-            ENCODED=$(echo "$PLUGIN" | sed 's|/|%2F|g')
-            echo "Setting ${ORG}/${PLUGIN} to public..."
-            gh api --method PATCH \
-              "/orgs/${ORG}/packages/container/${ENCODED}" \
-              -f visibility=public \
-              2>/dev/null || echo "  (skipped — may already be public or insufficient permissions)"
+            set_public "$PLUGIN"
           done
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more packages could not be set to public."
+            echo "If these are 404/permission errors, ensure PACKAGES_ADMIN_TOKEN is set to a token that can administer org packages."
+            exit 1
+          fi

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -175,8 +175,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PACKAGES_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          REGISTRY="${{ inputs.registry }}"
-          ORG="${REGISTRY#*/}"
+          ORG="drasi-project"
 
           FAILED=0
 
@@ -199,8 +198,8 @@ jobs:
           # Set each plugin package to public. list-plugins prints plugin lines
           # as "  <type>/<kind> v<version> (<path>)"; match only those so the
           # indented "SDK: ..." summary line is excluded.
-          PLUGINS=$(cargo run -p xtask -- list-plugins 2>/dev/null \
-            | grep -E '^[[:space:]]+[a-z-]+/[^[:space:]]+ v[0-9]' \
+          PLUGINS=$(cargo run -p xtask -- list-plugins \
+            | { grep -E '^[[:space:]]+[a-z-]+/[^[:space:]]+ v[0-9]' || true; } \
             | awk '{print $1}')
           for PLUGIN in $PLUGINS; do
             set_public "$PLUGIN"


### PR DESCRIPTION
# Description


The `set-public-visibility` job failed for every package with `404 Not Found`, falsely reported as "may already be public." Two root causes:

1. **Wrong token.** The step used `GITHUB_TOKEN`, which cannot administer org-level container package visibility — those endpoints return `404` when the token isn't authorized.
2. **Broken plugin parsing.** `grep '^\s'` also matched the indented `SDK: ...` summary line from `list-plugins`, producing a bogus `Setting drasi-project/SDK: to public...` entry.

Errors were also swallowed by `2>/dev/null || echo "(skipped...)"`, so the job passed green despite doing nothing.

### Changes
- Use `secrets.PACKAGES_ADMIN_TOKEN` (falls back to `GITHUB_TOKEN`) — a PAT with package-admin rights on the org.
- Tighten the plugin filter to `^[[:space:]]+[a-z-]+/[^[:space:]]+ v[0-9]` so only real `type/kind vX.Y.Z` lines match, excluding the `SDK:` line.
- Stop silencing failures: each failed PATCH emits a `::error::` annotation and the step exits non-zero with a hint about the token.
- Refactor the repeated PATCH logic into a `set_public()` helper.


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
