### PR TITLE
fix(mssql): real change timestamps and dedupe bootstrap/CDC element IDs (#603)

### DIFF
--- a/components/bootstrappers/mssql/src/mssql.rs
+++ b/components/bootstrappers/mssql/src/mssql.rs
@@ -242,12 +242,23 @@ impl MsSqlBootstrapHandler {
 
         let mut total_count = 0;
 
+        // Timestamp applied to every bootstrapped row's `effective_from`, so
+        // `drasi.changeDateTime()` reflects the snapshot time instead of epoch 0.
+        let effective_from = chrono::Utc::now().timestamp_millis() as u64;
+
         // Bootstrap each node label
         for (label, table_name) in &tables {
             info!("Bootstrapping table '{table_name}' with label '{label}'");
 
             let count = self
-                .bootstrap_table(client, label, table_name, context, &event_tx)
+                .bootstrap_table(
+                    client,
+                    label,
+                    table_name,
+                    effective_from,
+                    context,
+                    &event_tx,
+                )
                 .await?;
 
             total_count += count;
@@ -338,6 +349,7 @@ impl MsSqlBootstrapHandler {
         client: &mut tiberius::Client<tokio_util::compat::Compat<tokio::net::TcpStream>>,
         label: &str,
         table_name: &str,
+        effective_from: u64,
         context: &BootstrapContext,
         event_tx: &tokio::sync::mpsc::Sender<BootstrapEvent>,
     ) -> Result<usize> {
@@ -357,7 +369,9 @@ impl MsSqlBootstrapHandler {
 
         for row_set in rows {
             for row in row_set {
-                let source_change = self.row_to_source_change(&row, label, table_name).await?;
+                let source_change = self
+                    .row_to_source_change(&row, label, table_name, effective_from)
+                    .await?;
 
                 batch.push(SourceChangeEvent {
                     source_id: self.source_id.clone(),
@@ -388,6 +402,7 @@ impl MsSqlBootstrapHandler {
         row: &Row,
         label: &str,
         table_name: &str,
+        effective_from: u64,
     ) -> Result<SourceChange> {
         let mut properties = ElementPropertyMap::new();
 
@@ -411,7 +426,7 @@ impl MsSqlBootstrapHandler {
                 metadata: ElementMetadata {
                     reference: ElementReference::new(&self.source_id, &element_id),
                     labels: Arc::from([Arc::from(label)]),
-                    effective_from: 0,
+                    effective_from,
                 },
                 properties,
             },

--- a/components/mssql-common/src/keys.rs
+++ b/components/mssql-common/src/keys.rs
@@ -29,6 +29,12 @@ use tokio_util::compat::Compat;
 pub struct PrimaryKeyCache {
     /// Map of table name -> ordered list of primary key column names
     keys: HashMap<String, Vec<String>>,
+    /// Map of lowercased bare table name -> canonical `schema.table` (using the
+    /// catalog's casing). Used to produce a stable element-ID prefix that is
+    /// identical regardless of how the table was written in config (`Products`,
+    /// `dbo.Products`, `DBO.products` all resolve to the same canonical name),
+    /// so the bootstrap and CDC paths agree on element IDs.
+    canonical_names: HashMap<String, String>,
 }
 
 impl PrimaryKeyCache {
@@ -36,13 +42,15 @@ impl PrimaryKeyCache {
     pub fn new() -> Self {
         Self {
             keys: HashMap::new(),
+            canonical_names: HashMap::new(),
         }
     }
 
     /// Discover primary keys from MS SQL system catalogs
     ///
-    /// Queries sys.indexes, sys.index_columns, sys.columns, and sys.tables
-    /// to find primary key columns for all tables in the database.
+    /// Queries sys.indexes, sys.index_columns, sys.columns, sys.tables, and
+    /// sys.schemas to find primary key columns (and the owning schema) for all
+    /// tables in the database.
     pub async fn discover_keys(
         &mut self,
         client: &mut Client<Compat<TcpStream>>,
@@ -50,6 +58,7 @@ impl PrimaryKeyCache {
     ) -> Result<()> {
         let query = "
             SELECT 
+                s.name AS schema_name,
                 t.name AS table_name,
                 c.name AS column_name,
                 ic.key_ordinal
@@ -59,6 +68,7 @@ impl PrimaryKeyCache {
             INNER JOIN sys.columns c ON ic.object_id = c.object_id 
                 AND ic.column_id = c.column_id
             INNER JOIN sys.tables t ON i.object_id = t.object_id
+            INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
             WHERE i.is_primary_key = 1
             ORDER BY t.name, ic.key_ordinal
         ";
@@ -67,13 +77,18 @@ impl PrimaryKeyCache {
         let rows = stream.into_first_result().await?;
 
         for row in rows {
-            let table_name: &str = row.get(0).ok_or_else(|| anyhow!("Missing table_name"))?;
-            let column_name: &str = row.get(1).ok_or_else(|| anyhow!("Missing column_name"))?;
+            let schema_name: &str = row.get(0).ok_or_else(|| anyhow!("Missing schema_name"))?;
+            let table_name: &str = row.get(1).ok_or_else(|| anyhow!("Missing table_name"))?;
+            let column_name: &str = row.get(2).ok_or_else(|| anyhow!("Missing column_name"))?;
 
             self.keys
                 .entry(table_name.to_string())
                 .or_default()
                 .push(column_name.to_string());
+
+            self.canonical_names
+                .entry(table_name.to_lowercase())
+                .or_insert_with(|| format!("{schema_name}.{table_name}"));
         }
 
         // Merge with configured table_keys (which take precedence)
@@ -107,9 +122,32 @@ impl PrimaryKeyCache {
         None
     }
 
+    /// Resolve any table reference to a canonical `schema.table` name.
+    ///
+    /// This makes the element-ID prefix independent of how the table was written
+    /// in config: `Products`, `dbo.Products`, and `DBO.products` all map to the
+    /// same canonical name (using the catalog's casing when discovered). When the
+    /// table is not in the discovered catalog (e.g. a `table_keys`-only table),
+    /// it falls back to the schema given in the input, or `dbo` if none — which
+    /// is still deterministic across the bootstrap and CDC paths.
+    pub fn canonical_table(&self, table: &str) -> String {
+        let bare = table.rsplit('.').next().unwrap_or(table);
+        if let Some(canonical) = self.canonical_names.get(&bare.to_lowercase()) {
+            return canonical.clone();
+        }
+        match table.split_once('.') {
+            Some((schema, tbl)) => format!("{schema}.{tbl}"),
+            None => format!("dbo.{bare}"),
+        }
+    }
+
     /// Generate element ID from a row using primary key values
     ///
-    /// Format: `{table_name}:{key_values}`
+    /// Format: `{canonical_schema.table}:{key_values}`
+    ///
+    /// The table portion is canonicalized via [`canonical_table`](Self::canonical_table)
+    /// so that the bootstrap and CDC paths produce identical element IDs for the
+    /// same row even when configured with differently-formatted table names.
     ///
     /// # Arguments
     /// * `table` - Table name
@@ -165,7 +203,11 @@ impl PrimaryKeyCache {
                      Using remaining key columns for element ID."
                 );
             }
-            Ok(format!("{}:{}", table, key_values.join("_")))
+            Ok(format!(
+                "{}:{}",
+                self.canonical_table(table),
+                key_values.join("_")
+            ))
         } else {
             // All primary key values are NULL - this is an error
             Err(MsSqlError::PrimaryKey(PrimaryKeyError::AllNull {
@@ -215,5 +257,31 @@ mod tests {
         assert_eq!(keys.len(), 2);
         assert_eq!(keys[0], "order_id");
         assert_eq!(keys[1], "product_id");
+    }
+
+    #[test]
+    fn test_canonical_table_uses_catalog() {
+        let mut cache = PrimaryKeyCache::new();
+        cache
+            .canonical_names
+            .insert("products".to_string(), "dbo.Products".to_string());
+
+        // All input formats resolve to the same canonical name (catalog casing).
+        assert_eq!(cache.canonical_table("Products"), "dbo.Products");
+        assert_eq!(cache.canonical_table("dbo.Products"), "dbo.Products");
+        assert_eq!(cache.canonical_table("DBO.products"), "dbo.Products");
+        assert_eq!(cache.canonical_table("sales.products"), "dbo.Products");
+    }
+
+    #[test]
+    fn test_canonical_table_fallback_without_catalog() {
+        let cache = PrimaryKeyCache::new();
+
+        // Bare and schema-qualified inputs both default to a `dbo.`-qualified
+        // canonical name, so bootstrap and CDC still agree.
+        assert_eq!(cache.canonical_table("Products"), "dbo.Products");
+        assert_eq!(cache.canonical_table("dbo.Products"), "dbo.Products");
+        // An explicit non-default schema is preserved.
+        assert_eq!(cache.canonical_table("sales.Orders"), "sales.Orders");
     }
 }

--- a/components/mssql-common/src/keys.rs
+++ b/components/mssql-common/src/keys.rs
@@ -88,6 +88,17 @@ impl PrimaryKeyCache {
 
             self.canonical_names
                 .entry(table_name.to_lowercase())
+                .and_modify(|existing| {
+                    let new_name = format!("{schema_name}.{table_name}");
+                    if *existing != new_name {
+                        warn!(
+                            "Table '{table_name}' exists in schemas '{}' and '{schema_name}'; \
+                             unqualified references will resolve to element-ID prefix '{existing}'. \
+                             Use schema-qualified table names in config to disambiguate.",
+                            existing.split('.').next().unwrap_or("?")
+                        );
+                    }
+                })
                 .or_insert_with(|| format!("{schema_name}.{table_name}"));
         }
 

--- a/components/mssql-common/src/keys.rs
+++ b/components/mssql-common/src/keys.rs
@@ -125,19 +125,32 @@ impl PrimaryKeyCache {
     /// Resolve any table reference to a canonical `schema.table` name.
     ///
     /// This makes the element-ID prefix independent of how the table was written
-    /// in config: `Products`, `dbo.Products`, and `DBO.products` all map to the
-    /// same canonical name (using the catalog's casing when discovered). When the
-    /// table is not in the discovered catalog (e.g. a `table_keys`-only table),
-    /// it falls back to the schema given in the input, or `dbo` if none — which
-    /// is still deterministic across the bootstrap and CDC paths.
+    /// in config, while never collapsing distinct schemas:
+    /// - An **unqualified** name (`Products`) adopts the discovered catalog name
+    ///   (e.g. `dbo.Products`), or defaults to `dbo.<table>` when not discovered.
+    /// - A **schema-qualified** name (`dbo.Products`) adopts the catalog's casing
+    ///   only when the schema matches; an explicit, non-matching schema (e.g.
+    ///   `sales.Products` when the catalog discovered `dbo.Products`) is preserved
+    ///   as-is so same-named tables in different schemas get distinct element IDs.
     pub fn canonical_table(&self, table: &str) -> String {
-        let bare = table.rsplit('.').next().unwrap_or(table);
-        if let Some(canonical) = self.canonical_names.get(&bare.to_lowercase()) {
-            return canonical.clone();
-        }
         match table.split_once('.') {
-            Some((schema, tbl)) => format!("{schema}.{tbl}"),
-            None => format!("dbo.{bare}"),
+            Some((schema, tbl)) => {
+                // Only adopt the catalog canonical when it is the same schema.
+                if let Some(canonical) = self.canonical_names.get(&tbl.to_lowercase()) {
+                    if let Some((canonical_schema, _)) = canonical.split_once('.') {
+                        if canonical_schema.eq_ignore_ascii_case(schema) {
+                            return canonical.clone();
+                        }
+                    }
+                }
+                // Preserve the explicit schema (different schema, or undiscovered).
+                format!("{schema}.{tbl}")
+            }
+            None => self
+                .canonical_names
+                .get(&table.to_lowercase())
+                .cloned()
+                .unwrap_or_else(|| format!("dbo.{table}")),
         }
     }
 
@@ -266,11 +279,12 @@ mod tests {
             .canonical_names
             .insert("products".to_string(), "dbo.Products".to_string());
 
-        // All input formats resolve to the same canonical name (catalog casing).
+        // Unqualified and same-schema inputs resolve to the catalog casing.
         assert_eq!(cache.canonical_table("Products"), "dbo.Products");
         assert_eq!(cache.canonical_table("dbo.Products"), "dbo.Products");
         assert_eq!(cache.canonical_table("DBO.products"), "dbo.Products");
-        assert_eq!(cache.canonical_table("sales.products"), "dbo.Products");
+        // An explicit, different schema is preserved (no cross-schema collapse).
+        assert_eq!(cache.canonical_table("sales.products"), "sales.products");
     }
 
     #[test]

--- a/components/mssql-common/src/keys.rs
+++ b/components/mssql-common/src/keys.rs
@@ -27,7 +27,10 @@ use tokio_util::compat::Compat;
 
 /// Cache of primary keys for tables
 pub struct PrimaryKeyCache {
-    /// Map of table name -> ordered list of primary key column names
+    /// Map of canonical `schema.table` name -> ordered list of primary key
+    /// column names. Keying by the canonical schema-qualified name keeps
+    /// same-named tables in different schemas (e.g. `dbo.Orders` and
+    /// `sales.Orders`) from merging their primary-key columns into one entry.
     keys: HashMap<String, Vec<String>>,
     /// Map of lowercased bare table name -> canonical `schema.table` (using the
     /// catalog's casing). Used to produce a stable element-ID prefix that is
@@ -70,7 +73,7 @@ impl PrimaryKeyCache {
             INNER JOIN sys.tables t ON i.object_id = t.object_id
             INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
             WHERE i.is_primary_key = 1
-            ORDER BY t.name, ic.key_ordinal
+            ORDER BY s.name, t.name, ic.key_ordinal
         ";
 
         let stream = client.query(query, &[]).await?;
@@ -81,16 +84,17 @@ impl PrimaryKeyCache {
             let table_name: &str = row.get(1).ok_or_else(|| anyhow!("Missing table_name"))?;
             let column_name: &str = row.get(2).ok_or_else(|| anyhow!("Missing column_name"))?;
 
+            let canonical = format!("{schema_name}.{table_name}");
+
             self.keys
-                .entry(table_name.to_string())
+                .entry(canonical.clone())
                 .or_default()
                 .push(column_name.to_string());
 
             self.canonical_names
                 .entry(table_name.to_lowercase())
                 .and_modify(|existing| {
-                    let new_name = format!("{schema_name}.{table_name}");
-                    if *existing != new_name {
+                    if *existing != canonical {
                         warn!(
                             "Table '{table_name}' exists in schemas '{}' and '{schema_name}'; \
                              unqualified references will resolve to element-ID prefix '{existing}'. \
@@ -99,12 +103,14 @@ impl PrimaryKeyCache {
                         );
                     }
                 })
-                .or_insert_with(|| format!("{schema_name}.{table_name}"));
+                .or_insert_with(|| canonical.clone());
         }
 
-        // Merge with configured table_keys (which take precedence)
+        // Merge with configured table_keys (which take precedence). Insert by the
+        // canonical `schema.table` so config lookups match discovery keying.
         for tk in &config.table_keys {
-            self.keys.insert(tk.table.clone(), tk.key_columns.clone());
+            let canonical = self.canonical_table(&tk.table);
+            self.keys.insert(canonical, tk.key_columns.clone());
         }
 
         log::info!("Discovered primary keys for {} tables", self.keys.len());
@@ -115,22 +121,20 @@ impl PrimaryKeyCache {
         Ok(())
     }
 
-    /// Get primary key columns for a table
-    /// Handles both "table" and "schema.table" formats
+    /// Get primary key columns for a table.
+    ///
+    /// Resolves the reference to its canonical `schema.table` name (via
+    /// [`canonical_table`](Self::canonical_table)) before looking it up, so that
+    /// `Orders`, `dbo.Orders`, and `DBO.orders` all find the same entry while
+    /// distinct schemas (`dbo.Orders` vs `sales.Orders`) stay separate.
     pub fn get(&self, table: &str) -> Option<&Vec<String>> {
-        // Try exact match first
-        if let Some(keys) = self.keys.get(table) {
+        // Primary lookup: canonical schema.table (how keys are stored).
+        if let Some(keys) = self.keys.get(&self.canonical_table(table)) {
             return Some(keys);
         }
 
-        // Try without schema prefix (e.g., "dbo.Orders" -> "Orders")
-        if let Some(table_only) = table.split('.').nth(1) {
-            if let Some(keys) = self.keys.get(table_only) {
-                return Some(keys);
-            }
-        }
-
-        None
+        // Fallback: an exact, verbatim match (e.g. a caller-inserted key).
+        self.keys.get(table)
     }
 
     /// Resolve any table reference to a canonical `schema.table` name.
@@ -264,23 +268,54 @@ mod tests {
         let mut cache = PrimaryKeyCache::new();
         cache
             .keys
-            .insert("orders".to_string(), vec!["order_id".to_string()]);
+            .insert("dbo.orders".to_string(), vec!["order_id".to_string()]);
+        cache
+            .canonical_names
+            .insert("orders".to_string(), "dbo.orders".to_string());
 
+        // Bare, same-schema, and differently-cased references all resolve.
         assert_eq!(cache.get("orders").unwrap(), &vec!["order_id"]);
+        assert_eq!(cache.get("dbo.orders").unwrap(), &vec!["order_id"]);
+        assert_eq!(cache.get("DBO.Orders").unwrap(), &vec!["order_id"]);
     }
 
     #[test]
     fn test_composite_key() {
         let mut cache = PrimaryKeyCache::new();
         cache.keys.insert(
-            "order_items".to_string(),
+            "dbo.order_items".to_string(),
             vec!["order_id".to_string(), "product_id".to_string()],
         );
+        cache
+            .canonical_names
+            .insert("order_items".to_string(), "dbo.order_items".to_string());
 
         let keys = cache.get("order_items").unwrap();
         assert_eq!(keys.len(), 2);
         assert_eq!(keys[0], "order_id");
         assert_eq!(keys[1], "product_id");
+    }
+
+    #[test]
+    fn test_same_table_name_across_schemas_stays_distinct() {
+        // Regression: `dbo.Orders` and `sales.Orders` must not merge their PK
+        // column lists into a single bare-name entry.
+        let mut cache = PrimaryKeyCache::new();
+        cache
+            .keys
+            .insert("dbo.Orders".to_string(), vec!["OrderId".to_string()]);
+        cache
+            .keys
+            .insert("sales.Orders".to_string(), vec!["SaleId".to_string()]);
+        // The catalog discovered `dbo.Orders` first, so the bare name resolves there.
+        cache
+            .canonical_names
+            .insert("orders".to_string(), "dbo.Orders".to_string());
+
+        assert_eq!(cache.get("dbo.Orders").unwrap(), &vec!["OrderId"]);
+        assert_eq!(cache.get("sales.Orders").unwrap(), &vec!["SaleId"]);
+        // The unqualified reference follows the discovered canonical schema.
+        assert_eq!(cache.get("Orders").unwrap(), &vec!["OrderId"]);
     }
 
     #[test]

--- a/components/sources/mssql/src/decoder.rs
+++ b/components/sources/mssql/src/decoder.rs
@@ -88,6 +88,12 @@ pub mod cdc_columns {
     /// Bit mask showing which columns were updated
     pub const UPDATE_MASK: &str = "__$update_mask";
 
+    /// Computed column (added by the source's CDC query) carrying the commit
+    /// time mapped from `__$start_lsn` via `sys.fn_cdc_map_lsn_to_time`. Not a
+    /// native CDC column; aliased with the `__$` prefix so it is treated as a
+    /// metadata column and excluded from element properties.
+    pub const COMMIT_TIME: &str = "__$commit_time";
+
     /// Check if a column name is a CDC metadata column
     pub fn is_metadata_column(name: &str) -> bool {
         name.starts_with("__$")

--- a/components/sources/mssql/src/stream.rs
+++ b/components/sources/mssql/src/stream.rs
@@ -385,6 +385,11 @@ async fn poll_cdc_changes(
             let operation = extract_operation(&row)?;
             let row_lsn = extract_lsn(&row)?;
 
+            // Real change time, mapped from the LSN's commit time. Falls back to
+            // wall-clock if the LSN is not yet in cdc.lsn_time_mapping.
+            let effective_from = extract_commit_time(&row)
+                .unwrap_or_else(|| chrono::Utc::now().timestamp_millis() as u64);
+
             // Generate element ID from primary key
             let element_id = pk_cache.generate_element_id(table, &row)?;
 
@@ -400,7 +405,7 @@ async fn poll_cdc_changes(
                             metadata: ElementMetadata {
                                 reference: ElementReference::new(source_id, &element_id),
                                 labels: Arc::from([Arc::from(label)]),
-                                effective_from: 0,
+                                effective_from,
                             },
                             properties,
                         },
@@ -413,7 +418,7 @@ async fn poll_cdc_changes(
                             metadata: ElementMetadata {
                                 reference: ElementReference::new(source_id, &element_id),
                                 labels: Arc::from([Arc::from(label)]),
-                                effective_from: 0,
+                                effective_from,
                             },
                             properties,
                         },
@@ -423,7 +428,7 @@ async fn poll_cdc_changes(
                     metadata: ElementMetadata {
                         reference: ElementReference::new(source_id, &element_id),
                         labels: Arc::from([Arc::from(label)]),
-                        effective_from: 0,
+                        effective_from,
                     },
                 },
                 CdcOperation::UpdateBefore => {
@@ -478,9 +483,12 @@ async fn query_table_changes(
     // If table already contains schema (e.g., "dbo.Orders"), replace dot with underscore
     let capture_instance = table.replace('.', "_");
 
-    // Tiberius uses @P1, @P2, etc. for positional parameters
+    // Tiberius uses @P1, @P2, etc. for positional parameters.
+    // The `__$commit_time` computed column maps each change's LSN to its commit
+    // time so the source can set a real `effective_from` (drasi.changeDateTime).
     let query = format!(
-        "SELECT * FROM cdc.fn_cdc_get_all_changes_{capture_instance}(@P1, @P2, 'all') ORDER BY __$start_lsn, __$seqval, __$operation"
+        "SELECT *, sys.fn_cdc_map_lsn_to_time(__$start_lsn) AS {commit_time} FROM cdc.fn_cdc_get_all_changes_{capture_instance}(@P1, @P2, 'all') ORDER BY __$start_lsn, __$seqval, __$operation",
+        commit_time = cdc_columns::COMMIT_TIME,
     );
 
     debug!("CDC query: {query}");
@@ -610,6 +618,21 @@ fn extract_lsn(row: &tiberius::Row) -> Result<Lsn> {
         .ok_or_else(|| anyhow!("__$start_lsn is NULL"))?;
 
     Lsn::from_bytes(lsn_bytes)
+}
+
+/// Extract the CDC commit time (the `__$commit_time` computed column, mapped
+/// from `__$start_lsn` via `sys.fn_cdc_map_lsn_to_time`) as epoch milliseconds.
+///
+/// Returns `None` if the column is absent or NULL — e.g. the LSN is not yet in
+/// `cdc.lsn_time_mapping` — so the caller can fall back to the wall clock.
+fn extract_commit_time(row: &tiberius::Row) -> Option<u64> {
+    let col_idx = row
+        .columns()
+        .iter()
+        .position(|c| c.name() == cdc_columns::COMMIT_TIME)?;
+
+    let dt: chrono::NaiveDateTime = row.try_get(col_idx).ok()??;
+    Some(dt.and_utc().timestamp_millis() as u64)
 }
 
 #[cfg(test)]

--- a/components/sources/mssql/src/stream.rs
+++ b/components/sources/mssql/src/stream.rs
@@ -486,8 +486,11 @@ async fn query_table_changes(
     // Tiberius uses @P1, @P2, etc. for positional parameters.
     // The `__$commit_time` computed column maps each change's LSN to its commit
     // time so the source can set a real `effective_from` (drasi.changeDateTime).
+    // `sys.fn_cdc_map_lsn_to_time` returns the commit time in the SQL Server
+    // instance's local time zone, so we shift it to UTC using the server's
+    // current UTC offset before the host interprets it as a UTC timestamp.
     let query = format!(
-        "SELECT *, sys.fn_cdc_map_lsn_to_time(__$start_lsn) AS {commit_time} FROM cdc.fn_cdc_get_all_changes_{capture_instance}(@P1, @P2, 'all') ORDER BY __$start_lsn, __$seqval, __$operation",
+        "SELECT *, DATEADD(MINUTE, DATEDIFF(MINUTE, GETDATE(), GETUTCDATE()), sys.fn_cdc_map_lsn_to_time(__$start_lsn)) AS {commit_time} FROM cdc.fn_cdc_get_all_changes_{capture_instance}(@P1, @P2, 'all') ORDER BY __$start_lsn, __$seqval, __$operation",
         commit_time = cdc_columns::COMMIT_TIME,
     );
 
@@ -621,10 +624,11 @@ fn extract_lsn(row: &tiberius::Row) -> Result<Lsn> {
 }
 
 /// Extract the CDC commit time (the `__$commit_time` computed column, mapped
-/// from `__$start_lsn` via `sys.fn_cdc_map_lsn_to_time`) as epoch milliseconds.
+/// from `__$start_lsn` and shifted to UTC) as epoch milliseconds.
 ///
-/// Returns `None` if the column is absent or NULL — e.g. the LSN is not yet in
-/// `cdc.lsn_time_mapping` — so the caller can fall back to the wall clock.
+/// Returns `None` if the column is absent, NULL (e.g. the LSN is not yet in
+/// `cdc.lsn_time_mapping`), or maps to a pre-1970 instant — so the caller can
+/// fall back to the wall clock.
 fn extract_commit_time(row: &tiberius::Row) -> Option<u64> {
     let col_idx = row
         .columns()
@@ -632,7 +636,7 @@ fn extract_commit_time(row: &tiberius::Row) -> Option<u64> {
         .position(|c| c.name() == cdc_columns::COMMIT_TIME)?;
 
     let dt: chrono::NaiveDateTime = row.try_get(col_idx).ok()??;
-    Some(dt.and_utc().timestamp_millis() as u64)
+    u64::try_from(dt.and_utc().timestamp_millis()).ok()
 }
 
 #[cfg(test)]

--- a/components/sources/mssql/tests/integration_test.rs
+++ b/components/sources/mssql/tests/integration_test.rs
@@ -172,6 +172,7 @@ async fn prepare_database(config: &MssqlConfig) -> Result<MssqlConfig> {
     // Wait for CDC to be fully initialized (max LSN must be available).
     // CDC capture job starts asynchronously and the first max LSN may not
     // be available immediately after sp_cdc_enable_table returns.
+    let mut cdc_ready = false;
     for _ in 0..30 {
         let result = db_client
             .query("SELECT sys.fn_cdc_get_max_lsn() AS lsn", &[])
@@ -180,11 +181,16 @@ async fn prepare_database(config: &MssqlConfig) -> Result<MssqlConfig> {
             .await?;
         if let Some(row) = result.first() {
             if row.try_get::<&[u8], _>(0).ok().flatten().is_some() {
+                cdc_ready = true;
                 break;
             }
         }
         sleep(Duration::from_secs(1)).await;
     }
+    anyhow::ensure!(
+        cdc_ready,
+        "CDC max LSN never became available for dbo.Products; capture job failed to start"
+    );
 
     Ok(db_config)
 }
@@ -692,6 +698,7 @@ async fn prepare_types_database(config: &MssqlConfig) -> Result<MssqlConfig> {
     // Wait for CDC to be fully initialized (max LSN must be available) before
     // the source starts from StartPosition::Current, otherwise the first INSERT
     // can land before the capture job is ready and never be observed.
+    let mut cdc_ready = false;
     for _ in 0..30 {
         let result = db_client
             .query("SELECT sys.fn_cdc_get_max_lsn() AS lsn", &[])
@@ -700,11 +707,16 @@ async fn prepare_types_database(config: &MssqlConfig) -> Result<MssqlConfig> {
             .await?;
         if let Some(row) = result.first() {
             if row.try_get::<&[u8], _>(0).ok().flatten().is_some() {
+                cdc_ready = true;
                 break;
             }
         }
         sleep(Duration::from_secs(1)).await;
     }
+    anyhow::ensure!(
+        cdc_ready,
+        "CDC max LSN never became available for dbo.TypesTest; capture job failed to start"
+    );
 
     Ok(db_config)
 }

--- a/components/sources/mssql/tests/integration_test.rs
+++ b/components/sources/mssql/tests/integration_test.rs
@@ -146,11 +146,28 @@ async fn prepare_database(config: &MssqlConfig) -> Result<MssqlConfig> {
         "CREATE TABLE dbo.Products (\n            ProductId INT PRIMARY KEY,\n            Name NVARCHAR(100) NOT NULL,\n            Price DECIMAL(10,2) NOT NULL\n        );",
     )
     .await?;
-    execute_sql(
-        &mut db_client,
-        "IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Products' AND is_tracked_by_cdc = 1)\n            EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'Products', @role_name = NULL;",
-    )
-    .await?;
+    // Enabling CDC on the table creates a capture job via SQL Server Agent. The
+    // Agent can still be starting up right after the container is ready, which
+    // surfaces as transient error 14258 ("Cannot perform this operation while
+    // SQLServerAgent is starting"). Retry until it succeeds.
+    let enable_cdc_sql =
+        "IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Products' AND is_tracked_by_cdc = 1)\n            EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'Products', @role_name = NULL;";
+    let mut last_err = None;
+    for _ in 0..30 {
+        match execute_sql(&mut db_client, enable_cdc_sql).await {
+            Ok(()) => {
+                last_err = None;
+                break;
+            }
+            Err(e) => {
+                last_err = Some(e);
+                sleep(Duration::from_secs(2)).await;
+            }
+        }
+    }
+    if let Some(e) = last_err {
+        return Err(e).context("Failed to enable CDC on dbo.Products after retries");
+    }
 
     // Wait for CDC to be fully initialized (max LSN must be available).
     // CDC capture job starts asynchronously and the first max LSN may not
@@ -651,11 +668,43 @@ async fn prepare_types_database(config: &MssqlConfig) -> Result<MssqlConfig> {
         );",
     )
     .await?;
-    execute_sql(
-        &mut db_client,
-        "IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'TypesTest' AND is_tracked_by_cdc = 1)\n            EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'TypesTest', @role_name = NULL;",
-    )
-    .await?;
+    // Enable CDC on the table, retrying past the transient SQL Server Agent
+    // startup race (error 14258), then wait for the capture job to initialize.
+    let enable_cdc_sql =
+        "IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'TypesTest' AND is_tracked_by_cdc = 1)\n            EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'TypesTest', @role_name = NULL;";
+    let mut last_err = None;
+    for _ in 0..30 {
+        match execute_sql(&mut db_client, enable_cdc_sql).await {
+            Ok(()) => {
+                last_err = None;
+                break;
+            }
+            Err(e) => {
+                last_err = Some(e);
+                sleep(Duration::from_secs(2)).await;
+            }
+        }
+    }
+    if let Some(e) = last_err {
+        return Err(e).context("Failed to enable CDC on dbo.TypesTest after retries");
+    }
+
+    // Wait for CDC to be fully initialized (max LSN must be available) before
+    // the source starts from StartPosition::Current, otherwise the first INSERT
+    // can land before the capture job is ready and never be observed.
+    for _ in 0..30 {
+        let result = db_client
+            .query("SELECT sys.fn_cdc_get_max_lsn() AS lsn", &[])
+            .await?
+            .into_first_result()
+            .await?;
+        if let Some(row) = result.first() {
+            if row.try_get::<&[u8], _>(0).ok().flatten().is_some() {
+                break;
+            }
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
 
     Ok(db_config)
 }
@@ -1896,6 +1945,503 @@ async fn test_ffi_mssql_full_restart_picks_up_offline_changes() -> Result<()> {
         Err(_) => {
             anyhow::bail!("test_ffi_mssql_full_restart_picks_up_offline_changes timed out")
         }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Regression tests for issue #603
+//
+//  Bug 1: `effective_from` is hardcoded to 0 in the MS SQL source and
+//         bootstrapper, so `drasi.changeDateTime()` always returns epoch.
+//  Bug 2: bootstrap and CDC generate *different* element IDs for the same row
+//         (e.g. `Products:1` vs `dbo.Products:1` when the source and bootstrap
+//         are configured with differently-formatted table names), so an UPDATE
+//         delivered via CDC creates a duplicate node instead of updating the
+//         bootstrapped node in place.
+//
+// These tests are written to FAIL against the current (buggy) code and PASS
+// once the fixes land. The existing `element_id_int` helper deliberately
+// strips the table prefix, so Bug 2 can only be observed by comparing the
+// FULL element id (see `test_mssql_bootstrap_cdc_element_id_match`).
+// ============================================================================
+
+/// Plausible `effective_from` range in milliseconds (2001-09-09 .. 2100-01-01),
+/// used to assert the timestamp is a real millisecond epoch and not 0 / nanos.
+const PLAUSIBLE_MS_RANGE: std::ops::RangeInclusive<u64> = 1_000_000_000_000..=4_102_444_800_000;
+
+/// Subscribe directly to a started source and return its bootstrap + CDC receivers.
+async fn subscribe_direct(
+    source: &MsSqlSource,
+    query_id: &str,
+) -> Result<(
+    tokio::sync::mpsc::Receiver<drasi_lib::channels::BootstrapEvent>,
+    Box<dyn drasi_lib::channels::ChangeReceiver<drasi_lib::channels::SourceEventWrapper>>,
+)> {
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(15) {
+        if source.status().await == ComponentStatus::Running {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    anyhow::ensure!(
+        source.status().await == ComponentStatus::Running,
+        "MSSQL source did not reach Running state"
+    );
+
+    let settings = SourceSubscriptionSettings {
+        source_id: SOURCE_ID.to_string(),
+        enable_bootstrap: true,
+        query_id: query_id.to_string(),
+        nodes: HashSet::from(["Products".to_string()]),
+        relations: HashSet::new(),
+        resume_from: None,
+        request_position_handle: true,
+    };
+    let response = source
+        .subscribe(settings)
+        .await
+        .context("Failed to subscribe to MSSQL source")?;
+    let bootstrap_rx = response
+        .bootstrap_receiver
+        .expect("bootstrap_receiver should be present when enable_bootstrap is true");
+    Ok((bootstrap_rx, response.receiver))
+}
+
+/// Bug 1: `effective_from` must be a real millisecond timestamp (not 0) for
+/// both the bootstrap snapshot and live CDC changes. `drasi.changeDateTime()`
+/// is a thin wrapper over `effective_from`, so a non-zero value here is exactly
+/// what makes `changeDateTime()` return a real time instead of epoch 0.
+#[tokio::test]
+#[ignore] // Run with: cargo test -p drasi-source-mssql --test integration_test -- --ignored --nocapture
+#[cfg(not(target_arch = "aarch64"))]
+async fn test_mssql_effective_from_populated() -> Result<()> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let result = tokio::time::timeout(Duration::from_secs(300), async {
+        let mssql = setup_mssql()
+            .await
+            .context("Failed to start MSSQL container")?;
+        let db_config = prepare_database(mssql.config())
+            .await
+            .context("Failed to prepare MSSQL database")?;
+
+        // Seed one row BEFORE subscribing so it is part of the bootstrap snapshot.
+        let mut client = db_config.connect().await?;
+        execute_sql(
+            &mut client,
+            "INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (1, 'Seed1', 1.00);",
+        )
+        .await?;
+        sleep(Duration::from_secs(5)).await;
+
+        let bootstrap_provider = MsSqlBootstrapProvider::builder()
+            .with_source_id(SOURCE_ID)
+            .with_host(&db_config.host)
+            .with_port(db_config.port)
+            .with_database(&db_config.database)
+            .with_user(&db_config.user)
+            .with_password(&db_config.password)
+            .with_tables(vec![TEST_TABLE.to_string()])
+            .build()
+            .context("Failed to build MSSQL bootstrap provider")?;
+
+        let source = MsSqlSource::builder(SOURCE_ID)
+            .with_host(&db_config.host)
+            .with_port(db_config.port)
+            .with_database(&db_config.database)
+            .with_user(&db_config.user)
+            .with_password(&db_config.password)
+            .with_table(TEST_TABLE)
+            .with_poll_interval_ms(250)
+            .with_start_position(StartPosition::Current)
+            .with_trust_server_certificate(true)
+            .with_bootstrap_provider(bootstrap_provider)
+            .build()
+            .context("Failed to build MSSQL source")?;
+
+        source
+            .start()
+            .await
+            .context("Failed to start MSSQL source")?;
+        let (mut bootstrap_rx, mut cdc_rx) = subscribe_direct(&source, "q-eff").await?;
+
+        // Drain bootstrap; capture the seed row's effective_from.
+        let mut bootstrap_eff: Option<u64> = None;
+        loop {
+            match tokio::time::timeout(Duration::from_secs(60), bootstrap_rx.recv()).await {
+                Ok(Some(event)) => {
+                    if let SourceChange::Insert { element } = &event.change {
+                        if element_id_int(element.get_reference().element_id.as_ref()) == Some(1) {
+                            bootstrap_eff = Some(element.get_effective_from());
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(_) => anyhow::bail!("Timed out draining bootstrap snapshot"),
+            }
+        }
+        let bootstrap_eff = bootstrap_eff.context("bootstrap did not emit seed row 1")?;
+        anyhow::ensure!(
+            bootstrap_eff != 0,
+            "BUG 1: bootstrap effective_from is 0 (drasi.changeDateTime() would be epoch)"
+        );
+        anyhow::ensure!(
+            PLAUSIBLE_MS_RANGE.contains(&bootstrap_eff),
+            "bootstrap effective_from {bootstrap_eff} is not a plausible millisecond timestamp"
+        );
+
+        // Live CDC changes must also carry a real effective_from.
+        execute_sql(
+            &mut client,
+            "UPDATE dbo.Products SET Name = 'Seed1b' WHERE ProductId = 1;",
+        )
+        .await?;
+        execute_sql(
+            &mut client,
+            "INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (2, 'Seed2', 2.00);",
+        )
+        .await?;
+
+        let mut cdc_effs: Vec<u64> = Vec::new();
+        let started = Instant::now();
+        while started.elapsed() < Duration::from_secs(30) && cdc_effs.len() < 2 {
+            match tokio::time::timeout(Duration::from_millis(500), cdc_rx.recv()).await {
+                Ok(Ok(wrapper)) => {
+                    if let SourceEvent::Change(change) = &wrapper.event {
+                        cdc_effs.push(change.get_transaction_time());
+                    }
+                }
+                Ok(Err(_)) => break,
+                Err(_) => {}
+            }
+        }
+        anyhow::ensure!(!cdc_effs.is_empty(), "no CDC changes observed");
+        for eff in &cdc_effs {
+            anyhow::ensure!(
+                *eff != 0,
+                "BUG 1: CDC effective_from is 0 (drasi.changeDateTime() would be epoch)"
+            );
+            anyhow::ensure!(
+                PLAUSIBLE_MS_RANGE.contains(eff),
+                "CDC effective_from {eff} is not a plausible millisecond timestamp"
+            );
+        }
+
+        source.stop().await.context("Failed to stop MSSQL source")?;
+        mssql.cleanup().await;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await;
+
+    match result {
+        Ok(inner) => inner?,
+        Err(_) => anyhow::bail!("test_mssql_effective_from_populated timed out"),
+    }
+
+    Ok(())
+}
+
+/// Bug 2 (root cause): bootstrap and CDC must produce the SAME full element id
+/// for the same row, even when the source and bootstrap are configured with
+/// differently-formatted table names. Here the source is configured with the
+/// schema-qualified `dbo.Products` (required for CDC) while the bootstrap is
+/// configured with the bare `Products`. Today this yields `dbo.Products:1` from
+/// CDC and `Products:1` from bootstrap — a mismatch that makes an UPDATE create
+/// a duplicate node.
+#[tokio::test]
+#[ignore]
+#[cfg(not(target_arch = "aarch64"))]
+async fn test_mssql_bootstrap_cdc_element_id_match() -> Result<()> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let result = tokio::time::timeout(Duration::from_secs(300), async {
+        let mssql = setup_mssql()
+            .await
+            .context("Failed to start MSSQL container")?;
+        let db_config = prepare_database(mssql.config())
+            .await
+            .context("Failed to prepare MSSQL database")?;
+
+        let mut client = db_config.connect().await?;
+        execute_sql(
+            &mut client,
+            "INSERT INTO dbo.Products (ProductId, Name, Price) VALUES (1, 'Parking', 1.00);",
+        )
+        .await?;
+        sleep(Duration::from_secs(5)).await;
+
+        // Deliberately divergent table-name formats (the real-world trigger).
+        let bootstrap_provider = MsSqlBootstrapProvider::builder()
+            .with_source_id(SOURCE_ID)
+            .with_host(&db_config.host)
+            .with_port(db_config.port)
+            .with_database(&db_config.database)
+            .with_user(&db_config.user)
+            .with_password(&db_config.password)
+            .with_tables(vec!["Products".to_string()]) // bare
+            .build()
+            .context("Failed to build MSSQL bootstrap provider")?;
+
+        let source = MsSqlSource::builder(SOURCE_ID)
+            .with_host(&db_config.host)
+            .with_port(db_config.port)
+            .with_database(&db_config.database)
+            .with_user(&db_config.user)
+            .with_password(&db_config.password)
+            .with_table(TEST_TABLE) // schema-qualified dbo.Products
+            .with_poll_interval_ms(250)
+            .with_start_position(StartPosition::Current)
+            .with_trust_server_certificate(true)
+            .with_bootstrap_provider(bootstrap_provider)
+            .build()
+            .context("Failed to build MSSQL source")?;
+
+        source
+            .start()
+            .await
+            .context("Failed to start MSSQL source")?;
+        let (mut bootstrap_rx, mut cdc_rx) = subscribe_direct(&source, "q-idmatch").await?;
+
+        // Capture the FULL element id the bootstrap produced for row 1.
+        let mut bootstrap_id: Option<String> = None;
+        loop {
+            match tokio::time::timeout(Duration::from_secs(60), bootstrap_rx.recv()).await {
+                Ok(Some(event)) => {
+                    if let SourceChange::Insert { element } = &event.change {
+                        let id = element.get_reference().element_id.to_string();
+                        if element_id_int(&id) == Some(1) {
+                            bootstrap_id = Some(id);
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(_) => anyhow::bail!("Timed out draining bootstrap snapshot"),
+            }
+        }
+        let bootstrap_id = bootstrap_id.context("bootstrap did not emit row 1")?;
+
+        // Update row 1 via CDC and capture the FULL element id CDC produced.
+        execute_sql(
+            &mut client,
+            "UPDATE dbo.Products SET Name = 'Curbside' WHERE ProductId = 1;",
+        )
+        .await?;
+
+        let mut cdc_id: Option<String> = None;
+        let started = Instant::now();
+        while started.elapsed() < Duration::from_secs(30) {
+            match tokio::time::timeout(Duration::from_millis(500), cdc_rx.recv()).await {
+                Ok(Ok(wrapper)) => {
+                    if let SourceEvent::Change(change) = &wrapper.event {
+                        let id = change.get_reference().element_id.to_string();
+                        if element_id_int(&id) == Some(1) {
+                            cdc_id = Some(id);
+                            break;
+                        }
+                    }
+                }
+                Ok(Err(_)) => break,
+                Err(_) => {}
+            }
+        }
+        let cdc_id = cdc_id.context("no CDC change observed for row 1")?;
+
+        anyhow::ensure!(
+            bootstrap_id == cdc_id,
+            "BUG 2: bootstrap element id ({bootstrap_id}) != CDC element id ({cdc_id}); \
+             an UPDATE will create a duplicate node instead of updating in place"
+        );
+
+        source.stop().await.context("Failed to stop MSSQL source")?;
+        mssql.cleanup().await;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await;
+
+    match result {
+        Ok(inner) => inner?,
+        Err(_) => anyhow::bail!("test_mssql_bootstrap_cdc_element_id_match timed out"),
+    }
+
+    Ok(())
+}
+
+/// Bug 2 (user-visible symptom): a row loaded at bootstrap and then UPDATEd via
+/// CDC must update IN PLACE in query results — not appear as a second node.
+/// Also asserts Bug 1 at the query level: `drasi.changeDateTime()` is not epoch.
+#[tokio::test]
+#[ignore]
+#[cfg(not(target_arch = "aarch64"))]
+async fn test_mssql_update_after_bootstrap_no_duplicate() -> Result<()> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let result = tokio::time::timeout(Duration::from_secs(300), async {
+        let mssql = setup_mssql()
+            .await
+            .context("Failed to start MSSQL container")?;
+        let db_config = prepare_database(mssql.config())
+            .await
+            .context("Failed to prepare MSSQL database")?;
+
+        // Seed three rows BEFORE start so they are bootstrapped.
+        let mut client = db_config.connect().await?;
+        for id in 1..=3 {
+            execute_sql(
+                &mut client,
+                &format!(
+                    "INSERT INTO dbo.Products (ProductId, Name, Price) VALUES ({id}, 'Parking', 1.00);"
+                ),
+            )
+            .await?;
+        }
+        sleep(Duration::from_secs(5)).await;
+
+        // Divergent table-name formats (the real-world trigger for Bug 2).
+        let bootstrap_provider = MsSqlBootstrapProvider::builder()
+            .with_source_id(SOURCE_ID)
+            .with_host(&db_config.host)
+            .with_port(db_config.port)
+            .with_database(&db_config.database)
+            .with_user(&db_config.user)
+            .with_password(&db_config.password)
+            .with_tables(vec!["Products".to_string()]) // bare
+            .build()
+            .context("Failed to build MSSQL bootstrap provider")?;
+
+        let source = MsSqlSource::builder(SOURCE_ID)
+            .with_host(&db_config.host)
+            .with_port(db_config.port)
+            .with_database(&db_config.database)
+            .with_user(&db_config.user)
+            .with_password(&db_config.password)
+            .with_table(TEST_TABLE) // schema-qualified dbo.Products
+            .with_poll_interval_ms(250)
+            .with_start_position(StartPosition::Current)
+            .with_trust_server_certificate(true)
+            .with_bootstrap_provider(bootstrap_provider)
+            .build()
+            .context("Failed to build MSSQL source")?;
+
+        let query = Query::cypher(QUERY_ID)
+            .query(
+                r#"
+                MATCH (p:Products)
+                RETURN p.ProductId AS id, p.Name AS name, drasi.changeDateTime(p) AS cdt
+            "#,
+            )
+            .from_source(SOURCE_ID)
+            .auto_start(true)
+            .enable_bootstrap(true)
+            .build();
+
+        let (reaction, handle) = ApplicationReaction::builder("app-reaction")
+            .with_query(QUERY_ID)
+            .build();
+
+        let core = DrasiLib::builder()
+            .with_id("mssql-dup-test")
+            .with_source(source)
+            .with_query(query)
+            .with_reaction(reaction)
+            .build()
+            .await
+            .context("Failed to build DrasiLib")?;
+
+        core.start().await.context("Failed to start DrasiLib")?;
+
+        let mut subscription = handle
+            .subscribe_with_options(
+                SubscriptionOptions::default().with_timeout(Duration::from_secs(5)),
+            )
+            .await
+            .context("Failed to create subscription")?;
+
+        // Let bootstrap settle before mutating.
+        sleep(Duration::from_secs(3)).await;
+
+        // UPDATE a bootstrapped row via CDC.
+        execute_sql(
+            &mut client,
+            "UPDATE dbo.Products SET Name = 'Curbside' WHERE ProductId = 2;",
+        )
+        .await?;
+
+        // Collect diffs for ~20s and classify what happened to row 2.
+        let mut saw_update_curbside = false;
+        let mut saw_add_curbside = false;
+        let mut cdt_datetime: Option<String> = None;
+        let started = Instant::now();
+        while started.elapsed() < Duration::from_secs(20) {
+            match tokio::time::timeout(Duration::from_secs(2), subscription.recv()).await {
+                Ok(Some(result)) => {
+                    for entry in &result.results {
+                        match entry {
+                            ResultDiff::Update { after, .. }
+                                if matches_fields(after, &[("id", "2"), ("name", "Curbside")]) =>
+                            {
+                                saw_update_curbside = true;
+                                cdt_datetime = after
+                                    .get("cdt")
+                                    .and_then(|c| c.as_str())
+                                    .map(|s| s.to_string());
+                            }
+                            ResultDiff::Add { data, .. }
+                                if matches_fields(data, &[("id", "2"), ("name", "Curbside")]) =>
+                            {
+                                saw_add_curbside = true;
+                                cdt_datetime = data
+                                    .get("cdt")
+                                    .and_then(|c| c.as_str())
+                                    .map(|s| s.to_string());
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(_) => {
+                    if saw_update_curbside {
+                        break;
+                    }
+                }
+            }
+        }
+
+        anyhow::ensure!(
+            !saw_add_curbside,
+            "BUG 2: UPDATE of a bootstrapped row produced a NEW node (duplicate ADD) \
+             instead of an in-place UPDATE"
+        );
+        anyhow::ensure!(
+            saw_update_curbside,
+            "expected an in-place UPDATE for row 2 -> 'Curbside' but none was observed"
+        );
+
+        // Bug 1 at the query level: changeDateTime must not be epoch 0.
+        let cdt = cdt_datetime.context("did not capture drasi.changeDateTime() for row 2")?;
+        anyhow::ensure!(
+            !cdt.starts_with("1970"),
+            "BUG 1: drasi.changeDateTime() returned epoch ({cdt}) for a live CDC change"
+        );
+
+        core.stop().await.context("Failed to stop DrasiLib")?;
+        mssql.cleanup().await;
+        Ok::<(), anyhow::Error>(())
+    })
+    .await;
+
+    match result {
+        Ok(inner) => inner?,
+        Err(_) => anyhow::bail!("test_mssql_update_after_bootstrap_no_duplicate timed out"),
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Fixes #603. The `source/mssql` CDC source (with `bootstrap/mssql`) streams changes fine but had two defects that produce **incorrect query results** (the PostgreSQL source behaves correctly in the same scenario):

1. **`effective_from` always `0`** — `drasi.changeDateTime()` returned epoch `1970-01-01T00:00:00Z` for every row (bootstrap *and* live CDC), because `effective_from` was hardcoded to `0`.
2. **Duplicate elements after UPDATE** — bootstrap and CDC generated *different* element IDs for the same row when configured with differently-formatted table names (e.g. `Products` vs `dbo.Products`), so an UPDATE delivered via CDC created a **second node** instead of updating the bootstrapped node in place.

## Changes

**Bug 1 — change timestamps**
- `components/sources/mssql/src/stream.rs` / `decoder.rs`: the CDC changes query now adds a computed `__$commit_time` column via `sys.fn_cdc_map_lsn_to_time(__$start_lsn)`; `effective_from` is derived from it (millisecond epoch), with a wall-clock fallback when the LSN is not yet in `cdc.lsn_time_mapping`.
- `components/bootstrappers/mssql/src/mssql.rs`: bootstrap stamps every row with the snapshot time instead of `0`.

**Bug 2 — element-ID mismatch**
- `components/mssql-common/src/keys.rs`: `discover_keys` now also reads the schema (`sys.schemas`), and a new `canonical_table()` makes `generate_element_id` emit a canonical fully-qualified `schema.table` prefix. `Products`, `dbo.Products`, and `DBO.products` all resolve to the same ID, so the bootstrap and CDC paths always agree. Because both paths share `PrimaryKeyCache` (drasi-mssql-common), a single change fixes both.

## Tests

Added end-to-end regression tests in `components/sources/mssql/tests/integration_test.rs`, each written to **fail against the buggy code** and pass after the fix:
- `test_mssql_effective_from_populated` — bootstrap + CDC `effective_from` is a real timestamp, not `0`.
- `test_mssql_bootstrap_cdc_element_id_match` — the **full** element ID from bootstrap equals the one from CDC (the existing `element_id_int` helper strips the prefix and masked this).
- `test_mssql_update_after_bootstrap_no_duplicate` — an UPDATE of a bootstrapped row produces an in-place UPDATE (no duplicate ADD), and `drasi.changeDateTime()` is not epoch.

Also hardened `prepare_types_database` (retry `sp_cdc_enable_table` past the transient SQL Server Agent startup race + wait for the CDC max LSN), matching `prepare_database`.

## Verification

- New tests: ✅ (verified failing first, then passing)
- Existing MS SQL e2e tests (non-FFI): ✅ all 8 pass
- FFI boundary test (the path drasi-server uses, via built cdylibs): ✅
- `drasi-mssql-common` unit tests, `clippy`, `rustfmt`: ✅

> Note: changing the element-ID format is a behavior change for any persisted index keyed on the old prefix, but the current IDs are already inconsistent between the two paths (the bug). No FFI version bump is needed — no `#[repr(C)]`/model struct layout changed (only an existing field's value and element-ID string content).