### PR TITLE
fix(dashboard): de-duplicate rows via row_signature, graceful shutdown, collapsible panel (#605)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/drasi-project/drasi-core"
@@ -152,9 +152,9 @@ drasi-middleware = { version = "0.5.7", path = "middleware" }
 drasi-identity-azure = { version = "0.2.9", path = "components/identity/azure" }
 drasi-identity-aws = { version = "0.2.3", path = "components/identity/aws" }
 drasi-lib = { version = "0.8.8", path = "lib" }
-drasi-ffi-primitives = { version = "0.9.1", path = "components/ffi-primitives" }
-drasi-plugin-sdk = { version = "0.9.1", path = "components/plugin-sdk" }
-drasi-host-sdk = { version = "0.9.1", path = "components/host-sdk" }
+drasi-ffi-primitives = { version = "0.10.0", path = "components/ffi-primitives" }
+drasi-plugin-sdk = { version = "0.10.0", path = "components/plugin-sdk" }
+drasi-host-sdk = { version = "0.10.0", path = "components/host-sdk" }
 
 # Common dependencies
 im = "15"

--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -511,10 +511,10 @@ extern "C" fn snapshot_iter_next(iter_ctx: *mut c_void) -> drasi_plugin_sdk::ffi
         (Some(rt), Some(s)) => (rt, s),
         _ => return drasi_plugin_sdk::ffi::FfiOwnedStr::from_string(String::new()),
     };
-    use tokio_stream::StreamExt;
-    match rt.block_on(stream.next()) {
-        Some(row) => {
-            let json = serde_json::to_string(&row).unwrap_or_else(|_| "null".into());
+    match rt.block_on(stream.next_keyed()) {
+        Some((sig, row)) => {
+            let envelope = drasi_lib::queries::output_state::KeyedSnapshotRow { k: sig, v: row };
+            let json = serde_json::to_string(&envelope).unwrap_or_else(|_| "null".into());
             drasi_plugin_sdk::ffi::FfiOwnedStr::from_string(json)
         }
         None => drasi_plugin_sdk::ffi::FfiOwnedStr::from_string(String::new()),

--- a/components/host-sdk/src/snapshot_fetcher_bridge.rs
+++ b/components/host-sdk/src/snapshot_fetcher_bridge.rs
@@ -96,9 +96,11 @@ extern "C" fn snapshot_iter_next(iter_ctx: *mut c_void) -> FfiOwnedStr {
             (Some(rt), Some(s)) => (rt, s),
             _ => return FfiOwnedStr::from_string(String::new()),
         };
-        match rt.block_on(stream.next()) {
-            Some(row) => {
-                let json = serde_json::to_string(&row).unwrap_or_else(|_| "null".into());
+        match rt.block_on(stream.next_keyed()) {
+            Some((sig, row)) => {
+                let envelope =
+                    drasi_lib::queries::output_state::KeyedSnapshotRow { k: sig, v: row };
+                let json = serde_json::to_string(&envelope).unwrap_or_else(|_| "null".into());
                 FfiOwnedStr::from_string(json)
             }
             None => FfiOwnedStr::from_string(String::new()),
@@ -239,14 +241,18 @@ mod tests {
         }
     }
 
-    /// Helper: call `next_fn` and return the deserialized JSON, or `None` on EOF.
+    /// Helper: call `next_fn` and return the deserialized row JSON, or `None` on EOF.
+    ///
+    /// Rows now cross FFI as a `KeyedSnapshotRow { k, v }` envelope; return the `v`.
     unsafe fn pull_next(iter: &FfiSnapshotIterator) -> Option<serde_json::Value> {
         let owned = (iter.next_fn)(iter.iter_ctx);
         let json_str = owned.into_string();
         if json_str.is_empty() {
             None
         } else {
-            Some(serde_json::from_str(&json_str).expect("valid JSON"))
+            let envelope: drasi_lib::queries::output_state::KeyedSnapshotRow =
+                serde_json::from_str(&json_str).expect("valid KeyedSnapshotRow envelope");
+            Some(envelope.v)
         }
     }
 

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -30,7 +30,11 @@ use super::types::FfiStr;
 /// - `0.10.0`: source change / bootstrap events now cross the boundary as
 ///   serialized (MessagePack) payloads instead of reinterpreted `repr(Rust)`
 ///   opaque pointers (fixes #602 cross-cdylib heap corruption).
-pub const FFI_SDK_VERSION: &str = "0.10.0";
+/// - `0.11.0`: snapshot rows cross the snapshot iterator as a
+///   `KeyedSnapshotRow { k: <row_signature>, v: <row> }` JSON envelope instead
+///   of a bare row, so the engine's canonical `row_signature` survives FFI
+///   (fixes #605 duplicate dashboard rows on the plugin path).
+pub const FFI_SDK_VERSION: &str = "0.11.0";
 
 /// The target triple this crate was compiled for.
 pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");

--- a/components/plugin-sdk/src/ffi/snapshot_fetcher_proxy.rs
+++ b/components/plugin-sdk/src/ffi/snapshot_fetcher_proxy.rs
@@ -88,7 +88,7 @@ impl drasi_lib::SnapshotFetcher for FfiSnapshotFetcherProxy {
         let stream = make_snapshot_stream(resp.iterator);
 
         Ok(
-            drasi_lib::queries::output_state::SnapshotStream::from_stream(
+            drasi_lib::queries::output_state::SnapshotStream::from_keyed_stream(
                 stream,
                 as_of_sequence,
                 config_hash,

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -3595,3 +3595,71 @@ pub fn build_secret_store_plugin_vtable<T: SecretStorePluginDescriptor + 'static
         drop_fn: drop_fn::<T>,
     }
 }
+
+#[cfg(test)]
+mod snapshot_stream_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Test iterator state: yields `payload` once, then EOF (empty string).
+    struct TestIter {
+        remaining: AtomicUsize,
+        payload: String,
+    }
+
+    extern "C" fn test_next(ctx: *mut c_void) -> FfiOwnedStr {
+        let state = unsafe { &*(ctx as *const TestIter) };
+        let n = state.remaining.load(Ordering::SeqCst);
+        if n == 0 {
+            return FfiOwnedStr::from_string(String::new());
+        }
+        state.remaining.store(n - 1, Ordering::SeqCst);
+        FfiOwnedStr::from_string(state.payload.clone())
+    }
+
+    extern "C" fn test_drop(ctx: *mut c_void) {
+        if !ctx.is_null() {
+            unsafe { drop(Box::from_raw(ctx as *mut TestIter)) };
+        }
+    }
+
+    fn make_iter(payload: &str) -> FfiSnapshotIterator {
+        let state = Box::new(TestIter {
+            remaining: AtomicUsize::new(1),
+            payload: payload.to_string(),
+        });
+        FfiSnapshotIterator {
+            iter_ctx: Box::into_raw(state) as *mut c_void,
+            next_fn: test_next,
+            drop_fn: test_drop,
+        }
+    }
+
+    #[tokio::test]
+    async fn make_snapshot_stream_parses_keyed_envelope() {
+        use tokio_stream::StreamExt;
+        let rows: Vec<(u64, serde_json::Value)> =
+            make_snapshot_stream(make_iter(r#"{"k":42,"v":{"id":2}}"#))
+                .collect()
+                .await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, 42);
+        assert_eq!(rows[0].1, serde_json::json!({"id": 2}));
+    }
+
+    #[tokio::test]
+    async fn make_snapshot_stream_falls_back_to_bare_row() {
+        // FFI backward-compat: a pre-0.10 plugin sends a bare row (no envelope).
+        use tokio_stream::StreamExt;
+        let rows: Vec<(u64, serde_json::Value)> = make_snapshot_stream(make_iter(r#"{"id":1}"#))
+            .collect()
+            .await;
+        assert_eq!(
+            rows.len(),
+            1,
+            "bare row should still yield exactly one item"
+        );
+        assert_eq!(rows[0].0, 0, "bare row gets the unknown signature 0");
+        assert_eq!(rows[0].1, serde_json::json!({"id": 1}));
+    }
+}

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -165,7 +165,7 @@ impl Drop for FfiSnapshotIterHandle {
 /// the stream ends and `drop_fn` is called.
 pub(crate) fn make_snapshot_stream(
     iter: FfiSnapshotIterator,
-) -> impl tokio_stream::Stream<Item = serde_json::Value> + Send {
+) -> impl tokio_stream::Stream<Item = (u64, serde_json::Value)> + Send {
     let handle = FfiSnapshotIterHandle {
         iter_ctx: iter.iter_ctx,
         next_fn: iter.next_fn,
@@ -184,12 +184,21 @@ pub(crate) fn make_snapshot_stream(
                 if json_str.is_empty() {
                     None
                 } else {
-                    match serde_json::from_str::<serde_json::Value>(&json_str) {
-                        Ok(val) => Some(val),
-                        Err(e) => {
-                            log::error!("[FFI snapshot stream] failed to deserialize row: {e}");
-                            None
-                        }
+                    // Rows cross FFI as a `KeyedSnapshotRow` envelope so the
+                    // canonical `row_signature` identity survives. Fall back to
+                    // treating the payload as a bare row (signature 0) for
+                    // forward/backward resilience.
+                    match serde_json::from_str::<drasi_lib::queries::output_state::KeyedSnapshotRow>(
+                        &json_str,
+                    ) {
+                        Ok(envelope) => Some((envelope.k, envelope.v)),
+                        Err(_) => match serde_json::from_str::<serde_json::Value>(&json_str) {
+                            Ok(val) => Some((0u64, val)),
+                            Err(e) => {
+                                log::error!("[FFI snapshot stream] failed to deserialize row: {e}");
+                                None
+                            }
+                        },
                     }
                 }
             })
@@ -331,7 +340,7 @@ impl drasi_lib::reactions::BootstrapBackend for FfiBootstrapBackend {
         let stream = make_snapshot_stream(resp.iterator);
 
         Ok(
-            drasi_lib::queries::output_state::SnapshotStream::from_stream(
+            drasi_lib::queries::output_state::SnapshotStream::from_keyed_stream(
                 stream,
                 as_of_sequence,
                 config_hash,

--- a/components/reactions/dashboard/Makefile
+++ b/components/reactions/dashboard/Makefile
@@ -6,6 +6,7 @@ test: test-js
 
 test-js:
 	node tests/handlebars_helpers.test.js
+	node tests/apply_result_diff.test.js
 
 integration-test:
 	cargo test -p drasi-reaction-dashboard -- --ignored --nocapture

--- a/components/reactions/dashboard/src/api.rs
+++ b/components/reactions/dashboard/src/api.rs
@@ -15,7 +15,7 @@
 //! REST API handlers for dashboard CRUD and query metadata.
 
 use crate::storage::{DashboardConfig, DashboardStorage, DashboardWidget, GridOptions};
-use crate::websocket::{QuerySnapshot, QuerySnapshotStore};
+use crate::websocket::{QuerySnapshot, QuerySnapshotStore, SnapshotRow};
 use anyhow::anyhow;
 use axum::{
     body::{to_bytes, Body},
@@ -279,8 +279,15 @@ async fn get_query_snapshot(
     // Fall back to the internal snapshot fetcher if configured and local snapshot is empty.
     if let Some(ref fetcher) = state.snapshot_fetcher {
         if let Ok(stream) = fetcher.fetch_snapshot(&query_id).await {
-            let rows = stream.collect_vec().await;
-            if !rows.is_empty() {
+            let keyed = stream.collect_keyed_vec().await;
+            if !keyed.is_empty() {
+                let rows = keyed
+                    .into_iter()
+                    .map(|(row_signature, data)| SnapshotRow {
+                        row_signature,
+                        data,
+                    })
+                    .collect();
                 return Ok(Json(QuerySnapshot {
                     rows,
                     aggregation: None,

--- a/components/reactions/dashboard/src/dashboard.rs
+++ b/components/reactions/dashboard/src/dashboard.rs
@@ -53,6 +53,7 @@ pub struct DashboardReaction {
     websocket_hub: WebSocketHub,
     snapshot_store: QuerySnapshotStore,
     task_handles: Arc<tokio::sync::Mutex<Vec<JoinHandle<()>>>>,
+    /// Handle for the running axum HTTP/WebSocket server task.
     server_handle: Arc<tokio::sync::Mutex<Option<JoinHandle<()>>>>,
     /// Signals the HTTP/WebSocket server to shut down gracefully. `true` means
     /// "shut down now": the axum server stops accepting and closes idle
@@ -241,6 +242,44 @@ impl Reaction for DashboardReaction {
             )
             .await;
 
+        let snapshot_fetcher = self
+            .base
+            .context()
+            .await
+            .and_then(|ctx| ctx.snapshot_fetcher.clone());
+
+        // Seed the accumulated snapshot store from the bootstrap snapshot so the
+        // live WebSocket stream starts from the same baseline the fallback fetcher
+        // reads, instead of starting empty (see issue #605). This runs BEFORE the
+        // processing task is spawned so a concurrently-arriving live diff (e.g. a
+        // delete) can't be applied before seeding and then resurrected by the stale
+        // bootstrap snapshot. Seeding is best-effort: failures (e.g. bootstrap not
+        // yet complete) are logged and skipped, and the fallback fetcher in the API
+        // still serves initial state. The collection is capped at the store's
+        // per-query row limit to bound peak memory on large result sets.
+        if let Some(fetcher) = snapshot_fetcher.as_ref() {
+            let cap = self.snapshot_store.max_rows_per_query();
+            for query_id in &self.base.queries {
+                match fetcher.fetch_snapshot(query_id).await {
+                    Ok(stream) => {
+                        let rows = stream.collect_keyed_vec_capped(cap).await;
+                        let count = rows.len();
+                        self.snapshot_store.seed_rows(query_id, rows).await;
+                        debug!(
+                            "[{}] seeded {count} bootstrap row(s) for query '{query_id}'",
+                            self.base.id
+                        );
+                    }
+                    Err(err) => {
+                        debug!(
+                            "[{}] could not seed bootstrap snapshot for query '{query_id}': {err}",
+                            self.base.id
+                        );
+                    }
+                }
+            }
+        }
+
         let mut shutdown_rx = self.base.create_shutdown_channel().await;
         let status_handle = self.base.status_handle();
         let reaction_id = self.base.id.clone();
@@ -292,39 +331,6 @@ impl Reaction for DashboardReaction {
             }
         });
         self.task_handles.lock().await.push(heartbeat_handle);
-
-        let snapshot_fetcher = self
-            .base
-            .context()
-            .await
-            .and_then(|ctx| ctx.snapshot_fetcher.clone());
-
-        // Seed the accumulated snapshot store from the bootstrap snapshot so the
-        // live WebSocket stream starts from the same baseline the fallback fetcher
-        // reads, instead of starting empty (see issue #605). Seeding is best-effort:
-        // failures (e.g. bootstrap not yet complete) are logged and skipped, and the
-        // fallback fetcher in the API still serves initial state.
-        if let Some(fetcher) = snapshot_fetcher.as_ref() {
-            for query_id in &self.base.queries {
-                match fetcher.fetch_snapshot(query_id).await {
-                    Ok(stream) => {
-                        let rows = stream.collect_keyed_vec().await;
-                        let count = rows.len();
-                        self.snapshot_store.seed_rows(query_id, rows).await;
-                        debug!(
-                            "[{}] seeded {count} bootstrap row(s) for query '{query_id}'",
-                            self.base.id
-                        );
-                    }
-                    Err(err) => {
-                        debug!(
-                            "[{}] could not seed bootstrap snapshot for query '{query_id}': {err}",
-                            self.base.id
-                        );
-                    }
-                }
-            }
-        }
 
         let api_state = ApiState::new(
             self.base.id.clone(),

--- a/components/reactions/dashboard/src/dashboard.rs
+++ b/components/reactions/dashboard/src/dashboard.rs
@@ -311,7 +311,7 @@ impl Reaction for DashboardReaction {
             for query_id in &self.base.queries {
                 match fetcher.fetch_snapshot(query_id).await {
                     Ok(stream) => {
-                        let rows = stream.collect_vec().await;
+                        let rows = stream.collect_keyed_vec().await;
                         let count = rows.len();
                         self.snapshot_store.seed_rows(query_id, rows).await;
                         debug!(

--- a/components/reactions/dashboard/src/dashboard.rs
+++ b/components/reactions/dashboard/src/dashboard.rs
@@ -53,6 +53,11 @@ pub struct DashboardReaction {
     websocket_hub: WebSocketHub,
     snapshot_store: QuerySnapshotStore,
     task_handles: Arc<tokio::sync::Mutex<Vec<JoinHandle<()>>>>,
+    server_handle: Arc<tokio::sync::Mutex<Option<JoinHandle<()>>>>,
+    /// Signals the HTTP/WebSocket server to shut down gracefully. `true` means
+    /// "shut down now": the axum server stops accepting and closes idle
+    /// keep-alive connections, and WebSocket handlers terminate.
+    shutdown_tx: tokio::sync::watch::Sender<bool>,
     predefined_dashboards: Vec<DashboardConfig>,
 }
 
@@ -90,6 +95,8 @@ impl DashboardReaction {
             websocket_hub: WebSocketHub::new(WEBSOCKET_BROADCAST_CAPACITY),
             snapshot_store: QuerySnapshotStore::new(),
             task_handles: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            server_handle: Arc::new(tokio::sync::Mutex::new(None)),
+            shutdown_tx: tokio::sync::watch::channel(false).0,
             predefined_dashboards,
         }
     }
@@ -106,7 +113,19 @@ fn serve_asset(path: &str) -> Response {
     match DashboardAssets::get(effective_path) {
         Some(content) => {
             let mime = content.metadata.mimetype();
-            ([(header::CONTENT_TYPE, mime)], content.data.into_owned()).into_response()
+            // Force revalidation so a browser tab can't serve a stale shell/JS
+            // from its in-memory cache after the reaction is restarted.
+            (
+                [
+                    (header::CONTENT_TYPE, mime.to_string()),
+                    (
+                        header::CACHE_CONTROL,
+                        "no-cache, no-store, must-revalidate".to_string(),
+                    ),
+                ],
+                content.data.into_owned(),
+            )
+                .into_response()
         }
         None => StatusCode::NOT_FOUND.into_response(),
     }
@@ -283,6 +302,33 @@ impl Reaction for DashboardReaction {
             .await
             .and_then(|ctx| ctx.snapshot_fetcher.clone());
 
+        // Seed the accumulated snapshot store from the bootstrap snapshot so the
+        // live WebSocket stream starts from the same baseline the fallback fetcher
+        // reads, instead of starting empty (see issue #605). Seeding is best-effort:
+        // failures (e.g. bootstrap not yet complete) are logged and skipped, and the
+        // fallback fetcher in the API still serves initial state.
+        if let Some(fetcher) = snapshot_fetcher.as_ref() {
+            for query_id in &self.base.queries {
+                match fetcher.fetch_snapshot(query_id).await {
+                    Ok(stream) => {
+                        let rows = stream.collect_vec().await;
+                        let count = rows.len();
+                        self.snapshot_store.seed_rows(query_id, rows).await;
+                        debug!(
+                            "[{}] seeded {count} bootstrap row(s) for query '{query_id}'",
+                            self.base.id
+                        );
+                    }
+                    Err(err) => {
+                        debug!(
+                            "[{}] could not seed bootstrap snapshot for query '{query_id}': {err}",
+                            self.base.id
+                        );
+                    }
+                }
+            }
+        }
+
         let api_state = ApiState::new(
             self.base.id.clone(),
             self.base.queries.clone(),
@@ -293,6 +339,11 @@ impl Reaction for DashboardReaction {
         let websocket_hub = self.websocket_hub.clone();
         let query_ids = self.base.queries.clone();
         let server_status_handle = self.base.status_handle();
+        // Reset the shutdown flag for this run (supports stop/start cycles) and
+        // derive receivers for the server and per-connection WebSocket handlers.
+        let _ = self.shutdown_tx.send(false);
+        let mut server_shutdown_rx = self.shutdown_tx.subscribe();
+        let ws_shutdown_rx = self.shutdown_tx.subscribe();
         let server_handle = tokio::spawn(async move {
             let cors = CorsLayer::new()
                 .allow_origin(tower_http::cors::AllowOrigin::exact(
@@ -311,6 +362,7 @@ impl Reaction for DashboardReaction {
 
             let websocket_hub_for_route = websocket_hub.clone();
             let query_ids_for_route = query_ids.clone();
+            let ws_shutdown_for_route = ws_shutdown_rx.clone();
             let app = Router::new()
                 .route("/", get(index_handler))
                 .route("/dashboard/:id", get(dashboard_page_handler))
@@ -322,6 +374,7 @@ impl Reaction for DashboardReaction {
                             upgrade,
                             websocket_hub_for_route.clone(),
                             query_ids_for_route.clone(),
+                            ws_shutdown_for_route.clone(),
                         )
                     }),
                 )
@@ -334,7 +387,12 @@ impl Reaction for DashboardReaction {
                 .unwrap_or_else(|_| format!("{host}:{port}"));
             info!("dashboard server listening on {bound_addr}");
 
-            if let Err(err) = axum::serve(listener, app).await {
+            let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+                // Resolves when stop() sets the flag to `true`, or if the sender
+                // is dropped (treated as shutdown).
+                let _ = server_shutdown_rx.wait_for(|signalled| *signalled).await;
+            });
+            if let Err(err) = server.await {
                 error!("dashboard server error: {err}");
                 server_status_handle
                     .set_status(
@@ -344,13 +402,35 @@ impl Reaction for DashboardReaction {
                     .await;
             }
         });
-        self.task_handles.lock().await.push(server_handle);
+        *self.server_handle.lock().await = Some(server_handle);
 
         Ok(())
     }
 
     async fn stop(&self) -> anyhow::Result<()> {
         self.base.stop_common().await?;
+
+        // Signal the HTTP/WebSocket server to shut down gracefully. This stops
+        // accepting new connections AND closes idle keep-alive connections and
+        // active WebSockets, so a browser tab pointed at the old server can't
+        // reuse a pooled connection on refresh (otherwise the new reaction is
+        // shadowed by orphaned connection tasks from the old one).
+        let _ = self.shutdown_tx.send(true);
+
+        // Give the server a bounded window to drain and close connections, then
+        // abort it as a fallback if graceful shutdown stalls.
+        if let Some(mut handle) = self.server_handle.lock().await.take() {
+            if tokio::time::timeout(Duration::from_secs(5), &mut handle)
+                .await
+                .is_err()
+            {
+                debug!(
+                    "[{}] dashboard server did not shut down within timeout; aborting",
+                    self.base.id
+                );
+                handle.abort();
+            }
+        }
 
         let mut task_handles = self.task_handles.lock().await;
         for handle in task_handles.drain(..) {

--- a/components/reactions/dashboard/src/dashboard.rs
+++ b/components/reactions/dashboard/src/dashboard.rs
@@ -117,11 +117,8 @@ fn serve_asset(path: &str) -> Response {
             // from its in-memory cache after the reaction is restarted.
             (
                 [
-                    (header::CONTENT_TYPE, mime.to_string()),
-                    (
-                        header::CACHE_CONTROL,
-                        "no-cache, no-store, must-revalidate".to_string(),
-                    ),
+                    (header::CONTENT_TYPE, mime),
+                    (header::CACHE_CONTROL, "no-cache, no-store, must-revalidate"),
                 ],
                 content.data.into_owned(),
             )

--- a/components/reactions/dashboard/src/tests.rs
+++ b/components/reactions/dashboard/src/tests.rs
@@ -800,7 +800,7 @@ async fn test_snapshot_store_delete_row() {
         .await;
     let snapshot = store.get_snapshot("q1").await;
     assert_eq!(snapshot.rows.len(), 1);
-    assert_eq!(snapshot.rows[0]["id"], 2);
+    assert_eq!(snapshot.rows[0].data["id"], 2);
 }
 
 #[tokio::test]
@@ -829,7 +829,7 @@ async fn test_snapshot_store_update_row() {
         .await;
     let snapshot = store.get_snapshot("q1").await;
     assert_eq!(snapshot.rows.len(), 1);
-    assert_eq!(snapshot.rows[0]["name"], "Alicia");
+    assert_eq!(snapshot.rows[0].data["name"], "Alicia");
 }
 
 #[tokio::test]
@@ -862,8 +862,8 @@ async fn test_snapshot_store_fifo_eviction_rows_only() {
     let snapshot = store.get_snapshot("q1").await;
     // Should keep only 2 newest rows (evict id:1)
     assert_eq!(snapshot.rows.len(), 2);
-    assert_eq!(snapshot.rows[0]["id"], 2);
-    assert_eq!(snapshot.rows[1]["id"], 3);
+    assert_eq!(snapshot.rows[0].data["id"], 2);
+    assert_eq!(snapshot.rows[1].data["id"], 3);
     // Aggregation must NOT be evicted
     assert_eq!(snapshot.aggregation, Some(serde_json::json!({"total": 6})));
 }
@@ -914,10 +914,86 @@ async fn test_snapshot_serialization_format() {
         .await;
     let snapshot = store.get_snapshot("q1").await;
     let json = serde_json::to_value(&snapshot).unwrap();
-    // Verify the JSON structure the frontend expects
+    // Verify the JSON structure the frontend expects: rows are { k, v } envelopes
+    // carrying the row_signature so the client can key by identity.
     assert!(json["rows"].is_array());
     assert_eq!(json["rows"].as_array().unwrap().len(), 1);
+    assert_eq!(json["rows"][0]["v"]["id"], 1);
+    assert_eq!(json["rows"][0]["k"], 0);
     assert_eq!(json["aggregation"]["total"], 42);
+}
+
+#[tokio::test]
+async fn test_snapshot_store_add_upserts_by_row_signature() {
+    // With a real row_signature and no `id` field, an `add` for the same
+    // signature must upsert (the canonical identity, independent of `id`).
+    let store = QuerySnapshotStore::new();
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"location": "Parking"}),
+                row_signature: 7777,
+            }],
+        ))
+        .await;
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"location": "Curbside"}),
+                row_signature: 7777,
+            }],
+        ))
+        .await;
+    let snapshot = store.get_snapshot("q1").await;
+    assert_eq!(snapshot.rows.len(), 1, "same signature must upsert");
+    assert_eq!(snapshot.rows[0].data["location"], "Curbside");
+    assert_eq!(snapshot.rows[0].row_signature, 7777);
+}
+
+#[tokio::test]
+async fn test_snapshot_store_seeded_signature_then_add_upserts() {
+    // Seed with a signature, then a live add for the same signature upserts even
+    // though the rows carry no `id` column (the #605 plugin scenario).
+    let store = QuerySnapshotStore::new();
+    store
+        .seed_rows("q1", vec![(42, serde_json::json!({"location": "Parking"}))])
+        .await;
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"location": "Curbside"}),
+                row_signature: 42,
+            }],
+        ))
+        .await;
+    let snapshot = store.get_snapshot("q1").await;
+    assert_eq!(snapshot.rows.len(), 1);
+    assert_eq!(snapshot.rows[0].data["location"], "Curbside");
+}
+
+#[tokio::test]
+async fn test_snapshot_store_distinct_signatures_append() {
+    let store = QuerySnapshotStore::new();
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![
+                ResultDiff::Add {
+                    data: serde_json::json!({"v": 1}),
+                    row_signature: 1,
+                },
+                ResultDiff::Add {
+                    data: serde_json::json!({"v": 2}),
+                    row_signature: 2,
+                },
+            ],
+        ))
+        .await;
+    let snapshot = store.get_snapshot("q1").await;
+    assert_eq!(snapshot.rows.len(), 2);
 }
 
 // -----------------------------------------------------------------------
@@ -951,7 +1027,7 @@ async fn test_snapshot_store_add_upserts_existing_id() {
 
     let snapshot = store.get_snapshot("q1").await;
     assert_eq!(snapshot.rows.len(), 1, "duplicate row was appended");
-    assert_eq!(snapshot.rows[0]["location"], "Curbside");
+    assert_eq!(snapshot.rows[0].data["location"], "Curbside");
 }
 
 #[tokio::test]
@@ -983,8 +1059,8 @@ async fn test_snapshot_store_seed_rows_populates_store() {
         .seed_rows(
             "q1",
             vec![
-                serde_json::json!({"id": "A1234", "location": "Parking"}),
-                serde_json::json!({"id": "B5678", "location": "Parking"}),
+                (0, serde_json::json!({"id": "A1234", "location": "Parking"})),
+                (0, serde_json::json!({"id": "B5678", "location": "Parking"})),
             ],
         )
         .await;
@@ -1002,7 +1078,7 @@ async fn test_snapshot_store_seeded_row_then_add_upserts() {
     store
         .seed_rows(
             "q1",
-            vec![serde_json::json!({"id": "A1234", "location": "Parking"})],
+            vec![(0, serde_json::json!({"id": "A1234", "location": "Parking"}))],
         )
         .await;
     store
@@ -1017,7 +1093,7 @@ async fn test_snapshot_store_seeded_row_then_add_upserts() {
 
     let snapshot = store.get_snapshot("q1").await;
     assert_eq!(snapshot.rows.len(), 1);
-    assert_eq!(snapshot.rows[0]["location"], "Curbside");
+    assert_eq!(snapshot.rows[0].data["location"], "Curbside");
 }
 
 #[tokio::test]
@@ -1037,8 +1113,8 @@ async fn test_snapshot_store_seed_rows_does_not_overwrite_existing() {
         .seed_rows(
             "q1",
             vec![
-                serde_json::json!({"id": "A1234", "location": "Parking"}),
-                serde_json::json!({"id": "B5678", "location": "Parking"}),
+                (0, serde_json::json!({"id": "A1234", "location": "Parking"})),
+                (0, serde_json::json!({"id": "B5678", "location": "Parking"})),
             ],
         )
         .await;
@@ -1048,7 +1124,10 @@ async fn test_snapshot_store_seed_rows_does_not_overwrite_existing() {
     let a = snapshot
         .rows
         .iter()
-        .find(|r| r["id"] == "A1234")
+        .find(|r| r.data["id"] == "A1234")
         .expect("A1234 present");
-    assert_eq!(a["location"], "Curbside", "stale seed overwrote live data");
+    assert_eq!(
+        a.data["location"], "Curbside",
+        "stale seed overwrote live data"
+    );
 }

--- a/components/reactions/dashboard/src/tests.rs
+++ b/components/reactions/dashboard/src/tests.rs
@@ -919,7 +919,7 @@ async fn test_snapshot_serialization_format() {
     assert!(json["rows"].is_array());
     assert_eq!(json["rows"].as_array().unwrap().len(), 1);
     assert_eq!(json["rows"][0]["v"]["id"], 1);
-    assert_eq!(json["rows"][0]["k"], 0);
+    assert_eq!(json["rows"][0]["k"], "0");
     assert_eq!(json["aggregation"]["total"], 42);
 }
 

--- a/components/reactions/dashboard/src/tests.rs
+++ b/components/reactions/dashboard/src/tests.rs
@@ -1131,3 +1131,35 @@ async fn test_snapshot_store_seed_rows_does_not_overwrite_existing() {
         "stale seed overwrote live data"
     );
 }
+
+#[tokio::test]
+async fn test_snapshot_store_sig0_seed_then_real_signature_upserts() {
+    // FFI backward-compat path: a row may be seeded with signature 0 (id known),
+    // then a live diff arrives carrying the real engine signature. The signature
+    // search must fall through to id/equality so the row is replaced, not
+    // duplicated.
+    let store = QuerySnapshotStore::new();
+    store
+        .seed_rows(
+            "q1",
+            vec![(0, serde_json::json!({"id": "A1234", "location": "Parking"}))],
+        )
+        .await;
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": "A1234", "location": "Curbside"}),
+                row_signature: 42,
+            }],
+        ))
+        .await;
+
+    let snapshot = store.get_snapshot("q1").await;
+    assert_eq!(
+        snapshot.rows.len(),
+        1,
+        "real-signature diff must replace the sig-0 seeded row, not duplicate it"
+    );
+    assert_eq!(snapshot.rows[0].data["location"], "Curbside");
+}

--- a/components/reactions/dashboard/src/tests.rs
+++ b/components/reactions/dashboard/src/tests.rs
@@ -919,3 +919,136 @@ async fn test_snapshot_serialization_format() {
     assert_eq!(json["rows"].as_array().unwrap().len(), 1);
     assert_eq!(json["aggregation"]["total"], 42);
 }
+
+// -----------------------------------------------------------------------
+// Upsert-on-add and bootstrap seeding (issue #605)
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_snapshot_store_add_upserts_existing_id() {
+    // An `add` for a row whose `id` already exists must replace it (upsert),
+    // not append a duplicate. This is the core of issue #605: the MSSQL source
+    // delivers the first post-bootstrap change to an existing row as `op: add`.
+    let store = QuerySnapshotStore::new();
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": "A1234", "location": "Parking"}),
+                row_signature: 0,
+            }],
+        ))
+        .await;
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": "A1234", "location": "Curbside"}),
+                row_signature: 0,
+            }],
+        ))
+        .await;
+
+    let snapshot = store.get_snapshot("q1").await;
+    assert_eq!(snapshot.rows.len(), 1, "duplicate row was appended");
+    assert_eq!(snapshot.rows[0]["location"], "Curbside");
+}
+
+#[tokio::test]
+async fn test_snapshot_store_add_appends_distinct_ids() {
+    let store = QuerySnapshotStore::new();
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![
+                ResultDiff::Add {
+                    data: serde_json::json!({"id": "A", "v": 1}),
+                    row_signature: 0,
+                },
+                ResultDiff::Add {
+                    data: serde_json::json!({"id": "B", "v": 2}),
+                    row_signature: 0,
+                },
+            ],
+        ))
+        .await;
+    let snapshot = store.get_snapshot("q1").await;
+    assert_eq!(snapshot.rows.len(), 2);
+}
+
+#[tokio::test]
+async fn test_snapshot_store_seed_rows_populates_store() {
+    let store = QuerySnapshotStore::new();
+    store
+        .seed_rows(
+            "q1",
+            vec![
+                serde_json::json!({"id": "A1234", "location": "Parking"}),
+                serde_json::json!({"id": "B5678", "location": "Parking"}),
+            ],
+        )
+        .await;
+
+    let snapshot = store.get_snapshot("q1").await;
+    assert_eq!(snapshot.rows.len(), 2);
+    assert!(store.has_data("q1").await);
+}
+
+#[tokio::test]
+async fn test_snapshot_store_seeded_row_then_add_upserts() {
+    // The end-to-end #605 scenario: bootstrap seeds a row, then the first
+    // post-bootstrap change arrives as `op: add` and must replace, not duplicate.
+    let store = QuerySnapshotStore::new();
+    store
+        .seed_rows(
+            "q1",
+            vec![serde_json::json!({"id": "A1234", "location": "Parking"})],
+        )
+        .await;
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": "A1234", "location": "Curbside"}),
+                row_signature: 0,
+            }],
+        ))
+        .await;
+
+    let snapshot = store.get_snapshot("q1").await;
+    assert_eq!(snapshot.rows.len(), 1);
+    assert_eq!(snapshot.rows[0]["location"], "Curbside");
+}
+
+#[tokio::test]
+async fn test_snapshot_store_seed_rows_does_not_overwrite_existing() {
+    // Seeding must not clobber newer live data that already arrived for a key.
+    let store = QuerySnapshotStore::new();
+    store
+        .apply(&make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"id": "A1234", "location": "Curbside"}),
+                row_signature: 0,
+            }],
+        ))
+        .await;
+    store
+        .seed_rows(
+            "q1",
+            vec![
+                serde_json::json!({"id": "A1234", "location": "Parking"}),
+                serde_json::json!({"id": "B5678", "location": "Parking"}),
+            ],
+        )
+        .await;
+
+    let snapshot = store.get_snapshot("q1").await;
+    assert_eq!(snapshot.rows.len(), 2);
+    let a = snapshot
+        .rows
+        .iter()
+        .find(|r| r["id"] == "A1234")
+        .expect("A1234 present");
+    assert_eq!(a["location"], "Curbside", "stale seed overwrote live data");
+}

--- a/components/reactions/dashboard/src/websocket.rs
+++ b/components/reactions/dashboard/src/websocket.rs
@@ -37,6 +37,10 @@ pub enum ClientMessage {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WebSocketResultDiff {
     pub op: String,
+    /// The row's engine-stamped `row_signature` — the canonical row identity.
+    /// Serialized as `k`; `0` means unknown (clients fall back to id/equality).
+    #[serde(rename = "k", default)]
+    pub row_signature: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -94,15 +98,23 @@ impl HubMessage {
             .results
             .iter()
             .map(|result_diff| match result_diff {
-                ResultDiff::Add { data, .. } => WebSocketResultDiff {
+                ResultDiff::Add {
+                    data,
+                    row_signature,
+                } => WebSocketResultDiff {
                     op: "add".to_string(),
+                    row_signature: *row_signature,
                     data: Some(data.clone()),
                     before: None,
                     after: None,
                     grouping_keys: None,
                 },
-                ResultDiff::Delete { data, .. } => WebSocketResultDiff {
+                ResultDiff::Delete {
+                    data,
+                    row_signature,
+                } => WebSocketResultDiff {
                     op: "delete".to_string(),
+                    row_signature: *row_signature,
                     data: Some(data.clone()),
                     before: None,
                     after: None,
@@ -113,16 +125,22 @@ impl HubMessage {
                     before,
                     after,
                     grouping_keys,
-                    ..
+                    row_signature,
                 } => WebSocketResultDiff {
                     op: "update".to_string(),
+                    row_signature: *row_signature,
                     data: Some(data.clone()),
                     before: Some(before.clone()),
                     after: Some(after.clone()),
                     grouping_keys: grouping_keys.clone(),
                 },
-                ResultDiff::Aggregation { before, after, .. } => WebSocketResultDiff {
+                ResultDiff::Aggregation {
+                    before,
+                    after,
+                    row_signature,
+                } => WebSocketResultDiff {
                     op: "aggregation".to_string(),
+                    row_signature: *row_signature,
                     data: None,
                     before: before.clone(),
                     after: Some(after.clone()),
@@ -130,6 +148,7 @@ impl HubMessage {
                 },
                 ResultDiff::Noop => WebSocketResultDiff {
                     op: "noop".to_string(),
+                    row_signature: 0,
                     data: None,
                     before: None,
                     after: None,
@@ -178,10 +197,22 @@ impl WebSocketHub {
     }
 }
 
+/// A single accumulated snapshot row paired with its canonical identity.
+///
+/// `row_signature` is the engine-stamped identity (`0` when unknown, in which
+/// case matching falls back to an `id`/equality heuristic on `data`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SnapshotRow {
+    #[serde(rename = "k", default)]
+    pub row_signature: u64,
+    #[serde(rename = "v")]
+    pub data: Value,
+}
+
 /// Snapshot of accumulated query results, separating rows from aggregation state.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct QuerySnapshot {
-    pub rows: Vec<Value>,
+    pub rows: Vec<SnapshotRow>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregation: Option<Value>,
 }
@@ -224,26 +255,41 @@ impl QuerySnapshotStore {
 
         for diff in &query_result.results {
             match diff {
-                ResultDiff::Add { data, .. } => {
+                ResultDiff::Add {
+                    data,
+                    row_signature,
+                } => {
                     // Insert-of-an-existing-element is an upsert in drasi: replace
-                    // an existing row with the same key instead of appending a
+                    // an existing row with the same identity instead of appending a
                     // duplicate (see issue #605).
-                    if let Some(idx) = find_row_index(&snapshot.rows, data) {
-                        snapshot.rows[idx] = data.clone();
-                    } else {
-                        snapshot.rows.push(data.clone());
-                    }
+                    upsert_row(&mut snapshot.rows, *row_signature, data);
                 }
-                ResultDiff::Delete { data, .. } => {
-                    if let Some(idx) = find_row_index(&snapshot.rows, data) {
+                ResultDiff::Delete {
+                    data,
+                    row_signature,
+                } => {
+                    if let Some(idx) = find_row_index(&snapshot.rows, *row_signature, data) {
                         snapshot.rows.remove(idx);
                     }
                 }
-                ResultDiff::Update { before, after, .. } => {
-                    if let Some(idx) = find_row_index(&snapshot.rows, before) {
-                        snapshot.rows[idx] = after.clone();
+                ResultDiff::Update {
+                    before,
+                    after,
+                    row_signature,
+                    ..
+                } => {
+                    // The row_signature is stable across an update; match on it,
+                    // falling back to the `before` payload when it is unknown.
+                    if let Some(idx) = find_row_index(&snapshot.rows, *row_signature, before) {
+                        snapshot.rows[idx] = SnapshotRow {
+                            row_signature: *row_signature,
+                            data: after.clone(),
+                        };
                     } else {
-                        snapshot.rows.push(after.clone());
+                        snapshot.rows.push(SnapshotRow {
+                            row_signature: *row_signature,
+                            data: after.clone(),
+                        });
                     }
                 }
                 ResultDiff::Aggregation { after, .. } => {
@@ -264,19 +310,23 @@ impl QuerySnapshotStore {
     ///
     /// Used to populate the store from the initial bootstrap snapshot so the live
     /// WebSocket stream starts from the same baseline the fallback fetcher reads
-    /// (see issue #605). To avoid clobbering newer live data that may have already
-    /// arrived, this only inserts rows whose key is not already present; existing
-    /// rows are left untouched. Respects `max_rows_per_query`.
-    pub async fn seed_rows(&self, query_id: &str, rows: Vec<Value>) {
+    /// (see issue #605). Rows carry their `row_signature` so subsequent live diffs
+    /// match them by identity. To avoid clobbering newer live data that may have
+    /// already arrived, this only inserts rows whose identity is not already
+    /// present; existing rows are left untouched. Respects `max_rows_per_query`.
+    pub async fn seed_rows(&self, query_id: &str, rows: Vec<(u64, Value)>) {
         if rows.is_empty() {
             return;
         }
         let mut snapshots = self.snapshots.write().await;
         let snapshot = snapshots.entry(query_id.to_string()).or_default();
 
-        for row in rows {
-            if find_row_index(&snapshot.rows, &row).is_none() {
-                snapshot.rows.push(row);
+        for (row_signature, data) in rows {
+            if find_row_index(&snapshot.rows, row_signature, &data).is_none() {
+                snapshot.rows.push(SnapshotRow {
+                    row_signature,
+                    data,
+                });
             }
         }
 
@@ -303,12 +353,35 @@ impl QuerySnapshotStore {
     }
 }
 
-fn find_row_index(rows: &[Value], target: &Value) -> Option<usize> {
-    // Match by "id" field if present, otherwise by full equality.
-    if let Some(target_id) = target.get("id") {
-        rows.iter().position(|r| r.get("id") == Some(target_id))
+/// Insert or replace a row by its identity.
+fn upsert_row(rows: &mut Vec<SnapshotRow>, row_signature: u64, data: &Value) {
+    if let Some(idx) = find_row_index(rows, row_signature, data) {
+        rows[idx] = SnapshotRow {
+            row_signature,
+            data: data.clone(),
+        };
     } else {
-        rows.iter().position(|r| r == target)
+        rows.push(SnapshotRow {
+            row_signature,
+            data: data.clone(),
+        });
+    }
+}
+
+/// Find a row by its canonical identity.
+///
+/// Matches on `row_signature` (the engine-stamped identity) when it is known
+/// (non-zero); otherwise falls back to matching by the `id` field, then by full
+/// data equality.
+fn find_row_index(rows: &[SnapshotRow], row_signature: u64, data: &Value) -> Option<usize> {
+    if row_signature != 0 {
+        return rows.iter().position(|r| r.row_signature == row_signature);
+    }
+    if let Some(target_id) = data.get("id") {
+        rows.iter()
+            .position(|r| r.data.get("id") == Some(target_id))
+    } else {
+        rows.iter().position(|r| &r.data == data)
     }
 }
 

--- a/components/reactions/dashboard/src/websocket.rs
+++ b/components/reactions/dashboard/src/websocket.rs
@@ -371,11 +371,16 @@ fn upsert_row(rows: &mut Vec<SnapshotRow>, row_signature: u64, data: &Value) {
 /// Find a row by its canonical identity.
 ///
 /// Matches on `row_signature` (the engine-stamped identity) when it is known
-/// (non-zero); otherwise falls back to matching by the `id` field, then by full
-/// data equality.
+/// (non-zero); otherwise — or when the signature search misses (e.g. a row was
+/// seeded with signature `0` via the FFI backward-compat fallback) — falls back
+/// to matching by the `id` field, then by full data equality.
 fn find_row_index(rows: &[SnapshotRow], row_signature: u64, data: &Value) -> Option<usize> {
     if row_signature != 0 {
-        return rows.iter().position(|r| r.row_signature == row_signature);
+        if let Some(idx) = rows.iter().position(|r| r.row_signature == row_signature) {
+            return Some(idx);
+        }
+        // Fall through: a previously-seeded row may carry signature 0, so match
+        // it by id/equality rather than appending a duplicate.
     }
     if let Some(target_id) = data.get("id") {
         rows.iter()

--- a/components/reactions/dashboard/src/websocket.rs
+++ b/components/reactions/dashboard/src/websocket.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::{broadcast, RwLock};
+use tokio::sync::{broadcast, watch, RwLock};
 
 /// Supported client-to-server WebSocket messages.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -225,7 +225,14 @@ impl QuerySnapshotStore {
         for diff in &query_result.results {
             match diff {
                 ResultDiff::Add { data, .. } => {
-                    snapshot.rows.push(data.clone());
+                    // Insert-of-an-existing-element is an upsert in drasi: replace
+                    // an existing row with the same key instead of appending a
+                    // duplicate (see issue #605).
+                    if let Some(idx) = find_row_index(&snapshot.rows, data) {
+                        snapshot.rows[idx] = data.clone();
+                    } else {
+                        snapshot.rows.push(data.clone());
+                    }
                 }
                 ResultDiff::Delete { data, .. } => {
                     if let Some(idx) = find_row_index(&snapshot.rows, data) {
@@ -243,6 +250,33 @@ impl QuerySnapshotStore {
                     snapshot.aggregation = Some(after.clone());
                 }
                 ResultDiff::Noop => {}
+            }
+        }
+
+        // Evict oldest rows if over limit (FIFO)
+        if snapshot.rows.len() > self.max_rows_per_query {
+            let excess = snapshot.rows.len() - self.max_rows_per_query;
+            snapshot.rows.drain(..excess);
+        }
+    }
+
+    /// Seed the accumulated snapshot for a query with bootstrap rows.
+    ///
+    /// Used to populate the store from the initial bootstrap snapshot so the live
+    /// WebSocket stream starts from the same baseline the fallback fetcher reads
+    /// (see issue #605). To avoid clobbering newer live data that may have already
+    /// arrived, this only inserts rows whose key is not already present; existing
+    /// rows are left untouched. Respects `max_rows_per_query`.
+    pub async fn seed_rows(&self, query_id: &str, rows: Vec<Value>) {
+        if rows.is_empty() {
+            return;
+        }
+        let mut snapshots = self.snapshots.write().await;
+        let snapshot = snapshots.entry(query_id.to_string()).or_default();
+
+        for row in rows {
+            if find_row_index(&snapshot.rows, &row).is_none() {
+                snapshot.rows.push(row);
             }
         }
 
@@ -291,11 +325,17 @@ pub async fn ws_upgrade(
     ws: WebSocketUpgrade,
     hub: WebSocketHub,
     query_ids: Vec<String>,
+    shutdown_rx: watch::Receiver<bool>,
 ) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_socket(socket, hub, query_ids))
+    ws.on_upgrade(move |socket| handle_socket(socket, hub, query_ids, shutdown_rx))
 }
 
-async fn handle_socket(socket: WebSocket, hub: WebSocketHub, query_ids: Vec<String>) {
+async fn handle_socket(
+    socket: WebSocket,
+    hub: WebSocketHub,
+    query_ids: Vec<String>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
     let (mut sender, mut receiver) = socket.split();
     let mut hub_receiver = hub.subscribe();
 
@@ -382,6 +422,12 @@ async fn handle_socket(socket: WebSocket, hub: WebSocketHub, query_ids: Vec<Stri
     tokio::select! {
         _ = &mut send_task => receive_task.abort(),
         _ = &mut receive_task => send_task.abort(),
+        // Server shutdown: terminate both tasks so the connection closes and the
+        // axum graceful-shutdown can complete promptly.
+        _ = shutdown_rx.wait_for(|signalled| *signalled) => {
+            send_task.abort();
+            receive_task.abort();
+        }
     }
 }
 

--- a/components/reactions/dashboard/src/websocket.rs
+++ b/components/reactions/dashboard/src/websocket.rs
@@ -19,11 +19,38 @@ use axum::response::IntoResponse;
 use drasi_lib::channels::{QueryResult, ResultDiff};
 use futures::{SinkExt, StreamExt};
 use log::{debug, error, warn};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::{broadcast, watch, RwLock};
+
+/// Serialize a `row_signature` (`u64`) as a JSON **string**.
+///
+/// JavaScript `Number` only represents integers exactly up to 2^53−1, but
+/// `row_signature` is a full 64-bit hash. Sending it as a string preserves all
+/// 64 bits so the browser can compare identities without precision loss.
+fn serialize_row_signature<S: Serializer>(value: &u64, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&value.to_string())
+}
+
+/// Deserialize a `row_signature` from either a JSON string or number.
+///
+/// Strings are the canonical form (see [`serialize_row_signature`]); numbers are
+/// accepted for resilience.
+fn deserialize_row_signature<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+    use serde::de::Error as _;
+    match Value::deserialize(deserializer)? {
+        Value::String(s) => s.parse::<u64>().map_err(D::Error::custom),
+        Value::Number(n) => n
+            .as_u64()
+            .ok_or_else(|| D::Error::custom("row_signature is not a u64")),
+        Value::Null => Ok(0),
+        other => Err(D::Error::custom(format!(
+            "unexpected row_signature type: {other}"
+        ))),
+    }
+}
 
 /// Supported client-to-server WebSocket messages.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -38,8 +65,14 @@ pub enum ClientMessage {
 pub struct WebSocketResultDiff {
     pub op: String,
     /// The row's engine-stamped `row_signature` — the canonical row identity.
-    /// Serialized as `k`; `0` means unknown (clients fall back to id/equality).
-    #[serde(rename = "k", default)]
+    /// Serialized as `k` (a JSON string to preserve all 64 bits in the browser);
+    /// `0` means unknown (clients fall back to id/equality).
+    #[serde(
+        rename = "k",
+        default,
+        serialize_with = "serialize_row_signature",
+        deserialize_with = "deserialize_row_signature"
+    )]
     pub row_signature: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
@@ -203,7 +236,12 @@ impl WebSocketHub {
 /// case matching falls back to an `id`/equality heuristic on `data`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct SnapshotRow {
-    #[serde(rename = "k", default)]
+    #[serde(
+        rename = "k",
+        default,
+        serialize_with = "serialize_row_signature",
+        deserialize_with = "deserialize_row_signature"
+    )]
     pub row_signature: u64,
     #[serde(rename = "v")]
     pub data: Value,
@@ -246,6 +284,11 @@ impl QuerySnapshotStore {
             snapshots: Arc::new(RwLock::new(HashMap::new())),
             max_rows_per_query: max_rows,
         }
+    }
+
+    /// The configured per-query row cap.
+    pub fn max_rows_per_query(&self) -> usize {
+        self.max_rows_per_query
     }
 
     /// Apply a query result's diffs to the accumulated snapshot.
@@ -577,5 +620,28 @@ mod tests {
         assert_eq!(parsed["results"][0]["op"], "add");
         assert_eq!(parsed["results"][1]["op"], "update");
         assert_eq!(parsed["results"][2]["op"], "delete");
+        // row_signature is serialized as a string under `k` (64-bit precision-safe).
+        assert_eq!(parsed["results"][0]["k"], "0");
+    }
+
+    #[test]
+    fn test_row_signature_serialized_as_string_roundtrips() {
+        let big = 12_345_678_901_234_567_890u64; // > 2^53, would lose precision as a JSON number
+        let diff = WebSocketResultDiff {
+            op: "add".to_string(),
+            row_signature: big,
+            data: Some(serde_json::json!({"id": 1})),
+            before: None,
+            after: None,
+            grouping_keys: None,
+        };
+        let json = serde_json::to_value(&diff).unwrap();
+        assert_eq!(json["k"], serde_json::Value::String(big.to_string()));
+        let back: WebSocketResultDiff = serde_json::from_value(json).unwrap();
+        assert_eq!(back.row_signature, big);
+        // Also accepts a numeric form on the wire for resilience.
+        let from_num: WebSocketResultDiff =
+            serde_json::from_str(r#"{"op":"add","k":42,"data":{"id":1}}"#).unwrap();
+        assert_eq!(from_num.row_signature, 42);
     }
 }

--- a/components/reactions/dashboard/static/css/app.css
+++ b/components/reactions/dashboard/static/css/app.css
@@ -559,6 +559,16 @@ p { margin: 0.5em 0; }
   grid-template-columns: 260px 1fr;
   gap: 16px;
   min-height: calc(100vh - 160px);
+  position: relative;
+}
+
+/* Collapsed: hide the sidebar and give the canvas full width. */
+.editor-layout.sidebar-collapsed {
+  grid-template-columns: 1fr;
+}
+
+.editor-layout.sidebar-collapsed .editor-sidebar {
+  display: none;
 }
 
 .editor-sidebar {
@@ -569,6 +579,53 @@ p { margin: 0.5em 0; }
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sidebar-header .dashboard-name-editable {
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-toggle-btn,
+.sidebar-expand-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.sidebar-toggle-btn:hover,
+.sidebar-expand-btn:hover {
+  background: var(--accent-muted);
+  color: var(--accent);
+}
+
+/* Floating "show panel" button, only visible when collapsed. */
+.sidebar-expand-btn {
+  display: none;
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 5;
+}
+
+.editor-layout.sidebar-collapsed .sidebar-expand-btn {
+  display: inline-flex;
 }
 
 .sidebar-section-title {

--- a/components/reactions/dashboard/static/index.html
+++ b/components/reactions/dashboard/static/index.html
@@ -62,9 +62,9 @@
           Save
         </button>
       </div>
-      <div class="editor-layout">
-        <aside class="editor-sidebar">
-          <div>
+      <div class="editor-layout" id="editor-layout">
+        <aside class="editor-sidebar" id="editor-sidebar">
+          <div class="sidebar-header">
             <input
               type="text"
               id="editor-title"
@@ -72,6 +72,9 @@
               placeholder="Dashboard name"
               value="Dashboard"
             />
+            <button id="sidebar-collapse-btn" type="button" class="sidebar-toggle-btn" title="Collapse panel" aria-label="Collapse panel" aria-expanded="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+            </button>
           </div>
           <div>
             <div class="sidebar-section-title">Available Queries</div>
@@ -82,6 +85,9 @@
             <strong>⚙</strong> icon on any widget to configure it.
           </p>
         </aside>
+        <button id="sidebar-expand-btn" type="button" class="sidebar-expand-btn" title="Show panel" aria-label="Show panel">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
         <div class="editor-canvas">
           <div class="grid-stack" id="dashboard-grid"></div>
         </div>

--- a/components/reactions/dashboard/static/js/app.js
+++ b/components/reactions/dashboard/static/js/app.js
@@ -2,7 +2,7 @@ import { DashboardDesigner } from "./dashboard.js";
 import { DashboardSocket } from "./websocket.js";
 import { promptModal, confirmModal, showToast } from "./modal.js";
 import { initTheme, toggleTheme } from "./theme.js";
-import { reThemeAllCharts } from "./widgets.js";
+import { reThemeAllCharts, resizeAllCharts } from "./widgets.js";
 
 // ─── Theme ──────────────────────────────────────────────────
 initTheme();
@@ -23,6 +23,11 @@ const newDashboardButton = document.getElementById("new-dashboard-btn");
 const backButton = document.getElementById("back-btn");
 const saveButton = document.getElementById("save-dashboard-btn");
 const addWidgetButton = document.getElementById("add-widget-btn");
+const editorLayout = document.getElementById("editor-layout");
+const sidebarCollapseButton = document.getElementById("sidebar-collapse-btn");
+const sidebarExpandButton = document.getElementById("sidebar-expand-btn");
+
+const SIDEBAR_COLLAPSED_KEY = "drasi-dashboard-sidebar-collapsed";
 
 // ─── State ──────────────────────────────────────────────────
 const designer = new DashboardDesigner("dashboard-grid");
@@ -63,6 +68,33 @@ function showListView() {
 function showEditorView() {
   editorView.classList.add("active");
   listView.classList.remove("active");
+}
+
+// ─── Sidebar Collapse ───────────────────────────────────────
+function applySidebarCollapsed(collapsed) {
+  editorLayout.classList.toggle("sidebar-collapsed", collapsed);
+  sidebarCollapseButton.setAttribute("aria-expanded", String(!collapsed));
+  // Let the layout settle, then reflow charts to the new canvas width.
+  window.setTimeout(() => resizeAllCharts(), 50);
+}
+
+function setSidebarCollapsed(collapsed) {
+  try {
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
+  } catch (error) {
+    // Ignore storage errors (e.g. private mode); collapse still works in-session.
+  }
+  applySidebarCollapsed(collapsed);
+}
+
+function initSidebarCollapsed() {
+  let collapsed = false;
+  try {
+    collapsed = localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1";
+  } catch (error) {
+    collapsed = false;
+  }
+  applySidebarCollapsed(collapsed);
 }
 
 // ─── Socket Status ──────────────────────────────────────────
@@ -251,6 +283,9 @@ function bindEvents() {
     designer.openWidgetPicker();
   });
 
+  sidebarCollapseButton.addEventListener("click", () => setSidebarCollapsed(true));
+  sidebarExpandButton.addEventListener("click", () => setSidebarCollapsed(false));
+
   designer.onChanged(async (dashboard) => {
     if (!dashboard) return;
     currentDashboard = dashboard;
@@ -271,6 +306,7 @@ function bootSocket() {
 async function init() {
   designer.init();
   bindEvents();
+  initSidebarCollapsed();
   bootSocket();
   await refreshQueryList();
   await refreshDashboards();

--- a/components/reactions/dashboard/static/js/dashboard.js
+++ b/components/reactions/dashboard/static/js/dashboard.js
@@ -9,6 +9,7 @@ import {
   AGGREGATION_MODES,
   resizeAllCharts,
   disposeWidgetChart,
+  snapshotRowToAddDiff,
 } from "./widgets.js";
 import { openModal, closeModal, showToast } from "./modal.js";
 
@@ -535,13 +536,7 @@ export class DashboardDesigner {
         // Only populate if the runtime has no data yet
         if (runtime.rows.length === 0 && runtime.aggregation === null) {
           for (const entry of rows) {
-            // Snapshot rows arrive as { k: row_signature, v: data }; pass the
-            // signature through so live diffs match by identity (issue #605).
-            const isEnvelope =
-              entry && typeof entry === "object" && "k" in entry && "v" in entry;
-            const data = isEnvelope ? entry.v : entry;
-            const k = isEnvelope ? entry.k : undefined;
-            applyResultDiff(runtime, { op: "add", data, k });
+            applyResultDiff(runtime, snapshotRowToAddDiff(entry));
           }
           if (aggregation !== null) {
             applyResultDiff(runtime, { op: "aggregation", after: aggregation });

--- a/components/reactions/dashboard/static/js/dashboard.js
+++ b/components/reactions/dashboard/static/js/dashboard.js
@@ -534,8 +534,12 @@ export class DashboardDesigner {
         const runtime = this.runtimeByWidgetId.get(widget.id) ?? createWidgetRuntime();
         // Only populate if the runtime has no data yet
         if (runtime.rows.length === 0 && runtime.aggregation === null) {
-          for (const row of rows) {
-            applyResultDiff(runtime, { op: "add", data: row });
+          for (const entry of rows) {
+            // Snapshot rows arrive as { k: row_signature, v: data }; pass the
+            // signature through so live diffs match by identity (issue #605).
+            const data = entry && typeof entry === "object" && "v" in entry ? entry.v : entry;
+            const k = entry && typeof entry === "object" ? entry.k : undefined;
+            applyResultDiff(runtime, { op: "add", data, k });
           }
           if (aggregation !== null) {
             applyResultDiff(runtime, { op: "aggregation", after: aggregation });

--- a/components/reactions/dashboard/static/js/dashboard.js
+++ b/components/reactions/dashboard/static/js/dashboard.js
@@ -537,8 +537,10 @@ export class DashboardDesigner {
           for (const entry of rows) {
             // Snapshot rows arrive as { k: row_signature, v: data }; pass the
             // signature through so live diffs match by identity (issue #605).
-            const data = entry && typeof entry === "object" && "v" in entry ? entry.v : entry;
-            const k = entry && typeof entry === "object" ? entry.k : undefined;
+            const isEnvelope =
+              entry && typeof entry === "object" && "k" in entry && "v" in entry;
+            const data = isEnvelope ? entry.v : entry;
+            const k = isEnvelope ? entry.k : undefined;
             applyResultDiff(runtime, { op: "add", data, k });
           }
           if (aggregation !== null) {

--- a/components/reactions/dashboard/static/js/widgets.js
+++ b/components/reactions/dashboard/static/js/widgets.js
@@ -322,14 +322,46 @@ export function createDefaultWidget(widgetType, index = 0) {
 
 // ─── Runtime data accumulation ──────────────────────────────
 
+// The engine stamps every row with a `row_signature` (delivered as `k`) that is
+// the canonical row identity. We key rows by it when known, attaching it to the
+// stored row object as a non-enumerable `__sig` so it never leaks into rendering
+// (templates, table columns, JSON). When the signature is unknown (0/absent) we
+// fall back to an `id`/equality heuristic.
+
+function rowSig(value) {
+  return typeof value === "number" && value > 0 ? value : 0;
+}
+
+function tagSig(row, sig) {
+  if (row && typeof row === "object" && sig) {
+    Object.defineProperty(row, "__sig", {
+      value: sig,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return row;
+}
+
 function rowKey(row) {
-  if (!row || typeof row !== "object") return JSON.stringify(row);
-  if (row.id !== undefined) return `id:${row.id}`;
+  if (row && typeof row === "object") {
+    const sig = rowSig(row.__sig);
+    if (sig) return `sig:${sig}`;
+    if (row.id !== undefined) return `id:${row.id}`;
+    return JSON.stringify(row);
+  }
   return JSON.stringify(row);
 }
 
-function findRowIndex(rows, ref) {
-  const key = rowKey(ref);
+// Identity key for an incoming diff payload, given its signature and data.
+function diffKey(sig, data) {
+  if (sig) return `sig:${sig}`;
+  if (data && typeof data === "object" && data.id !== undefined) return `id:${data.id}`;
+  return JSON.stringify(data);
+}
+
+function findRowIndexByKey(rows, key) {
   return rows.findIndex((r) => rowKey(r) === key);
 }
 
@@ -343,24 +375,29 @@ function normalizeDiffData(diff) {
 export function applyResultDiff(runtime, diff) {
   if (!runtime) return;
 
+  const sig = rowSig(diff.k ?? diff.row_signature);
+
   if (diff.op === "add") {
     const row = normalizeDiffData(diff);
-    if (row) {
-      // Insert-of-an-existing-element is an upsert in drasi: replace an existing
-      // row with the same key instead of appending a duplicate (see issue #605).
-      const idx = findRowIndex(runtime.rows, row);
-      if (idx >= 0) runtime.rows[idx] = row;
-      else runtime.rows.push(row);
-      runtime.latest = row;
-    }
+    if (!row) return;
+    // Insert-of-an-existing-element is an upsert in drasi: replace an existing
+    // row with the same identity instead of appending a duplicate (issue #605).
+    const idx = findRowIndexByKey(runtime.rows, diffKey(sig, row));
+    tagSig(row, sig);
+    if (idx >= 0) runtime.rows[idx] = row;
+    else runtime.rows.push(row);
+    runtime.latest = row;
     return;
   }
   if (diff.op === "update") {
     const after = normalizeDiffData(diff);
     if (!after) return;
-    // Try matching by `before` state first, then fall back to matching by `after` key
-    let idx = diff.before ? findRowIndex(runtime.rows, diff.before) : -1;
-    if (idx < 0) idx = findRowIndex(runtime.rows, after);
+    // row_signature is stable across an update; match by it first, then fall
+    // back to the `before` state, then the `after` key.
+    let idx = sig ? findRowIndexByKey(runtime.rows, `sig:${sig}`) : -1;
+    if (idx < 0 && diff.before) idx = findRowIndexByKey(runtime.rows, diffKey(0, diff.before));
+    if (idx < 0) idx = findRowIndexByKey(runtime.rows, diffKey(sig, after));
+    tagSig(after, sig);
     if (idx >= 0) runtime.rows[idx] = after;
     else runtime.rows.push(after);
     runtime.latest = after;
@@ -368,7 +405,7 @@ export function applyResultDiff(runtime, diff) {
   }
   if (diff.op === "delete") {
     const row = normalizeDiffData(diff);
-    const idx = findRowIndex(runtime.rows, row);
+    const idx = findRowIndexByKey(runtime.rows, diffKey(sig, row));
     if (idx >= 0) runtime.rows.splice(idx, 1);
     runtime.latest = runtime.rows.length > 0 ? runtime.rows[runtime.rows.length - 1] : null;
     return;

--- a/components/reactions/dashboard/static/js/widgets.js
+++ b/components/reactions/dashboard/static/js/widgets.js
@@ -365,6 +365,17 @@ function findRowIndexByKey(rows, key) {
   return rows.findIndex((r) => rowKey(r) === key);
 }
 
+// Locate a row matching an incoming diff. Matches on row_signature when known,
+// and falls back to the id/equality key when the signature search misses (e.g. a
+// row seeded with an unknown signature) so we replace rather than duplicate.
+function findRowIndexForDiff(rows, sig, data) {
+  if (sig) {
+    const idx = rows.findIndex((r) => rowSig(r.__sig) === sig);
+    if (idx >= 0) return idx;
+  }
+  return findRowIndexByKey(rows, diffKey(0, data));
+}
+
 function normalizeDiffData(diff) {
   if (diff.op === "add" || diff.op === "delete") return diff.data ?? null;
   if (diff.op === "update") return diff.after ?? diff.data ?? null;
@@ -375,14 +386,14 @@ function normalizeDiffData(diff) {
 export function applyResultDiff(runtime, diff) {
   if (!runtime) return;
 
-  const sig = rowSig(diff.k ?? diff.row_signature);
+  const sig = rowSig(diff.k);
 
   if (diff.op === "add") {
     const row = normalizeDiffData(diff);
     if (!row) return;
     // Insert-of-an-existing-element is an upsert in drasi: replace an existing
     // row with the same identity instead of appending a duplicate (issue #605).
-    const idx = findRowIndexByKey(runtime.rows, diffKey(sig, row));
+    const idx = findRowIndexForDiff(runtime.rows, sig, row);
     tagSig(row, sig);
     if (idx >= 0) runtime.rows[idx] = row;
     else runtime.rows.push(row);
@@ -394,9 +405,9 @@ export function applyResultDiff(runtime, diff) {
     if (!after) return;
     // row_signature is stable across an update; match by it first, then fall
     // back to the `before` state, then the `after` key.
-    let idx = sig ? findRowIndexByKey(runtime.rows, `sig:${sig}`) : -1;
+    let idx = sig ? runtime.rows.findIndex((r) => rowSig(r.__sig) === sig) : -1;
     if (idx < 0 && diff.before) idx = findRowIndexByKey(runtime.rows, diffKey(0, diff.before));
-    if (idx < 0) idx = findRowIndexByKey(runtime.rows, diffKey(sig, after));
+    if (idx < 0) idx = findRowIndexByKey(runtime.rows, diffKey(0, after));
     tagSig(after, sig);
     if (idx >= 0) runtime.rows[idx] = after;
     else runtime.rows.push(after);
@@ -405,7 +416,7 @@ export function applyResultDiff(runtime, diff) {
   }
   if (diff.op === "delete") {
     const row = normalizeDiffData(diff);
-    const idx = findRowIndexByKey(runtime.rows, diffKey(sig, row));
+    const idx = findRowIndexForDiff(runtime.rows, sig, row);
     if (idx >= 0) runtime.rows.splice(idx, 1);
     runtime.latest = runtime.rows.length > 0 ? runtime.rows[runtime.rows.length - 1] : null;
     return;

--- a/components/reactions/dashboard/static/js/widgets.js
+++ b/components/reactions/dashboard/static/js/widgets.js
@@ -329,7 +329,12 @@ export function createDefaultWidget(widgetType, index = 0) {
 // fall back to an `id`/equality heuristic.
 
 function rowSig(value) {
-  return typeof value === "number" && value > 0 ? value : 0;
+  // row_signature arrives as a string (`k`) to preserve all 64 bits; treat any
+  // non-empty, non-"0" string as a present signature. Numbers are accepted for
+  // resilience. Returns the signature (string or number) or 0 when unknown.
+  if (typeof value === "string") return value.length > 0 && value !== "0" ? value : 0;
+  if (typeof value === "number") return value > 0 ? value : 0;
+  return 0;
 }
 
 function tagSig(row, sig) {
@@ -381,6 +386,20 @@ function normalizeDiffData(diff) {
   if (diff.op === "update") return diff.after ?? diff.data ?? null;
   if (diff.op === "aggregation") return diff.after ?? null;
   return null;
+}
+
+// Convert a snapshot row from the REST API into a synthetic `add` diff.
+//
+// Snapshot rows arrive as a { k: row_signature, v: data } envelope; this threads
+// the signature through so a later live diff with the same signature upserts the
+// row instead of duplicating it (issue #605). Plain (pre-envelope) rows are passed
+// through with an unknown signature.
+export function snapshotRowToAddDiff(entry) {
+  const isEnvelope =
+    entry && typeof entry === "object" && "k" in entry && "v" in entry;
+  const data = isEnvelope ? entry.v : entry;
+  const k = isEnvelope ? entry.k : undefined;
+  return { op: "add", data, k };
 }
 
 export function applyResultDiff(runtime, diff) {

--- a/components/reactions/dashboard/static/js/widgets.js
+++ b/components/reactions/dashboard/static/js/widgets.js
@@ -345,7 +345,14 @@ export function applyResultDiff(runtime, diff) {
 
   if (diff.op === "add") {
     const row = normalizeDiffData(diff);
-    if (row) { runtime.rows.push(row); runtime.latest = row; }
+    if (row) {
+      // Insert-of-an-existing-element is an upsert in drasi: replace an existing
+      // row with the same key instead of appending a duplicate (see issue #605).
+      const idx = findRowIndex(runtime.rows, row);
+      if (idx >= 0) runtime.rows[idx] = row;
+      else runtime.rows.push(row);
+      runtime.latest = row;
+    }
     return;
   }
   if (diff.op === "update") {

--- a/components/reactions/dashboard/tests/apply_result_diff.test.js
+++ b/components/reactions/dashboard/tests/apply_result_diff.test.js
@@ -30,6 +30,7 @@ const widgetsSandbox = {
 
 // Strip ES module export/import syntax so it can run as a script in vm.
 const strippedSource = widgetsSource
+  .replace(/^export\s+\{[^}]*\};?\s*$/gm, "")
   .replace(/^export\s+/gm, "")
   .replace(/^import\s+.*$/gm, "");
 

--- a/components/reactions/dashboard/tests/apply_result_diff.test.js
+++ b/components/reactions/dashboard/tests/apply_result_diff.test.js
@@ -59,16 +59,60 @@ function newRuntime() {
 
 // ─── Tests ──────────────────────────────────────────────────────────
 
-console.log("\n=== applyResultDiff: upsert-on-add ===");
+console.log("\n=== applyResultDiff: row_signature keying ===");
 
 {
-  // add of an existing id replaces, not duplicates
+  // add of an existing row_signature replaces, not duplicates (no id needed)
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", k: 7777, data: { location: "Parking" } });
+  applyResultDiff(rt, { op: "add", k: 7777, data: { location: "Curbside" } });
+  assertEqual(rt.rows.length, 1, "add with same row_signature replaces (no duplicate)");
+  assertEqual(rt.rows[0].location, "Curbside", "replacement keeps newest value");
+}
+
+{
+  // distinct row_signatures append
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", k: 1, data: { location: "Parking" } });
+  applyResultDiff(rt, { op: "add", k: 2, data: { location: "Parking" } });
+  assertEqual(rt.rows.length, 2, "add with distinct row_signatures appends");
+}
+
+{
+  // update matches by row_signature even when before/after content differs
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", k: 42, data: { location: "Parking" } });
+  applyResultDiff(rt, { op: "update", k: 42, before: { location: "Parking" }, after: { location: "Curbside" } });
+  assertEqual(rt.rows.length, 1, "update matches by row_signature");
+  assertEqual(rt.rows[0].location, "Curbside", "update applies new value");
+}
+
+{
+  // seeded snapshot row (with k) then live add for same signature upserts (#605 plugin path)
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", k: 99, data: { location: "Parking" } }); // synthetic snapshot add
+  applyResultDiff(rt, { op: "add", k: 99, data: { location: "Curbside" } }); // first live change as add
+  assertEqual(rt.rows.length, 1, "seeded-then-add by signature upserts");
+  assertEqual(rt.rows[0].location, "Curbside", "live add replaces seeded row");
+}
+
+{
+  // delete by row_signature removes the row
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", k: 5, data: { location: "Parking" } });
+  applyResultDiff(rt, { op: "delete", k: 5, data: { location: "Parking" } });
+  assertEqual(rt.rows.length, 0, "delete by row_signature removes the row");
+}
+
+console.log("\n=== applyResultDiff: id/equality fallback (row_signature unknown) ===");
+
+{
+  // add of an existing id replaces when signature is 0/absent
   const rt = newRuntime();
   applyResultDiff(rt, { op: "add", data: { id: "A1234", location: "Parking" } });
   applyResultDiff(rt, { op: "add", data: { id: "A1234", location: "Curbside" } });
   assertEqual(rt.rows.length, 1, "add with existing id replaces (no duplicate)");
   assertEqual(rt.rows[0].location, "Curbside", "replacement keeps newest value");
-  assertEqual(rt.latest.location, "Curbside", "latest tracks newest add");
 }
 
 {
@@ -80,7 +124,7 @@ console.log("\n=== applyResultDiff: upsert-on-add ===");
 }
 
 {
-  // rows without id fall back to full-object equality
+  // rows without id or signature fall back to full-object equality
   const rt = newRuntime();
   applyResultDiff(rt, { op: "add", data: { name: "Alice" } });
   applyResultDiff(rt, { op: "add", data: { name: "Alice" } });
@@ -88,12 +132,11 @@ console.log("\n=== applyResultDiff: upsert-on-add ===");
 }
 
 {
-  // add after seed-equivalent state behaves like update for same key
+  // signature takes precedence over id when both present
   const rt = newRuntime();
-  applyResultDiff(rt, { op: "add", data: { id: "A1234", location: "Parking" } });
-  applyResultDiff(rt, { op: "update", before: { id: "A1234", location: "Parking" }, after: { id: "A1234", location: "Curbside" } });
-  assertEqual(rt.rows.length, 1, "update still matches by key after add");
-  assertEqual(rt.rows[0].location, "Curbside", "update applies new value");
+  applyResultDiff(rt, { op: "add", k: 1, data: { id: "X", v: 1 } });
+  applyResultDiff(rt, { op: "add", k: 2, data: { id: "X", v: 2 } });
+  assertEqual(rt.rows.length, 2, "different signatures with same id are distinct rows");
 }
 
 // ─── Summary ────────────────────────────────────────────────────────

--- a/components/reactions/dashboard/tests/apply_result_diff.test.js
+++ b/components/reactions/dashboard/tests/apply_result_diff.test.js
@@ -140,6 +140,15 @@ console.log("\n=== applyResultDiff: id/equality fallback (row_signature unknown)
   assertEqual(rt.rows.length, 2, "different signatures with same id are distinct rows");
 }
 
+{
+  // sig-0 seeded row (id known) then real-signature live add must replace it
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", data: { id: "A1234", location: "Parking" } }); // seeded, sig 0
+  applyResultDiff(rt, { op: "add", k: 42, data: { id: "A1234", location: "Curbside" } }); // live, real sig
+  assertEqual(rt.rows.length, 1, "real-signature add replaces sig-0 seeded row (id fallback)");
+  assertEqual(rt.rows[0].location, "Curbside", "row updated to live value");
+}
+
 // ─── Summary ────────────────────────────────────────────────────────
 console.log(`\n${passed + failed} tests, ${passed} passed, ${failed} failed\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/components/reactions/dashboard/tests/apply_result_diff.test.js
+++ b/components/reactions/dashboard/tests/apply_result_diff.test.js
@@ -1,0 +1,101 @@
+// Tests for applyResultDiff in widgets.js (issue #605).
+// Run: node tests/apply_result_diff.test.js
+//
+// Loads the actual widgets.js source into a VM sandbox so the production
+// implementation is tested directly. Focuses on upsert-on-add semantics:
+// an `add` for a row whose key already exists must replace it, not duplicate.
+
+const { readFileSync } = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const widgetsSource = readFileSync(
+  path.join(__dirname, "../static/js/widgets.js"),
+  "utf-8"
+);
+
+const widgetsSandbox = {
+  window: { Handlebars: { registerHelper: () => {} } },
+  document: { createElement: () => ({}), documentElement: { getAttribute: () => "dark" } },
+  Map,
+  Number,
+  Math,
+  Array,
+  String,
+  Object,
+  RegExp,
+  JSON,
+  console,
+};
+
+// Strip ES module export/import syntax so it can run as a script in vm.
+const strippedSource = widgetsSource
+  .replace(/^export\s+/gm, "")
+  .replace(/^import\s+.*$/gm, "");
+
+vm.runInNewContext(strippedSource, widgetsSandbox, { filename: "widgets.js" });
+
+const applyResultDiff = widgetsSandbox.applyResultDiff;
+
+// ─── Test runner ────────────────────────────────────────────────────
+let passed = 0;
+let failed = 0;
+
+function assertEqual(actual, expected, message) {
+  if (actual === expected) {
+    passed++;
+    console.log(`  ✓ ${message}`);
+  } else {
+    failed++;
+    console.error(`  ✗ ${message}`);
+    console.error(`    expected: ${JSON.stringify(expected)}`);
+    console.error(`    actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+function newRuntime() {
+  return { rows: [], latest: null, aggregation: null };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+console.log("\n=== applyResultDiff: upsert-on-add ===");
+
+{
+  // add of an existing id replaces, not duplicates
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", data: { id: "A1234", location: "Parking" } });
+  applyResultDiff(rt, { op: "add", data: { id: "A1234", location: "Curbside" } });
+  assertEqual(rt.rows.length, 1, "add with existing id replaces (no duplicate)");
+  assertEqual(rt.rows[0].location, "Curbside", "replacement keeps newest value");
+  assertEqual(rt.latest.location, "Curbside", "latest tracks newest add");
+}
+
+{
+  // add of distinct ids appends
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", data: { id: "A", v: 1 } });
+  applyResultDiff(rt, { op: "add", data: { id: "B", v: 2 } });
+  assertEqual(rt.rows.length, 2, "add with distinct ids appends");
+}
+
+{
+  // rows without id fall back to full-object equality
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", data: { name: "Alice" } });
+  applyResultDiff(rt, { op: "add", data: { name: "Alice" } });
+  assertEqual(rt.rows.length, 1, "add with identical keyless row upserts by equality");
+}
+
+{
+  // add after seed-equivalent state behaves like update for same key
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", data: { id: "A1234", location: "Parking" } });
+  applyResultDiff(rt, { op: "update", before: { id: "A1234", location: "Parking" }, after: { id: "A1234", location: "Curbside" } });
+  assertEqual(rt.rows.length, 1, "update still matches by key after add");
+  assertEqual(rt.rows[0].location, "Curbside", "update applies new value");
+}
+
+// ─── Summary ────────────────────────────────────────────────────────
+console.log(`\n${passed + failed} tests, ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/components/reactions/dashboard/tests/apply_result_diff.test.js
+++ b/components/reactions/dashboard/tests/apply_result_diff.test.js
@@ -37,6 +37,7 @@ const strippedSource = widgetsSource
 vm.runInNewContext(strippedSource, widgetsSandbox, { filename: "widgets.js" });
 
 const applyResultDiff = widgetsSandbox.applyResultDiff;
+const snapshotRowToAddDiff = widgetsSandbox.snapshotRowToAddDiff;
 
 // ─── Test runner ────────────────────────────────────────────────────
 let passed = 0;
@@ -146,6 +147,52 @@ console.log("\n=== applyResultDiff: id/equality fallback (row_signature unknown)
   applyResultDiff(rt, { op: "add", data: { id: "A1234", location: "Parking" } }); // seeded, sig 0
   applyResultDiff(rt, { op: "add", k: 42, data: { id: "A1234", location: "Curbside" } }); // live, real sig
   assertEqual(rt.rows.length, 1, "real-signature add replaces sig-0 seeded row (id fallback)");
+  assertEqual(rt.rows[0].location, "Curbside", "row updated to live value");
+}
+
+console.log("\n=== string-form row_signature (64-bit precision-safe wire) ===");
+
+{
+  // signatures arrive as strings on the wire; same string upserts
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", k: "12345678901234567890", data: { location: "Parking" } });
+  applyResultDiff(rt, { op: "add", k: "12345678901234567890", data: { location: "Curbside" } });
+  assertEqual(rt.rows.length, 1, "same string signature upserts");
+  assertEqual(rt.rows[0].location, "Curbside", "string-sig replacement keeps newest value");
+}
+
+{
+  // two large signatures that would collide as JS Numbers stay distinct as strings
+  const rt = newRuntime();
+  applyResultDiff(rt, { op: "add", k: "9007199254740993", data: { v: 1 } });
+  applyResultDiff(rt, { op: "add", k: "9007199254740992", data: { v: 2 } });
+  assertEqual(rt.rows.length, 2, "near-2^53 string signatures are not conflated");
+}
+
+console.log("\n=== snapshotRowToAddDiff: snapshot envelope decode ===");
+
+{
+  // { k, v } envelope is decoded into an add diff carrying the signature
+  const diff = snapshotRowToAddDiff({ k: "42", v: { location: "Parking" } });
+  assertEqual(diff.op, "add", "decodes to an add diff");
+  assertEqual(diff.k, "42", "carries the row_signature");
+  assertEqual(diff.data.location, "Parking", "carries the row data");
+}
+
+{
+  // a plain row containing a `v` field is NOT misread as an envelope
+  const diff = snapshotRowToAddDiff({ id: "X", v: 42 });
+  assertEqual(diff.data.id, "X", "plain row passed through (data)");
+  assertEqual(diff.data.v, 42, "plain row's v field preserved");
+  assertEqual(diff.k, undefined, "no signature for a plain row");
+}
+
+{
+  // snapshot-load then live diff: signature threads through end to end
+  const rt = newRuntime();
+  applyResultDiff(rt, snapshotRowToAddDiff({ k: "777", v: { location: "Parking" } }));
+  applyResultDiff(rt, { op: "add", k: "777", data: { location: "Curbside" } });
+  assertEqual(rt.rows.length, 1, "live diff replaces snapshot-loaded row by signature");
   assertEqual(rt.rows[0].location, "Curbside", "row updated to live value");
 }
 

--- a/components/reactions/dashboard/tests/handlebars_helpers.test.js
+++ b/components/reactions/dashboard/tests/handlebars_helpers.test.js
@@ -51,6 +51,7 @@ const widgetsSandbox = {
 
 // Strip ES module export syntax so it can run as a script in vm
 const strippedSource = widgetsSource
+  .replace(/^export\s+\{[^}]*\};?\s*$/gm, "")
   .replace(/^export\s+/gm, "")
   .replace(/^import\s+.*$/gm, "");
 

--- a/components/reactions/dashboard/tests/integration_tests.rs
+++ b/components/reactions/dashboard/tests/integration_tests.rs
@@ -51,6 +51,18 @@ where
     }
 }
 
+/// Reserve an ephemeral TCP port to avoid collisions with other tests/processes.
+///
+/// Binds `127.0.0.1:0`, reads the assigned port, and drops the listener so the
+/// reaction can bind it. There is a tiny TOCTOU window, but this is far more
+/// robust than a hard-coded port under parallel test execution.
+fn reserve_port() -> Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .context("failed to reserve an ephemeral port")?;
+    let port = listener.local_addr()?.port();
+    Ok(port)
+}
+
 #[tokio::test]
 async fn test_dashboard_reaction_end_to_end() -> Result<()> {
     let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -252,9 +264,10 @@ async fn test_dashboard_server_shuts_down_on_stop() -> Result<()> {
         .auto_start(true)
         .build();
 
+    let port = reserve_port()?;
     let reaction = DashboardReaction::builder("shutdown-dashboard")
         .with_query("shutdown-query")
-        .with_port(19111)
+        .with_port(port)
         .build()?;
 
     let core = DrasiLib::builder()
@@ -267,11 +280,14 @@ async fn test_dashboard_server_shuts_down_on_stop() -> Result<()> {
 
     core.start().await?;
 
+    let base_url = format!("http://127.0.0.1:{port}/");
+    let ws_url = format!("ws://127.0.0.1:{port}/ws");
+
     // Wait for the server to come up.
     let client = reqwest::Client::new();
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
-        if let Ok(resp) = client.get("http://localhost:19111/").send().await {
+        if let Ok(resp) = client.get(&base_url).send().await {
             if resp.status().is_success() {
                 break;
             }
@@ -283,7 +299,7 @@ async fn test_dashboard_server_shuts_down_on_stop() -> Result<()> {
     }
 
     // Verify no-cache headers are set on served assets.
-    let root_response = client.get("http://localhost:19111/").send().await?;
+    let root_response = client.get(&base_url).send().await?;
     let cache_control = root_response
         .headers()
         .get(reqwest::header::CACHE_CONTROL)
@@ -296,7 +312,7 @@ async fn test_dashboard_server_shuts_down_on_stop() -> Result<()> {
     );
 
     // Open a live WebSocket so we can observe it being closed on shutdown.
-    let (ws_stream, _) = connect_async("ws://localhost:19111/ws").await?;
+    let (ws_stream, _) = connect_async(&ws_url).await?;
     let (mut ws_sender, mut ws_receiver) = ws_stream.split();
     ws_sender
         .send(Message::Text(
@@ -332,7 +348,7 @@ async fn test_dashboard_server_shuts_down_on_stop() -> Result<()> {
     let released = {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         loop {
-            match client.get("http://localhost:19111/").send().await {
+            match client.get(&base_url).send().await {
                 Err(_) => break true,
                 Ok(_) => {
                     if tokio::time::Instant::now() > deadline {

--- a/components/reactions/dashboard/tests/integration_tests.rs
+++ b/components/reactions/dashboard/tests/integration_tests.rs
@@ -82,9 +82,10 @@ async fn test_dashboard_reaction_end_to_end() -> Result<()> {
         .auto_start(true)
         .build();
 
+    let port = reserve_port()?;
     let reaction = DashboardReaction::builder("test-dashboard")
         .with_query("test-query")
-        .with_port(19110)
+        .with_port(port)
         .build()?;
 
     let core = DrasiLib::builder()
@@ -97,11 +98,14 @@ async fn test_dashboard_reaction_end_to_end() -> Result<()> {
 
     core.start().await?;
 
+    let base = format!("http://127.0.0.1:{port}");
+    let ws_url = format!("ws://127.0.0.1:{port}/ws");
+
     // Poll until the server is ready (max 10 seconds).
     let client = reqwest::Client::new();
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
-        if let Ok(resp) = client.get("http://localhost:19110/").send().await {
+        if let Ok(resp) = client.get(format!("{base}/")).send().await {
             if resp.status().is_success() {
                 break;
             }
@@ -115,7 +119,7 @@ async fn test_dashboard_reaction_end_to_end() -> Result<()> {
     }
 
     // Verify static UI endpoint.
-    let root_response = client.get("http://localhost:19110/").send().await?;
+    let root_response = client.get(format!("{base}/")).send().await?;
     assert_eq!(root_response.status(), reqwest::StatusCode::OK);
     let root_body = root_response.text().await?;
     assert!(
@@ -125,7 +129,7 @@ async fn test_dashboard_reaction_end_to_end() -> Result<()> {
 
     // Dashboard CRUD via REST.
     let create_response = client
-        .post("http://localhost:19110/api/dashboards")
+        .post(format!("{base}/api/dashboards"))
         .json(&serde_json::json!({
             "name": "Integration Dashboard",
             "gridOptions": {"columns": 12, "rowHeight": 60, "margin": 10},
@@ -137,35 +141,26 @@ async fn test_dashboard_reaction_end_to_end() -> Result<()> {
     let created_dashboard: DashboardConfig = create_response.json().await?;
 
     let get_response = client
-        .get(format!(
-            "http://localhost:19110/api/dashboards/{}",
-            created_dashboard.id
-        ))
+        .get(format!("{base}/api/dashboards/{}", created_dashboard.id))
         .send()
         .await?;
     assert_eq!(get_response.status(), reqwest::StatusCode::OK);
 
     let update_response = client
-        .put(format!(
-            "http://localhost:19110/api/dashboards/{}",
-            created_dashboard.id
-        ))
+        .put(format!("{base}/api/dashboards/{}", created_dashboard.id))
         .json(&serde_json::json!({"name": "Integration Dashboard Updated"}))
         .send()
         .await?;
     assert_eq!(update_response.status(), reqwest::StatusCode::OK);
 
     let delete_response = client
-        .delete(format!(
-            "http://localhost:19110/api/dashboards/{}",
-            created_dashboard.id
-        ))
+        .delete(format!("{base}/api/dashboards/{}", created_dashboard.id))
         .send()
         .await?;
     assert_eq!(delete_response.status(), reqwest::StatusCode::NO_CONTENT);
 
     // WebSocket protocol harness.
-    let (ws_stream, _) = connect_async("ws://localhost:19110/ws").await?;
+    let (ws_stream, _) = connect_async(&ws_url).await?;
     let (mut ws_sender, mut ws_receiver) = ws_stream.split();
 
     ws_sender
@@ -189,13 +184,18 @@ async fn test_dashboard_reaction_end_to_end() -> Result<()> {
         )
         .await?;
     let insert_message = next_query_result(&mut ws_receiver).await?;
+    let add_diff = insert_message["results"]
+        .as_array()
+        .and_then(|results| results.iter().find(|result| result["op"] == "add"))
+        .expect("INSERT operation should produce add diff message");
+    // The row_signature (canonical identity, #605) must be wired through as a
+    // non-zero string `k` on the live diff.
+    let k = add_diff["k"]
+        .as_str()
+        .expect("add diff should carry a string row_signature `k`");
     assert!(
-        insert_message["results"]
-            .as_array()
-            .unwrap_or(&Vec::new())
-            .iter()
-            .any(|result| result["op"] == "add"),
-        "INSERT operation should produce add diff message"
+        !k.is_empty() && k != "0",
+        "add diff row_signature should be present and non-zero, got {k:?}"
     );
 
     // UPDATE verification.

--- a/components/reactions/dashboard/tests/integration_tests.rs
+++ b/components/reactions/dashboard/tests/integration_tests.rs
@@ -233,3 +233,120 @@ async fn test_dashboard_reaction_end_to_end() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression test for the "stale tab after reaction restart" bug: stopping the
+/// dashboard reaction must gracefully shut the HTTP/WebSocket server down —
+/// closing active WebSocket connections and releasing the listener — so a client
+/// can't keep talking to (or reuse a pooled connection against) the old server.
+#[tokio::test]
+async fn test_dashboard_server_shuts_down_on_stop() -> Result<()> {
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let (mock_source, _source_handle) = MockSource::new("shutdown-source")?;
+
+    let query = Query::cypher("shutdown-query")
+        .query("MATCH (p:Person) RETURN p.name AS name")
+        .from_source("shutdown-source")
+        .auto_start(true)
+        .build();
+
+    let reaction = DashboardReaction::builder("shutdown-dashboard")
+        .with_query("shutdown-query")
+        .with_port(19111)
+        .build()?;
+
+    let core = DrasiLib::builder()
+        .with_id("dashboard-shutdown-core")
+        .with_source(mock_source)
+        .with_query(query)
+        .with_reaction(reaction)
+        .build()
+        .await?;
+
+    core.start().await?;
+
+    // Wait for the server to come up.
+    let client = reqwest::Client::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(resp) = client.get("http://localhost:19111/").send().await {
+            if resp.status().is_success() {
+                break;
+            }
+        }
+        if tokio::time::Instant::now() > deadline {
+            return Err(anyhow::anyhow!("server did not become ready"));
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    // Verify no-cache headers are set on served assets.
+    let root_response = client.get("http://localhost:19111/").send().await?;
+    let cache_control = root_response
+        .headers()
+        .get(reqwest::header::CACHE_CONTROL)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        cache_control.contains("no-cache"),
+        "served assets should carry a no-cache Cache-Control header, got: {cache_control:?}"
+    );
+
+    // Open a live WebSocket so we can observe it being closed on shutdown.
+    let (ws_stream, _) = connect_async("ws://localhost:19111/ws").await?;
+    let (mut ws_sender, mut ws_receiver) = ws_stream.split();
+    ws_sender
+        .send(Message::Text(
+            r#"{"type":"subscribe","query_ids":["shutdown-query"]}"#.to_string(),
+        ))
+        .await?;
+    sleep(Duration::from_millis(50)).await;
+
+    // Stop the reaction (and the rest of the core).
+    core.stop().await?;
+
+    // The active WebSocket must be closed by the graceful shutdown: the stream
+    // should end (None) or error within a short window, rather than hanging open.
+    let ws_closed = timeout(Duration::from_secs(5), async {
+        loop {
+            match ws_receiver.next().await {
+                None => break true,
+                Some(Ok(Message::Close(_))) => break true,
+                Some(Err(_)) => break true,
+                Some(Ok(_)) => continue,
+            }
+        }
+    })
+    .await
+    .unwrap_or(false);
+    assert!(
+        ws_closed,
+        "active WebSocket should be closed when the reaction stops"
+    );
+
+    // The HTTP listener must be released: new requests to the old port should
+    // fail (connection refused) once shutdown completes.
+    let released = {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match client.get("http://localhost:19111/").send().await {
+                Err(_) => break true,
+                Ok(_) => {
+                    if tokio::time::Instant::now() > deadline {
+                        break false;
+                    }
+                    sleep(Duration::from_millis(50)).await;
+                }
+            }
+        }
+    };
+    assert!(
+        released,
+        "HTTP server should stop accepting connections after the reaction stops"
+    );
+
+    Ok(())
+}

--- a/lib/src/queries/mod.rs
+++ b/lib/src/queries/mod.rs
@@ -38,8 +38,8 @@ pub use config_hash::compute_config_hash;
 pub use label_extractor::*;
 pub use manager::*;
 pub use output_state::{
-    FetchError, OutboxGap, OutboxResponse, OutboxStream, QueryOutputState, SnapshotResponse,
-    SnapshotStream,
+    FetchError, KeyedSnapshotRow, OutboxGap, OutboxResponse, OutboxStream, QueryOutputState,
+    SnapshotResponse, SnapshotStream,
 };
 pub use priority_queue::*;
 pub use sequence_dedup::SequenceDedup;

--- a/lib/src/queries/output_state.rs
+++ b/lib/src/queries/output_state.rs
@@ -24,9 +24,22 @@ use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
 use tokio_stream::Stream;
 
 use crate::channels::{QueryResult, ResultDiff};
+
+/// Wire envelope pairing a row's engine-stamped `row_signature` with its data.
+///
+/// Used as the per-row serialization format when snapshot rows cross the FFI
+/// boundary, so the canonical row identity survives instead of being dropped.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyedSnapshotRow {
+    /// The row's `row_signature` (engine-computed identity). `0` means unknown.
+    pub k: u64,
+    /// The row data.
+    pub v: serde_json::Value,
+}
 
 /// Default outbox capacity if not configured.
 pub const DEFAULT_OUTBOX_CAPACITY: usize = 1000;
@@ -283,6 +296,14 @@ impl SnapshotResponse {
         tokio_stream::iter(self.results.into_iter().map(|(_, v)| v))
     }
 
+    /// Return an async stream of `(row_signature, value)` pairs.
+    ///
+    /// Like [`stream`](Self::stream) but preserves each row's `row_signature`
+    /// (the canonical identity) instead of dropping it.
+    pub fn stream_keyed(self) -> impl Stream<Item = (u64, serde_json::Value)> + Send {
+        tokio_stream::iter(self.results)
+    }
+
     /// Collect the results into a `Vec<serde_json::Value>`.
     pub fn to_vec(&self) -> Vec<serde_json::Value> {
         self.results.values().cloned().collect()
@@ -319,7 +340,7 @@ pub struct OutboxResponse {
 /// Consumers iterate with `while let Some(row) = stream.next().await { ... }`
 /// or call `collect_vec()` to drain all rows into a `Vec`.
 pub struct SnapshotStream {
-    inner: Pin<Box<dyn Stream<Item = serde_json::Value> + Send>>,
+    inner: Pin<Box<dyn Stream<Item = (u64, serde_json::Value)> + Send>>,
     /// The sequence number this snapshot reflects.
     pub as_of_sequence: u64,
     /// The query's configuration hash at the time of the snapshot.
@@ -332,15 +353,33 @@ impl SnapshotStream {
         let as_of_sequence = snapshot.as_of_sequence;
         let config_hash = snapshot.config_hash;
         Self {
-            inner: Box::pin(snapshot.stream()),
+            inner: Box::pin(snapshot.stream_keyed()),
             as_of_sequence,
             config_hash,
         }
     }
 
-    /// Create a `SnapshotStream` from an arbitrary `Stream` implementation.
+    /// Create a `SnapshotStream` from a stream of bare row values.
+    ///
+    /// Rows created this way have an unknown `row_signature` (stamped as `0`);
+    /// use [`from_keyed_stream`](Self::from_keyed_stream) when signatures are
+    /// available.
     pub fn from_stream(
         stream: impl Stream<Item = serde_json::Value> + Send + 'static,
+        as_of_sequence: u64,
+        config_hash: u64,
+    ) -> Self {
+        use tokio_stream::StreamExt;
+        Self {
+            inner: Box::pin(stream.map(|v| (0u64, v))),
+            as_of_sequence,
+            config_hash,
+        }
+    }
+
+    /// Create a `SnapshotStream` from a stream of `(row_signature, value)` pairs.
+    pub fn from_keyed_stream(
+        stream: impl Stream<Item = (u64, serde_json::Value)> + Send + 'static,
         as_of_sequence: u64,
         config_hash: u64,
     ) -> Self {
@@ -351,10 +390,22 @@ impl SnapshotStream {
         }
     }
 
-    /// Collect all rows from the stream into a `Vec`.
+    /// Collect all rows from the stream into a `Vec`, dropping signatures.
     pub async fn collect_vec(self) -> Vec<serde_json::Value> {
         use tokio_stream::StreamExt;
+        self.inner.map(|(_, v)| v).collect().await
+    }
+
+    /// Collect all rows from the stream into a `Vec` of `(row_signature, value)` pairs.
+    pub async fn collect_keyed_vec(self) -> Vec<(u64, serde_json::Value)> {
+        use tokio_stream::StreamExt;
         self.inner.collect().await
+    }
+
+    /// Pull the next `(row_signature, value)` pair from the stream.
+    pub async fn next_keyed(&mut self) -> Option<(u64, serde_json::Value)> {
+        use tokio_stream::StreamExt;
+        self.inner.next().await
     }
 }
 
@@ -365,7 +416,10 @@ impl Stream for SnapshotStream {
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        self.inner.as_mut().poll_next(cx)
+        self.inner
+            .as_mut()
+            .poll_next(cx)
+            .map(|opt| opt.map(|(_, v)| v))
     }
 }
 
@@ -694,5 +748,48 @@ mod tests {
         assert_eq!(collected[0]["id"], 1);
         assert_eq!(collected[1]["id"], 2);
         assert_eq!(collected[2]["id"], 3);
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_stream_preserves_row_signatures() {
+        use tokio_stream::StreamExt;
+
+        let mut map = im::HashMap::new();
+        map.insert(11u64, serde_json::json!({"id": 1}));
+        map.insert(22u64, serde_json::json!({"id": 2}));
+
+        let snap = SnapshotResponse::new(map, 5, 7);
+
+        // stream_keyed yields (row_signature, value) pairs.
+        let mut keyed: Vec<(u64, serde_json::Value)> = snap.clone().stream_keyed().collect().await;
+        keyed.sort_by_key(|(sig, _)| *sig);
+        assert_eq!(keyed.len(), 2);
+        assert_eq!(keyed[0].0, 11);
+        assert_eq!(keyed[0].1["id"], 1);
+        assert_eq!(keyed[1].0, 22);
+
+        // SnapshotStream::collect_keyed_vec preserves signatures too.
+        let stream = SnapshotStream::from_snapshot(snap);
+        assert_eq!(stream.as_of_sequence, 5);
+        let mut via_stream = stream.collect_keyed_vec().await;
+        via_stream.sort_by_key(|(sig, _)| *sig);
+        assert_eq!(via_stream.len(), 2);
+        assert_eq!(via_stream[0].0, 11);
+        assert_eq!(via_stream[1].0, 22);
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_stream_from_bare_values_uses_zero_signature() {
+        let stream = SnapshotStream::from_stream(
+            tokio_stream::iter(vec![serde_json::json!({"id": 1})]),
+            0,
+            0,
+        );
+        let keyed = stream.collect_keyed_vec().await;
+        assert_eq!(keyed.len(), 1);
+        assert_eq!(
+            keyed[0].0, 0,
+            "bare-value stream rows have unknown signature 0"
+        );
     }
 }

--- a/lib/src/queries/output_state.rs
+++ b/lib/src/queries/output_state.rs
@@ -37,7 +37,7 @@ use crate::channels::{QueryResult, ResultDiff};
 pub struct KeyedSnapshotRow {
     /// The row's `row_signature` (engine-computed identity). `0` means unknown.
     pub k: u64,
-    /// The row data.
+    /// The row's data payload as a JSON object (the query result columns and values).
     pub v: serde_json::Value,
 }
 
@@ -378,6 +378,10 @@ impl SnapshotStream {
     }
 
     /// Create a `SnapshotStream` from a stream of `(row_signature, value)` pairs.
+    ///
+    /// Prefer this over [`from_stream`](Self::from_stream) when row signatures are
+    /// available; signatures let downstream consumers deduplicate and match rows
+    /// by canonical identity (see `row_signature`).
     pub fn from_keyed_stream(
         stream: impl Stream<Item = (u64, serde_json::Value)> + Send + 'static,
         as_of_sequence: u64,
@@ -391,6 +395,9 @@ impl SnapshotStream {
     }
 
     /// Collect all rows from the stream into a `Vec`, dropping signatures.
+    ///
+    /// Use [`collect_keyed_vec`](Self::collect_keyed_vec) to retain each row's
+    /// `row_signature` alongside its data.
     pub async fn collect_vec(self) -> Vec<serde_json::Value> {
         use tokio_stream::StreamExt;
         self.inner.map(|(_, v)| v).collect().await
@@ -402,6 +409,15 @@ impl SnapshotStream {
         self.inner.collect().await
     }
 
+    /// Collect up to `limit` `(row_signature, value)` pairs, then stop pulling.
+    ///
+    /// Bounds peak memory when draining a potentially large snapshot into a
+    /// capped consumer (e.g. a store with a per-query row limit).
+    pub async fn collect_keyed_vec_capped(self, limit: usize) -> Vec<(u64, serde_json::Value)> {
+        use tokio_stream::StreamExt;
+        self.inner.take(limit).collect().await
+    }
+
     /// Pull the next `(row_signature, value)` pair from the stream.
     pub async fn next_keyed(&mut self) -> Option<(u64, serde_json::Value)> {
         use tokio_stream::StreamExt;
@@ -409,6 +425,13 @@ impl SnapshotStream {
     }
 }
 
+/// Yields `serde_json::Value` rows, **dropping each row's `row_signature`**.
+///
+/// This trait impl is retained for value-only consumers (e.g. bootstrap replay in
+/// other reactions). Identity-preserving consumers must instead use the keyed
+/// methods ([`next_keyed`](SnapshotStream::next_keyed) /
+/// [`collect_keyed_vec`](SnapshotStream::collect_keyed_vec)); routing snapshot rows
+/// through this lossy path is what previously caused the #605 deduplication bug.
 impl Stream for SnapshotStream {
     type Item = serde_json::Value;
 


### PR DESCRIPTION
## Summary

Fixes duplicate rows in the dashboard reaction (#605) by keying rows on the engine's
canonical identity, plus two related dashboard improvements.

### 1. Duplicate rows (#605) — keyed by `row_signature` end-to-end
The canonical row identity in drasi is `row_signature` (engine-stamped on every
`ResultDiff`; the query result state, live-results store, and outbox all key by it).
The dashboard discarded it and reinvented a weaker `id`/JSON-equality key, and the
snapshot/bootstrap path dropped the signature entirely — **including across FFI**, which
is why #605 reproduced on drasi-server (the plugin path). With the initial snapshot and
the live diff stream in different identity spaces, the browser couldn't dedupe → duplicates.

- **lib**: `SnapshotResponse::stream_keyed` + keyed `SnapshotStream` APIs
  (`from_keyed_stream`/`collect_keyed_vec`/`next_keyed`); the public `Stream` impl still
  yields bare values so existing consumers are untouched. Shared `KeyedSnapshotRow { k, v }`
  wire envelope.
- **FFI (host + plugin)**: snapshot rows cross FFI as `KeyedSnapshotRow` so the signature
  survives; the plugin parses it back (falling back to signature `0` for bare payloads).
  **`FFI_SDK_VERSION` bumped `0.9.1 → 0.10.0`** — the vtable layout is unchanged, but the
  per-row wire format changed semantically, so mismatched host/plugin must be rebuilt.
- **dashboard server**: `WebSocketResultDiff` carries `row_signature` (`k`); snapshot rows
  are `{ row_signature, data }`; `apply`/`seed_rows`/`find_row_index` key by signature,
  falling back to the `id`/equality heuristic only when the signature is unknown (`0`).
- **browser**: keys rows by `row_signature` (stored as a non-enumerable `__sig` so it never
  leaks into rendering); the snapshot loader threads the signature through; heuristic retained
  as fallback.

> Note: this supersedes the earlier upsert-by-`id` band-aid that was the first commit on this
> branch. The `id`/equality logic is kept only as a fallback for signature-less rows.

### 2. Stale browser tab after reaction restart
`axum::serve` ran with no graceful shutdown and `stop()` only aborted the accept loop, so
existing keep-alive/WebSocket connections stayed alive in-process and a refreshed tab reused
a pooled connection to the old server. Now driven by a `watch` shutdown signal
(`with_graceful_shutdown`), WebSocket handlers close on shutdown, and assets are served with
`Cache-Control: no-cache`.

### 3. Collapsible "Available Queries" panel
The editor's left sidebar can be collapsed/expanded; state persisted in `localStorage`, charts
reflow on toggle.

## Testing
- `cargo test -p drasi-reaction-dashboard` — 57 unit + 2 integration tests (incl. graceful-shutdown
  regression and the real-query WS round-trip exercising `row_signature`).
- `cargo test -p drasi-lib` snapshot-stream signature-preservation tests; `host-sdk`/`plugin-sdk`
  lib unit tests (incl. the FFI snapshot bridge).
- JS: `tests/apply_result_diff.test.js` (signature keying + id/equality fallback) and existing
  handlebars tests, wired into `make test-js`.
- `cargo build --workspace`; clippy `-D warnings` and `cargo fmt --check` clean on touched crates.

> Pre-existing `host-sdk` `integration_test.rs` cases that require prebuilt cdylib artifacts
> ("SKIP: … not built as cdylib") fail identically on a clean tree and are unrelated.
