### PR TITLE
fix(ffi): serialize plugin event payloads to fix cross-cdylib heap corruption (#602)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,33 @@ test-host-sdk: build-test-plugins
 	cargo test -p drasi-host-sdk --test integration_test -- --test-threads=1
 	@echo "=== host-sdk integration tests passed ==="
 
+# Deterministic cross-cdylib layout-mismatch regression for issue #602.
+#
+# Builds the mock-source cdylib with one layout seed and runs the host-sdk
+# layout-mismatch test with a DIFFERENT seed under glibc heap hardening. Before
+# the #602 fix this aborts (free(): invalid pointer / SIGSEGV); after the fix the
+# serialized event transfer is layout-independent and the test passes.
+#
+# Requires a nightly toolchain (for -Zrandomize-layout / -Zlayout-seed).
+PLUGIN_LAYOUT_SEED  ?= 1
+HOST_LAYOUT_SEED    ?= 2
+test-ffi-layout-mismatch:
+	@echo "=== [#602] Building mock plugin with layout seed $(PLUGIN_LAYOUT_SEED) (nightly) ==="
+	RUSTFLAGS="-Zrandomize-layout -Zlayout-seed=$(PLUGIN_LAYOUT_SEED)" \
+		cargo +nightly build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin
+	@mkdir -p $(PLUGIN_OUT_DIR)
+	@for ext in dylib so dll; do \
+		for f in target/debug/libdrasi_source_mock.$$ext target/debug/drasi_source_mock.$$ext; do \
+			[ -f "$$f" ] && cp "$$f" $(PLUGIN_OUT_DIR)/ || true; \
+		done; \
+	done
+	@echo "=== [#602] Running layout-mismatch test with host seed $(HOST_LAYOUT_SEED) + MALLOC_CHECK_=3 ==="
+	MALLOC_CHECK_=3 MALLOC_PERTURB_=165 GLIBC_TUNABLES=glibc.malloc.check=3 \
+		RUSTFLAGS="-Zrandomize-layout -Zlayout-seed=$(HOST_LAYOUT_SEED)" \
+		cargo +nightly test -p drasi-host-sdk --test ffi_layout_mismatch_test -- \
+			--ignored --nocapture --test-threads=1
+	@echo "=== [#602] layout-mismatch regression passed (no heap corruption) ==="
+
 # === Plugin Build & Publish (via xtask) ===
 
 # Build all dynamic plugins (debug)

--- a/components/host-sdk/Cargo.toml
+++ b/components/host-sdk/Cargo.toml
@@ -23,7 +23,6 @@ tokio = { version = "1", features = ["rt", "sync", "time"] }
 bytes = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rmp-serde = "1"
 log = "0.4"
 tokio-stream = "0.1"
 indexmap = "2"
@@ -53,6 +52,7 @@ workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+rmp-serde = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "io-util"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 futures-util = "0.3"

--- a/components/host-sdk/Cargo.toml
+++ b/components/host-sdk/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1", features = ["rt", "sync", "time"] }
 bytes = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rmp-serde = "1"
 log = "0.4"
 tokio-stream = "0.1"
 indexmap = "2"

--- a/components/host-sdk/src/proxies/agents.md
+++ b/components/host-sdk/src/proxies/agents.md
@@ -29,25 +29,39 @@ If a trait method is added/changed in `drasi-lib`, you need to update **both sid
 2. **Host-side** — The corresponding proxy file in this directory (implement the new
    trait method by dispatching through the vtable)
 
-### Opaque pointer reconstruction
+### Rich event payloads cross as serialized bytes (issue #602)
 
-Several proxies reconstruct Rust types from opaque `*mut c_void` pointers:
+`SourceEventWrapper`, `BootstrapEvent`, and `QueryResult` are `repr(Rust)` types
+that embed `bytes::Bytes` / `Arc<str>`. They cross the boundary **by value as
+serialized MessagePack bytes**, NOT as reinterpreted opaque pointers:
 
-- `change_receiver.rs:57` — `Box::from_raw(opaque as *mut SourceEventWrapper)`
-- `change_receiver.rs:198` — `Box::from_raw(opaque as *mut BootstrapEvent)`
-- `bootstrap_provider.rs:142` — `Box::from_raw(opaque as *mut BootstrapEvent)`
+- `change_receiver.rs` — `decode_source_event` / `decode_bootstrap_event`
+  deserialize the host's own value from `FfiSourceEvent.payload_ptr` /
+  `FfiBootstrapEvent.payload_ptr`, then free the plugin's buffer via the
+  plugin-supplied `payload_drop_fn`.
+- `reaction.rs` — `QueryResult` is serialized (`encode_query_result`) into an
+  `FfiQueryResult` buffer; the plugin deserializes its own copy.
+- Reconstruction helpers live in `drasi_plugin_sdk::ffi::payload`
+  (`decode_source_event_payload`, `decode_bootstrap_event_payload`,
+  `decode_query_result`).
 
-`ReactionProxy` transfers ownership **to** the plugin via opaque pointers:
+> **Never** `Box::from_raw` / `Box::into_raw` / `std::ptr::read` / `&*ptr`-read a
+> `repr(Rust)` payload type across the cdylib boundary. `repr(Rust)` has no stable
+> cross-compilation layout, and `bytes::Bytes` carries a `&'static` vtable valid
+> only in the producing module — doing so caused #602's heap corruption
+> (`free(): invalid pointer`). The `#[repr(C)]` **envelope** structs
+> (`FfiSourceEvent`, `FfiBootstrapEvent`, `FfiQueryResult`) themselves are POD and
+> may be freed across the boundary with `Box::from_raw`.
 
-- `reaction.rs` — `Box::into_raw(Box::new(query_result)) as *mut c_void` passed to
-  `enqueue_query_result_fn`. The plugin takes ownership via `Box::from_raw`.
+**Safety**: The SDK version check (`loader.rs`) validates only the `#[repr(C)]`
+envelope/vtable ABI — it does **not** and cannot guarantee `repr(Rust)` payload
+layout agreement. That is why payloads must be serialized.
 
-**Safety**: These casts are only valid if the plugin and host agree on the type's memory
-layout. This is enforced by SDK version validation in `loader.rs`.
-
-If you change the definition of `SourceEventWrapper`, `BootstrapEvent`, or any other
-opaque-pointer type (in `drasi-core/core/src/models/` or `drasi-core/lib/src/channels/`),
-you **must** bump `FFI_SDK_VERSION` in `components/plugin-sdk/src/ffi/metadata.rs`.
+If you change the definition of `SourceEventWrapper`, `BootstrapEvent`,
+`QueryResult`, or the payload structs (in `drasi-core/core/src/models/`,
+`drasi-core/lib/src/channels/`, or `plugin-sdk/src/ffi/payload.rs`), keep their
+`serde` derives intact and bump `FFI_SDK_VERSION` in
+`components/plugin-sdk/src/ffi/metadata.rs`.
 
 ### `Arc<Library>` lifetime management
 

--- a/components/host-sdk/src/proxies/bootstrap_provider.rs
+++ b/components/host-sdk/src/proxies/bootstrap_provider.rs
@@ -25,6 +25,7 @@ use drasi_lib::bootstrap::{
 use drasi_lib::channels::events::{BootstrapEvent, BootstrapEventSender};
 use drasi_lib::config::SourceSubscriptionSettings;
 use drasi_plugin_sdk::descriptor::BootstrapPluginDescriptor;
+use drasi_plugin_sdk::ffi::payload::decode_bootstrap_event_payload;
 use drasi_plugin_sdk::ffi::{
     BootstrapPluginVtable, BootstrapProviderVtable, FfiBootstrapEvent, FfiBootstrapSender, FfiStr,
 };
@@ -188,10 +189,29 @@ fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSen
                 return -1;
             }
             let ffi_event = unsafe { &*event };
-            let bootstrap_event =
-                unsafe { *Box::from_raw(ffi_event.opaque as *mut BootstrapEvent) };
-            // Free the FFI envelope but not the opaque (we took ownership)
+            // Decode the serialized payload into a host-owned BootstrapEvent and
+            // free the plugin's buffer via its own deallocator (issue #602: never
+            // reinterpret/drop the plugin's repr(Rust) memory).
+            let decoded = if ffi_event.payload_ptr.is_null() || ffi_event.payload_len == 0 {
+                None
+            } else {
+                let slice = unsafe {
+                    std::slice::from_raw_parts(ffi_event.payload_ptr, ffi_event.payload_len)
+                };
+                decode_bootstrap_event_payload(slice)
+            };
+            if !ffi_event.payload_ptr.is_null() {
+                (ffi_event.payload_drop_fn)(
+                    ffi_event.payload_ptr as *mut u8,
+                    ffi_event.payload_len,
+                );
+            }
+            // Free the FFI envelope itself (#[repr(C)] POD).
             unsafe { drop(Box::from_raw(event)) };
+            let Some(bootstrap_event) = decoded else {
+                // Undecodable payload: skip this event, keep the stream alive.
+                return 0;
+            };
             match tx.send(bootstrap_event) {
                 Ok(()) => 0,
                 Err(_) => -1,

--- a/components/host-sdk/src/proxies/bootstrap_provider.rs
+++ b/components/host-sdk/src/proxies/bootstrap_provider.rs
@@ -25,7 +25,7 @@ use drasi_lib::bootstrap::{
 use drasi_lib::channels::events::{BootstrapEvent, BootstrapEventSender};
 use drasi_lib::config::SourceSubscriptionSettings;
 use drasi_plugin_sdk::descriptor::BootstrapPluginDescriptor;
-use drasi_plugin_sdk::ffi::payload::{decode_bootstrap_event_payload, take_ffi_payload};
+use drasi_plugin_sdk::ffi::payload::consume_bootstrap_event;
 use drasi_plugin_sdk::ffi::{
     BootstrapPluginVtable, BootstrapProviderVtable, FfiBootstrapEvent, FfiBootstrapSender, FfiStr,
 };
@@ -191,16 +191,9 @@ fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSen
             let ffi_event = unsafe { &*event };
             // Decode the serialized payload into a host-owned BootstrapEvent and
             // free the plugin's buffer via its own deallocator (issue #602: never
-            // reinterpret/drop the plugin's repr(Rust) memory). `take_ffi_payload`
-            // also bounds the size and null-guards the drop fn.
-            let decoded = unsafe {
-                take_ffi_payload(
-                    ffi_event.payload_ptr,
-                    ffi_event.payload_len,
-                    ffi_event.payload_drop_fn,
-                    decode_bootstrap_event_payload,
-                )
-            };
+            // reinterpret/drop the plugin's repr(Rust) memory). The canonical
+            // consumer also bounds the size and null-guards the drop fn.
+            let decoded = unsafe { consume_bootstrap_event(ffi_event) };
             // Free the FFI envelope itself (#[repr(C)] POD).
             unsafe { drop(Box::from_raw(event)) };
             let Some(bootstrap_event) = decoded else {

--- a/components/host-sdk/src/proxies/bootstrap_provider.rs
+++ b/components/host-sdk/src/proxies/bootstrap_provider.rs
@@ -25,7 +25,7 @@ use drasi_lib::bootstrap::{
 use drasi_lib::channels::events::{BootstrapEvent, BootstrapEventSender};
 use drasi_lib::config::SourceSubscriptionSettings;
 use drasi_plugin_sdk::descriptor::BootstrapPluginDescriptor;
-use drasi_plugin_sdk::ffi::payload::decode_bootstrap_event_payload;
+use drasi_plugin_sdk::ffi::payload::{decode_bootstrap_event_payload, take_ffi_payload};
 use drasi_plugin_sdk::ffi::{
     BootstrapPluginVtable, BootstrapProviderVtable, FfiBootstrapEvent, FfiBootstrapSender, FfiStr,
 };
@@ -191,21 +191,16 @@ fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSen
             let ffi_event = unsafe { &*event };
             // Decode the serialized payload into a host-owned BootstrapEvent and
             // free the plugin's buffer via its own deallocator (issue #602: never
-            // reinterpret/drop the plugin's repr(Rust) memory).
-            let decoded = if ffi_event.payload_ptr.is_null() || ffi_event.payload_len == 0 {
-                None
-            } else {
-                let slice = unsafe {
-                    std::slice::from_raw_parts(ffi_event.payload_ptr, ffi_event.payload_len)
-                };
-                decode_bootstrap_event_payload(slice)
-            };
-            if !ffi_event.payload_ptr.is_null() {
-                (ffi_event.payload_drop_fn)(
-                    ffi_event.payload_ptr as *mut u8,
+            // reinterpret/drop the plugin's repr(Rust) memory). `take_ffi_payload`
+            // also bounds the size and null-guards the drop fn.
+            let decoded = unsafe {
+                take_ffi_payload(
+                    ffi_event.payload_ptr,
                     ffi_event.payload_len,
-                );
-            }
+                    ffi_event.payload_drop_fn,
+                    decode_bootstrap_event_payload,
+                )
+            };
             // Free the FFI envelope itself (#[repr(C)] POD).
             unsafe { drop(Box::from_raw(event)) };
             let Some(bootstrap_event) = decoded else {

--- a/components/host-sdk/src/proxies/change_receiver.rs
+++ b/components/host-sdk/src/proxies/change_receiver.rs
@@ -27,9 +27,48 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use drasi_lib::channels::events::SourceEventWrapper;
+use drasi_lib::channels::events::{BootstrapEvent, SourceEventWrapper};
 use drasi_lib::channels::ChangeReceiver;
-use drasi_plugin_sdk::ffi::{FfiChangeReceiver, FfiSourceEvent};
+use drasi_plugin_sdk::ffi::payload::{decode_bootstrap_event_payload, decode_source_event_payload};
+use drasi_plugin_sdk::ffi::{FfiBootstrapEvent, FfiChangeReceiver, FfiSourceEvent};
+
+/// Decode a plugin-sent `FfiSourceEvent` into a **host-owned** `SourceEventWrapper`.
+///
+/// The payload crosses the cdylib boundary as MessagePack bytes (issue #602): the
+/// host deserializes its own copy and frees the plugin's buffer via the
+/// plugin-supplied `payload_drop_fn`. The host never reads or drops the plugin's
+/// `repr(Rust)` memory. Returns `None` if the payload cannot be decoded (the
+/// plugin buffer is freed regardless).
+fn decode_source_event(ffi_event: &FfiSourceEvent) -> Option<SourceEventWrapper> {
+    let decoded = if ffi_event.payload_ptr.is_null() || ffi_event.payload_len == 0 {
+        None
+    } else {
+        let slice =
+            unsafe { std::slice::from_raw_parts(ffi_event.payload_ptr, ffi_event.payload_len) };
+        decode_source_event_payload(slice)
+    };
+    // Free the plugin-owned payload buffer with the plugin's own deallocator.
+    if !ffi_event.payload_ptr.is_null() {
+        (ffi_event.payload_drop_fn)(ffi_event.payload_ptr as *mut u8, ffi_event.payload_len);
+    }
+    decoded
+}
+
+/// Decode a plugin-sent `FfiBootstrapEvent` into a host-owned `BootstrapEvent`.
+/// See [`decode_source_event`] for the ownership contract (issue #602).
+fn decode_bootstrap_event(ffi_event: &FfiBootstrapEvent) -> Option<BootstrapEvent> {
+    let decoded = if ffi_event.payload_ptr.is_null() || ffi_event.payload_len == 0 {
+        None
+    } else {
+        let slice =
+            unsafe { std::slice::from_raw_parts(ffi_event.payload_ptr, ffi_event.payload_len) };
+        decode_bootstrap_event_payload(slice)
+    };
+    if !ffi_event.payload_ptr.is_null() {
+        (ffi_event.payload_drop_fn)(ffi_event.payload_ptr as *mut u8, ffi_event.payload_len);
+    }
+    decoded
+}
 
 /// Context passed to the push callback. Holds the std mpsc sender and a
 /// tokio Notify to wake the host receiver.
@@ -69,8 +108,14 @@ fn change_push_callback_inner(ctx: *mut std::ffi::c_void, event: *mut FfiSourceE
     }
 
     let ffi_event = unsafe { &*event };
-    let wrapper = unsafe { *Box::from_raw(ffi_event.opaque as *mut SourceEventWrapper) };
+    let decoded = decode_source_event(ffi_event);
+    // Free the plugin-allocated `#[repr(C)]` envelope (POD; no recursive Drop).
     unsafe { drop(Box::from_raw(event)) };
+
+    let Some(wrapper) = decoded else {
+        // Undecodable payload — skip without tearing down the stream.
+        return true;
+    };
 
     let guard = context.tx.lock().expect("push callback mutex poisoned");
     if let Some(tx) = guard.as_ref() {
@@ -228,10 +273,14 @@ fn bootstrap_push_callback_inner(
     }
 
     let ffi_event = unsafe { &*event };
-    let bootstrap_event = unsafe {
-        *Box::from_raw(ffi_event.opaque as *mut drasi_lib::channels::events::BootstrapEvent)
-    };
+    let decoded = decode_bootstrap_event(ffi_event);
+    // Free the plugin-allocated `#[repr(C)]` envelope (POD; no recursive Drop).
     unsafe { drop(Box::from_raw(event)) };
+
+    let Some(bootstrap_event) = decoded else {
+        // Undecodable payload — skip without tearing down the stream.
+        return true;
+    };
 
     let guard = context
         .tx
@@ -350,5 +399,160 @@ impl BootstrapReceiverProxy {
         });
 
         out_rx
+    }
+}
+
+#[cfg(test)]
+mod ownership_tests {
+    //! T2 (part 2) — host-side FFI ownership for issue #602.
+    //!
+    //! These tests drive the **real** host consumer (`decode_source_event` /
+    //! `decode_bootstrap_event`) with an `FfiSourceEvent`/`FfiBootstrapEvent`
+    //! constructed exactly as the plugin producer does, using a call-counting
+    //! `payload_drop_fn`. They assert that:
+    //!   1. the host rebuilds a value-equal, host-owned event, and
+    //!   2. the host frees the plugin's payload buffer **exactly once** via the
+    //!      plugin-supplied `drop_fn` — never reinterpreting/dropping the
+    //!      plugin's `repr(Rust)` memory.
+
+    use super::*;
+    use drasi_core::models::{
+        Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
+    };
+    use drasi_lib::channels::events::SourceEvent;
+    use drasi_plugin_sdk::ffi::payload::{BootstrapEventPayload, SourceEventPayload};
+    use drasi_plugin_sdk::ffi::FfiChangeOp;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static SRC_DROPS: AtomicUsize = AtomicUsize::new(0);
+    static BOOT_DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    extern "C" fn counting_drop_src(ptr: *mut u8, len: usize) {
+        SRC_DROPS.fetch_add(1, Ordering::SeqCst);
+        if !ptr.is_null() && len > 0 {
+            unsafe {
+                drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
+            }
+        }
+    }
+
+    extern "C" fn counting_drop_boot(ptr: *mut u8, len: usize) {
+        BOOT_DROPS.fetch_add(1, Ordering::SeqCst);
+        if !ptr.is_null() && len > 0 {
+            unsafe {
+                drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
+            }
+        }
+    }
+
+    fn node() -> Element {
+        let mut props = ElementPropertyMap::new();
+        props.insert("plate", ElementValue::String(std::sync::Arc::from("A1234")));
+        Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("src-1", "vehicles:A1234"),
+                labels: std::sync::Arc::from(vec![std::sync::Arc::from("vehicles")]),
+                effective_from: 1_771_000_000_000,
+            },
+            properties: props,
+        }
+    }
+
+    /// Mirrors the plugin producer: serialize the payload (named MessagePack)
+    /// into a heap buffer and build the `#[repr(C)]` envelope.
+    fn make_source_event(payload: &SourceEventPayload) -> *mut FfiSourceEvent {
+        let bytes = rmp_serde::to_vec_named(payload).unwrap();
+        let payload_len = bytes.len();
+        let payload_ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+        Box::into_raw(Box::new(FfiSourceEvent {
+            payload_ptr,
+            payload_len,
+            payload_drop_fn: counting_drop_src,
+            op: FfiChangeOp::Insert,
+            timestamp_us: payload.timestamp_us,
+        }))
+    }
+
+    #[test]
+    fn decode_source_event_rebuilds_and_frees_buffer_once() {
+        SRC_DROPS.store(0, Ordering::SeqCst);
+        let payload = SourceEventPayload {
+            source_id: "src-1".to_string(),
+            event: SourceEvent::Change(SourceChange::Insert { element: node() }),
+            timestamp_us: 1_771_000_000_000_000,
+            sequence: Some(99),
+            source_position: Some(b"binlog:1".to_vec()),
+        };
+        let raw = make_source_event(&payload);
+        let ffi = unsafe { &*raw };
+
+        let wrapper = decode_source_event(ffi).expect("host-owned wrapper");
+        assert_eq!(wrapper.source_id, "src-1");
+        assert_eq!(wrapper.sequence, Some(99));
+        assert_eq!(wrapper.source_position.as_deref(), Some(&b"binlog:1"[..]));
+        assert_eq!(wrapper.event, payload.event);
+
+        // The plugin's payload buffer was freed exactly once, by the host
+        // calling the plugin-supplied drop_fn.
+        assert_eq!(SRC_DROPS.load(Ordering::SeqCst), 1);
+
+        // The host owns `wrapper`; dropping it must not touch the (already freed)
+        // plugin buffer or double-free.
+        drop(wrapper);
+        assert_eq!(SRC_DROPS.load(Ordering::SeqCst), 1);
+
+        // Free the #[repr(C)] envelope (as the real callback does).
+        unsafe { drop(Box::from_raw(raw)) };
+    }
+
+    #[test]
+    fn decode_source_event_handles_undecodable_payload_without_leak() {
+        SRC_DROPS.store(0, Ordering::SeqCst);
+        // Garbage bytes that are not a valid SourceEventPayload.
+        let bytes = vec![0xFFu8; 8];
+        let payload_len = bytes.len();
+        let payload_ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+        let raw = Box::into_raw(Box::new(FfiSourceEvent {
+            payload_ptr,
+            payload_len,
+            payload_drop_fn: counting_drop_src,
+            op: FfiChangeOp::Insert,
+            timestamp_us: 0,
+        }));
+        let ffi = unsafe { &*raw };
+
+        assert!(decode_source_event(ffi).is_none());
+        // Buffer still freed exactly once even though decode failed.
+        assert_eq!(SRC_DROPS.load(Ordering::SeqCst), 1);
+        unsafe { drop(Box::from_raw(raw)) };
+    }
+
+    #[test]
+    fn decode_bootstrap_event_rebuilds_and_frees_buffer_once() {
+        BOOT_DROPS.store(0, Ordering::SeqCst);
+        let payload = BootstrapEventPayload {
+            source_id: "src-1".to_string(),
+            change: SourceChange::Insert { element: node() },
+            timestamp_us: 1_771_000_000_000_000,
+            sequence: 5,
+        };
+        let bytes = rmp_serde::to_vec_named(&payload).unwrap();
+        let payload_len = bytes.len();
+        let payload_ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+        let raw = Box::into_raw(Box::new(FfiBootstrapEvent {
+            payload_ptr,
+            payload_len,
+            payload_drop_fn: counting_drop_boot,
+            timestamp_us: payload.timestamp_us,
+            sequence: 5,
+        }));
+        let ffi = unsafe { &*raw };
+
+        let event = decode_bootstrap_event(ffi).expect("host-owned bootstrap event");
+        assert_eq!(event.source_id, "src-1");
+        assert_eq!(event.sequence, 5);
+        assert_eq!(event.change, payload.change);
+        assert_eq!(BOOT_DROPS.load(Ordering::SeqCst), 1);
+        unsafe { drop(Box::from_raw(raw)) };
     }
 }

--- a/components/host-sdk/src/proxies/change_receiver.rs
+++ b/components/host-sdk/src/proxies/change_receiver.rs
@@ -61,9 +61,9 @@ struct PushCallbackContext {
 /// Uses `std::sync::mpsc` which is safe to call from any runtime.
 extern "C" fn change_push_callback(ctx: *mut std::ffi::c_void, event: *mut FfiSourceEvent) -> bool {
     // Catch panics to prevent unwinding across the extern "C" boundary (which is UB).
-    // On panic, return false to signal shutdown. The leaked Arc is NOT reclaimed here
-    // because we cannot know which code path panicked. It will be reclaimed when the
-    // forwarder task exits (via the null-event callback or send failure).
+    // On panic, return false to signal shutdown. The leaked Arc is NOT reclaimed here;
+    // it is reclaimed exactly once when the forwarder sends its final null sentinel
+    // (the plugin guarantees one on forwarder exit via SourceSentinelOnDrop).
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         change_push_callback_inner(ctx, event)
     }))
@@ -74,15 +74,20 @@ fn change_push_callback_inner(ctx: *mut std::ffi::c_void, event: *mut FfiSourceE
     let context = unsafe { &*(ctx as *const PushCallbackContext) };
 
     if event.is_null() {
-        // Channel closed — drop the sender to signal the host receiver
-        {
-            let mut guard = context.tx.lock().expect("push callback mutex poisoned");
+        // Forwarder-exit sentinel. The plugin guarantees exactly one null
+        // callback when its forwarder task ends (`SourceSentinelOnDrop`), so this
+        // is the SOLE point at which the leaked Arc reference is reclaimed — which
+        // guarantees the context outlives every event callback. Reclaiming on any
+        // other return path as well would double-free the context (the macOS arm64
+        // teardown UAF / "mutex poisoned" crash). Tolerate a poisoned lock so the
+        // reclaim below always runs (skipping it would leak the context).
+        if let Ok(mut guard) = context.tx.lock() {
             *guard = None;
-            context.notify.notify_one();
-            // guard must be dropped BEFORE reclaiming the Arc, otherwise
-            // MutexGuard::drop runs after the PushCallbackContext is freed.
         }
-        // Reclaim the leaked Arc reference (see ChangeReceiverProxy::new)
+        context.notify.notify_one();
+        // Reclaim the single leaked Arc reference (see ChangeReceiverProxy::new).
+        // The lock guard above is already dropped, so the Mutex is not touched
+        // after the context is freed.
         unsafe { Arc::from_raw(ctx as *const PushCallbackContext) };
         return false;
     }
@@ -97,22 +102,21 @@ fn change_push_callback_inner(ctx: *mut std::ffi::c_void, event: *mut FfiSourceE
         return true;
     };
 
-    let guard = context.tx.lock().expect("push callback mutex poisoned");
-    if let Some(tx) = guard.as_ref() {
-        let ok = tx.send(Arc::new(wrapper)).is_ok();
-        drop(guard);
-        if ok {
-            context.notify.notify_one();
-            true
-        } else {
-            // Receiver was dropped — reclaim the leaked Arc
-            unsafe { Arc::from_raw(ctx as *const PushCallbackContext) };
-            false
-        }
+    // Forward to the host receiver. On any failure (receiver gone or a poisoned
+    // lock) return false to stop the forwarder, but do NOT reclaim the leaked Arc
+    // here — the guaranteed null sentinel does that exactly once.
+    let Ok(guard) = context.tx.lock() else {
+        return false;
+    };
+    let Some(tx) = guard.as_ref() else {
+        return false;
+    };
+    let ok = tx.send(Arc::new(wrapper)).is_ok();
+    drop(guard);
+    if ok {
+        context.notify.notify_one();
+        true
     } else {
-        // Sender was already dropped — reclaim the leaked Arc
-        drop(guard);
-        unsafe { Arc::from_raw(ctx as *const PushCallbackContext) };
         false
     }
 }
@@ -237,17 +241,16 @@ fn bootstrap_push_callback_inner(
     let context = unsafe { &*(ctx as *const BootstrapPushCallbackContext) };
 
     if event.is_null() {
-        // Stream exhausted — drop the sender to signal completion
-        {
-            let mut guard = context
-                .tx
-                .lock()
-                .expect("bootstrap push callback mutex poisoned");
+        // Forwarder-exit sentinel (`BootstrapSentinelOnDrop`, guaranteed exactly
+        // once on forwarder exit). This is the SOLE point at which the leaked Arc
+        // reference is reclaimed, so the context outlives every event callback;
+        // reclaiming on any other return path too would double-free it. Tolerate a
+        // poisoned lock so the reclaim below always runs.
+        if let Ok(mut guard) = context.tx.lock() {
             *guard = None;
-            context.notify.notify_one();
-            // guard must be dropped BEFORE reclaiming the Arc
         }
-        // Reclaim the leaked Arc reference
+        context.notify.notify_one();
+        // Reclaim the single leaked Arc reference.
         unsafe { Arc::from_raw(ctx as *const BootstrapPushCallbackContext) };
         return false;
     }
@@ -262,23 +265,21 @@ fn bootstrap_push_callback_inner(
         return true;
     };
 
-    let guard = context
-        .tx
-        .lock()
-        .expect("bootstrap push callback mutex poisoned");
-    if let Some(tx) = guard.as_ref() {
-        let ok = tx.send(bootstrap_event).is_ok();
-        drop(guard);
-        if ok {
-            context.notify.notify_one();
-            true
-        } else {
-            unsafe { Arc::from_raw(ctx as *const BootstrapPushCallbackContext) };
-            false
-        }
+    // Forward to the host receiver. On any failure (receiver gone or a poisoned
+    // lock) return false to stop the forwarder, but do NOT reclaim the leaked Arc
+    // here — the guaranteed null sentinel does that exactly once.
+    let Ok(guard) = context.tx.lock() else {
+        return false;
+    };
+    let Some(tx) = guard.as_ref() else {
+        return false;
+    };
+    let ok = tx.send(bootstrap_event).is_ok();
+    drop(guard);
+    if ok {
+        context.notify.notify_one();
+        true
     } else {
-        drop(guard);
-        unsafe { Arc::from_raw(ctx as *const BootstrapPushCallbackContext) };
         false
     }
 }
@@ -567,5 +568,103 @@ mod ownership_tests {
         // Buffer still freed exactly once even though decode failed.
         assert_eq!(BOOT_DROPS_INVALID.load(Ordering::SeqCst), 1);
         unsafe { drop(Box::from_raw(raw)) };
+    }
+
+    // ---- leaked-Arc reclaim exactly once (macOS arm64 teardown double-free) ----
+    //
+    // The plugin forwarder leaks one Arc ref to the callback context (see
+    // `ChangeReceiverProxy::new`) and guarantees exactly one final null-event
+    // "sentinel" callback on exit (`SourceSentinelOnDrop`). The leaked ref must be
+    // reclaimed by that sentinel and by NOTHING else: when the host receiver is
+    // dropped first, a real event's `send()` fails, and if that path *also*
+    // reclaimed the Arc the subsequent sentinel would read freed memory and
+    // double-free it (the flaky "push callback mutex poisoned" + SIGSEGV). These
+    // tests pin the reclaim count via `Arc::strong_count`.
+
+    extern "C" fn free_only_drop(ptr: *mut u8, len: usize) {
+        free_bytes(ptr, len);
+    }
+
+    #[test]
+    fn change_callback_reclaims_leaked_arc_exactly_once_on_send_failure() {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Arc<SourceEventWrapper>>(4);
+        let ctx = Arc::new(PushCallbackContext {
+            tx: std::sync::Mutex::new(Some(tx)),
+            notify: Arc::new(tokio::sync::Notify::new()),
+        });
+        // Mirror new(): leak a second strong ref for the plugin forwarder.
+        let leaked = Arc::into_raw(ctx.clone()) as *mut std::ffi::c_void;
+        assert_eq!(Arc::strong_count(&ctx), 2);
+
+        // Receiver dropped first → the next send() fails (teardown order).
+        drop(rx);
+
+        let payload = SourceEventPayload {
+            source_id: "s".to_string(),
+            event: SourceEvent::Change(SourceChange::Insert { element: node() }),
+            timestamp_us: 0,
+            sequence: None,
+            source_position: None,
+        };
+        let ev = make_source_event(&payload, free_only_drop);
+        // Real event: decodes, but send() fails → returns false WITHOUT reclaiming.
+        assert!(!change_push_callback(leaked, ev));
+        assert_eq!(
+            Arc::strong_count(&ctx),
+            2,
+            "send-failure path must NOT reclaim the leaked Arc"
+        );
+
+        // Forwarder-exit sentinel: reclaims exactly once.
+        assert!(!change_push_callback(leaked, std::ptr::null_mut()));
+        assert_eq!(
+            Arc::strong_count(&ctx),
+            1,
+            "sentinel must reclaim the leaked Arc exactly once"
+        );
+    }
+
+    #[test]
+    fn bootstrap_callback_reclaims_leaked_arc_exactly_once_on_send_failure() {
+        let (tx, rx) =
+            std::sync::mpsc::sync_channel::<drasi_lib::channels::events::BootstrapEvent>(4);
+        let ctx = Arc::new(BootstrapPushCallbackContext {
+            tx: std::sync::Mutex::new(Some(tx)),
+            notify: Arc::new(tokio::sync::Notify::new()),
+        });
+        let leaked = Arc::into_raw(ctx.clone()) as *mut std::ffi::c_void;
+        assert_eq!(Arc::strong_count(&ctx), 2);
+
+        drop(rx);
+
+        let payload = BootstrapEventPayload {
+            source_id: "s".to_string(),
+            change: SourceChange::Insert { element: node() },
+            timestamp_us: 0,
+            sequence: 1,
+        };
+        let bytes = rmp_serde::to_vec_named(&payload).unwrap();
+        let payload_len = bytes.len();
+        let payload_ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+        let ev = Box::into_raw(Box::new(FfiBootstrapEvent {
+            payload_ptr,
+            payload_len,
+            payload_drop_fn: Some(free_only_drop),
+            timestamp_us: 0,
+            sequence: 1,
+        }));
+        assert!(!bootstrap_push_callback(leaked, ev));
+        assert_eq!(
+            Arc::strong_count(&ctx),
+            2,
+            "send-failure path must NOT reclaim the leaked Arc"
+        );
+
+        assert!(!bootstrap_push_callback(leaked, std::ptr::null_mut()));
+        assert_eq!(
+            Arc::strong_count(&ctx),
+            1,
+            "sentinel must reclaim the leaked Arc exactly once"
+        );
     }
 }

--- a/components/host-sdk/src/proxies/change_receiver.rs
+++ b/components/host-sdk/src/proxies/change_receiver.rs
@@ -424,20 +424,26 @@ mod ownership_tests {
     use drasi_plugin_sdk::ffi::FfiChangeOp;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    static SRC_DROPS: AtomicUsize = AtomicUsize::new(0);
+    static SRC_DROPS_VALID: AtomicUsize = AtomicUsize::new(0);
+    static SRC_DROPS_INVALID: AtomicUsize = AtomicUsize::new(0);
     static BOOT_DROPS: AtomicUsize = AtomicUsize::new(0);
 
-    extern "C" fn counting_drop_src(ptr: *mut u8, len: usize) {
-        SRC_DROPS.fetch_add(1, Ordering::SeqCst);
-        if !ptr.is_null() && len > 0 {
-            unsafe {
-                drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
-            }
-        }
+    extern "C" fn counting_drop_src_valid(ptr: *mut u8, len: usize) {
+        SRC_DROPS_VALID.fetch_add(1, Ordering::SeqCst);
+        free_bytes(ptr, len);
+    }
+
+    extern "C" fn counting_drop_src_invalid(ptr: *mut u8, len: usize) {
+        SRC_DROPS_INVALID.fetch_add(1, Ordering::SeqCst);
+        free_bytes(ptr, len);
     }
 
     extern "C" fn counting_drop_boot(ptr: *mut u8, len: usize) {
         BOOT_DROPS.fetch_add(1, Ordering::SeqCst);
+        free_bytes(ptr, len);
+    }
+
+    fn free_bytes(ptr: *mut u8, len: usize) {
         if !ptr.is_null() && len > 0 {
             unsafe {
                 drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
@@ -460,14 +466,17 @@ mod ownership_tests {
 
     /// Mirrors the plugin producer: serialize the payload (named MessagePack)
     /// into a heap buffer and build the `#[repr(C)]` envelope.
-    fn make_source_event(payload: &SourceEventPayload) -> *mut FfiSourceEvent {
+    fn make_source_event(
+        payload: &SourceEventPayload,
+        drop_fn: extern "C" fn(*mut u8, usize),
+    ) -> *mut FfiSourceEvent {
         let bytes = rmp_serde::to_vec_named(payload).unwrap();
         let payload_len = bytes.len();
         let payload_ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
         Box::into_raw(Box::new(FfiSourceEvent {
             payload_ptr,
             payload_len,
-            payload_drop_fn: counting_drop_src,
+            payload_drop_fn: drop_fn,
             op: FfiChangeOp::Insert,
             timestamp_us: payload.timestamp_us,
         }))
@@ -475,7 +484,6 @@ mod ownership_tests {
 
     #[test]
     fn decode_source_event_rebuilds_and_frees_buffer_once() {
-        SRC_DROPS.store(0, Ordering::SeqCst);
         let payload = SourceEventPayload {
             source_id: "src-1".to_string(),
             event: SourceEvent::Change(SourceChange::Insert { element: node() }),
@@ -483,7 +491,7 @@ mod ownership_tests {
             sequence: Some(99),
             source_position: Some(b"binlog:1".to_vec()),
         };
-        let raw = make_source_event(&payload);
+        let raw = make_source_event(&payload, counting_drop_src_valid);
         let ffi = unsafe { &*raw };
 
         let wrapper = decode_source_event(ffi).expect("host-owned wrapper");
@@ -494,12 +502,12 @@ mod ownership_tests {
 
         // The plugin's payload buffer was freed exactly once, by the host
         // calling the plugin-supplied drop_fn.
-        assert_eq!(SRC_DROPS.load(Ordering::SeqCst), 1);
+        assert_eq!(SRC_DROPS_VALID.load(Ordering::SeqCst), 1);
 
         // The host owns `wrapper`; dropping it must not touch the (already freed)
         // plugin buffer or double-free.
         drop(wrapper);
-        assert_eq!(SRC_DROPS.load(Ordering::SeqCst), 1);
+        assert_eq!(SRC_DROPS_VALID.load(Ordering::SeqCst), 1);
 
         // Free the #[repr(C)] envelope (as the real callback does).
         unsafe { drop(Box::from_raw(raw)) };
@@ -507,7 +515,6 @@ mod ownership_tests {
 
     #[test]
     fn decode_source_event_handles_undecodable_payload_without_leak() {
-        SRC_DROPS.store(0, Ordering::SeqCst);
         // Garbage bytes that are not a valid SourceEventPayload.
         let bytes = vec![0xFFu8; 8];
         let payload_len = bytes.len();
@@ -515,7 +522,7 @@ mod ownership_tests {
         let raw = Box::into_raw(Box::new(FfiSourceEvent {
             payload_ptr,
             payload_len,
-            payload_drop_fn: counting_drop_src,
+            payload_drop_fn: counting_drop_src_invalid,
             op: FfiChangeOp::Insert,
             timestamp_us: 0,
         }));
@@ -523,13 +530,12 @@ mod ownership_tests {
 
         assert!(decode_source_event(ffi).is_none());
         // Buffer still freed exactly once even though decode failed.
-        assert_eq!(SRC_DROPS.load(Ordering::SeqCst), 1);
+        assert_eq!(SRC_DROPS_INVALID.load(Ordering::SeqCst), 1);
         unsafe { drop(Box::from_raw(raw)) };
     }
 
     #[test]
     fn decode_bootstrap_event_rebuilds_and_frees_buffer_once() {
-        BOOT_DROPS.store(0, Ordering::SeqCst);
         let payload = BootstrapEventPayload {
             source_id: "src-1".to_string(),
             change: SourceChange::Insert { element: node() },

--- a/components/host-sdk/src/proxies/change_receiver.rs
+++ b/components/host-sdk/src/proxies/change_receiver.rs
@@ -29,9 +29,7 @@ use async_trait::async_trait;
 
 use drasi_lib::channels::events::{BootstrapEvent, SourceEventWrapper};
 use drasi_lib::channels::ChangeReceiver;
-use drasi_plugin_sdk::ffi::payload::{
-    decode_bootstrap_event_payload, decode_source_event_payload, take_ffi_payload,
-};
+use drasi_plugin_sdk::ffi::payload::{consume_bootstrap_event, consume_source_event};
 use drasi_plugin_sdk::ffi::{FfiBootstrapEvent, FfiChangeReceiver, FfiSourceEvent};
 
 /// Decode a plugin-sent `FfiSourceEvent` into a **host-owned** `SourceEventWrapper`.
@@ -40,30 +38,16 @@ use drasi_plugin_sdk::ffi::{FfiBootstrapEvent, FfiChangeReceiver, FfiSourceEvent
 /// host deserializes its own copy and frees the plugin's buffer via the
 /// plugin-supplied `payload_drop_fn`. The host never reads or drops the plugin's
 /// `repr(Rust)` memory. Returns `None` if the payload cannot be decoded (the
-/// plugin buffer is freed regardless). Size/null hardening lives in
-/// [`take_ffi_payload`].
+/// plugin buffer is freed regardless). Delegates to the canonical
+/// [`consume_source_event`], where the size/null hardening lives.
 fn decode_source_event(ffi_event: &FfiSourceEvent) -> Option<SourceEventWrapper> {
-    unsafe {
-        take_ffi_payload(
-            ffi_event.payload_ptr,
-            ffi_event.payload_len,
-            ffi_event.payload_drop_fn,
-            decode_source_event_payload,
-        )
-    }
+    unsafe { consume_source_event(ffi_event) }
 }
 
 /// Decode a plugin-sent `FfiBootstrapEvent` into a host-owned `BootstrapEvent`.
 /// See [`decode_source_event`] for the ownership contract (issue #602).
 fn decode_bootstrap_event(ffi_event: &FfiBootstrapEvent) -> Option<BootstrapEvent> {
-    unsafe {
-        take_ffi_payload(
-            ffi_event.payload_ptr,
-            ffi_event.payload_len,
-            ffi_event.payload_drop_fn,
-            decode_bootstrap_event_payload,
-        )
-    }
+    unsafe { consume_bootstrap_event(ffi_event) }
 }
 
 /// Context passed to the push callback. Holds the std mpsc sender and a

--- a/components/host-sdk/src/proxies/change_receiver.rs
+++ b/components/host-sdk/src/proxies/change_receiver.rs
@@ -29,7 +29,9 @@ use async_trait::async_trait;
 
 use drasi_lib::channels::events::{BootstrapEvent, SourceEventWrapper};
 use drasi_lib::channels::ChangeReceiver;
-use drasi_plugin_sdk::ffi::payload::{decode_bootstrap_event_payload, decode_source_event_payload};
+use drasi_plugin_sdk::ffi::payload::{
+    decode_bootstrap_event_payload, decode_source_event_payload, take_ffi_payload,
+};
 use drasi_plugin_sdk::ffi::{FfiBootstrapEvent, FfiChangeReceiver, FfiSourceEvent};
 
 /// Decode a plugin-sent `FfiSourceEvent` into a **host-owned** `SourceEventWrapper`.
@@ -38,36 +40,30 @@ use drasi_plugin_sdk::ffi::{FfiBootstrapEvent, FfiChangeReceiver, FfiSourceEvent
 /// host deserializes its own copy and frees the plugin's buffer via the
 /// plugin-supplied `payload_drop_fn`. The host never reads or drops the plugin's
 /// `repr(Rust)` memory. Returns `None` if the payload cannot be decoded (the
-/// plugin buffer is freed regardless).
+/// plugin buffer is freed regardless). Size/null hardening lives in
+/// [`take_ffi_payload`].
 fn decode_source_event(ffi_event: &FfiSourceEvent) -> Option<SourceEventWrapper> {
-    let decoded = if ffi_event.payload_ptr.is_null() || ffi_event.payload_len == 0 {
-        None
-    } else {
-        let slice =
-            unsafe { std::slice::from_raw_parts(ffi_event.payload_ptr, ffi_event.payload_len) };
-        decode_source_event_payload(slice)
-    };
-    // Free the plugin-owned payload buffer with the plugin's own deallocator.
-    if !ffi_event.payload_ptr.is_null() {
-        (ffi_event.payload_drop_fn)(ffi_event.payload_ptr as *mut u8, ffi_event.payload_len);
+    unsafe {
+        take_ffi_payload(
+            ffi_event.payload_ptr,
+            ffi_event.payload_len,
+            ffi_event.payload_drop_fn,
+            decode_source_event_payload,
+        )
     }
-    decoded
 }
 
 /// Decode a plugin-sent `FfiBootstrapEvent` into a host-owned `BootstrapEvent`.
 /// See [`decode_source_event`] for the ownership contract (issue #602).
 fn decode_bootstrap_event(ffi_event: &FfiBootstrapEvent) -> Option<BootstrapEvent> {
-    let decoded = if ffi_event.payload_ptr.is_null() || ffi_event.payload_len == 0 {
-        None
-    } else {
-        let slice =
-            unsafe { std::slice::from_raw_parts(ffi_event.payload_ptr, ffi_event.payload_len) };
-        decode_bootstrap_event_payload(slice)
-    };
-    if !ffi_event.payload_ptr.is_null() {
-        (ffi_event.payload_drop_fn)(ffi_event.payload_ptr as *mut u8, ffi_event.payload_len);
+    unsafe {
+        take_ffi_payload(
+            ffi_event.payload_ptr,
+            ffi_event.payload_len,
+            ffi_event.payload_drop_fn,
+            decode_bootstrap_event_payload,
+        )
     }
-    decoded
 }
 
 /// Context passed to the push callback. Holds the std mpsc sender and a
@@ -476,7 +472,7 @@ mod ownership_tests {
         Box::into_raw(Box::new(FfiSourceEvent {
             payload_ptr,
             payload_len,
-            payload_drop_fn: drop_fn,
+            payload_drop_fn: Some(drop_fn),
             op: FfiChangeOp::Insert,
             timestamp_us: payload.timestamp_us,
         }))
@@ -522,7 +518,7 @@ mod ownership_tests {
         let raw = Box::into_raw(Box::new(FfiSourceEvent {
             payload_ptr,
             payload_len,
-            payload_drop_fn: counting_drop_src_invalid,
+            payload_drop_fn: Some(counting_drop_src_invalid),
             op: FfiChangeOp::Insert,
             timestamp_us: 0,
         }));
@@ -548,7 +544,7 @@ mod ownership_tests {
         let raw = Box::into_raw(Box::new(FfiBootstrapEvent {
             payload_ptr,
             payload_len,
-            payload_drop_fn: counting_drop_boot,
+            payload_drop_fn: Some(counting_drop_boot),
             timestamp_us: payload.timestamp_us,
             sequence: 5,
         }));

--- a/components/host-sdk/src/proxies/change_receiver.rs
+++ b/components/host-sdk/src/proxies/change_receiver.rs
@@ -407,6 +407,7 @@ mod ownership_tests {
     static SRC_DROPS_VALID: AtomicUsize = AtomicUsize::new(0);
     static SRC_DROPS_INVALID: AtomicUsize = AtomicUsize::new(0);
     static BOOT_DROPS: AtomicUsize = AtomicUsize::new(0);
+    static BOOT_DROPS_INVALID: AtomicUsize = AtomicUsize::new(0);
 
     extern "C" fn counting_drop_src_valid(ptr: *mut u8, len: usize) {
         SRC_DROPS_VALID.fetch_add(1, Ordering::SeqCst);
@@ -420,6 +421,11 @@ mod ownership_tests {
 
     extern "C" fn counting_drop_boot(ptr: *mut u8, len: usize) {
         BOOT_DROPS.fetch_add(1, Ordering::SeqCst);
+        free_bytes(ptr, len);
+    }
+
+    extern "C" fn counting_drop_boot_invalid(ptr: *mut u8, len: usize) {
+        BOOT_DROPS_INVALID.fetch_add(1, Ordering::SeqCst);
         free_bytes(ptr, len);
     }
 
@@ -539,6 +545,27 @@ mod ownership_tests {
         assert_eq!(event.sequence, 5);
         assert_eq!(event.change, payload.change);
         assert_eq!(BOOT_DROPS.load(Ordering::SeqCst), 1);
+        unsafe { drop(Box::from_raw(raw)) };
+    }
+
+    #[test]
+    fn decode_bootstrap_event_handles_undecodable_payload_without_leak() {
+        // Garbage bytes that are not a valid BootstrapEventPayload.
+        let bytes = vec![0xFFu8; 8];
+        let payload_len = bytes.len();
+        let payload_ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+        let raw = Box::into_raw(Box::new(FfiBootstrapEvent {
+            payload_ptr,
+            payload_len,
+            payload_drop_fn: Some(counting_drop_boot_invalid),
+            timestamp_us: 0,
+            sequence: 0,
+        }));
+        let ffi = unsafe { &*raw };
+
+        assert!(decode_bootstrap_event(ffi).is_none());
+        // Buffer still freed exactly once even though decode failed.
+        assert_eq!(BOOT_DROPS_INVALID.load(Ordering::SeqCst), 1);
         unsafe { drop(Box::from_raw(raw)) };
     }
 }

--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -146,7 +146,7 @@ fn result_push_callback_inner(ctx: *mut c_void, sentinel: *mut c_void) -> *mut c
                 Box::into_raw(Box::new(FfiQueryResult {
                     payload_ptr,
                     payload_len,
-                    payload_drop_fn: drop_query_result_bytes,
+                    payload_drop_fn: Some(drop_query_result_bytes),
                 })) as *mut c_void
             }
             Err(_) => {

--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -101,8 +101,9 @@ fn signal_forwarder_done(context: &ResultPushContext) {
 extern "C" fn drop_query_result_bytes(ptr: *mut u8, len: usize) {
     if !ptr.is_null() && len > 0 {
         unsafe {
-            let slice = std::slice::from_raw_parts_mut(ptr, len);
-            drop(Box::from_raw(slice as *mut [u8]));
+            // Rebuild the boxed slice from a *raw* slice pointer — never create a
+            // `&mut [u8]` reference to memory we are about to free (that would be UB).
+            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
         }
     }
 }

--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -95,6 +95,18 @@ fn signal_forwarder_done(context: &ResultPushContext) {
 ///
 /// Wrapped in `catch_unwind` because this is `extern "C"` — panics unwinding
 /// across the FFI boundary are undefined behavior.
+extern "C" fn result_push_callback(ctx: *mut c_void, sentinel: *mut c_void) -> *mut c_void {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        result_push_callback_inner(ctx, sentinel)
+    }))
+    .unwrap_or_else(|_| {
+        // On panic, signal done so drop() doesn't deadlock
+        let context = unsafe { &*(ctx as *const ResultPushContext) };
+        signal_forwarder_done(context);
+        std::ptr::null_mut()
+    })
+}
+
 /// Frees a serialized `QueryResult` byte buffer produced by the host in
 /// [`result_push_callback_inner`]. Called by the consuming plugin after it has
 /// deserialized its own copy (issue #602).
@@ -106,18 +118,6 @@ extern "C" fn drop_query_result_bytes(ptr: *mut u8, len: usize) {
             drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
         }
     }
-}
-
-extern "C" fn result_push_callback(ctx: *mut c_void, sentinel: *mut c_void) -> *mut c_void {
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        result_push_callback_inner(ctx, sentinel)
-    }))
-    .unwrap_or_else(|_| {
-        // On panic, signal done so drop() doesn't deadlock
-        let context = unsafe { &*(ctx as *const ResultPushContext) };
-        signal_forwarder_done(context);
-        std::ptr::null_mut()
-    })
 }
 
 fn result_push_callback_inner(ctx: *mut c_void, sentinel: *mut c_void) -> *mut c_void {

--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -25,9 +25,10 @@ use drasi_lib::reactions::Reaction;
 use drasi_lib::recovery::ReactionRecoveryPolicy;
 use drasi_lib::{ComponentStatus, ReactionRuntimeContext};
 use drasi_plugin_sdk::descriptor::ReactionPluginDescriptor;
+use drasi_plugin_sdk::ffi::payload::encode_query_result;
 use drasi_plugin_sdk::ffi::{
     FfiBootstrapContext, FfiCheckpoint, FfiCheckpointResult, FfiComponentStatus, FfiOutboxIterator,
-    FfiOutboxIteratorResponse, FfiResult, FfiRuntimeContext, FfiSnapshotIterator,
+    FfiOutboxIteratorResponse, FfiQueryResult, FfiResult, FfiRuntimeContext, FfiSnapshotIterator,
     FfiSnapshotIteratorResponse, FfiStr, ReactionPluginVtable, ReactionVtable,
 };
 use libloading::Library;
@@ -94,6 +95,18 @@ fn signal_forwarder_done(context: &ResultPushContext) {
 ///
 /// Wrapped in `catch_unwind` because this is `extern "C"` — panics unwinding
 /// across the FFI boundary are undefined behavior.
+/// Frees a serialized `QueryResult` byte buffer produced by the host in
+/// [`result_push_callback_inner`]. Called by the consuming plugin after it has
+/// deserialized its own copy (issue #602).
+extern "C" fn drop_query_result_bytes(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() && len > 0 {
+        unsafe {
+            let slice = std::slice::from_raw_parts_mut(ptr, len);
+            drop(Box::from_raw(slice as *mut [u8]));
+        }
+    }
+}
+
 extern "C" fn result_push_callback(ctx: *mut c_void, sentinel: *mut c_void) -> *mut c_void {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         result_push_callback_inner(ctx, sentinel)
@@ -123,7 +136,18 @@ fn result_push_callback_inner(ctx: *mut c_void, sentinel: *mut c_void) -> *mut c
         .expect("result_push_callback lock poisoned");
     if let Some(ref rx) = *guard {
         match rx.recv() {
-            Ok(result) => Box::into_raw(Box::new(result)) as *mut c_void,
+            Ok(result) => {
+                // Serialize the QueryResult for cross-cdylib transfer (issue #602):
+                // never hand the plugin a reinterpreted `repr(Rust)` pointer.
+                let bytes = encode_query_result(&result);
+                let payload_len = bytes.len();
+                let payload_ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+                Box::into_raw(Box::new(FfiQueryResult {
+                    payload_ptr,
+                    payload_len,
+                    payload_drop_fn: drop_query_result_bytes,
+                })) as *mut c_void
+            }
             Err(_) => {
                 // Channel closed — return null so the forwarder breaks.
                 // Do NOT signal forwarder_done here; the forwarder will

--- a/components/host-sdk/tests/ffi_layout_mismatch_test.rs
+++ b/components/host-sdk/tests/ffi_layout_mismatch_test.rs
@@ -159,3 +159,99 @@ async fn mock_source_change_stream_survives_layout_mismatch() {
     drop(plugin);
     drop(_event_rx);
 }
+
+/// Drive the **bootstrap** event path from the mock-source cdylib across the FFI
+/// boundary under the same layout mismatch. Bootstrap events embed the same
+/// `repr(Rust)` `Element`/`Arc<str>` payloads as change events and follow the
+/// same serialize/`drop_fn` contract (issue #602), so they need their own
+/// regression. Before the fix, receiving and dropping a bootstrap event under a
+/// layout mismatch corrupts the heap; after the fix the serialized transfer is
+/// layout-independent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "gated: run via `make test-ffi-layout-mismatch` (nightly -Zlayout-seed + MALLOC_CHECK_)"]
+async fn mock_source_bootstrap_stream_survives_layout_mismatch() {
+    let path = plugin_dir().join(plugin_filename("drasi-source-mock"));
+    assert!(
+        path.exists(),
+        "mock source cdylib not found at {} — build it first (see make test-ffi-layout-mismatch)",
+        path.display()
+    );
+
+    let plugin = load_plugin_from_path(
+        &path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("Failed to load mock source plugin");
+
+    let config = serde_json::json!({
+        "dataType": { "type": "generic" },
+        "intervalMs": 5
+    });
+    let source = plugin.source_plugins[0]
+        .create_source("layout-mismatch-boot-src", &config, false)
+        .await
+        .expect("Should create mock source instance");
+
+    let (event_tx, _event_rx) =
+        tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(100);
+    let context = drasi_lib::context::SourceRuntimeContext::new(
+        "layout-mismatch-boot-instance",
+        "layout-mismatch-boot-src",
+        None,
+        event_tx,
+        None,
+    );
+    source.initialize(context).await;
+    source.start().await.expect("Should start source");
+
+    // enable_bootstrap: true drives the FfiBootstrapEvent deserialization path.
+    let settings = drasi_lib::config::SourceSubscriptionSettings {
+        source_id: "layout-mismatch-boot-src".to_string(),
+        enable_bootstrap: true,
+        query_id: "layout-mismatch-boot-query".to_string(),
+        nodes: HashSet::new(),
+        relations: HashSet::new(),
+        resume_from: None,
+        request_position_handle: false,
+    };
+    let sub = source.subscribe(settings).await.expect("Should subscribe");
+    let mut bootstrap_receiver = sub
+        .bootstrap_receiver
+        .expect("mock source should provide a bootstrap receiver when enable_bootstrap is true");
+
+    // Drain bootstrap events. Each carries an `Element` with `Arc<str>` data;
+    // touching and dropping it under a layout mismatch corrupts the heap before
+    // the fix.
+    let mut received = 0usize;
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), bootstrap_receiver.recv()).await {
+            Ok(Some(event)) => {
+                // Touch the event's heap data — reads through `Arc<str>`. This is
+                // what corrupts/aborts before the fix.
+                let _ = event.source_id.len();
+                let _ = format!("{:?}", event.change.get_reference());
+                received += 1;
+                // Drop the host-owned event explicitly to exercise the drop glue.
+                drop(event);
+            }
+            Ok(None) => break,  // bootstrap channel closed (stream complete)
+            Err(_) => continue, // timeout tick
+        }
+    }
+
+    assert!(
+        received >= 1,
+        "expected to receive at least one bootstrap event from the mock source"
+    );
+    println!("LAYOUT_MISMATCH_OK: received {received} bootstrap events without corruption");
+
+    source.stop().await.expect("Should stop source");
+    drop(bootstrap_receiver);
+    drop(source);
+    drop(plugin);
+    drop(_event_rx);
+}

--- a/components/host-sdk/tests/ffi_layout_mismatch_test.rs
+++ b/components/host-sdk/tests/ffi_layout_mismatch_test.rs
@@ -1,0 +1,161 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! T3 — cross-cdylib **layout-mismatch** regression for issue #602.
+//!
+//! Issue #602 was a heap corruption (`free(): invalid pointer`) caused by the
+//! host taking ownership of a plugin-allocated `repr(Rust)` `SourceEventWrapper`
+//! (which embeds `bytes::Bytes` / `Arc<str>`) via `Box::from_raw`. That is sound
+//! only if the host and plugin agree on the `repr(Rust)` layout — which Rust does
+//! not guarantee across independently compiled cdylibs. The fix transfers events
+//! as serialized MessagePack bytes instead.
+//!
+//! This test reproduces the bug **deterministically** by forcing a layout
+//! disagreement: the mock-source cdylib is built with one `-Zlayout-seed` and the
+//! test host with another, then run under glibc heap hardening (`MALLOC_CHECK_`).
+//!
+//! - **Before the fix:** the host reads `SourceEventWrapper`/`Element` fields at
+//!   the wrong offsets → frees a garbage interior pointer → SIGABRT/SIGSEGV.
+//! - **After the fix:** the serialized transfer is layout-independent → clean.
+//!
+//! An in-workspace cdylib test with **matching** layout/toolchain does NOT
+//! reproduce the bug (confirmed empirically), so the forced seed mismatch is
+//! required. Because that needs the nightly `-Zrandomize-layout`/`-Zlayout-seed`
+//! flags, this test is `#[ignore]`d by default and is driven by the Makefile
+//! target:
+//!
+//! ```text
+//! make test-ffi-layout-mismatch
+//! ```
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use drasi_host_sdk::callbacks;
+use drasi_host_sdk::loader::load_plugin_from_path;
+use drasi_lib::sources::Source;
+use drasi_plugin_sdk::descriptor::SourcePluginDescriptor;
+
+fn plugin_dir() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("Cannot find workspace root from CARGO_MANIFEST_DIR");
+    workspace_root.join("target").join("debug").join("plugins")
+}
+
+fn plugin_filename(crate_name: &str) -> String {
+    let lib_name = crate_name.replace('-', "_");
+    if cfg!(target_os = "macos") {
+        format!("lib{lib_name}.dylib")
+    } else if cfg!(target_os = "windows") {
+        format!("{lib_name}.dll")
+    } else {
+        format!("lib{lib_name}.so")
+    }
+}
+
+/// Drive a stream of source change events from the mock-source cdylib across the
+/// FFI boundary and assert the process survives and delivers value-correct,
+/// host-owned events.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "gated: run via `make test-ffi-layout-mismatch` (nightly -Zlayout-seed + MALLOC_CHECK_)"]
+async fn mock_source_change_stream_survives_layout_mismatch() {
+    let path = plugin_dir().join(plugin_filename("drasi-source-mock"));
+    assert!(
+        path.exists(),
+        "mock source cdylib not found at {} — build it first (see make test-ffi-layout-mismatch)",
+        path.display()
+    );
+
+    let plugin = load_plugin_from_path(
+        &path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("Failed to load mock source plugin");
+
+    let config = serde_json::json!({
+        "dataType": { "type": "generic" },
+        "intervalMs": 5
+    });
+    let source = plugin.source_plugins[0]
+        .create_source("layout-mismatch-src", &config, false)
+        .await
+        .expect("Should create mock source instance");
+
+    let (event_tx, _event_rx) =
+        tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(100);
+    let context = drasi_lib::context::SourceRuntimeContext::new(
+        "layout-mismatch-instance",
+        "layout-mismatch-src",
+        None,
+        event_tx,
+        None,
+    );
+    source.initialize(context).await;
+    source.start().await.expect("Should start source");
+
+    let settings = drasi_lib::config::SourceSubscriptionSettings {
+        source_id: "layout-mismatch-src".to_string(),
+        enable_bootstrap: false,
+        query_id: "layout-mismatch-query".to_string(),
+        nodes: HashSet::new(),
+        relations: HashSet::new(),
+        resume_from: None,
+        request_position_handle: false,
+    };
+    let sub = source.subscribe(settings).await.expect("Should subscribe");
+    let mut receiver = sub.receiver;
+
+    // Drain a batch of change events. Each event carries an `Element` with
+    // `Arc<str>` data; before the fix, receiving (and dropping) it under a layout
+    // mismatch corrupts the heap. After the fix it is deserialized into a
+    // host-owned value and is safe to read and drop.
+    let mut received = 0usize;
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    while received < 50 && std::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(500), receiver.recv()).await {
+            Ok(Ok(wrapper)) => {
+                // Touch the event's heap data — reads through `Arc<str>` and any
+                // `bytes::Bytes`. This is what corrupts/aborts before the fix.
+                let _ = wrapper.source_id.len();
+                if let drasi_lib::channels::events::SourceEvent::Change(change) = &wrapper.event {
+                    let _ = format!("{:?}", change.get_reference());
+                }
+                received += 1;
+                // Drop the host-owned wrapper explicitly to exercise the drop glue.
+                drop(wrapper);
+            }
+            Ok(Err(_)) => break, // channel closed
+            Err(_) => continue,  // timeout tick
+        }
+    }
+
+    assert!(
+        received >= 1,
+        "expected to receive at least one change event from the mock source"
+    );
+    println!("LAYOUT_MISMATCH_OK: received {received} change events without corruption");
+
+    source.stop().await.expect("Should stop source");
+    drop(receiver);
+    drop(source);
+    drop(plugin);
+    drop(_event_rx);
+}

--- a/components/host-sdk/tests/ffi_layout_mismatch_test.rs
+++ b/components/host-sdk/tests/ffi_layout_mismatch_test.rs
@@ -16,10 +16,13 @@
 //!
 //! Issue #602 was a heap corruption (`free(): invalid pointer`) caused by the
 //! host taking ownership of a plugin-allocated `repr(Rust)` `SourceEventWrapper`
-//! (which embeds `bytes::Bytes` / `Arc<str>`) via `Box::from_raw`. That is sound
-//! only if the host and plugin agree on the `repr(Rust)` layout — which Rust does
-//! not guarantee across independently compiled cdylibs. The fix transfers events
-//! as serialized MessagePack bytes instead.
+//! (which embeds `bytes::Bytes` / `Arc<str>`) via `Box::from_raw`. That is
+//! unconditionally undefined behaviour, for two independent reasons: `repr(Rust)`
+//! has no stable layout across independently compiled cdylibs, *and* `bytes::Bytes`
+//! carries a `&'static Vtable` pointer that is only valid in the producing
+//! module's address space — so even byte-identical layouts would still free a
+//! foreign interior pointer. The fix transfers events as serialized MessagePack
+//! bytes instead.
 //!
 //! This test reproduces the bug **deterministically** by forcing a layout
 //! disagreement: the mock-source cdylib is built with one `-Zlayout-seed` and the

--- a/components/plugin-sdk/Cargo.toml
+++ b/components/plugin-sdk/Cargo.toml
@@ -13,6 +13,7 @@ drasi-core = { workspace = true }
 bytes = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rmp-serde = "1"
 thiserror = "2.0"
 utoipa = { version = "4", features = ["chrono"] }
 async-trait = "0.1"

--- a/components/plugin-sdk/src/ffi/agents.md
+++ b/components/plugin-sdk/src/ffi/agents.md
@@ -20,7 +20,7 @@ FFI boundary through this directory. The general patterns are:
 | Domain type category | FFI pattern | Key file |
 |---------------------|-------------|----------|
 | Trait methods (Source, Reaction, BootstrapProvider) | Function pointer vtables | `vtables.rs`, `vtable_gen.rs` |
-| Opaque Rust types (SourceEventWrapper, BootstrapEvent, QueryResult) | `*mut c_void` in `#[repr(C)]` envelopes or vtable args | `vtables.rs` (envelope defs), `vtable_gen.rs` (wrapping) |
+| Rich event payloads (SourceEventWrapper, BootstrapEvent, QueryResult) | **Serialized MessagePack bytes** (`ptr+len+drop_fn`) in `#[repr(C)]` envelopes — never `repr(Rust)` opaque pointers (issue #602) | `payload.rs` (DTOs + codec), `vtables.rs` (envelopes), `vtable_gen.rs` |
 | Simple enums (ComponentStatus, DispatchMode) | Mirrored `#[repr(C)]` enums | `types.rs` |
 | Strings | `FfiStr` (borrowed) / `FfiOwnedStr` (owned) | `types.rs` |
 | Complex structs (SubscriptionSettings) | Deconstructed into `FfiStr` args or JSON | `vtable_gen.rs` |

--- a/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
+++ b/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
@@ -68,9 +68,26 @@ impl BootstrapProvider for FfiBootstrapProviderProxy {
                 return -1;
             }
             let ffi_event = unsafe { &*event };
-            let bootstrap_event = unsafe {
-                let opaque = ffi_event.opaque as *mut drasi_lib::channels::events::BootstrapEvent;
-                std::ptr::read(opaque)
+            // Decode the serialized payload into a plugin-owned BootstrapEvent and
+            // free the producer's buffer via its own deallocator (issue #602: never
+            // reinterpret/drop the other side's repr(Rust) memory).
+            let decoded = if ffi_event.payload_ptr.is_null() || ffi_event.payload_len == 0 {
+                None
+            } else {
+                let slice = unsafe {
+                    std::slice::from_raw_parts(ffi_event.payload_ptr, ffi_event.payload_len)
+                };
+                crate::ffi::payload::decode_bootstrap_event_payload(slice)
+            };
+            if !ffi_event.payload_ptr.is_null() {
+                (ffi_event.payload_drop_fn)(
+                    ffi_event.payload_ptr as *mut u8,
+                    ffi_event.payload_len,
+                );
+            }
+            unsafe { drop(Box::from_raw(event)) };
+            let Some(bootstrap_event) = decoded else {
+                return 0;
             };
             match sender_state.tx.send(bootstrap_event) {
                 Ok(()) => 0,

--- a/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
+++ b/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
@@ -70,16 +70,9 @@ impl BootstrapProvider for FfiBootstrapProviderProxy {
             let ffi_event = unsafe { &*event };
             // Decode the serialized payload into a plugin-owned BootstrapEvent and
             // free the producer's buffer via its own deallocator (issue #602: never
-            // reinterpret/drop the other side's repr(Rust) memory). `take_ffi_payload`
-            // also bounds the size and null-guards the drop fn.
-            let decoded = unsafe {
-                crate::ffi::payload::take_ffi_payload(
-                    ffi_event.payload_ptr,
-                    ffi_event.payload_len,
-                    ffi_event.payload_drop_fn,
-                    crate::ffi::payload::decode_bootstrap_event_payload,
-                )
-            };
+            // reinterpret/drop the other side's repr(Rust) memory). The canonical
+            // consumer also bounds the size and null-guards the drop fn.
+            let decoded = unsafe { crate::ffi::payload::consume_bootstrap_event(ffi_event) };
             unsafe { drop(Box::from_raw(event)) };
             let Some(bootstrap_event) = decoded else {
                 return 0;

--- a/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
+++ b/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
@@ -70,21 +70,16 @@ impl BootstrapProvider for FfiBootstrapProviderProxy {
             let ffi_event = unsafe { &*event };
             // Decode the serialized payload into a plugin-owned BootstrapEvent and
             // free the producer's buffer via its own deallocator (issue #602: never
-            // reinterpret/drop the other side's repr(Rust) memory).
-            let decoded = if ffi_event.payload_ptr.is_null() || ffi_event.payload_len == 0 {
-                None
-            } else {
-                let slice = unsafe {
-                    std::slice::from_raw_parts(ffi_event.payload_ptr, ffi_event.payload_len)
-                };
-                crate::ffi::payload::decode_bootstrap_event_payload(slice)
-            };
-            if !ffi_event.payload_ptr.is_null() {
-                (ffi_event.payload_drop_fn)(
-                    ffi_event.payload_ptr as *mut u8,
+            // reinterpret/drop the other side's repr(Rust) memory). `take_ffi_payload`
+            // also bounds the size and null-guards the drop fn.
+            let decoded = unsafe {
+                crate::ffi::payload::take_ffi_payload(
+                    ffi_event.payload_ptr,
                     ffi_event.payload_len,
-                );
-            }
+                    ffi_event.payload_drop_fn,
+                    crate::ffi::payload::decode_bootstrap_event_payload,
+                )
+            };
             unsafe { drop(Box::from_raw(event)) };
             let Some(bootstrap_event) = decoded else {
                 return 0;

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -18,7 +18,7 @@ use super::types::FfiStr;
 
 /// The FFI ABI contract version of this SDK. Used for compatibility checks at
 /// plugin load time: the host (`loader.rs`) rejects any plugin whose reported
-/// `sdk_version` differs in **major.minor** from this value.
+/// `sdk_version` differs in the **major or minor** component from this value.
 ///
 /// This is intentionally **decoupled from the crate release version**
 /// (`CARGO_PKG_VERSION`): it identifies the layout/ABI of the `#[repr(C)]`

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -16,8 +16,21 @@
 
 use super::types::FfiStr;
 
-/// The SDK version of this crate. Used for compatibility checks at plugin load time.
-pub const FFI_SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// The FFI ABI contract version of this SDK. Used for compatibility checks at
+/// plugin load time: the host (`loader.rs`) rejects any plugin whose reported
+/// `sdk_version` differs in **major.minor** from this value.
+///
+/// This is intentionally **decoupled from the crate release version**
+/// (`CARGO_PKG_VERSION`): it identifies the layout/ABI of the `#[repr(C)]`
+/// envelope structs and the wire format of serialized payloads, not the package
+/// release. **Bump the minor (pre-1.0) on any `#[repr(C)]` layout change or
+/// payload wire-format change.**
+///
+/// History:
+/// - `0.10.0`: source change / bootstrap events now cross the boundary as
+///   serialized (MessagePack) payloads instead of reinterpreted `repr(Rust)`
+///   opaque pointers (fixes #602 cross-cdylib heap corruption).
+pub const FFI_SDK_VERSION: &str = "0.10.0";
 
 /// The target triple this crate was compiled for.
 pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");

--- a/components/plugin-sdk/src/ffi/mod.rs
+++ b/components/plugin-sdk/src/ffi/mod.rs
@@ -33,6 +33,7 @@ pub mod callbacks;
 pub mod identity;
 pub mod identity_proxy;
 pub mod metadata;
+pub mod payload;
 pub mod secret_store;
 pub mod snapshot_fetcher_proxy;
 pub mod state_store_proxy;
@@ -50,6 +51,7 @@ pub use callbacks::{
 pub use metadata::{
     PluginMetadata, BUILD_TIMESTAMP, FFI_SDK_VERSION, GIT_COMMIT_SHA, TARGET_TRIPLE,
 };
+pub use payload::{BootstrapEventPayload, SourceEventPayload};
 pub use types::{
     catch_panic_ffi, now_us, AsyncExecutorFn, FfiChangeOp, FfiComponentStatus, FfiCreateResult,
     FfiDispatchMode, FfiGetResult, FfiOwnedStr, FfiResult, FfiStr, FfiStringArray, SendMutPtr,
@@ -70,10 +72,10 @@ pub use vtables::{
     FfiBootstrapResultCallbackFn, FfiBootstrapResultReceiver, FfiBootstrapSender,
     FfiBootstrapWriteCheckpointFn, FfiChangePushCallbackFn, FfiChangeReceiver, FfiCheckpoint,
     FfiCheckpointResult, FfiOutboxIterator, FfiOutboxIteratorResponse, FfiPluginRegistration,
-    FfiResultPushCallbackFn, FfiRuntimeContext, FfiSnapshotIterator, FfiSnapshotIteratorResponse,
-    FfiSourceEvent, FfiSubscriptionResponse, IdentityProviderPluginVtable, ReactionPluginVtable,
-    ReactionVtable, SecretStorePluginVtable, SnapshotFetcherVtable, SourcePluginVtable,
-    SourceVtable, StateStoreVtable, WalProviderVtable,
+    FfiQueryResult, FfiResultPushCallbackFn, FfiRuntimeContext, FfiSnapshotIterator,
+    FfiSnapshotIteratorResponse, FfiSourceEvent, FfiSubscriptionResponse,
+    IdentityProviderPluginVtable, ReactionPluginVtable, ReactionVtable, SecretStorePluginVtable,
+    SnapshotFetcherVtable, SourcePluginVtable, SourceVtable, StateStoreVtable, WalProviderVtable,
 };
 
 pub use bootstrap_proxy::FfiBootstrapProviderProxy;

--- a/components/plugin-sdk/src/ffi/payload.rs
+++ b/components/plugin-sdk/src/ffi/payload.rs
@@ -1,0 +1,286 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Serialized event payloads that cross the cdylib FFI boundary.
+//!
+//! # Why this exists (issue #602)
+//!
+//! `SourceEventWrapper` / `BootstrapEvent` are `repr(Rust)` types that contain
+//! `bytes::Bytes` and `Arc<str>`. The previous design transferred them across the
+//! cdylib boundary as opaque `Box::into_raw` pointers and reconstructed them on the
+//! other side with `Box::from_raw`. That is **undefined behavior**: `repr(Rust)`
+//! has no stable layout across independently compiled cdylibs, and `bytes::Bytes`
+//! carries a `&'static Vtable` pointer that is only valid in the producing module's
+//! address space. The result was non-deterministic heap corruption
+//! (`free(): invalid pointer`).
+//!
+//! Instead, the producing side serializes these self-describing payloads to
+//! MessagePack (via `rmp-serde`) and transfers them as raw `ptr + len` byte
+//! buffers; the consuming side deserializes into its own host-owned values and
+//! frees the producer's buffer through a producer-supplied `drop_fn`. No side ever
+//! reads or drops the other side's `repr(Rust)` memory.
+//!
+//! Both the plugin SDK and the host SDK depend on this crate, so they share these
+//! exact struct definitions and therefore agree on the wire schema.
+
+use bytes::Bytes;
+use chrono::DateTime;
+use drasi_core::models::SourceChange;
+use drasi_lib::channels::events::{BootstrapEvent, SourceEvent, SourceEventWrapper};
+use serde::{Deserialize, Serialize};
+
+/// Serialized form of a `SourceEventWrapper` for FFI transfer.
+///
+/// Carries everything the host needs to rebuild a host-owned
+/// `SourceEventWrapper`. `profiling` is intentionally omitted: it is `None` at the
+/// point a source emits an event and is populated later by the framework.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SourceEventPayload {
+    pub source_id: String,
+    pub event: SourceEvent,
+    /// Event timestamp in microseconds since the Unix epoch.
+    pub timestamp_us: i64,
+    /// Monotonic sequence number; `None` for volatile sources.
+    pub sequence: Option<u64>,
+    /// Opaque, source-defined replication position bytes.
+    pub source_position: Option<Vec<u8>>,
+}
+
+/// Serialized form of a `BootstrapEvent` for FFI transfer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BootstrapEventPayload {
+    pub source_id: String,
+    pub change: SourceChange,
+    /// Event timestamp in microseconds since the Unix epoch.
+    pub timestamp_us: i64,
+    pub sequence: u64,
+}
+
+impl SourceEventPayload {
+    /// Build a payload from a `SourceEventWrapper` (producing side).
+    pub fn from_wrapper(wrapper: &SourceEventWrapper) -> Self {
+        let timestamp_us = wrapper
+            .timestamp
+            .timestamp_nanos_opt()
+            .map(|n| n / 1000)
+            .unwrap_or(0);
+        Self {
+            source_id: wrapper.source_id.clone(),
+            event: wrapper.event.clone(),
+            timestamp_us,
+            sequence: wrapper.sequence,
+            source_position: wrapper.source_position.as_ref().map(|b| b.to_vec()),
+        }
+    }
+
+    /// Reconstruct a host/plugin-owned `SourceEventWrapper` (consuming side).
+    pub fn into_wrapper(self) -> SourceEventWrapper {
+        let timestamp =
+            DateTime::from_timestamp_micros(self.timestamp_us).unwrap_or_else(chrono::Utc::now);
+        SourceEventWrapper {
+            source_id: self.source_id,
+            event: self.event,
+            timestamp,
+            profiling: None,
+            sequence: self.sequence,
+            source_position: self.source_position.map(Bytes::from),
+        }
+    }
+}
+
+impl BootstrapEventPayload {
+    /// Build a payload from a `BootstrapEvent` (producing side).
+    pub fn from_event(record: &BootstrapEvent) -> Self {
+        let timestamp_us = record
+            .timestamp
+            .timestamp_nanos_opt()
+            .map(|n| n / 1000)
+            .unwrap_or(0);
+        Self {
+            source_id: record.source_id.clone(),
+            change: record.change.clone(),
+            timestamp_us,
+            sequence: record.sequence,
+        }
+    }
+
+    /// Reconstruct a host/plugin-owned `BootstrapEvent` (consuming side).
+    pub fn into_event(self) -> BootstrapEvent {
+        let timestamp =
+            DateTime::from_timestamp_micros(self.timestamp_us).unwrap_or_else(chrono::Utc::now);
+        BootstrapEvent {
+            source_id: self.source_id,
+            change: self.change,
+            timestamp,
+            sequence: self.sequence,
+        }
+    }
+}
+
+/// Decode raw MessagePack FFI payload bytes into a `SourceEventWrapper`.
+/// Returns `None` (and logs) on decode failure.
+pub fn decode_source_event_payload(bytes: &[u8]) -> Option<SourceEventWrapper> {
+    match rmp_serde::from_slice::<SourceEventPayload>(bytes) {
+        Ok(p) => Some(p.into_wrapper()),
+        Err(e) => {
+            log::error!("Failed to decode FFI source event payload: {e}");
+            None
+        }
+    }
+}
+
+/// Decode raw MessagePack FFI payload bytes into a `BootstrapEvent`.
+/// Returns `None` (and logs) on decode failure.
+pub fn decode_bootstrap_event_payload(bytes: &[u8]) -> Option<BootstrapEvent> {
+    match rmp_serde::from_slice::<BootstrapEventPayload>(bytes) {
+        Ok(p) => Some(p.into_event()),
+        Err(e) => {
+            log::error!("Failed to decode FFI bootstrap event payload: {e}");
+            None
+        }
+    }
+}
+
+/// Encode a `QueryResult` to MessagePack bytes for host→plugin FFI transfer.
+pub fn encode_query_result(result: &drasi_lib::channels::QueryResult) -> Vec<u8> {
+    // `to_vec_named` (field-name map) tolerates `#[serde(skip_serializing_if)]`
+    // fields such as `QueryResult::profiling`; the compact positional encoding
+    // would emit fewer elements than the decoder expects.
+    match rmp_serde::to_vec_named(result) {
+        Ok(b) => b,
+        Err(e) => {
+            log::error!("Failed to encode FFI query result payload: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Decode raw MessagePack FFI payload bytes into a `QueryResult`.
+/// Returns `None` (and logs) on decode failure.
+pub fn decode_query_result(bytes: &[u8]) -> Option<drasi_lib::channels::QueryResult> {
+    match rmp_serde::from_slice::<drasi_lib::channels::QueryResult>(bytes) {
+        Ok(r) => Some(r),
+        Err(e) => {
+            log::error!("Failed to decode FFI query result payload: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! T2 (part 1) — payload round-trip fidelity and the named-encoding
+    //! regression guard for issue #602's cross-cdylib serialized transfer.
+
+    use super::*;
+    use bytes::Bytes;
+    use chrono::Utc;
+    use drasi_core::models::{
+        Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
+    };
+    use drasi_lib::channels::events::SourceEvent;
+    use std::sync::Arc;
+
+    fn sample_node() -> Element {
+        let mut props = ElementPropertyMap::new();
+        props.insert("plate", ElementValue::String(Arc::from("A1234")));
+        props.insert("speed", ElementValue::Integer(55));
+        Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("src-1", "vehicles:A1234"),
+                labels: Arc::from(vec![Arc::from("vehicles")]),
+                effective_from: 1_771_000_000_000,
+            },
+            properties: props,
+        }
+    }
+
+    #[test]
+    fn source_event_payload_roundtrips_via_named_encoding() {
+        let wrapper = SourceEventWrapper {
+            source_id: "src-1".to_string(),
+            event: SourceEvent::Change(SourceChange::Insert {
+                element: sample_node(),
+            }),
+            timestamp: Utc::now(),
+            profiling: None,
+            sequence: Some(42),
+            source_position: Some(Bytes::from_static(b"binlog:000003:1766")),
+        };
+
+        let payload = SourceEventPayload::from_wrapper(&wrapper);
+        let bytes = rmp_serde::to_vec_named(&payload).expect("serialize");
+        let decoded = decode_source_event_payload(&bytes).expect("decode");
+
+        assert_eq!(decoded.source_id, wrapper.source_id);
+        assert_eq!(decoded.sequence, wrapper.sequence);
+        assert_eq!(decoded.event, wrapper.event);
+        assert_eq!(
+            decoded.source_position.as_deref(),
+            Some(&b"binlog:000003:1766"[..])
+        );
+        assert_eq!(
+            decoded.timestamp.timestamp_micros(),
+            wrapper.timestamp.timestamp_micros()
+        );
+    }
+
+    #[test]
+    fn bootstrap_event_payload_roundtrips() {
+        let record = BootstrapEvent {
+            source_id: "src-1".to_string(),
+            change: SourceChange::Delete {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("src-1", "vehicles:B5678"),
+                    labels: Arc::from(vec![Arc::from("vehicles")]),
+                    effective_from: 9,
+                },
+            },
+            timestamp: Utc::now(),
+            sequence: 7,
+        };
+
+        let payload = BootstrapEventPayload::from_event(&record);
+        let bytes = rmp_serde::to_vec_named(&payload).expect("serialize");
+        let decoded = decode_bootstrap_event_payload(&bytes).expect("decode");
+
+        assert_eq!(decoded.source_id, record.source_id);
+        assert_eq!(decoded.sequence, record.sequence);
+        assert_eq!(decoded.change, record.change);
+    }
+
+    #[test]
+    fn query_result_roundtrips_with_skipped_profiling_field() {
+        // Regression guard: `QueryResult::profiling` is
+        // `#[serde(skip_serializing_if = "Option::is_none")]`. The compact
+        // positional MessagePack encoding emits 5 elements for a 6-field struct
+        // and fails to decode ("invalid length 5, expected 6"); named encoding
+        // (`encode_query_result`) tolerates the skipped field.
+        let qr = drasi_lib::channels::QueryResult::new(
+            "q-1".to_string(),
+            3,
+            Utc::now(),
+            Vec::new(),
+            std::collections::HashMap::new(),
+        );
+        assert!(qr.profiling.is_none());
+
+        let bytes = encode_query_result(&qr);
+        let decoded = decode_query_result(&bytes).expect("decode QueryResult");
+
+        assert_eq!(decoded.query_id, qr.query_id);
+        assert_eq!(decoded.sequence, qr.sequence);
+        assert!(decoded.profiling.is_none());
+    }
+}

--- a/components/plugin-sdk/src/ffi/payload.rs
+++ b/components/plugin-sdk/src/ffi/payload.rs
@@ -86,8 +86,11 @@ impl SourceEventPayload {
 
     /// Reconstruct a host/plugin-owned `SourceEventWrapper` (consuming side).
     pub fn into_wrapper(self) -> SourceEventWrapper {
-        let timestamp =
-            DateTime::from_timestamp_micros(self.timestamp_us).unwrap_or_else(chrono::Utc::now);
+        let timestamp = DateTime::from_timestamp_micros(self.timestamp_us)
+            // Deterministic fallback (Unix epoch) on an out-of-range/invalid
+            // timestamp — never `Utc::now()`, which would be non-deterministic
+            // and could silently mask a corrupt payload.
+            .unwrap_or(DateTime::UNIX_EPOCH);
         SourceEventWrapper {
             source_id: self.source_id,
             event: self.event,
@@ -117,8 +120,11 @@ impl BootstrapEventPayload {
 
     /// Reconstruct a host/plugin-owned `BootstrapEvent` (consuming side).
     pub fn into_event(self) -> BootstrapEvent {
-        let timestamp =
-            DateTime::from_timestamp_micros(self.timestamp_us).unwrap_or_else(chrono::Utc::now);
+        let timestamp = DateTime::from_timestamp_micros(self.timestamp_us)
+            // Deterministic fallback (Unix epoch) on an out-of-range/invalid
+            // timestamp — never `Utc::now()`, which would be non-deterministic
+            // and could silently mask a corrupt payload.
+            .unwrap_or(DateTime::UNIX_EPOCH);
         BootstrapEvent {
             source_id: self.source_id,
             change: self.change,

--- a/components/plugin-sdk/src/ffi/payload.rs
+++ b/components/plugin-sdk/src/ffi/payload.rs
@@ -34,6 +34,7 @@
 //! Both the plugin SDK and the host SDK depend on this crate, so they share these
 //! exact struct definitions and therefore agree on the wire schema.
 
+use super::vtables::{FfiBootstrapEvent, FfiSourceEvent};
 use bytes::Bytes;
 use chrono::DateTime;
 use drasi_core::models::SourceChange;
@@ -221,13 +222,14 @@ pub fn encode_query_result(result: &drasi_lib::channels::QueryResult) -> Vec<u8>
     // `to_vec_named` (field-name map) tolerates `#[serde(skip_serializing_if)]`
     // fields such as `QueryResult::profiling`; the compact positional encoding
     // would emit fewer elements than the decoder expects.
-    match rmp_serde::to_vec_named(result) {
-        Ok(b) => b,
-        Err(e) => {
-            log::error!("Failed to encode FFI query result payload: {e}");
-            Vec::new()
-        }
-    }
+    //
+    // Serialization of this in-memory, properly-derived type cannot fail at
+    // runtime (no I/O; no fallible custom `Serialize` impl). If it ever does it
+    // is a programming error — a non-serializable field was added. Returning an
+    // empty buffer would be silently decoded by the consumer as "no result",
+    // i.e. undetectable data loss in a reactive pipeline, so we fail loudly.
+    rmp_serde::to_vec_named(result)
+        .expect("BUG: failed to encode FFI query result payload (non-serializable field added?)")
 }
 
 /// Decode raw MessagePack FFI payload bytes into a `QueryResult`.
@@ -239,6 +241,48 @@ pub fn decode_query_result(bytes: &[u8]) -> Option<drasi_lib::channels::QueryRes
             log::error!("Failed to decode FFI query result payload: {e}");
             None
         }
+    }
+}
+
+/// Consume a peer-produced `FfiSourceEvent`: decode its serialized payload into a
+/// host-owned `SourceEventWrapper` and free the peer's payload buffer via the
+/// envelope's `payload_drop_fn` (delegating null/size hardening to
+/// [`take_ffi_payload`]). The `#[repr(C)]` envelope itself is borrowed and not
+/// freed here.
+///
+/// This is the single canonical source-event consumer shared by every FFI
+/// consumer site (host and plugin), so the decode→free→hardening sequence is
+/// implemented exactly once (issue #602).
+///
+/// # Safety
+/// `ffi` must reference a valid envelope produced by the peer's serializer, whose
+/// `payload_ptr`/`payload_len`/`payload_drop_fn` describe a peer-owned buffer.
+pub unsafe fn consume_source_event(ffi: &FfiSourceEvent) -> Option<SourceEventWrapper> {
+    unsafe {
+        take_ffi_payload(
+            ffi.payload_ptr,
+            ffi.payload_len,
+            ffi.payload_drop_fn,
+            decode_source_event_payload,
+        )
+    }
+}
+
+/// Consume a peer-produced `FfiBootstrapEvent`: decode its serialized payload into
+/// a host-owned `BootstrapEvent` and free the peer's payload buffer via the
+/// envelope's `payload_drop_fn`. The `#[repr(C)]` envelope itself is borrowed and
+/// not freed here. Single canonical bootstrap-event consumer (issue #602).
+///
+/// # Safety
+/// See [`consume_source_event`].
+pub unsafe fn consume_bootstrap_event(ffi: &FfiBootstrapEvent) -> Option<BootstrapEvent> {
+    unsafe {
+        take_ffi_payload(
+            ffi.payload_ptr,
+            ffi.payload_len,
+            ffi.payload_drop_fn,
+            decode_bootstrap_event_payload,
+        )
     }
 }
 

--- a/components/plugin-sdk/src/ffi/payload.rs
+++ b/components/plugin-sdk/src/ffi/payload.rs
@@ -40,6 +40,64 @@ use drasi_core::models::SourceChange;
 use drasi_lib::channels::events::{BootstrapEvent, SourceEvent, SourceEventWrapper};
 use serde::{Deserialize, Serialize};
 
+/// Maximum accepted serialized FFI payload size.
+///
+/// Defends the consuming process against unbounded allocation from a buggy or
+/// malicious peer that supplies an enormous `payload_len`. 256 MiB is far larger
+/// than any realistic single change event / query result, so legitimate traffic
+/// is never affected. This bound also caps the `source_position` bytes, which are
+/// carried inside the payload.
+pub const MAX_FFI_PAYLOAD_BYTES: usize = 256 * 1024 * 1024;
+
+/// Read a peer-owned serialized payload buffer, decode it, and free the peer's
+/// buffer via `drop_fn`.
+///
+/// This is the single, hardened entry point used by **every** FFI payload
+/// consumer (source events, bootstrap events, query results, on both the host and
+/// plugin sides). It defends against a buggy or malicious producer:
+///
+/// - null / empty buffer → returns `None`;
+/// - `len > MAX_FFI_PAYLOAD_BYTES` → rejected (no allocation) to prevent a
+///   memory-exhaustion DoS;
+/// - **null `drop_fn`** → the buffer is leaked with a logged error instead of
+///   calling a null function pointer (which would crash the process — there is no
+///   panic recovery across `extern "C"`). The ABI requires `drop_fn` to be
+///   non-null; this guard is defense-in-depth.
+///
+/// The producer's buffer is always freed when `drop_fn` is non-null, even if
+/// decoding fails.
+///
+/// # Safety
+/// `ptr` / `len` must describe a buffer produced by the peer's serializer that is
+/// owned by the peer and freeable by `drop_fn`.
+pub unsafe fn take_ffi_payload<T>(
+    ptr: *const u8,
+    len: usize,
+    drop_fn: Option<extern "C" fn(*mut u8, usize)>,
+    decode: impl FnOnce(&[u8]) -> Option<T>,
+) -> Option<T> {
+    let decoded = if ptr.is_null() || len == 0 {
+        None
+    } else if len > MAX_FFI_PAYLOAD_BYTES {
+        log::error!("Rejecting oversized FFI payload ({len} bytes > {MAX_FFI_PAYLOAD_BYTES} max)");
+        None
+    } else {
+        decode(unsafe { std::slice::from_raw_parts(ptr, len) })
+    };
+    // Free the producer's buffer. A null `drop_fn` (ABI violation by a buggy or
+    // malicious producer) leaks the buffer with a logged error rather than
+    // crashing the process — there is no panic recovery across `extern "C"`.
+    if !ptr.is_null() {
+        match drop_fn {
+            Some(free) => free(ptr as *mut u8, len),
+            None => {
+                log::error!("FFI contract violation: null payload_drop_fn; leaking {len} bytes")
+            }
+        }
+    }
+    decoded
+}
+
 /// Serialized form of a `SourceEventWrapper` for FFI transfer.
 ///
 /// Carries everything the host needs to rebuild a host-owned
@@ -288,5 +346,119 @@ mod tests {
         assert_eq!(decoded.query_id, qr.query_id);
         assert_eq!(decoded.sequence, qr.sequence);
         assert!(decoded.profiling.is_none());
+    }
+
+    // ---- take_ffi_payload hardening (security review) ----
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Dedicated per-test counters (no shared static / `store(0)` resets that would
+    // race under parallel test execution).
+    static DROPS_DECODE: AtomicUsize = AtomicUsize::new(0);
+    static DROPS_OVERSIZED: AtomicUsize = AtomicUsize::new(0);
+
+    /// Counts calls but never frees, so a test can pass a deliberately wrong
+    /// `len` (e.g. the oversized case) without triggering an invalid free.
+    extern "C" fn count_drop_decode(_ptr: *mut u8, _len: usize) {
+        DROPS_DECODE.fetch_add(1, Ordering::SeqCst);
+    }
+    extern "C" fn count_drop_oversized(_ptr: *mut u8, _len: usize) {
+        DROPS_OVERSIZED.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn encoded_source_event() -> Vec<u8> {
+        let wrapper = SourceEventWrapper {
+            source_id: "src-1".to_string(),
+            event: SourceEvent::Change(SourceChange::Insert {
+                element: sample_node(),
+            }),
+            timestamp: Utc::now(),
+            profiling: None,
+            sequence: Some(1),
+            source_position: None,
+        };
+        let payload = SourceEventPayload::from_wrapper(&wrapper);
+        rmp_serde::to_vec_named(&payload).unwrap()
+    }
+
+    #[test]
+    fn take_ffi_payload_decodes_and_calls_drop() {
+        let bytes = encoded_source_event();
+        let len = bytes.len();
+        let ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+
+        let decoded = unsafe {
+            take_ffi_payload(
+                ptr,
+                len,
+                Some(count_drop_decode),
+                decode_source_event_payload,
+            )
+        };
+        assert!(decoded.is_some());
+        assert_eq!(DROPS_DECODE.load(Ordering::SeqCst), 1);
+
+        unsafe {
+            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                ptr as *mut u8,
+                len,
+            )))
+        };
+    }
+
+    #[test]
+    fn take_ffi_payload_rejects_oversized_without_reading() {
+        // A real (small) buffer, but we lie about its length to exceed the cap.
+        // `take_ffi_payload` must reject it *before* slicing/decoding (no OOB read),
+        // and must still invoke the producer's drop fn.
+        let bytes = vec![0u8; 16];
+        let real_len = bytes.len();
+        let ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+
+        let decoded = unsafe {
+            take_ffi_payload(
+                ptr,
+                MAX_FFI_PAYLOAD_BYTES + 1,
+                Some(count_drop_oversized),
+                decode_source_event_payload,
+            )
+        };
+        assert!(decoded.is_none(), "oversized payload must be rejected");
+        assert_eq!(
+            DROPS_OVERSIZED.load(Ordering::SeqCst),
+            1,
+            "buffer must still be freed"
+        );
+
+        unsafe {
+            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                ptr as *mut u8,
+                real_len,
+            )))
+        };
+    }
+
+    #[test]
+    fn take_ffi_payload_null_drop_fn_does_not_crash() {
+        // A buggy/malicious producer setting `drop_fn = None` (null) must not crash
+        // the process (no panic recovery across `extern "C"`). The buffer leaks, but
+        // the consumer stays alive and still decodes the event.
+        let bytes = encoded_source_event();
+        let len = bytes.len();
+        let ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+
+        let decoded = unsafe { take_ffi_payload(ptr, len, None, decode_source_event_payload) };
+        assert!(
+            decoded.is_some(),
+            "decode should still succeed; only the free is skipped"
+        );
+
+        // Buffer was leaked (drop fn was null) — reclaim it so the test doesn't leak.
+        unsafe {
+            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                ptr as *mut u8,
+                len,
+            )))
+        };
     }
 }

--- a/components/plugin-sdk/src/ffi/payload.rs
+++ b/components/plugin-sdk/src/ffi/payload.rs
@@ -123,6 +123,8 @@ pub struct BootstrapEventPayload {
     pub change: SourceChange,
     /// Event timestamp in microseconds since the Unix epoch.
     pub timestamp_us: i64,
+    /// Monotonic sequence number; always present for bootstrap events
+    /// (unlike `SourceEventPayload::sequence`, which is `None` for volatile sources).
     pub sequence: u64,
 }
 
@@ -218,16 +220,18 @@ pub fn decode_bootstrap_event_payload(bytes: &[u8]) -> Option<BootstrapEvent> {
 }
 
 /// Encode a `QueryResult` to MessagePack bytes for host→plugin FFI transfer.
+///
+/// # Panics
+/// Panics if `QueryResult` fails to serialize. This is unreachable in practice
+/// (serializing an in-memory, properly-derived type with no I/O cannot fail) and
+/// would indicate a programming error such as adding a non-serializable field.
+/// Failing loudly is deliberate: returning an empty buffer would be silently
+/// decoded by the consumer as "no result" — undetectable data loss in a reactive
+/// pipeline.
 pub fn encode_query_result(result: &drasi_lib::channels::QueryResult) -> Vec<u8> {
     // `to_vec_named` (field-name map) tolerates `#[serde(skip_serializing_if)]`
     // fields such as `QueryResult::profiling`; the compact positional encoding
     // would emit fewer elements than the decoder expects.
-    //
-    // Serialization of this in-memory, properly-derived type cannot fail at
-    // runtime (no I/O; no fallible custom `Serialize` impl). If it ever does it
-    // is a programming error — a non-serializable field was added. Returning an
-    // empty buffer would be silently decoded by the consumer as "no result",
-    // i.e. undetectable data loss in a reactive pipeline, so we fail loudly.
     rmp_serde::to_vec_named(result)
         .expect("BUG: failed to encode FFI query result payload (non-serializable field added?)")
 }

--- a/components/plugin-sdk/src/ffi/payload.rs
+++ b/components/plugin-sdk/src/ffi/payload.rs
@@ -34,7 +34,7 @@
 //! Both the plugin SDK and the host SDK depend on this crate, so they share these
 //! exact struct definitions and therefore agree on the wire schema.
 
-use super::vtables::{FfiBootstrapEvent, FfiSourceEvent};
+use super::vtables::{FfiBootstrapEvent, FfiQueryResult, FfiSourceEvent};
 use bytes::Bytes;
 use chrono::DateTime;
 use drasi_core::models::SourceChange;
@@ -286,6 +286,36 @@ pub unsafe fn consume_bootstrap_event(ffi: &FfiBootstrapEvent) -> Option<Bootstr
     }
 }
 
+/// Consume a peer-produced `*mut FfiQueryResult`: decode its serialized payload
+/// into an owned `QueryResult`, free the peer's payload buffer via the envelope's
+/// `payload_drop_fn`, **and** free the `#[repr(C)]` envelope `Box` itself (whose
+/// ownership the producer transferred via `Box::into_raw`). Single canonical
+/// query-result consumer (issue #602).
+///
+/// Unlike [`consume_source_event`]/[`consume_bootstrap_event`] (which borrow their
+/// envelope), the query-result envelope is passed by owned pointer, so this also
+/// reclaims it.
+///
+/// # Safety
+/// `ptr` must be a non-null `*mut FfiQueryResult` produced by the peer via
+/// `Box::into_raw`, whose `payload_ptr`/`payload_len`/`payload_drop_fn` describe a
+/// peer-owned buffer.
+pub unsafe fn consume_query_result(
+    ptr: *mut FfiQueryResult,
+) -> Option<drasi_lib::channels::QueryResult> {
+    let ffi = unsafe { &*ptr };
+    let decoded = unsafe {
+        take_ffi_payload(
+            ffi.payload_ptr,
+            ffi.payload_len,
+            ffi.payload_drop_fn,
+            decode_query_result,
+        )
+    };
+    unsafe { drop(Box::from_raw(ptr)) };
+    decoded
+}
+
 #[cfg(test)]
 mod tests {
     //! T2 (part 1) — payload round-trip fidelity and the named-encoding
@@ -504,5 +534,73 @@ mod tests {
                 len,
             )))
         };
+    }
+
+    // ---- consume_query_result ownership (host→plugin path) ----
+
+    // Dedicated per-test counters (avoid shared-static / reset races under
+    // parallel test execution).
+    static QR_DROPS_VALID: AtomicUsize = AtomicUsize::new(0);
+    static QR_DROPS_INVALID: AtomicUsize = AtomicUsize::new(0);
+
+    extern "C" fn count_drop_qr_valid(ptr: *mut u8, len: usize) {
+        QR_DROPS_VALID.fetch_add(1, Ordering::SeqCst);
+        free_raw_bytes(ptr, len);
+    }
+    extern "C" fn count_drop_qr_invalid(ptr: *mut u8, len: usize) {
+        QR_DROPS_INVALID.fetch_add(1, Ordering::SeqCst);
+        free_raw_bytes(ptr, len);
+    }
+
+    fn free_raw_bytes(ptr: *mut u8, len: usize) {
+        if !ptr.is_null() && len > 0 {
+            unsafe { drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len))) };
+        }
+    }
+
+    /// Mirror the host producer: build a `*mut FfiQueryResult` from a serialized
+    /// payload buffer guarded by a counting `payload_drop_fn`.
+    fn make_ffi_query_result(
+        bytes: Vec<u8>,
+        drop_fn: extern "C" fn(*mut u8, usize),
+    ) -> *mut FfiQueryResult {
+        let payload_len = bytes.len();
+        let payload_ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+        Box::into_raw(Box::new(FfiQueryResult {
+            payload_ptr,
+            payload_len,
+            payload_drop_fn: Some(drop_fn),
+        }))
+    }
+
+    #[test]
+    fn consume_query_result_decodes_and_frees_buffer_once() {
+        let qr = drasi_lib::channels::QueryResult::new(
+            "q-1".to_string(),
+            7,
+            Utc::now(),
+            Vec::new(),
+            std::collections::HashMap::new(),
+        );
+        let raw = make_ffi_query_result(encode_query_result(&qr), count_drop_qr_valid);
+
+        let decoded = unsafe { consume_query_result(raw) }.expect("owned QueryResult");
+        assert_eq!(decoded.query_id, "q-1");
+        assert_eq!(decoded.sequence, 7);
+
+        // The host's payload buffer was freed exactly once (no leak, no double-free),
+        // and the envelope `Box` was reclaimed by `consume_query_result`.
+        assert_eq!(QR_DROPS_VALID.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn consume_query_result_handles_undecodable_payload_without_leak() {
+        // Garbage bytes that are not a valid QueryResult.
+        let raw = make_ffi_query_result(vec![0xFFu8; 8], count_drop_qr_invalid);
+
+        let decoded = unsafe { consume_query_result(raw) };
+        assert!(decoded.is_none(), "garbage payload must not decode");
+        // Buffer still freed exactly once even though decode failed.
+        assert_eq!(QR_DROPS_INVALID.load(Ordering::SeqCst), 1);
     }
 }

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -78,13 +78,14 @@ fn serialize_ffi_payload<T: serde::Serialize>(value: &T) -> (*const u8, usize) {
     // `to_vec_named` encodes structs as field-name maps, which (unlike the
     // compact positional encoding) tolerates `#[serde(skip_serializing_if)]`
     // fields and field additions across SDK versions.
-    let bytes = match rmp_serde::to_vec_named(value) {
-        Ok(b) => b,
-        Err(e) => {
-            log::error!("Failed to serialize FFI event payload: {e}");
-            Vec::new()
-        }
-    };
+    //
+    // Serialization of a properly-derived, in-memory struct cannot fail at
+    // runtime (no I/O; no fallible custom `Serialize` impl). If it ever does it
+    // is a programming error — a non-serializable field was added. Returning an
+    // empty buffer would be silently decoded by the consumer as "no event", i.e.
+    // undetectable data loss in a reactive pipeline, so we fail loudly instead.
+    let bytes = rmp_serde::to_vec_named(value)
+        .expect("BUG: failed to serialize FFI event payload (non-serializable field added?)");
     let len = bytes.len();
     let ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
     (ptr, len)

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -42,6 +42,7 @@ use drasi_lib::{ComponentStatus, DispatchMode, SourceRuntimeContext, StateStoreP
 use super::bootstrap_proxy::FfiBootstrapProviderProxy;
 use super::callbacks::FfiLifecycleEvent;
 use super::callbacks::FfiLifecycleEventType;
+use super::payload::{BootstrapEventPayload, SourceEventPayload};
 use super::state_store_proxy::FfiStateStoreProxy;
 use super::types::*;
 use super::vtables::*;
@@ -65,6 +66,64 @@ fn ffi_guard<T, F: FnOnce() -> T>(default: T, f: F) -> T {
         Ok(v) => v,
         Err(_) => default,
     }
+}
+
+/// Serialize an FFI event payload (`SourceEventPayload` / `BootstrapEventPayload`)
+/// to a heap-allocated MessagePack byte buffer for cross-cdylib transfer.
+///
+/// Returns `(ptr, len)`; the buffer must be freed by the consuming side via
+/// [`ffi_drop_payload_bytes`] (passed as the envelope's `payload_drop_fn`). This
+/// replaces the previous `repr(Rust)` opaque-pointer transfer that caused #602.
+fn serialize_ffi_payload<T: serde::Serialize>(value: &T) -> (*const u8, usize) {
+    // `to_vec_named` encodes structs as field-name maps, which (unlike the
+    // compact positional encoding) tolerates `#[serde(skip_serializing_if)]`
+    // fields and field additions across SDK versions.
+    let bytes = match rmp_serde::to_vec_named(value) {
+        Ok(b) => b,
+        Err(e) => {
+            log::error!("Failed to serialize FFI event payload: {e}");
+            Vec::new()
+        }
+    };
+    let len = bytes.len();
+    let ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+    (ptr, len)
+}
+
+/// Frees a payload buffer produced by [`serialize_ffi_payload`].
+extern "C" fn ffi_drop_payload_bytes(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() && len > 0 {
+        unsafe {
+            let slice = std::slice::from_raw_parts_mut(ptr, len);
+            drop(Box::from_raw(slice as *mut [u8]));
+        }
+    }
+}
+
+/// Decode a host-sent `*mut FfiQueryResult` into a plugin-owned `QueryResult`.
+///
+/// Deserializes the host's MessagePack buffer, frees that buffer via the host's
+/// `payload_drop_fn`, and frees the `#[repr(C)]` envelope. Returns `None` if the
+/// payload could not be decoded (buffers are freed regardless). The host never
+/// hands the plugin a reinterpreted `repr(Rust)` pointer (issue #602).
+///
+/// # Safety
+/// `ptr` must be a non-null `*mut FfiQueryResult` produced by the host.
+unsafe fn decode_ffi_query_result(
+    ptr: *mut FfiQueryResult,
+) -> Option<drasi_lib::channels::QueryResult> {
+    let ffi = unsafe { &*ptr };
+    let decoded = if ffi.payload_ptr.is_null() || ffi.payload_len == 0 {
+        None
+    } else {
+        let slice = unsafe { std::slice::from_raw_parts(ffi.payload_ptr, ffi.payload_len) };
+        super::payload::decode_query_result(slice)
+    };
+    if !ffi.payload_ptr.is_null() {
+        (ffi.payload_drop_fn)(ffi.payload_ptr as *mut u8, ffi.payload_len);
+    }
+    unsafe { drop(Box::from_raw(ptr)) };
+    decoded
 }
 
 // Compile-time assertions that transmute between raw pointers and callback
@@ -98,17 +157,6 @@ fn dispatch_to_runtime<R: Send + 'static>(
         let _ = tx.send(result);
     });
     rx.recv().expect("plugin runtime task dropped unexpectedly")
-}
-
-/// Helper to extract ElementMetadata from a SourceChange.
-fn source_change_metadata(change: &SourceChange) -> Option<&ElementMetadata> {
-    match change {
-        SourceChange::Insert { element } | SourceChange::Update { element } => {
-            Some(element.get_metadata())
-        }
-        SourceChange::Delete { metadata } => Some(metadata),
-        SourceChange::Future { .. } => None,
-    }
 }
 
 // ============================================================================
@@ -1513,7 +1561,10 @@ pub fn build_reaction_vtable<T: Reaction + 'static>(
                     break;
                 }
                 let query_result =
-                    unsafe { *Box::from_raw(result_ptr as *mut drasi_lib::channels::QueryResult) };
+                    match unsafe { decode_ffi_query_result(result_ptr as *mut FfiQueryResult) } {
+                        Some(qr) => qr,
+                        None => continue,
+                    };
                 let inner = unsafe { ptr.as_ref() };
                 if let Err(e) = inner.inner.enqueue_query_result(query_result).await {
                     log::error!("Failed to enqueue query result: {e}");
@@ -1915,10 +1966,12 @@ pub fn build_reaction_vtable_from_boxed(
                     if result_ptr.is_null() {
                         break;
                     }
-                    let query_result = {
-                        let rp = result_ptr;
-                        unsafe { *Box::from_raw(rp as *mut drasi_lib::channels::QueryResult) }
-                    };
+                    let query_result =
+                        match unsafe { decode_ffi_query_result(result_ptr as *mut FfiQueryResult) }
+                        {
+                            Some(qr) => qr,
+                            None => continue,
+                        };
                     if let Err(e) = arc.inner.enqueue_query_result(query_result).await {
                         log::error!("Failed to enqueue query result: {e}");
                     }
@@ -2122,32 +2175,18 @@ pub fn build_bootstrap_provider_vtable(
         // Forward records from std::sync::mpsc to FFI sender
         let mut count: usize = 0;
         while let Ok(record) = std_rx.recv() {
-            let source_id_owned = record.source_id.clone();
-            let timestamp_us = record
-                .timestamp
-                .timestamp_nanos_opt()
-                .map(|n| n / 1000)
-                .unwrap_or(0);
-            let sequence = record.sequence;
-
-            // Extract entity metadata for FFI envelope
-            let entity_id_str = source_change_metadata(&record.change)
-                .map(|m| m.reference.element_id.to_string())
-                .unwrap_or_default();
-            let label_str = source_change_metadata(&record.change)
-                .and_then(|m| m.labels.first().map(|l| l.to_string()))
-                .unwrap_or_default();
-
-            let boxed = Box::new(record);
-            let ptr = Box::into_raw(boxed);
+            // Serialize the event payload for cross-cdylib transfer (issue #602):
+            // never hand the host a reinterpreted `repr(Rust)` pointer.
+            let payload = BootstrapEventPayload::from_event(&record);
+            let timestamp_us = payload.timestamp_us;
+            let sequence = payload.sequence;
+            let (payload_ptr, payload_len) = serialize_ffi_payload(&payload);
             let event = Box::new(FfiBootstrapEvent {
-                opaque: ptr as *mut c_void,
-                source_id: FfiStr::from_str(&source_id_owned),
+                payload_ptr,
+                payload_len,
+                payload_drop_fn: ffi_drop_payload_bytes,
                 timestamp_us,
                 sequence,
-                label: FfiStr::from_str(&label_str),
-                entity_id: FfiStr::from_str(&entity_id_str),
-                drop_fn: bootstrap_event_drop,
             });
             let event_ptr = Box::into_raw(event);
             let result = (send_fn)(sender_state, event_ptr);
@@ -2210,14 +2249,6 @@ pub fn build_bootstrap_provider_vtable(
                 drop(Box::from_raw(slice as *mut [u8]));
             }
         }
-    }
-
-    extern "C" fn bootstrap_event_drop(opaque: *mut c_void) {
-        ffi_guard((), || {
-            if !opaque.is_null() {
-                unsafe { drop(Box::from_raw(opaque as *mut BootstrapEvent)) };
-            }
-        });
     }
 
     extern "C" fn drop_fn(state: *mut c_void) {
@@ -2757,7 +2788,12 @@ fn wrap_subscription_response(
         receiver: Arc<DrasiLibChangeReceiver>,
     }
 
-    /// Convert a SourceEventWrapper into a heap-allocated FfiSourceEvent.
+    /// Serialize a `SourceEventWrapper` into a heap-allocated `FfiSourceEvent`.
+    ///
+    /// The event crosses the cdylib boundary as a MessagePack-encoded
+    /// `SourceEventPayload` (raw bytes), never as a reinterpreted `repr(Rust)`
+    /// pointer. The plugin keeps ownership of its own `wrapper` (dropped here);
+    /// the host deserializes a fresh, host-owned copy. Fixes #602.
     fn wrap_source_event(wrapper: Arc<SourceEventWrapper>) -> *mut FfiSourceEvent {
         let op = match &wrapper.event {
             drasi_lib::channels::events::SourceEvent::Change(change) => match change {
@@ -2768,29 +2804,15 @@ fn wrap_subscription_response(
             },
             _ => FfiChangeOp::Update,
         };
-        let timestamp_us = wrapper
-            .timestamp
-            .timestamp_nanos_opt()
-            .map(|n| n / 1000)
-            .unwrap_or(0);
-        let boxed = Box::new(Arc::try_unwrap(wrapper).unwrap_or_else(|arc| (*arc).clone()));
-        let source_id = FfiStr::from_str(&boxed.source_id);
-        let opaque = Box::into_raw(boxed) as *mut c_void;
-        extern "C" fn drop_wrapper(ptr: *mut c_void) {
-            ffi_guard((), || {
-                if !ptr.is_null() {
-                    unsafe { drop(Box::from_raw(ptr as *mut SourceEventWrapper)) };
-                }
-            });
-        }
+        let payload = SourceEventPayload::from_wrapper(&wrapper);
+        let timestamp_us = payload.timestamp_us;
+        let (payload_ptr, payload_len) = serialize_ffi_payload(&payload);
         Box::into_raw(Box::new(FfiSourceEvent {
-            opaque,
-            source_id,
-            timestamp_us,
+            payload_ptr,
+            payload_len,
+            payload_drop_fn: ffi_drop_payload_bytes,
             op,
-            label: FfiStr::from_str(""),
-            entity_id: FfiStr::from_str(""),
-            drop_fn: drop_wrapper,
+            timestamp_us,
         }))
     }
 
@@ -2905,40 +2927,21 @@ fn wrap_subscription_response(
             receiver: Arc<DrasiLibBootstrapReceiver>,
         }
 
-        /// Convert a BootstrapEvent into a heap-allocated FfiBootstrapEvent.
+        /// Serialize a `BootstrapEvent` into a heap-allocated `FfiBootstrapEvent`.
         ///
-        /// The `source_id` FfiStr borrows from the boxed record (kept alive
-        /// via `opaque`). The `label` and `entity_id` fields use static
-        /// empty strings — the host currently extracts the full event from
-        /// `opaque` and does not read these metadata fields.
+        /// Crosses the boundary as a MessagePack-encoded `BootstrapEventPayload`
+        /// (raw bytes), never as a reinterpreted `repr(Rust)` pointer. Fixes #602.
         fn wrap_bootstrap_event(record: BootstrapEvent) -> *mut FfiBootstrapEvent {
-            let timestamp_us = record
-                .timestamp
-                .timestamp_nanos_opt()
-                .map(|n| n / 1000)
-                .unwrap_or(0);
-            let sequence = record.sequence;
-
-            // Box the record first so FfiStr can borrow from the
-            // heap-stable data inside it (same pattern as wrap_source_event).
-            let boxed = Box::new(record);
-            let source_id = FfiStr::from_str(&boxed.source_id);
-            let opaque = Box::into_raw(boxed) as *mut c_void;
-            extern "C" fn drop_bootstrap(ptr: *mut c_void) {
-                ffi_guard((), || {
-                    if !ptr.is_null() {
-                        unsafe { drop(Box::from_raw(ptr as *mut BootstrapEvent)) };
-                    }
-                });
-            }
+            let payload = BootstrapEventPayload::from_event(&record);
+            let timestamp_us = payload.timestamp_us;
+            let sequence = payload.sequence;
+            let (payload_ptr, payload_len) = serialize_ffi_payload(&payload);
             Box::into_raw(Box::new(FfiBootstrapEvent {
-                opaque,
-                source_id,
+                payload_ptr,
+                payload_len,
+                payload_drop_fn: ffi_drop_payload_bytes,
                 timestamp_us,
                 sequence,
-                label: FfiStr::from_str(""),
-                entity_id: FfiStr::from_str(""),
-                drop_fn: drop_bootstrap,
             }))
         }
 

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -114,15 +114,14 @@ unsafe fn decode_ffi_query_result(
     ptr: *mut FfiQueryResult,
 ) -> Option<drasi_lib::channels::QueryResult> {
     let ffi = unsafe { &*ptr };
-    let decoded = if ffi.payload_ptr.is_null() || ffi.payload_len == 0 {
-        None
-    } else {
-        let slice = unsafe { std::slice::from_raw_parts(ffi.payload_ptr, ffi.payload_len) };
-        super::payload::decode_query_result(slice)
+    let decoded = unsafe {
+        super::payload::take_ffi_payload(
+            ffi.payload_ptr,
+            ffi.payload_len,
+            ffi.payload_drop_fn,
+            super::payload::decode_query_result,
+        )
     };
-    if !ffi.payload_ptr.is_null() {
-        (ffi.payload_drop_fn)(ffi.payload_ptr as *mut u8, ffi.payload_len);
-    }
     unsafe { drop(Box::from_raw(ptr)) };
     decoded
 }
@@ -2185,7 +2184,7 @@ pub fn build_bootstrap_provider_vtable(
             let event = Box::new(FfiBootstrapEvent {
                 payload_ptr,
                 payload_len,
-                payload_drop_fn: ffi_drop_payload_bytes,
+                payload_drop_fn: Some(ffi_drop_payload_bytes),
                 timestamp_us,
                 sequence,
             });
@@ -2812,7 +2811,7 @@ fn wrap_subscription_response(
         Box::into_raw(Box::new(FfiSourceEvent {
             payload_ptr,
             payload_len,
-            payload_drop_fn: ffi_drop_payload_bytes,
+            payload_drop_fn: Some(ffi_drop_payload_bytes),
             op,
             timestamp_us,
         }))
@@ -2941,7 +2940,7 @@ fn wrap_subscription_response(
             Box::into_raw(Box::new(FfiBootstrapEvent {
                 payload_ptr,
                 payload_len,
-                payload_drop_fn: ffi_drop_payload_bytes,
+                payload_drop_fn: Some(ffi_drop_payload_bytes),
                 timestamp_us,
                 sequence,
             }))

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -104,7 +104,8 @@ extern "C" fn ffi_drop_payload_bytes(ptr: *mut u8, len: usize) {
 
 /// Decode a host-sent `*mut FfiQueryResult` into a plugin-owned `QueryResult`.
 ///
-/// Deserializes the host's MessagePack buffer, frees that buffer via the host's
+/// Delegates to the canonical [`super::payload::consume_query_result`], which
+/// deserializes the host's MessagePack buffer, frees that buffer via the host's
 /// `payload_drop_fn`, and frees the `#[repr(C)]` envelope. Returns `None` if the
 /// payload could not be decoded (buffers are freed regardless). The host never
 /// hands the plugin a reinterpreted `repr(Rust)` pointer (issue #602).
@@ -114,17 +115,7 @@ extern "C" fn ffi_drop_payload_bytes(ptr: *mut u8, len: usize) {
 unsafe fn decode_ffi_query_result(
     ptr: *mut FfiQueryResult,
 ) -> Option<drasi_lib::channels::QueryResult> {
-    let ffi = unsafe { &*ptr };
-    let decoded = unsafe {
-        super::payload::take_ffi_payload(
-            ffi.payload_ptr,
-            ffi.payload_len,
-            ffi.payload_drop_fn,
-            super::payload::decode_query_result,
-        )
-    };
-    unsafe { drop(Box::from_raw(ptr)) };
-    decoded
+    unsafe { super::payload::consume_query_result(ptr) }
 }
 
 // Compile-time assertions that transmute between raw pointers and callback

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -94,8 +94,9 @@ fn serialize_ffi_payload<T: serde::Serialize>(value: &T) -> (*const u8, usize) {
 extern "C" fn ffi_drop_payload_bytes(ptr: *mut u8, len: usize) {
     if !ptr.is_null() && len > 0 {
         unsafe {
-            let slice = std::slice::from_raw_parts_mut(ptr, len);
-            drop(Box::from_raw(slice as *mut [u8]));
+            // Rebuild the boxed slice from a *raw* slice pointer — never create a
+            // `&mut [u8]` reference to memory we are about to free (that would be UB).
+            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
         }
     }
 }
@@ -2245,8 +2246,9 @@ pub fn build_bootstrap_provider_vtable(
     extern "C" fn ffi_drop_position_bytes(ptr: *mut u8, len: usize) {
         if !ptr.is_null() && len > 0 {
             unsafe {
-                let slice = std::slice::from_raw_parts_mut(ptr, len);
-                drop(Box::from_raw(slice as *mut [u8]));
+                // Rebuild the boxed slice from a *raw* slice pointer — never create a
+                // `&mut [u8]` reference to memory we are about to free (that would be UB).
+                drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
             }
         }
     }
@@ -3163,8 +3165,9 @@ fn wrap_subscription_response(
         extern "C" fn ffi_drop_position_bytes(ptr: *mut u8, len: usize) {
             if !ptr.is_null() && len > 0 {
                 unsafe {
-                    let slice = std::slice::from_raw_parts_mut(ptr, len);
-                    drop(Box::from_raw(slice as *mut [u8]));
+                    // Rebuild the boxed slice from a *raw* slice pointer — never create
+                    // a `&mut [u8]` reference to memory we are about to free.
+                    drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
                 }
             }
         }

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -47,8 +47,12 @@ pub struct FfiSourceEvent {
     pub payload_ptr: *const u8,
     /// Length in bytes of `payload_ptr`.
     pub payload_len: usize,
-    /// Frees `payload_ptr` using the plugin's allocator. Never null.
-    pub payload_drop_fn: extern "C" fn(*mut u8, usize),
+    /// Frees `payload_ptr` using the producer's allocator. `None` is tolerated
+    /// (the buffer is then leaked with a logged error) so a buggy/malicious
+    /// producer cannot crash the consumer with a null function pointer.
+    /// `Option<extern "C" fn>` is null-pointer-optimized: same `#[repr(C)]` ABI
+    /// as a bare `extern "C" fn`, with the null bit-pattern decoded as `None`.
+    pub payload_drop_fn: Option<extern "C" fn(*mut u8, usize)>,
     /// Operation kind — a cheap routing hint mirrored from the payload.
     pub op: FfiChangeOp,
     /// Event timestamp in microseconds — a cheap routing hint mirrored from the payload.
@@ -65,8 +69,12 @@ pub struct FfiBootstrapEvent {
     pub payload_ptr: *const u8,
     /// Length in bytes of `payload_ptr`.
     pub payload_len: usize,
-    /// Frees `payload_ptr` using the plugin's allocator. Never null.
-    pub payload_drop_fn: extern "C" fn(*mut u8, usize),
+    /// Frees `payload_ptr` using the producer's allocator. `None` is tolerated
+    /// (the buffer is then leaked with a logged error) so a buggy/malicious
+    /// producer cannot crash the consumer with a null function pointer.
+    /// `Option<extern "C" fn>` is null-pointer-optimized: same `#[repr(C)]` ABI
+    /// as a bare `extern "C" fn`, with the null bit-pattern decoded as `None`.
+    pub payload_drop_fn: Option<extern "C" fn(*mut u8, usize)>,
     /// Event timestamp in microseconds — a cheap routing hint mirrored from the payload.
     pub timestamp_us: i64,
     /// Sequence number — a cheap routing hint mirrored from the payload.
@@ -86,8 +94,12 @@ pub struct FfiQueryResult {
     pub payload_ptr: *const u8,
     /// Length in bytes of `payload_ptr`.
     pub payload_len: usize,
-    /// Frees `payload_ptr` using the host's allocator. Never null.
-    pub payload_drop_fn: extern "C" fn(*mut u8, usize),
+    /// Frees `payload_ptr` using the producer's allocator. `None` is tolerated
+    /// (the buffer is then leaked with a logged error) so a buggy/malicious
+    /// producer cannot crash the consumer with a null function pointer.
+    /// `Option<extern "C" fn>` is null-pointer-optimized: same `#[repr(C)]` ABI
+    /// as a bare `extern "C" fn`, with the null bit-pattern decoded as `None`.
+    pub payload_drop_fn: Option<extern "C" fn(*mut u8, usize)>,
 }
 
 // ============================================================================

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -30,30 +30,64 @@ use super::types::{
 // ============================================================================
 
 /// Represents a source change event that crosses the FFI boundary.
-/// The opaque pointer holds a heap-allocated Rust type (e.g., `SourceEventWrapper`)
-/// that the plugin owns. The FFI metadata fields expose key information so the
-/// host can route/filter without deserializing.
+///
+/// The event is carried as a **serialized, self-describing payload**
+/// ([`crate::ffi::payload::SourceEventPayload`] encoded with `rmp-serde`), not as
+/// a `repr(Rust)` opaque pointer. The producing plugin owns `payload_ptr`; the
+/// host copies/deserializes it into a host-owned `SourceEventWrapper` and then
+/// frees the plugin's buffer via `payload_drop_fn`. Neither side ever reads or
+/// drops the other side's `repr(Rust)` memory (fixes #602).
+///
+/// The envelope struct itself is `#[repr(C)]` POD and is allocated by the plugin
+/// (`Box::into_raw`); the host frees it with `Box::from_raw`, which is sound
+/// because the layout is stable and there is no recursive `Drop`.
 #[repr(C)]
 pub struct FfiSourceEvent {
-    pub opaque: *mut c_void,
-    pub source_id: FfiStr,
-    pub timestamp_us: i64,
+    /// MessagePack-encoded `SourceEventPayload`. Plugin-owned, never null.
+    pub payload_ptr: *const u8,
+    /// Length in bytes of `payload_ptr`.
+    pub payload_len: usize,
+    /// Frees `payload_ptr` using the plugin's allocator. Never null.
+    pub payload_drop_fn: extern "C" fn(*mut u8, usize),
+    /// Operation kind — a cheap routing hint mirrored from the payload.
     pub op: FfiChangeOp,
-    pub label: FfiStr,
-    pub entity_id: FfiStr,
-    pub drop_fn: extern "C" fn(*mut c_void),
+    /// Event timestamp in microseconds — a cheap routing hint mirrored from the payload.
+    pub timestamp_us: i64,
 }
 
 /// Bootstrap event — initial state data loaded before streaming begins.
+///
+/// Carried as a serialized [`crate::ffi::payload::BootstrapEventPayload`]
+/// (`rmp-serde`); see [`FfiSourceEvent`] for the ownership contract.
 #[repr(C)]
 pub struct FfiBootstrapEvent {
-    pub opaque: *mut c_void,
-    pub source_id: FfiStr,
+    /// MessagePack-encoded `BootstrapEventPayload`. Plugin-owned, never null.
+    pub payload_ptr: *const u8,
+    /// Length in bytes of `payload_ptr`.
+    pub payload_len: usize,
+    /// Frees `payload_ptr` using the plugin's allocator. Never null.
+    pub payload_drop_fn: extern "C" fn(*mut u8, usize),
+    /// Event timestamp in microseconds — a cheap routing hint mirrored from the payload.
     pub timestamp_us: i64,
+    /// Sequence number — a cheap routing hint mirrored from the payload.
     pub sequence: u64,
-    pub label: FfiStr,
-    pub entity_id: FfiStr,
-    pub drop_fn: extern "C" fn(*mut c_void),
+}
+
+/// A `QueryResult` delivered from the host to a reaction plugin.
+///
+/// Carried as a serialized (MessagePack via `rmp-serde`) `QueryResult` byte
+/// buffer, **not** a reinterpreted `repr(Rust)` opaque pointer (issue #602). The
+/// **host** owns `payload_ptr`; the consuming plugin deserializes its own
+/// `QueryResult` and frees the host's buffer via `payload_drop_fn`. The plugin
+/// frees the `#[repr(C)]` envelope itself with `Box::from_raw`.
+#[repr(C)]
+pub struct FfiQueryResult {
+    /// MessagePack-encoded `QueryResult`. Host-owned, never null.
+    pub payload_ptr: *const u8,
+    /// Length in bytes of `payload_ptr`.
+    pub payload_len: usize,
+    /// Frees `payload_ptr` using the host's allocator. Never null.
+    pub payload_drop_fn: extern "C" fn(*mut u8, usize),
 }
 
 // ============================================================================

--- a/components/sources/mock/src/bootstrap.rs
+++ b/components/sources/mock/src/bootstrap.rs
@@ -1,0 +1,101 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A minimal bootstrap provider for the mock source.
+//!
+//! It emits a deterministic batch of node-insert bootstrap events. Each element
+//! carries `Arc<str>` labels/properties — the exact `repr(Rust)` payload shape
+//! that caused issue #602 — so the dynamic-plugin bootstrap path is exercised
+//! end to end across the cdylib FFI boundary (see the bootstrap scenario in
+//! `host-sdk/tests/ffi_layout_mismatch_test.rs`).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use drasi_core::models::{
+    Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
+};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
+use drasi_lib::channels::events::BootstrapEvent;
+use drasi_lib::channels::BootstrapEventSender;
+
+/// Number of synthetic bootstrap events the mock source emits per subscription.
+pub const MOCK_BOOTSTRAP_EVENT_COUNT: u64 = 10;
+
+/// Emits a fixed batch of node-insert bootstrap events for the mock source.
+pub struct MockBootstrapProvider {
+    source_id: String,
+    count: u64,
+}
+
+impl MockBootstrapProvider {
+    /// Create a provider that emits [`MOCK_BOOTSTRAP_EVENT_COUNT`] events.
+    pub fn new(source_id: impl Into<String>) -> Self {
+        Self {
+            source_id: source_id.into(),
+            count: MOCK_BOOTSTRAP_EVENT_COUNT,
+        }
+    }
+}
+
+#[async_trait]
+impl BootstrapProvider for MockBootstrapProvider {
+    async fn bootstrap(
+        &self,
+        _request: BootstrapRequest,
+        _context: &BootstrapContext,
+        event_tx: BootstrapEventSender,
+        _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
+    ) -> anyhow::Result<BootstrapResult> {
+        let mut sent = 0usize;
+        for seq in 1..=self.count {
+            let element_id = format!("bootstrap_{seq}");
+            let reference = ElementReference::new(&self.source_id, &element_id);
+
+            let mut properties = ElementPropertyMap::new();
+            properties.insert("value", ElementValue::Integer(seq as i64));
+            properties.insert("name", ElementValue::String(Arc::from(element_id.as_str())));
+
+            let metadata = ElementMetadata {
+                reference,
+                labels: Arc::from(vec![Arc::from("Bootstrap")]),
+                effective_from: 0,
+            };
+            let element = Element::Node {
+                metadata,
+                properties,
+            };
+
+            let event = BootstrapEvent {
+                source_id: self.source_id.clone(),
+                change: SourceChange::Insert { element },
+                timestamp: chrono::Utc::now(),
+                sequence: seq,
+            };
+
+            // Receiver dropped (e.g. subscriber went away) — stop early.
+            if event_tx.send(event).await.is_err() {
+                break;
+            }
+            sent += 1;
+        }
+
+        Ok(BootstrapResult {
+            event_count: sent,
+            source_position: None,
+        })
+    }
+}

--- a/components/sources/mock/src/descriptor.rs
+++ b/components/sources/mock/src/descriptor.rs
@@ -114,6 +114,7 @@ impl SourcePluginDescriptor for MockSourceDescriptor {
             .with_data_type(data_type)
             .with_interval_ms(interval_ms)
             .with_auto_start(auto_start)
+            .with_bootstrap_provider(crate::bootstrap::MockBootstrapProvider::new(id))
             .build()?;
 
         source.base.set_raw_config(config_json.clone());

--- a/components/sources/mock/src/lib.rs
+++ b/components/sources/mock/src/lib.rs
@@ -128,6 +128,7 @@
 //! - [`MockSource::test_subscribe()`] - Subscribe to receive events directly from the source,
 //!   bypassing DrasiLib's subscription mechanism
 
+pub mod bootstrap;
 mod config;
 mod conversion;
 pub mod descriptor;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,8 +24,8 @@ bytes = "1"
 drasi-query-ast.workspace = true
 drasi-query-cypher.workspace = true
 hashers = "1.0.1"
-ordered-float = "3.7.0"
-serde = { version = "1", features = ["derive"] }
+ordered-float = { version = "3.7.0", features = ["serde"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 rand = { version = "0.8.5", features = ["small_rng"] }
 tokio = { version =  "1.29.1", features = ["rt", "sync", "time", "macros"] }
@@ -56,3 +56,4 @@ time-macros = { version = "0.2.6", features = ["serde"] }
 
 [dev-dependencies]
 mockall = "0.13.1"
+rmp-serde = "1"

--- a/core/src/interface/future_queue.rs
+++ b/core/src/interface/future_queue.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 use crate::models::{ElementReference, ElementTimestamp};
 
@@ -25,7 +26,7 @@ pub enum PushType {
     Overwrite,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FutureElementRef {
     pub element_ref: ElementReference,
     pub original_time: ElementTimestamp,

--- a/core/src/models/agents.md
+++ b/core/src/models/agents.md
@@ -2,42 +2,50 @@
 
 ## FFI Boundary Warning
 
-The types in this directory cross the dynamic plugin FFI boundary as **opaque pointers**
-inside `#[repr(C)]` envelope structs. Both the host binary and cdylib plugins statically
-link this crate, so the in-memory layout of these types **must remain identical** on both
-sides.
+The types in this directory cross the dynamic plugin FFI boundary **by value, as
+serialized (MessagePack via `rmp-serde`) bytes** — NOT as reinterpreted
+`repr(Rust)` pointers. They therefore **must derive `serde::Serialize` and
+`serde::Deserialize`** (see `SourceChange`, `Element`, `ElementValue`,
+`ElementMetadata`, `ElementReference`, `FutureElementRef`).
 
-### Types that cross FFI
+> **History (issue #602):** these types used to cross as opaque `Box::into_raw`
+> pointers that the other side reclaimed with `Box::from_raw`. That is **undefined
+> behavior** across independently compiled cdylibs: `repr(Rust)` has no stable
+> layout, and `bytes::Bytes` / `Arc<str>` carry pointers (incl. a `&'static`
+> `Bytes` vtable) that are only valid in the producing module. The result was
+> non-deterministic heap corruption (`free(): invalid pointer`). The SDK version
+> check does **not** make the opaque pattern sound — it validates only the
+> `#[repr(C)]` envelope ABI, never the `repr(Rust)` payload layout.
 
-| Type | File | How it crosses | FFI wrapper |
-|------|------|---------------|-------------|
-| `SourceChange` | `source_change.rs` | Opaque pointer inside `SourceEventWrapper` | `FfiSourceEvent.opaque` |
-| `Element` | `element.rs` | Contained within `SourceChange` variants | (transitive) |
-| `ElementMetadata` | `element.rs` | Metadata extracted for FFI envelope fields | `FfiSourceEvent.entity_id`, `.label` |
-| `ElementValue` | `element_value.rs` | Contained within `Element` properties | (transitive) |
+### Types that cross FFI (serialized)
+
+| Type | File | How it crosses |
+|------|------|----------------|
+| `SourceChange` | `source_change.rs` | Inside `SourceEventPayload` / `BootstrapEventPayload`, serialized into `FfiSourceEvent.payload_ptr` / `FfiBootstrapEvent.payload_ptr` |
+| `Element` | `element.rs` | Contained within `SourceChange` variants (serialized transitively) |
+| `ElementMetadata` | `element.rs` | Contained within `Element` / `SourceChange::Delete` (serialized transitively) |
+| `ElementValue` | `element_value.rs` | Contained within `Element` properties (serialized transitively) |
+
+The serialized payload structs live in `components/plugin-sdk/src/ffi/payload.rs`.
 
 ### What to update when changing these types
 
-If you add, remove, or reorder fields on any of these types, you **must** also update:
+1. **Keep `Serialize`/`Deserialize` derives intact.** Adding/removing/reordering
+   fields is safe for the wire format **only** with the named-map encoding
+   (`rmp_serde::to_vec_named`, which the SDK uses) — positional encoding is
+   intolerant of `#[serde(skip_serializing_if)]` and field-count changes.
 
-1. **Plugin SDK vtable generation** — `components/plugin-sdk/src/ffi/vtable_gen.rs`
-   - Search for the type name to find where metadata is extracted or the type is wrapped/unwrapped
-   - `SourceChange` metadata extraction: look for `extract_source_change_metadata`
-   - `SourceEventWrapper` wrapping: look for `FfiSourceEvent` construction
+2. **Plugin SDK payloads** — `components/plugin-sdk/src/ffi/payload.rs`
+   (`SourceEventPayload` / `BootstrapEventPayload` and their `from_*`/`into_*`).
 
-2. **Plugin SDK FFI types** — `components/plugin-sdk/src/ffi/types.rs`
-   - If new enum variants are added (e.g., new `SourceChange` variant), update the
-     corresponding `Ffi*` enum (e.g., `FfiChangeOp`)
-
-3. **Host SDK proxy reconstruction** — `components/host-sdk/src/proxies/change_receiver.rs`
-   - Where opaque pointers are cast back to concrete types via `Box::from_raw`
-
-4. **Version bump** — `components/plugin-sdk/src/ffi/metadata.rs`
-   - Bump `FFI_SDK_VERSION` minor (or major for breaking layout changes) so the host
-     rejects plugins built against the old layout
+3. **Version bump** — bump `FFI_SDK_VERSION` in
+   `components/plugin-sdk/src/ffi/metadata.rs` if you change the wire format or any
+   `#[repr(C)]` envelope in `vtables.rs`, so the host rejects incompatible plugins.
 
 ### Safety invariant
 
-The opaque pointer pattern relies on both sides agreeing on the memory layout of these
-types. The `drasi_plugin_metadata()` check (SDK version + target triple) guards against
-mismatches, but **only if you bump the version when layouts change**.
+Never reintroduce `Box::into_raw` / `Box::from_raw` (or `&*ptr` reads, or
+`std::ptr::read`) of these `repr(Rust)` types across the cdylib boundary. Cross
+them only as serialized bytes. The `#[repr(C)]` **envelope** structs in
+`vtables.rs` may cross as `Box`es (their layout is stable); the rich `repr(Rust)`
+payloads may not.

--- a/core/src/models/element.rs
+++ b/core/src/models/element.rs
@@ -17,11 +17,13 @@ use std::{
     sync::Arc,
 };
 
+use serde::{Deserialize, Serialize};
+
 use crate::evaluation::variable_value::VariableValue;
 
 use super::{ElementPropertyMap, ElementValue};
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ElementReference {
     pub source_id: Arc<str>,
     pub element_id: Arc<str>,
@@ -92,7 +94,7 @@ pub fn validate_effective_from(value: ElementTimestamp) -> Result<(), String> {
     Ok(())
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ElementMetadata {
     pub reference: ElementReference,
     pub labels: Arc<[Arc<str>]>,
@@ -113,7 +115,7 @@ impl Display for ElementMetadata {
     }
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Element {
     // Incoming changes get turned into an Element
     Node {

--- a/core/src/models/element_value.rs
+++ b/core/src/models/element_value.rs
@@ -29,8 +29,9 @@ use std::sync::Arc;
 
 use chrono::{DateTime, FixedOffset, NaiveDateTime};
 use ordered_float::OrderedFloat;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub enum ElementValue {
     #[default]
     Null,
@@ -226,7 +227,7 @@ impl TryInto<ElementPropertyMap> for &VariableValue {
     }
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ElementPropertyMap {
     values: BTreeMap<Arc<str>, ElementValue>,
 }

--- a/core/src/models/source_change.rs
+++ b/core/src/models/source_change.rs
@@ -14,9 +14,11 @@
 
 use crate::interface::FutureElementRef;
 
+use serde::{Deserialize, Serialize};
+
 use super::{Element, ElementMetadata, ElementReference, ElementTimestamp};
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SourceChange {
     Insert { element: Element },
     Update { element: Element },
@@ -50,5 +52,154 @@ impl SourceChange {
             SourceChange::Delete { metadata } => metadata.effective_from,
             SourceChange::Future { future_ref } => future_ref.due_time,
         }
+    }
+}
+
+#[cfg(test)]
+mod serde_roundtrip_tests {
+    //! T1 — codec round-trip fidelity (regression for issue #602).
+    //!
+    //! After #602, `SourceChange` payloads cross the cdylib FFI boundary as
+    //! serialized MessagePack bytes (via `rmp-serde`) instead of as reinterpreted
+    //! `repr(Rust)` opaque pointers. These tests pin the lossless round-trip that
+    //! the serialized transfer depends on. They fail to even compile against the
+    //! pre-fix code (the model types did not derive `serde`), and they exercise
+    //! edge values (`NaN`/`Infinity`) that the legacy `ElementValue -> serde_json`
+    //! projection cannot represent (it `unwrap()`s on `Number::from_f64`).
+
+    use super::*;
+    use crate::interface::FutureElementRef;
+    use crate::models::{
+        Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue,
+    };
+    use chrono::{DateTime, FixedOffset, NaiveDate};
+    use ordered_float::OrderedFloat;
+    use std::sync::Arc;
+
+    fn roundtrip(change: &SourceChange) -> SourceChange {
+        let bytes = rmp_serde::to_vec(change).expect("serialize SourceChange");
+        rmp_serde::from_slice(&bytes).expect("deserialize SourceChange")
+    }
+
+    fn rich_properties() -> ElementPropertyMap {
+        let mut props = ElementPropertyMap::new();
+        props.insert("null", ElementValue::Null);
+        props.insert("bool", ElementValue::Bool(true));
+        props.insert("int", ElementValue::Integer(-9_223_372_036_854_775_808));
+        props.insert("float", ElementValue::Float(OrderedFloat(1.234_567_89)));
+        props.insert("string", ElementValue::String(Arc::from("héllo 世界")));
+        props.insert(
+            "list",
+            ElementValue::List(vec![
+                ElementValue::Integer(1),
+                ElementValue::String(Arc::from("two")),
+                ElementValue::Null,
+            ]),
+        );
+        let mut nested = ElementPropertyMap::new();
+        nested.insert("inner", ElementValue::Bool(false));
+        props.insert("object", ElementValue::Object(nested));
+        props.insert(
+            "local_dt",
+            ElementValue::LocalDateTime(
+                NaiveDate::from_ymd_opt(2024, 6, 15)
+                    .unwrap()
+                    .and_hms_opt(13, 45, 30)
+                    .unwrap(),
+            ),
+        );
+        props.insert(
+            "zoned_dt",
+            ElementValue::ZonedDateTime(
+                DateTime::<FixedOffset>::parse_from_rfc3339("2024-06-15T13:45:30+02:00").unwrap(),
+            ),
+        );
+        props
+    }
+
+    fn node(properties: ElementPropertyMap) -> Element {
+        Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("src-1", "vehicles:A1234"),
+                labels: Arc::from(vec![Arc::from("vehicles"), Arc::from("Vehicle")]),
+                effective_from: 1_771_000_000_000,
+            },
+            properties,
+        }
+    }
+
+    #[test]
+    fn insert_node_with_all_value_kinds_roundtrips() {
+        let change = SourceChange::Insert {
+            element: node(rich_properties()),
+        };
+        assert_eq!(roundtrip(&change), change);
+    }
+
+    #[test]
+    fn float_nan_and_infinity_roundtrip_losslessly() {
+        // The legacy ElementValue -> serde_json projection panics on NaN/Inf
+        // (Number::from_f64(..).unwrap()). The binary codec must preserve them.
+        for special in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let mut props = ElementPropertyMap::new();
+            props.insert("f", ElementValue::Float(OrderedFloat(special)));
+            let change = SourceChange::Insert {
+                element: node(props),
+            };
+            let back = roundtrip(&change);
+            let SourceChange::Insert { element } = &back else {
+                panic!("expected Insert");
+            };
+            let ElementValue::Float(f) = element.get_property("f") else {
+                panic!("expected Float");
+            };
+            if special.is_nan() {
+                assert!(f.into_inner().is_nan(), "NaN must round-trip");
+            } else {
+                assert_eq!(f.into_inner(), special);
+            }
+        }
+    }
+
+    #[test]
+    fn relation_element_roundtrips() {
+        let change = SourceChange::Update {
+            element: Element::Relation {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("src-1", "rel:1"),
+                    labels: Arc::from(vec![Arc::from("OWNS")]),
+                    effective_from: 42,
+                },
+                in_node: ElementReference::new("src-1", "a"),
+                out_node: ElementReference::new("src-1", "b"),
+                properties: rich_properties(),
+            },
+        };
+        assert_eq!(roundtrip(&change), change);
+    }
+
+    #[test]
+    fn delete_metadata_roundtrips() {
+        let change = SourceChange::Delete {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("src-1", "vehicles:B5678"),
+                labels: Arc::from(vec![Arc::from("vehicles")]),
+                effective_from: 7,
+            },
+        };
+        assert_eq!(roundtrip(&change), change);
+    }
+
+    #[test]
+    fn future_ref_roundtrips() {
+        let change = SourceChange::Future {
+            future_ref: FutureElementRef {
+                element_ref: ElementReference::new("src-1", "vehicles:C9999"),
+                original_time: 100,
+                due_time: 200,
+                group_signature: 12345,
+            },
+        };
+        assert_eq!(roundtrip(&change), change);
     }
 }

--- a/core/src/models/source_change.rs
+++ b/core/src/models/source_change.rs
@@ -77,7 +77,9 @@ mod serde_roundtrip_tests {
     use std::sync::Arc;
 
     fn roundtrip(change: &SourceChange) -> SourceChange {
-        let bytes = rmp_serde::to_vec(change).expect("serialize SourceChange");
+        // Mirror the production FFI wire format: named-map encoding
+        // (`to_vec_named`), which tolerates skipped fields and field-count changes.
+        let bytes = rmp_serde::to_vec_named(change).expect("serialize SourceChange");
         rmp_serde::from_slice(&bytes).expect("deserialize SourceChange")
     }
 

--- a/lib/src/bootstrap/agents.md
+++ b/lib/src/bootstrap/agents.md
@@ -14,7 +14,7 @@ mediated by the host.
 | `BootstrapProvider` trait | Wrapped as `BootstrapProviderVtable` (plugin→host) AND reverse-wrapped as vtable (host→plugin) | Both directions |
 | `BootstrapRequest` | Deconstructed into individual FFI args (query_id, node_labels, etc.) | Multiple `FfiStr` + `*const FfiStr` arrays |
 | `BootstrapContext` | Deconstructed into individual FFI args (server_id, source_id) | Multiple `FfiStr` args |
-| `BootstrapEvent` | Opaque pointer (`Box<BootstrapEvent>` → `*mut c_void`) | `FfiBootstrapEvent.opaque` |
+| `BootstrapEvent` | Serialized to MessagePack bytes (`BootstrapEventPayload`) and transferred as a `payload_ptr` + `payload_len` buffer freed via `payload_drop_fn`; never a reinterpreted `repr(Rust)` pointer (issue #602) | `FfiBootstrapEvent` + `payload.rs::consume_bootstrap_event` |
 
 ### Cross-plugin bootstrap flow
 

--- a/lib/src/channels/agents.md
+++ b/lib/src/channels/agents.md
@@ -20,7 +20,7 @@ mirrors.
 |------|------|---------------|-------------|
 | `SourceEventWrapper` | `events.rs` | Serialized `SourceEventPayload` bytes | `FfiSourceEvent.payload_ptr` |
 | `BootstrapEvent` | `events.rs` | Serialized `BootstrapEventPayload` bytes | `FfiBootstrapEvent.payload_ptr` |
-| `QueryResult` | `events.rs` | Serialized bytes | `FfiQueryResult.payload_ptr` |
+| `QueryResult` | `events.rs` | Serialized `QueryResult` bytes | `FfiQueryResult.payload_ptr` |
 | `SubscriptionResponse` | `events.rs` | Converted field-by-field to `FfiSubscriptionResponse` | `FfiSubscriptionResponse` |
 | `ComponentStatus` | `events.rs` | Mapped to `FfiComponentStatus` enum | `FfiComponentStatus` |
 | `DispatchMode` | `dispatcher.rs` | Mapped to `FfiDispatchMode` enum | `FfiDispatchMode` |

--- a/lib/src/channels/agents.md
+++ b/lib/src/channels/agents.md
@@ -2,17 +2,25 @@
 
 ## FFI Boundary Warning
 
-Several types in this directory cross the dynamic plugin FFI boundary. They are passed
-as opaque pointers inside `#[repr(C)]` structs or have their fields extracted into
-FFI-safe representations.
+Several types in this directory cross the dynamic plugin FFI boundary. Rich
+`repr(Rust)` event payloads (`SourceEventWrapper`, `BootstrapEvent`,
+`QueryResult`) cross **by value as serialized MessagePack bytes** (issue #602) —
+they must keep their `serde` derives. Simple enums are mapped to `#[repr(C)]`
+mirrors.
+
+> **Do not** transfer these `repr(Rust)` types as opaque `Box::into_raw` /
+> `Box::from_raw` pointers: `repr(Rust)` has no stable cross-cdylib layout and
+> `bytes::Bytes`/`Arc<str>` carry module-local pointers, which caused #602's heap
+> corruption. The SDK version check validates only the `#[repr(C)]` envelope ABI,
+> not the payload layout.
 
 ### Types that cross FFI
 
 | Type | File | How it crosses | FFI wrapper |
 |------|------|---------------|-------------|
-| `SourceEventWrapper` | `events.rs` | Opaque pointer (`Box<SourceEventWrapper>` → `*mut c_void`) | `FfiSourceEvent.opaque` |
-| `BootstrapEvent` | `events.rs` | Opaque pointer (`Box<BootstrapEvent>` → `*mut c_void`) | `FfiBootstrapEvent.opaque` |
-| `QueryResult` | `events.rs` | Opaque pointer (`Box<QueryResult>` → `*mut c_void`) | `ReactionVtable.enqueue_query_result_fn` arg |
+| `SourceEventWrapper` | `events.rs` | Serialized `SourceEventPayload` bytes | `FfiSourceEvent.payload_ptr` |
+| `BootstrapEvent` | `events.rs` | Serialized `BootstrapEventPayload` bytes | `FfiBootstrapEvent.payload_ptr` |
+| `QueryResult` | `events.rs` | Serialized bytes | `FfiQueryResult.payload_ptr` |
 | `SubscriptionResponse` | `events.rs` | Converted field-by-field to `FfiSubscriptionResponse` | `FfiSubscriptionResponse` |
 | `ComponentStatus` | `events.rs` | Mapped to `FfiComponentStatus` enum | `FfiComponentStatus` |
 | `DispatchMode` | `dispatcher.rs` | Mapped to `FfiDispatchMode` enum | `FfiDispatchMode` |

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -210,7 +210,7 @@ pub enum ControlOperation {
 }
 
 /// Unified event envelope carrying both data changes and control messages
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum SourceEvent {
     /// Data change event from source
     Change(SourceChange),


### PR DESCRIPTION
## Summary

Fixes #602 — the cross-cdylib heap corruption (`free(): invalid pointer` / SIGSEGV / `double free or corruption`) that crashes the host on every binlog row event for the published `source/mysql` plugin.

**Root cause.** Rich event types — `SourceEventWrapper`, `BootstrapEvent`, `QueryResult` — embed `bytes::Bytes` and `Arc<str>` and were transferred across the cdylib boundary as opaque `Box::into_raw` pointers that the other side reclaimed with `Box::from_raw`. That is undefined behaviour across independently compiled cdylibs: `repr(Rust)` has no stable layout, and `bytes::Bytes` carries a `&'static` vtable pointer valid only in the producing module. The SDK version gate validates only the `#[repr(C)]` envelope ABI — **never** the `repr(Rust)` payload layout — so it could not make the opaque pattern sound. The corruption is heap-layout dependent (hence non-deterministic on Linux, deterministic on Windows).

**Fix.** Transfer these payloads **by value as serialized MessagePack bytes** (`rmp-serde`, named encoding). Producers expose `payload_ptr + len + drop_fn`; consumers deserialize their own host/plugin-owned value and free the producer's buffer via its `drop_fn`. Neither side reads or drops the other side's `repr(Rust)` memory — the same pattern the codebase already used for `source_position`.

All three affected paths are fixed under **one ABI bump**:
- source change events (`FfiSourceEvent`)
- bootstrap events (`FfiBootstrapEvent`, both consumer sites)
- reaction query results (new `FfiQueryResult` envelope)

`FFI_SDK_VERSION` is bumped to **`0.10.0`** and decoupled from the crate release version, so the loader cleanly rejects old `0.9.x` plugins instead of silently corrupting.

## How it was found

Reproduced deterministically with the released `drasi-server 0.2.0-preview` + published `source/mysql:0.2.4` under glibc heap hardening (`MALLOC_CHECK_=3`): **8/8 SIGABRT**. Valgrind pinpointed an invalid interior-pointer `free()` in `ContinuousQuery::process_source_change_with_hook`, plus `bytes::bytes::shared_drop` in the plugin operating on uninitialised values — i.e. the host dropping a plugin-constructed `Bytes`. Full investigation in #602.

## Changes

- **core** — enable serde `rc` + `ordered-float` `serde`; derive `Serialize`/`Deserialize` on `SourceChange`/`Element`/`ElementValue`/`ElementMetadata`/`ElementReference`/`FutureElementRef`; `SourceEvent` made serializable in `lib`.
- **plugin-sdk** — new `ffi/payload.rs` (`SourceEventPayload`/`BootstrapEventPayload` + codec, **named** MessagePack to tolerate `#[serde(skip_serializing_if)]`); rework `FfiSourceEvent`/`FfiBootstrapEvent`; add `FfiQueryResult`; serialize on the producing side; `FFI_SDK_VERSION="0.10.0"`.
- **host-sdk** — deserialize host-owned values and free producer buffers via `drop_fn` in `change_receiver`/`bootstrap_provider`/`reaction`; remove every `Box::from_raw`/`std::ptr::read` of a `repr(Rust)` payload.
- **docs** — correct four `agents.md` files that documented the false "version check guarantees layout safety" invariant.

Also fixes a latent encoding bug surfaced while fixing the reaction path: `QueryResult::profiling`'s `#[serde(skip_serializing_if)]` breaks positional MessagePack encoding (`invalid length 5, expected 6`); named encoding tolerates it.

## Tests (deterministic — fail before, pass after)

- **T1** (`core/src/models/source_change.rs`) — `rmp-serde` round-trip for every `ElementValue` variant incl. `NaN`/`Infinity`, nested containers, relations, datetimes. Fails before: the types weren't `serde`-serializable and the legacy `ElementValue → serde_json` projection `.unwrap()`s on NaN.
- **T2** (`plugin-sdk/src/ffi/payload.rs` + `host-sdk/.../change_receiver.rs`) — payload round-trip + host-owned rebuild + **buffer freed exactly once** via a call-counting `drop_fn` (no leak, no double-free); mirrored for bootstrap events.
- **T3** (`host-sdk/tests/ffi_layout_mismatch_test.rs` + `make test-ffi-layout-mismatch`) — loads the mock-source cdylib built with a **different `-Zlayout-seed`** than the host, under `MALLOC_CHECK_=3`. **Proven fail-before** (pre-fix worktree aborts with a corruption panic) and **pass-after** (50 events, no corruption). Gated (nightly) + `#[ignore]` by default; an in-workspace matched-layout build does not reproduce, so the forced seed mismatch is required.

## Validation

- `cargo build --workspace --all-targets` ✓
- `cargo clippy -p drasi-core -p drasi-lib -p drasi-plugin-sdk -p drasi-host-sdk --all-targets -- -D warnings` ✓
- `cargo +nightly fmt --check` ✓
- drasi-core 730 / drasi-lib 866 / source-mysql 33 / host-sdk integration 45 (real cdylib, all three paths) — all pass.

## Compatibility note

The `0.10.0` SDK bump is intentional: it forces all dynamic plugins to be rebuilt/republished together. The loader rejects mismatched plugins (clean refusal) rather than risking corruption.

---

> [!NOTE]
> Draft: the workspace release version (`0.9.1`) is intentionally left untouched — `FFI_SDK_VERSION` is now an independent ABI constant. Maintainers may want to fold the customary `chore: release` version bump / CHANGELOG entries into the release process separately.
