### PR TITLE
Fix FFI vtable struct leak in FfiIdentityProviderProxy::clone_box()

### DIFF
--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -77,6 +77,7 @@ jobs:
           cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin
           cargo build --lib -p drasi-reaction-log --features drasi-reaction-log/dynamic-plugin
           cargo build --lib -p drasi-reaction-sse --features drasi-reaction-sse/dynamic-plugin
+          cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin
 
       - name: Copy plugins to test directory
         shell: bash
@@ -84,7 +85,7 @@ jobs:
           mkdir -p target/debug/plugins
           PREFIX="${{ matrix.lib_prefix }}"
           EXT="${{ matrix.lib_ext }}"
-          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse; do
+          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_identity_test; do
             SRC="target/debug/${PREFIX}${name}.${EXT}"
             if [ -f "$SRC" ]; then
               cp "$SRC" target/debug/plugins/
@@ -100,7 +101,7 @@ jobs:
           PREFIX="${{ matrix.lib_prefix }}"
           EXT="${{ matrix.lib_ext }}"
           MISSING=0
-          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse; do
+          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_identity_test; do
             FILE="target/debug/plugins/${PREFIX}${name}.${EXT}"
             if [ ! -f "$FILE" ]; then
               echo "ERROR: Expected plugin not found: $FILE"
@@ -112,7 +113,7 @@ jobs:
             ls -la target/debug/plugins/ || true
             exit 1
           fi
-          echo "All 3 test plugins verified."
+          echo "All 4 test plugins verified."
 
       - name: Run host-sdk FFI integration tests
         shell: bash

--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -77,6 +77,7 @@ jobs:
           cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin
           cargo build --lib -p drasi-reaction-log --features drasi-reaction-log/dynamic-plugin
           cargo build --lib -p drasi-reaction-sse --features drasi-reaction-sse/dynamic-plugin
+          cargo build --lib -p drasi-reaction-snapshot-test
           cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin
 
       - name: Copy plugins to test directory
@@ -85,7 +86,7 @@ jobs:
           mkdir -p target/debug/plugins
           PREFIX="${{ matrix.lib_prefix }}"
           EXT="${{ matrix.lib_ext }}"
-          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_identity_test; do
+          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test; do
             SRC="target/debug/${PREFIX}${name}.${EXT}"
             if [ -f "$SRC" ]; then
               cp "$SRC" target/debug/plugins/
@@ -101,7 +102,7 @@ jobs:
           PREFIX="${{ matrix.lib_prefix }}"
           EXT="${{ matrix.lib_ext }}"
           MISSING=0
-          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_identity_test; do
+          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test; do
             FILE="target/debug/plugins/${PREFIX}${name}.${EXT}"
             if [ ! -f "$FILE" ]; then
               echo "ERROR: Expected plugin not found: $FILE"
@@ -113,7 +114,7 @@ jobs:
             ls -la target/debug/plugins/ || true
             exit 1
           fi
-          echo "All 4 test plugins verified."
+          echo "All 5 test plugins verified."
 
       - name: Run host-sdk FFI integration tests
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ members = [
   # Identity Provider Plugins
   "components/identity/azure",
   "components/identity/aws",
+  "components/identity/test-fixture",
 
   # Secret Store Plugins
   "components/secret_stores/file",
@@ -133,7 +134,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/drasi-project/drasi-core"
@@ -152,9 +153,9 @@ drasi-middleware = { version = "0.5.7", path = "middleware" }
 drasi-identity-azure = { version = "0.2.9", path = "components/identity/azure" }
 drasi-identity-aws = { version = "0.2.3", path = "components/identity/aws" }
 drasi-lib = { version = "0.8.8", path = "lib" }
-drasi-ffi-primitives = { version = "0.9.1", path = "components/ffi-primitives" }
-drasi-plugin-sdk = { version = "0.9.1", path = "components/plugin-sdk" }
-drasi-host-sdk = { version = "0.9.1", path = "components/host-sdk" }
+drasi-ffi-primitives = { version = "0.10.0", path = "components/ffi-primitives" }
+drasi-plugin-sdk = { version = "0.10.0", path = "components/plugin-sdk" }
+drasi-host-sdk = { version = "0.10.0", path = "components/host-sdk" }
 
 # Common dependencies
 im = "15"

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ build-test-plugins:
 	cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin
 	cargo build --lib -p drasi-reaction-log --features drasi-reaction-log/dynamic-plugin
 	cargo build --lib -p drasi-reaction-sse --features drasi-reaction-sse/dynamic-plugin
+	cargo build --lib -p drasi-reaction-snapshot-test
 	cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin
 	@mkdir -p $(PLUGIN_OUT_DIR)
 	@echo "=== Copying plugins to $(PLUGIN_OUT_DIR) ==="
@@ -56,10 +57,12 @@ build-test-plugins:
 		for f in target/debug/libdrasi_source_mock.$$ext \
 		         target/debug/libdrasi_reaction_log.$$ext \
 		         target/debug/libdrasi_reaction_sse.$$ext \
+		         target/debug/libdrasi_reaction_snapshot_test.$$ext \
 		         target/debug/libdrasi_identity_test.$$ext \
 		         target/debug/drasi_source_mock.$$ext \
 		         target/debug/drasi_reaction_log.$$ext \
 		         target/debug/drasi_reaction_sse.$$ext \
+		         target/debug/drasi_reaction_snapshot_test.$$ext \
 		         target/debug/drasi_identity_test.$$ext; do \
 			[ -f "$$f" ] && cp "$$f" $(PLUGIN_OUT_DIR)/ || true; \
 		done; \

--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,18 @@ build-test-plugins:
 	cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin
 	cargo build --lib -p drasi-reaction-log --features drasi-reaction-log/dynamic-plugin
 	cargo build --lib -p drasi-reaction-sse --features drasi-reaction-sse/dynamic-plugin
+	cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin
 	@mkdir -p $(PLUGIN_OUT_DIR)
 	@echo "=== Copying plugins to $(PLUGIN_OUT_DIR) ==="
 	@for ext in dylib so dll; do \
 		for f in target/debug/libdrasi_source_mock.$$ext \
 		         target/debug/libdrasi_reaction_log.$$ext \
 		         target/debug/libdrasi_reaction_sse.$$ext \
+		         target/debug/libdrasi_identity_test.$$ext \
 		         target/debug/drasi_source_mock.$$ext \
 		         target/debug/drasi_reaction_log.$$ext \
-		         target/debug/drasi_reaction_sse.$$ext; do \
+		         target/debug/drasi_reaction_sse.$$ext \
+		         target/debug/drasi_identity_test.$$ext; do \
 			[ -f "$$f" ] && cp "$$f" $(PLUGIN_OUT_DIR)/ || true; \
 		done; \
 	done

--- a/components/host-sdk/Cargo.toml
+++ b/components/host-sdk/Cargo.toml
@@ -52,6 +52,7 @@ workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+libloading = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "io-util"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 futures-util = "0.3"

--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -263,6 +263,20 @@ impl Reaction for ReactionProxy {
         };
 
         (self.vtable.initialize_fn)(self.vtable.state, &ffi_ctx as *const FfiRuntimeContext);
+
+        // Reclaim the identity-provider vtable struct we allocated for `ip_ptr`. The
+        // plugin copies the vtable fields by value during `initialize_fn` (see
+        // `FfiIdentityProviderProxy::new`) and does not retain this pointer, so it is safe
+        // to free the struct here. This frees only the `IdentityProviderVtable` struct
+        // (no `Drop` impl) — the underlying state remains owned by the plugin proxy and is
+        // released via `drop_fn` when that proxy is dropped.
+        if !ip_ptr.is_null() {
+            unsafe {
+                drop(Box::from_raw(
+                    ip_ptr as *mut drasi_plugin_sdk::ffi::identity::IdentityProviderVtable,
+                ));
+            }
+        }
     }
 
     async fn start(&self) -> anyhow::Result<()> {

--- a/components/host-sdk/src/proxies/reaction.rs
+++ b/components/host-sdk/src/proxies/reaction.rs
@@ -236,9 +236,9 @@ impl Reaction for ReactionProxy {
         )
         .map(crate::identity_bridge::IdentityProviderVtableBuilder::build);
 
-        let ip_ptr = identity_vtable
-            .map(|v| Box::into_raw(Box::new(v)) as *const _)
-            .unwrap_or(std::ptr::null());
+        let ip_ptr: *mut drasi_plugin_sdk::ffi::identity::IdentityProviderVtable = identity_vtable
+            .map(|v| Box::into_raw(Box::new(v)))
+            .unwrap_or(std::ptr::null_mut());
 
         let snapshot_fetcher_vtable = context
             .snapshot_fetcher
@@ -253,7 +253,7 @@ impl Reaction for ReactionProxy {
             instance_id: instance_id_ffi,
             component_id: component_id_ffi,
             state_store: ss_ptr,
-            identity_provider: ip_ptr,
+            identity_provider: ip_ptr as *const _,
             log_callback: Some(crate::callbacks::instance_log_callback),
             log_ctx: ctx_ptr,
             lifecycle_callback: Some(crate::callbacks::instance_lifecycle_callback),
@@ -264,17 +264,18 @@ impl Reaction for ReactionProxy {
 
         (self.vtable.initialize_fn)(self.vtable.state, &ffi_ctx as *const FfiRuntimeContext);
 
-        // Reclaim the identity-provider vtable struct we allocated for `ip_ptr`. The
-        // plugin copies the vtable fields by value during `initialize_fn` (see
-        // `FfiIdentityProviderProxy::new`) and does not retain this pointer, so it is safe
-        // to free the struct here. This frees only the `IdentityProviderVtable` struct
-        // (no `Drop` impl) — the underlying state remains owned by the plugin proxy and is
-        // released via `drop_fn` when that proxy is dropped.
+        // Reclaim the identity-provider vtable struct we allocated for `ip_ptr`. This is a
+        // transient pointer: the plugin SDK (>= 0.10.0) copies the vtable fields by value in
+        // `FfiIdentityProviderProxy::new` during `initialize_fn` and never retains `ip_ptr`,
+        // so it is safe to free the struct here. Plugins built against SDK < 0.10.0 retained
+        // the raw pointer; they are rejected by the loader's exact major.minor version gate
+        // (see `validate_plugin_metadata` in `host-sdk/src/loader.rs`), which prevents a
+        // use-after-free. This frees only the `IdentityProviderVtable` struct (no `Drop`
+        // impl) — the underlying state remains owned by the plugin proxy and is released via
+        // `drop_fn` when that proxy is dropped.
         if !ip_ptr.is_null() {
             unsafe {
-                drop(Box::from_raw(
-                    ip_ptr as *mut drasi_plugin_sdk::ffi::identity::IdentityProviderVtable,
-                ));
+                drop(Box::from_raw(ip_ptr));
             }
         }
     }

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -495,6 +495,20 @@ impl Source for SourceProxy {
         };
 
         (self.vtable.initialize_fn)(self.vtable.state, &ffi_ctx as *const FfiRuntimeContext);
+
+        // Reclaim the identity-provider vtable struct we allocated for `ip_ptr`. The
+        // plugin copies the vtable fields by value during `initialize_fn` (see
+        // `FfiIdentityProviderProxy::new`) and does not retain this pointer, so it is safe
+        // to free the struct here. This frees only the `IdentityProviderVtable` struct
+        // (no `Drop` impl) — the underlying state remains owned by the plugin proxy and is
+        // released via `drop_fn` when that proxy is dropped.
+        if !ip_ptr.is_null() {
+            unsafe {
+                drop(Box::from_raw(
+                    ip_ptr as *mut drasi_plugin_sdk::ffi::identity::IdentityProviderVtable,
+                ));
+            }
+        }
     }
 
     async fn set_bootstrap_provider(&self, provider: Box<dyn BootstrapProvider + 'static>) {

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -477,15 +477,15 @@ impl Source for SourceProxy {
         )
         .map(crate::identity_bridge::IdentityProviderVtableBuilder::build);
 
-        let ip_ptr = identity_vtable
-            .map(|v| Box::into_raw(Box::new(v)) as *const _)
-            .unwrap_or(std::ptr::null());
+        let ip_ptr: *mut drasi_plugin_sdk::ffi::identity::IdentityProviderVtable = identity_vtable
+            .map(|v| Box::into_raw(Box::new(v)))
+            .unwrap_or(std::ptr::null_mut());
 
         let ffi_ctx = FfiRuntimeContext {
             instance_id: instance_id_ffi,
             component_id: component_id_ffi,
             state_store: ss_ptr,
-            identity_provider: ip_ptr,
+            identity_provider: ip_ptr as *const _,
             log_callback: Some(crate::callbacks::instance_log_callback),
             log_ctx: ctx_ptr,
             lifecycle_callback: Some(crate::callbacks::instance_lifecycle_callback),
@@ -496,17 +496,18 @@ impl Source for SourceProxy {
 
         (self.vtable.initialize_fn)(self.vtable.state, &ffi_ctx as *const FfiRuntimeContext);
 
-        // Reclaim the identity-provider vtable struct we allocated for `ip_ptr`. The
-        // plugin copies the vtable fields by value during `initialize_fn` (see
-        // `FfiIdentityProviderProxy::new`) and does not retain this pointer, so it is safe
-        // to free the struct here. This frees only the `IdentityProviderVtable` struct
-        // (no `Drop` impl) — the underlying state remains owned by the plugin proxy and is
-        // released via `drop_fn` when that proxy is dropped.
+        // Reclaim the identity-provider vtable struct we allocated for `ip_ptr`. This is a
+        // transient pointer: the plugin SDK (>= 0.10.0) copies the vtable fields by value in
+        // `FfiIdentityProviderProxy::new` during `initialize_fn` and never retains `ip_ptr`,
+        // so it is safe to free the struct here. Plugins built against SDK < 0.10.0 retained
+        // the raw pointer; they are rejected by the loader's exact major.minor version gate
+        // (see `validate_plugin_metadata` in `host-sdk/src/loader.rs`), which prevents a
+        // use-after-free. This frees only the `IdentityProviderVtable` struct (no `Drop`
+        // impl) — the underlying state remains owned by the plugin proxy and is released via
+        // `drop_fn` when that proxy is dropped.
         if !ip_ptr.is_null() {
             unsafe {
-                drop(Box::from_raw(
-                    ip_ptr as *mut drasi_plugin_sdk::ffi::identity::IdentityProviderVtable,
-                ));
+                drop(Box::from_raw(ip_ptr));
             }
         }
     }

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -1971,6 +1971,144 @@ async fn test_identity_provider_cross_cdylib_clone_stress() {
     drop(source);
 }
 
+/// Cross-cdylib regression test for the `ReactionProxy::initialize` host-side `ip_ptr`
+/// reclaim (issue #341) — the symmetric twin of the `SourceProxy` fix exercised by
+/// [`test_identity_provider_cross_cdylib_clone_stress`].
+///
+/// This drives the **full two-cdylib chain** through the *reaction* boundary:
+///
+/// ```text
+/// [drasi-identity-test cdylib]      <- returns canned Credentials, counts calls
+///        |  (host wraps the returned vtable)
+///   HostIdentityProviderProxy       <- Arc<dyn IdentityProvider> (host side, by value)
+///        |  (host builds ip_ptr vtable, passes via FfiRuntimeContext, reclaims after init)
+/// [drasi-reaction-snapshot-test cdylib] FfiIdentityProviderProxy::clone_box()  <- #341 leak site
+/// ```
+///
+/// The snapshot-test reaction's test-only clone hook (gated behind the
+/// `DRASI_SNAPSHOT_TEST_IDENTITY_CLONE_STRESS` env var) clones the injected provider N
+/// times (calling `get_credentials` on each clone) during `initialize`. On the host side,
+/// `ReactionProxy::initialize` allocates `ip_ptr`, passes it to the reaction plugin's
+/// `initialize_fn`, and then reclaims it — the path with no dedicated coverage before this
+/// test. Each `clone_box` invokes the FFI vtable `clone_fn` inside the reaction cdylib, and
+/// each `get_credentials` round-trips through the host back into the identity cdylib.
+///
+/// We assert that all N `get_credentials` calls reached the identity cdylib intact by
+/// reading its process-global counter back across the FFI boundary via an exported symbol.
+/// Running this test under `MALLOC_CHECK_=3` (or valgrind) additionally surfaces the
+/// per-clone vtable-struct leak / any cross-cdylib invalid free on the reaction path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn test_reaction_identity_provider_cross_cdylib_clone_stress() {
+    use drasi_plugin_sdk::descriptor::IdentityProviderPluginDescriptor;
+
+    const CLONE_STRESS: usize = 500;
+
+    let identity_path = find_cdylib("drasi-identity-test").unwrap_or_else(|| {
+        panic!(
+            "drasi-identity-test cdylib not built. Build with: \
+             cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin"
+        )
+    });
+    let reaction_path = find_cdylib("drasi-reaction-snapshot-test").unwrap_or_else(|| {
+        panic!(
+            "drasi-reaction-snapshot-test cdylib not built. Build with: \
+             cargo build --lib -p drasi-reaction-snapshot-test"
+        )
+    });
+
+    // --- Create a real identity provider from the identity-test cdylib ---
+    let identity_plugin = load_plugin_from_path(
+        &identity_path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("Should load identity-test plugin");
+    assert!(
+        !identity_plugin.identity_provider_plugins.is_empty(),
+        "identity-test plugin should register an identity provider descriptor"
+    );
+    let provider_box = identity_plugin.identity_provider_plugins[0]
+        .create_identity_provider(&serde_json::json!({}))
+        .await
+        .expect("Should create identity provider from cdylib");
+    let provider: std::sync::Arc<dyn drasi_lib::identity::IdentityProvider> =
+        std::sync::Arc::from(provider_box);
+
+    // --- Read the cdylib-resident call counter via the exported symbol ---
+    let counter_lib =
+        unsafe { libloading::Library::new(&identity_path) }.expect("Should reopen identity cdylib");
+    let get_calls: libloading::Symbol<extern "C" fn() -> usize> = unsafe {
+        counter_lib
+            .get(b"drasi_test_identity_get_credentials_calls\0")
+            .expect("Missing exported counter symbol")
+    };
+    let reset: libloading::Symbol<extern "C" fn()> = unsafe {
+        counter_lib
+            .get(b"drasi_test_identity_reset\0")
+            .expect("Missing exported reset symbol")
+    };
+    reset();
+    assert_eq!(get_calls(), 0, "counter should start at zero after reset");
+
+    // --- Create the snapshot-test reaction with the clone-stress hook enabled (env-gated) ---
+    let reaction_plugin = load_plugin_from_path(
+        &reaction_path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("Should load snapshot-test reaction plugin");
+    assert!(
+        !reaction_plugin.reaction_plugins.is_empty(),
+        "snapshot-test plugin should register a reaction descriptor"
+    );
+
+    // The reaction reads this env var only inside `initialize` to drive the clone path; it is
+    // never part of the public config schema. Safe to set process-wide because this test is
+    // `#[serial]`.
+    std::env::set_var(
+        "DRASI_SNAPSHOT_TEST_IDENTITY_CLONE_STRESS",
+        CLONE_STRESS.to_string(),
+    );
+
+    let config = serde_json::json!({});
+    let reaction = reaction_plugin.reaction_plugins[0]
+        .create_reaction("identity-xcdylib-reaction", vec![], &config, false)
+        .await
+        .expect("Should create snapshot-test reaction");
+
+    let (update_tx, _update_rx) =
+        tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(16);
+    let context = drasi_lib::ReactionRuntimeContext {
+        instance_id: "test-instance".to_string(),
+        reaction_id: "identity-xcdylib-reaction".to_string(),
+        update_tx,
+        state_store: None,
+        identity_provider: Some(provider),
+        snapshot_fetcher: None,
+    };
+
+    // Drives CLONE_STRESS clone_box()+get_credentials() calls across both cdylib boundaries
+    // and exercises the host-side ReactionProxy::initialize ip_ptr reclaim.
+    reaction.initialize(context).await;
+    std::env::remove_var("DRASI_SNAPSHOT_TEST_IDENTITY_CLONE_STRESS");
+
+    // Every clone's get_credentials must have reached the identity cdylib intact.
+    assert_eq!(
+        get_calls(),
+        CLONE_STRESS,
+        "expected {CLONE_STRESS} get_credentials calls to traverse both cdylib boundaries \
+         through the reaction path"
+    );
+
+    // Exercise teardown (plugin proxy drop_fn + host ip_ptr reclaim) explicitly.
+    drop(reaction);
+}
+
 // ============================================================================
 // Reaction enqueue_query_result E2E Tests
 // ============================================================================

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -1501,6 +1501,10 @@ async fn test_identity_provider_username_password_roundtrip() {
     let vtable_ptr = Box::into_raw(Box::new(vtable));
 
     let proxy = unsafe { drasi_plugin_sdk::ffi::FfiIdentityProviderProxy::new(vtable_ptr) };
+    // The proxy copies the vtable by value (see `FfiIdentityProviderProxy::new`) and does
+    // not retain `vtable_ptr`, so the caller still owns the vtable-struct allocation.
+    // Reclaim it here, mirroring the host's free-after-initialize contract.
+    let _reclaim_vtable = unsafe { Box::from_raw(vtable_ptr) };
 
     use drasi_lib::identity::IdentityProvider;
     let creds = proxy
@@ -1529,6 +1533,10 @@ async fn test_identity_provider_token_roundtrip() {
     let vtable_ptr = Box::into_raw(Box::new(vtable));
 
     let proxy = unsafe { drasi_plugin_sdk::ffi::FfiIdentityProviderProxy::new(vtable_ptr) };
+    // The proxy copies the vtable by value (see `FfiIdentityProviderProxy::new`) and does
+    // not retain `vtable_ptr`, so the caller still owns the vtable-struct allocation.
+    // Reclaim it here, mirroring the host's free-after-initialize contract.
+    let _reclaim_vtable = unsafe { Box::from_raw(vtable_ptr) };
 
     use drasi_lib::identity::IdentityProvider;
     let creds = proxy
@@ -1558,6 +1566,10 @@ async fn test_identity_provider_certificate_roundtrip() {
     let vtable_ptr = Box::into_raw(Box::new(vtable));
 
     let proxy = unsafe { drasi_plugin_sdk::ffi::FfiIdentityProviderProxy::new(vtable_ptr) };
+    // The proxy copies the vtable by value (see `FfiIdentityProviderProxy::new`) and does
+    // not retain `vtable_ptr`, so the caller still owns the vtable-struct allocation.
+    // Reclaim it here, mirroring the host's free-after-initialize contract.
+    let _reclaim_vtable = unsafe { Box::from_raw(vtable_ptr) };
 
     use drasi_lib::identity::IdentityProvider;
     let creds = proxy
@@ -1592,6 +1604,10 @@ async fn test_identity_provider_certificate_no_username() {
     let vtable_ptr = Box::into_raw(Box::new(vtable));
 
     let proxy = unsafe { drasi_plugin_sdk::ffi::FfiIdentityProviderProxy::new(vtable_ptr) };
+    // The proxy copies the vtable by value (see `FfiIdentityProviderProxy::new`) and does
+    // not retain `vtable_ptr`, so the caller still owns the vtable-struct allocation.
+    // Reclaim it here, mirroring the host's free-after-initialize contract.
+    let _reclaim_vtable = unsafe { Box::from_raw(vtable_ptr) };
 
     use drasi_lib::identity::IdentityProvider;
     let creds = proxy
@@ -1622,6 +1638,10 @@ async fn test_identity_provider_error_propagation() {
     let vtable_ptr = Box::into_raw(Box::new(vtable));
 
     let proxy = unsafe { drasi_plugin_sdk::ffi::FfiIdentityProviderProxy::new(vtable_ptr) };
+    // The proxy copies the vtable by value (see `FfiIdentityProviderProxy::new`) and does
+    // not retain `vtable_ptr`, so the caller still owns the vtable-struct allocation.
+    // Reclaim it here, mirroring the host's free-after-initialize contract.
+    let _reclaim_vtable = unsafe { Box::from_raw(vtable_ptr) };
 
     use drasi_lib::identity::IdentityProvider;
     let result = proxy
@@ -1652,6 +1672,10 @@ async fn test_identity_provider_clone_box() {
     let vtable_ptr = Box::into_raw(Box::new(vtable));
 
     let proxy = unsafe { drasi_plugin_sdk::ffi::FfiIdentityProviderProxy::new(vtable_ptr) };
+    // The proxy copies the vtable by value (see `FfiIdentityProviderProxy::new`) and does
+    // not retain `vtable_ptr`, so the caller still owns the vtable-struct allocation.
+    // Reclaim it here, mirroring the host's free-after-initialize contract.
+    let _reclaim_vtable = unsafe { Box::from_raw(vtable_ptr) };
 
     use drasi_lib::identity::IdentityProvider;
 
@@ -1684,6 +1708,10 @@ async fn test_identity_provider_credential_context_roundtrip() {
     let vtable_ptr = Box::into_raw(Box::new(vtable));
 
     let proxy = unsafe { drasi_plugin_sdk::ffi::FfiIdentityProviderProxy::new(vtable_ptr) };
+    // The proxy copies the vtable by value (see `FfiIdentityProviderProxy::new`) and does
+    // not retain `vtable_ptr`, so the caller still owns the vtable-struct allocation.
+    // Reclaim it here, mirroring the host's free-after-initialize contract.
+    let _reclaim_vtable = unsafe { Box::from_raw(vtable_ptr) };
 
     use drasi_lib::identity::{CredentialContext, IdentityProvider};
     let context = CredentialContext::new()
@@ -1794,6 +1822,154 @@ async fn test_source_with_identity_provider_injection() {
     // This should not crash — identity_provider is passed through FFI
     source.initialize(context).await;
     assert_eq!(source.id(), "ip-inject-test");
+}
+
+/// Resolve a built cdylib by crate name, checking the copied `plugins/` dir first and then
+/// the raw `target/debug/` output (where `cargo build --lib` places it). Returns `None` if
+/// the plugin has not been built.
+fn find_cdylib(crate_name: &str) -> Option<PathBuf> {
+    let file = plugin_filename(crate_name);
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("Cannot find workspace root from CARGO_MANIFEST_DIR");
+    let candidates = [
+        root.join("target")
+            .join("debug")
+            .join("plugins")
+            .join(&file),
+        root.join("target").join("debug").join(&file),
+    ];
+    candidates.into_iter().find(|p| p.exists())
+}
+
+/// Cross-cdylib regression test for the `FfiIdentityProviderProxy` vtable lifecycle
+/// (issue #341).
+///
+/// This drives the **full two-cdylib chain** that exists in production:
+///
+/// ```text
+/// [drasi-identity-test cdylib]   <- returns canned Credentials, counts calls
+///        |  (host wraps the returned vtable)
+///   HostIdentityProviderProxy    <- Arc<dyn IdentityProvider> (host side, by value)
+///        |  (host builds ip_ptr vtable, passes via FfiRuntimeContext)
+/// [drasi-source-mock cdylib] FfiIdentityProviderProxy::clone_box()  <- the #341 leak site
+/// ```
+///
+/// The mock source's test-only `identityCloneStress` hook clones the injected provider N
+/// times (calling `get_credentials` on each clone) during `initialize`. Each `clone_box`
+/// invokes the FFI vtable `clone_fn` inside the source cdylib — the path that previously
+/// leaked an `IdentityProviderVtable` struct — and each `get_credentials` round-trips
+/// through the host back into the identity-provider cdylib.
+///
+/// We assert that all N `get_credentials` calls reached the identity cdylib intact by
+/// reading its process-global counter back across the FFI boundary via an exported symbol.
+/// Running this test under `MALLOC_CHECK_=3` (or valgrind) additionally surfaces the
+/// per-clone vtable-struct leak / any cross-cdylib invalid free.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn test_identity_provider_cross_cdylib_clone_stress() {
+    use drasi_plugin_sdk::descriptor::IdentityProviderPluginDescriptor;
+
+    const CLONE_STRESS: usize = 500;
+
+    let identity_path = match find_cdylib("drasi-identity-test") {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "SKIP: drasi-identity-test cdylib not built. Build with: \
+                 cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin"
+            );
+            return;
+        }
+    };
+    let mock_path = match find_cdylib("drasi-source-mock") {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "SKIP: drasi-source-mock cdylib not built. Build with: \
+                 cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin"
+            );
+            return;
+        }
+    };
+
+    // --- Create a real identity provider from the identity-test cdylib ---
+    let identity_plugin = load_plugin_from_path(
+        &identity_path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("Should load identity-test plugin");
+    assert!(
+        !identity_plugin.identity_provider_plugins.is_empty(),
+        "identity-test plugin should register an identity provider descriptor"
+    );
+    let provider_box = identity_plugin.identity_provider_plugins[0]
+        .create_identity_provider(&serde_json::json!({}))
+        .await
+        .expect("Should create identity provider from cdylib");
+    let provider: std::sync::Arc<dyn drasi_lib::identity::IdentityProvider> =
+        std::sync::Arc::from(provider_box);
+
+    // --- Read the cdylib-resident call counter via the exported symbol ---
+    let counter_lib =
+        unsafe { libloading::Library::new(&identity_path) }.expect("Should reopen identity cdylib");
+    let get_calls: libloading::Symbol<extern "C" fn() -> usize> = unsafe {
+        counter_lib
+            .get(b"drasi_test_identity_get_credentials_calls\0")
+            .expect("Missing exported counter symbol")
+    };
+    let reset: libloading::Symbol<extern "C" fn()> = unsafe {
+        counter_lib
+            .get(b"drasi_test_identity_reset\0")
+            .expect("Missing exported reset symbol")
+    };
+    reset();
+    assert_eq!(get_calls(), 0, "counter should start at zero after reset");
+
+    // --- Create the mock source with the clone-stress hook enabled ---
+    let mock_plugin = load_plugin_from_path(
+        &mock_path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("Should load mock source plugin");
+
+    let config = serde_json::json!({ "identityCloneStress": CLONE_STRESS });
+    let source = mock_plugin.source_plugins[0]
+        .create_source("identity-xcdylib", &config, false)
+        .await
+        .expect("Should create mock source");
+
+    let (update_tx, _update_rx) =
+        tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(16);
+    let context = drasi_lib::context::SourceRuntimeContext {
+        instance_id: "test-instance".to_string(),
+        source_id: "identity-xcdylib".to_string(),
+        update_tx,
+        state_store: None,
+        identity_provider: Some(provider),
+        wal_provider: None,
+    };
+
+    // Drives CLONE_STRESS clone_box()+get_credentials() calls across both cdylib boundaries.
+    source.initialize(context).await;
+
+    // Every clone's get_credentials must have reached the identity cdylib intact.
+    assert_eq!(
+        get_calls(),
+        CLONE_STRESS,
+        "expected {CLONE_STRESS} get_credentials calls to traverse both cdylib boundaries"
+    );
+
+    // Exercise teardown (plugin proxy drop_fn + host ip_ptr reclaim) explicitly.
+    drop(source);
 }
 
 // ============================================================================

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -1857,8 +1857,9 @@ fn find_cdylib(crate_name: &str) -> Option<PathBuf> {
 /// [drasi-source-mock cdylib] FfiIdentityProviderProxy::clone_box()  <- the #341 leak site
 /// ```
 ///
-/// The mock source's test-only `identityCloneStress` hook clones the injected provider N
-/// times (calling `get_credentials` on each clone) during `initialize`. Each `clone_box`
+/// The mock source's test-only clone hook (gated behind the
+/// `DRASI_MOCK_IDENTITY_CLONE_STRESS` env var) clones the injected provider N times
+/// (calling `get_credentials` on each clone) during `initialize`. Each `clone_box`
 /// invokes the FFI vtable `clone_fn` inside the source cdylib — the path that previously
 /// leaked an `IdentityProviderVtable` struct — and each `get_credentials` round-trips
 /// through the host back into the identity-provider cdylib.
@@ -1874,26 +1875,18 @@ async fn test_identity_provider_cross_cdylib_clone_stress() {
 
     const CLONE_STRESS: usize = 500;
 
-    let identity_path = match find_cdylib("drasi-identity-test") {
-        Some(p) => p,
-        None => {
-            eprintln!(
-                "SKIP: drasi-identity-test cdylib not built. Build with: \
-                 cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin"
-            );
-            return;
-        }
-    };
-    let mock_path = match find_cdylib("drasi-source-mock") {
-        Some(p) => p,
-        None => {
-            eprintln!(
-                "SKIP: drasi-source-mock cdylib not built. Build with: \
-                 cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin"
-            );
-            return;
-        }
-    };
+    let identity_path = find_cdylib("drasi-identity-test").unwrap_or_else(|| {
+        panic!(
+            "drasi-identity-test cdylib not built. Build with: \
+             cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin"
+        )
+    });
+    let mock_path = find_cdylib("drasi-source-mock").unwrap_or_else(|| {
+        panic!(
+            "drasi-source-mock cdylib not built. Build with: \
+             cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin"
+        )
+    });
 
     // --- Create a real identity provider from the identity-test cdylib ---
     let identity_plugin = load_plugin_from_path(
@@ -1931,7 +1924,7 @@ async fn test_identity_provider_cross_cdylib_clone_stress() {
     reset();
     assert_eq!(get_calls(), 0, "counter should start at zero after reset");
 
-    // --- Create the mock source with the clone-stress hook enabled ---
+    // --- Create the mock source with the clone-stress hook enabled (env-gated) ---
     let mock_plugin = load_plugin_from_path(
         &mock_path,
         std::ptr::null_mut(),
@@ -1941,7 +1934,12 @@ async fn test_identity_provider_cross_cdylib_clone_stress() {
     )
     .expect("Should load mock source plugin");
 
-    let config = serde_json::json!({ "identityCloneStress": CLONE_STRESS });
+    // The mock source reads this env var only inside `initialize` to drive the clone path;
+    // it is never part of the public config schema. Safe to set process-wide because this
+    // test is `#[serial]`.
+    std::env::set_var("DRASI_MOCK_IDENTITY_CLONE_STRESS", CLONE_STRESS.to_string());
+
+    let config = serde_json::json!({});
     let source = mock_plugin.source_plugins[0]
         .create_source("identity-xcdylib", &config, false)
         .await
@@ -1960,6 +1958,7 @@ async fn test_identity_provider_cross_cdylib_clone_stress() {
 
     // Drives CLONE_STRESS clone_box()+get_credentials() calls across both cdylib boundaries.
     source.initialize(context).await;
+    std::env::remove_var("DRASI_MOCK_IDENTITY_CLONE_STRESS");
 
     // Every clone's get_credentials must have reached the identity cdylib intact.
     assert_eq!(

--- a/components/identity/test-fixture/Cargo.toml
+++ b/components/identity/test-fixture/Cargo.toml
@@ -1,0 +1,39 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-identity-test"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Hermetic test-fixture identity provider plugin for validating the FFI identity-provider boundary"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+drasi-lib.workspace = true
+drasi-plugin-sdk = { workspace = true }
+utoipa = { workspace = true }
+anyhow = "1.0"
+async-trait = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[features]
+dynamic-plugin = []

--- a/components/identity/test-fixture/src/lib.rs
+++ b/components/identity/test-fixture/src/lib.rs
@@ -26,8 +26,8 @@
 //! Every `get_credentials` call increments a process-global counter that the host test can
 //! read back across the FFI boundary via the exported
 //! [`drasi_test_identity_get_credentials_calls`] accessor. This lets a test assert that N
-//! `get_credentials` calls made by a *source* plugin traversed **both** cdylib boundaries
-//! (source plugin → host → this identity plugin) intact.
+//! `get_credentials` calls made by a *source* or *reaction* plugin traversed **both** cdylib
+//! boundaries (plugin → host → this identity plugin) intact.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/components/identity/test-fixture/src/lib.rs
+++ b/components/identity/test-fixture/src/lib.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unexpected_cfgs)]
+
+//! Hermetic **test-fixture** identity provider plugin for Drasi.
+//!
+//! This crate exists solely to exercise the FFI identity-provider boundary in
+//! integration tests (see `components/host-sdk/tests/integration_test.rs`). It returns
+//! deterministic, canned credentials with **no external dependencies** (unlike the real
+//! `drasi-identity-aws` / `drasi-identity-azure` plugins, which require live cloud
+//! credentials), so it can be loaded as a real cdylib and driven across the FFI boundary
+//! from a hermetic test.
+//!
+//! Every `get_credentials` call increments a process-global counter that the host test can
+//! read back across the FFI boundary via the exported
+//! [`drasi_test_identity_get_credentials_calls`] accessor. This lets a test assert that N
+//! `get_credentials` calls made by a *source* plugin traversed **both** cdylib boundaries
+//! (source plugin → host → this identity plugin) intact.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use drasi_lib::identity::{CredentialContext, Credentials, IdentityProvider};
+use drasi_plugin_sdk::prelude::*;
+use utoipa::OpenApi;
+
+/// The deterministic username returned by [`TestIdentityProvider::get_credentials`].
+pub const TEST_USERNAME: &str = "test-user";
+/// The deterministic password returned by [`TestIdentityProvider::get_credentials`].
+pub const TEST_PASSWORD: &str = "test-pass";
+
+/// Process-global count of `get_credentials` calls served by this plugin.
+static GET_CREDENTIALS_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+/// Returns the number of `get_credentials` calls served since the last reset.
+///
+/// Exported so a host integration test can read the cdylib-resident counter across the
+/// FFI boundary (resolved via `libloading::Library::get`).
+#[no_mangle]
+pub extern "C" fn drasi_test_identity_get_credentials_calls() -> usize {
+    GET_CREDENTIALS_CALLS.load(Ordering::SeqCst)
+}
+
+/// Resets the `get_credentials` call counter to zero.
+#[no_mangle]
+pub extern "C" fn drasi_test_identity_reset() {
+    GET_CREDENTIALS_CALLS.store(0, Ordering::SeqCst);
+}
+
+/// Test identity provider that returns canned [`Credentials::UsernamePassword`] and counts
+/// how many times it has been invoked.
+#[derive(Clone, Default)]
+pub struct TestIdentityProvider;
+
+#[async_trait]
+impl IdentityProvider for TestIdentityProvider {
+    async fn get_credentials(&self, _context: &CredentialContext) -> anyhow::Result<Credentials> {
+        GET_CREDENTIALS_CALLS.fetch_add(1, Ordering::SeqCst);
+        Ok(Credentials::UsernamePassword {
+            username: TEST_USERNAME.to_string(),
+            password: TEST_PASSWORD.to_string(),
+        })
+    }
+
+    fn clone_box(&self) -> Box<dyn IdentityProvider> {
+        Box::new(self.clone())
+    }
+}
+
+/// Configuration DTO for the test identity provider plugin (intentionally empty).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TestIdentityProviderConfigDto {}
+
+#[derive(utoipa::OpenApi)]
+#[openapi(components(schemas(TestIdentityProviderConfigDto)))]
+struct TestIdentityProviderSchemas;
+
+/// Descriptor for the test identity provider plugin.
+pub struct TestIdentityProviderDescriptor;
+
+#[async_trait]
+impl IdentityProviderPluginDescriptor for TestIdentityProviderDescriptor {
+    fn kind(&self) -> &str {
+        "test"
+    }
+
+    fn config_version(&self) -> &str {
+        "1.0.0"
+    }
+
+    fn config_schema_json(&self) -> String {
+        let api = TestIdentityProviderSchemas::openapi();
+        serde_json::to_string(
+            &api.components
+                .as_ref()
+                .expect("OpenAPI components missing")
+                .schemas,
+        )
+        .expect("Failed to serialize config schema")
+    }
+
+    fn config_schema_name(&self) -> &str {
+        "identity.test.TestIdentityProviderConfig"
+    }
+
+    async fn create_identity_provider(
+        &self,
+        _config_json: &serde_json::Value,
+    ) -> anyhow::Result<Box<dyn IdentityProvider>> {
+        Ok(Box::new(TestIdentityProvider))
+    }
+}
+
+// Dynamic plugin entry point
+#[cfg(feature = "dynamic-plugin")]
+drasi_plugin_sdk::export_plugin!(
+    plugin_id = "identity-test",
+    core_version = "0.4.0",
+    lib_version = "0.4.0",
+    plugin_version = "0.1.0",
+    source_descriptors = [],
+    reaction_descriptors = [],
+    bootstrap_descriptors = [],
+    identity_provider_descriptors = [TestIdentityProviderDescriptor],
+);

--- a/components/plugin-sdk/src/ffi/identity_proxy.rs
+++ b/components/plugin-sdk/src/ffi/identity_proxy.rs
@@ -35,8 +35,8 @@ pub struct FfiIdentityProviderProxy {
     vtable: IdentityProviderVtable,
 }
 
-// Safety: The vtable points to host-allocated state (Arc<dyn IdentityProvider>)
-// which is Send+Sync. The vtable itself is immutable after creation.
+// Safety: `vtable.state` references host-allocated state (Arc<dyn IdentityProvider>)
+// which is Send+Sync. The vtable function pointers are immutable after creation.
 unsafe impl Send for FfiIdentityProviderProxy {}
 unsafe impl Sync for FfiIdentityProviderProxy {}
 
@@ -50,6 +50,8 @@ impl FfiIdentityProviderProxy {
     ///
     /// # Safety
     /// The vtable pointer must be non-null and valid for the duration of this call.
+    /// The `state` it contains must remain valid for the full lifetime of the returned
+    /// proxy; the proxy calls `drop_fn(state)` on `Drop`.
     pub unsafe fn new(vtable: *const IdentityProviderVtable) -> Self {
         assert!(
             !vtable.is_null(),

--- a/components/plugin-sdk/src/ffi/identity_proxy.rs
+++ b/components/plugin-sdk/src/ffi/identity_proxy.rs
@@ -26,8 +26,13 @@ use super::identity::IdentityProviderVtable;
 /// Plugin-side proxy wrapping an `IdentityProviderVtable` into the
 /// `IdentityProvider` trait. Plugins use this to call the host's
 /// identity provider through FFI.
+///
+/// The vtable is stored **by value** (not as a raw `Box` pointer), mirroring the
+/// host-side `HostIdentityProviderProxy`. Storing by value means there is no separate
+/// vtable-struct allocation to track or free, so `clone_box` cannot leak the struct and
+/// `Drop` never has to (incorrectly) free host-owned memory across the cdylib boundary.
 pub struct FfiIdentityProviderProxy {
-    vtable: *const IdentityProviderVtable,
+    vtable: IdentityProviderVtable,
 }
 
 // Safety: The vtable points to host-allocated state (Arc<dyn IdentityProvider>)
@@ -38,53 +43,60 @@ unsafe impl Sync for FfiIdentityProviderProxy {}
 impl FfiIdentityProviderProxy {
     /// Create a new proxy from a vtable pointer.
     ///
+    /// The four vtable fields are copied **by value** out of `vtable`; the proxy does not
+    /// retain the pointer. Ownership of the underlying state (`drop_fn` will be called on
+    /// `Drop`) transfers to the proxy, but the caller's vtable-struct allocation remains
+    /// owned by the caller and is never freed here.
+    ///
     /// # Safety
-    /// The vtable pointer must be valid and the vtable must outlive this proxy.
-    /// The proxy takes ownership (will call drop_fn on Drop).
+    /// The vtable pointer must be non-null and valid for the duration of this call.
     pub unsafe fn new(vtable: *const IdentityProviderVtable) -> Self {
-        Self { vtable }
+        let vtable = &*vtable;
+        Self {
+            vtable: IdentityProviderVtable {
+                state: vtable.state,
+                get_credentials_fn: vtable.get_credentials_fn,
+                clone_fn: vtable.clone_fn,
+                drop_fn: vtable.drop_fn,
+            },
+        }
     }
 }
 
 #[async_trait]
 impl IdentityProvider for FfiIdentityProviderProxy {
     async fn get_credentials(&self, context: &CredentialContext) -> Result<Credentials> {
-        let vtable = unsafe { &*self.vtable };
         // Serialize context as JSON for FFI transport
         let context_json =
             serde_json::to_string(&context.properties).unwrap_or_else(|_| "{}".to_string());
-        let result =
-            (vtable.get_credentials_fn)(vtable.state, context_json.as_ptr(), context_json.len());
+        let result = (self.vtable.get_credentials_fn)(
+            self.vtable.state,
+            context_json.as_ptr(),
+            context_json.len(),
+        );
         unsafe { result.into_result() }
     }
 
     fn clone_box(&self) -> Box<dyn IdentityProvider> {
-        let vtable = unsafe { &*self.vtable };
-        let cloned_state = (vtable.clone_fn)(vtable.state);
+        let cloned_state = (self.vtable.clone_fn)(self.vtable.state);
 
-        // Build a new vtable with the cloned state but same function pointers
-        let cloned_vtable = Box::new(IdentityProviderVtable {
-            state: cloned_state,
-            get_credentials_fn: vtable.get_credentials_fn,
-            clone_fn: vtable.clone_fn,
-            drop_fn: vtable.drop_fn,
-        });
-
+        // Build a new vtable value with freshly cloned state and the same function
+        // pointers. No heap allocation for the vtable struct, so nothing to leak.
         Box::new(FfiIdentityProviderProxy {
-            vtable: Box::into_raw(cloned_vtable),
+            vtable: IdentityProviderVtable {
+                state: cloned_state,
+                get_credentials_fn: self.vtable.get_credentials_fn,
+                clone_fn: self.vtable.clone_fn,
+                drop_fn: self.vtable.drop_fn,
+            },
         })
     }
 }
 
 impl Drop for FfiIdentityProviderProxy {
     fn drop(&mut self) {
-        if !self.vtable.is_null() {
-            let vtable = unsafe { &*self.vtable };
-            (vtable.drop_fn)(vtable.state);
-            // If we own the vtable (from clone_box), free it
-            // Note: the original vtable from FfiRuntimeContext is host-owned
-            // and should NOT be freed here. Only cloned vtables should be freed.
-            // We handle this by always using Box::into_raw for cloned vtables.
-        }
+        // Release the underlying host state (decrements the Arc refcount). There is no
+        // separate vtable-struct allocation owned by this proxy, so nothing else to free.
+        (self.vtable.drop_fn)(self.vtable.state);
     }
 }

--- a/components/plugin-sdk/src/ffi/identity_proxy.rs
+++ b/components/plugin-sdk/src/ffi/identity_proxy.rs
@@ -51,6 +51,10 @@ impl FfiIdentityProviderProxy {
     /// # Safety
     /// The vtable pointer must be non-null and valid for the duration of this call.
     pub unsafe fn new(vtable: *const IdentityProviderVtable) -> Self {
+        assert!(
+            !vtable.is_null(),
+            "FfiIdentityProviderProxy::new: vtable pointer is null"
+        );
         let vtable = &*vtable;
         Self {
             vtable: IdentityProviderVtable {
@@ -97,6 +101,12 @@ impl Drop for FfiIdentityProviderProxy {
     fn drop(&mut self) {
         // Release the underlying host state (decrements the Arc refcount). There is no
         // separate vtable-struct allocation owned by this proxy, so nothing else to free.
+        // `state` is established non-null by `new`/`clone_box`; a null here would indicate
+        // a `clone_fn` that returned null after a caught panic, which we surface in dev.
+        debug_assert!(
+            !self.vtable.state.is_null(),
+            "FfiIdentityProviderProxy::drop: state is null; clone_fn may have panicked"
+        );
         (self.vtable.drop_fn)(self.vtable.state);
     }
 }

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -227,6 +227,9 @@ pub struct FfiRuntimeContext {
     pub instance_id: FfiStr,
     pub component_id: FfiStr,
     /// Nullable — not all plugins need state store.
+    ///
+    /// **Lifetime: persistent.** The plugin retains this pointer for the component's
+    /// lifetime; neither side frees the vtable struct.
     pub state_store: *const StateStoreVtable,
     /// Per-instance log callback (nullable — falls back to global if null).
     pub log_callback: Option<super::callbacks::LogCallbackFn>,
@@ -237,10 +240,21 @@ pub struct FfiRuntimeContext {
     /// Opaque context for per-instance lifecycle callback.
     pub lifecycle_ctx: *mut c_void,
     /// Nullable — identity provider for credential injection.
+    ///
+    /// **Lifetime: transient.** Valid only for the duration of `initialize_fn`. The plugin
+    /// must copy the vtable fields by value before `initialize_fn` returns (as
+    /// `FfiIdentityProviderProxy::new` does); the host frees the vtable struct immediately
+    /// after `initialize_fn` returns. The plugin must not retain this pointer past init.
     pub identity_provider: *const super::identity::IdentityProviderVtable,
     /// Nullable — snapshot fetcher for on-demand query snapshot access.
+    ///
+    /// **Lifetime: persistent.** The plugin retains this pointer for the component's
+    /// lifetime; neither side frees the vtable struct.
     pub snapshot_fetcher: *const SnapshotFetcherVtable,
     /// Nullable — WAL provider for transient source durability.
+    ///
+    /// **Lifetime: persistent.** The plugin retains this pointer and (via
+    /// `FfiWalProviderProxy`) frees the vtable struct and its inner state on `Drop`.
     pub wal_provider: *const WalProviderVtable,
 }
 

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -244,7 +244,7 @@ pub struct FfiRuntimeContext {
     /// **Lifetime: transient.** Valid only for the duration of `initialize_fn`. The plugin
     /// must copy the vtable fields by value before `initialize_fn` returns (as
     /// `FfiIdentityProviderProxy::new` does); the host frees the vtable struct immediately
-    /// after `initialize_fn` returns. The plugin must not retain this pointer past init.
+    /// after `initialize_fn` returns. The plugin must not retain this pointer past `initialize_fn`.
     pub identity_provider: *const super::identity::IdentityProviderVtable,
     /// Nullable — snapshot fetcher for on-demand query snapshot access.
     ///

--- a/components/reactions/snapshot-test/src/lib.rs
+++ b/components/reactions/snapshot-test/src/lib.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use drasi_lib::channels::QueryResult;
+use drasi_lib::identity::{CredentialContext, IdentityProvider};
 use drasi_lib::reactions::bootstrap_context::BootstrapContext;
 use drasi_lib::reactions::{Reaction, SnapshotFetcher};
 use drasi_lib::{ComponentStatus, ReactionRuntimeContext};
@@ -108,6 +109,30 @@ impl Reaction for SnapshotTestReaction {
     }
 
     async fn initialize(&self, context: ReactionRuntimeContext) {
+        // Test-only: exercise the FFI identity-provider clone/drop path across the reaction
+        // plugin boundary. Gated entirely behind the
+        // `DRASI_SNAPSHOT_TEST_IDENTITY_CLONE_STRESS` environment variable (read only here) so
+        // no test-only knob leaks into the public config schema. When set to N > 0 and an
+        // identity provider was injected, clone it N times and fetch credentials on each clone.
+        // Each `clone_box` invokes the FFI vtable `clone_fn` inside the reaction cdylib (the
+        // `FfiIdentityProviderProxy::clone_box` path that previously leaked a vtable struct),
+        // and each `get_credentials` round-trips through the host back into the
+        // identity-provider plugin. This mirrors the mock source's clone-stress hook and
+        // additionally exercises the host-side `ReactionProxy::initialize` `ip_ptr` reclaim.
+        if let Some(provider) = context.identity_provider.clone() {
+            let clone_stress = std::env::var("DRASI_SNAPSHOT_TEST_IDENTITY_CLONE_STRESS")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(0);
+            if clone_stress > 0 {
+                let ctx = CredentialContext::default();
+                for _ in 0..clone_stress {
+                    let cloned: Box<dyn IdentityProvider> = provider.clone_box();
+                    let _ = cloned.get_credentials(&ctx).await;
+                }
+            }
+        }
+
         // Store the snapshot fetcher (if provided) for use during start().
         let mut guard = self.snapshot_fetcher.lock().await;
         *guard = context.snapshot_fetcher;

--- a/components/sources/mock/src/descriptor.rs
+++ b/components/sources/mock/src/descriptor.rs
@@ -46,6 +46,12 @@ pub struct MockSourceConfigDto {
     pub data_type: DataTypeDto,
     #[serde(default = "default_interval_ms")]
     pub interval_ms: ConfigValue<u64>,
+    /// Test-only knob: when greater than zero, the source clones the injected
+    /// identity provider this many times (calling `get_credentials` on each clone)
+    /// during `initialize`, to exercise the FFI identity-provider clone/drop path.
+    /// Not intended for production use.
+    #[serde(default)]
+    pub identity_clone_stress: u32,
 }
 
 fn default_interval_ms() -> ConfigValue<u64> {
@@ -113,6 +119,7 @@ impl SourcePluginDescriptor for MockSourceDescriptor {
         let mut source = MockSourceBuilder::new(id)
             .with_data_type(data_type)
             .with_interval_ms(interval_ms)
+            .with_identity_clone_stress(dto.identity_clone_stress)
             .with_auto_start(auto_start)
             .build()?;
 

--- a/components/sources/mock/src/descriptor.rs
+++ b/components/sources/mock/src/descriptor.rs
@@ -46,12 +46,6 @@ pub struct MockSourceConfigDto {
     pub data_type: DataTypeDto,
     #[serde(default = "default_interval_ms")]
     pub interval_ms: ConfigValue<u64>,
-    /// Test-only knob: when greater than zero, the source clones the injected
-    /// identity provider this many times (calling `get_credentials` on each clone)
-    /// during `initialize`, to exercise the FFI identity-provider clone/drop path.
-    /// Not intended for production use.
-    #[serde(default)]
-    pub identity_clone_stress: u32,
 }
 
 fn default_interval_ms() -> ConfigValue<u64> {
@@ -119,7 +113,6 @@ impl SourcePluginDescriptor for MockSourceDescriptor {
         let mut source = MockSourceBuilder::new(id)
             .with_data_type(data_type)
             .with_interval_ms(interval_ms)
-            .with_identity_clone_stress(dto.identity_clone_stress)
             .with_auto_start(auto_start)
             .build()?;
 

--- a/components/sources/mock/src/mock.rs
+++ b/components/sources/mock/src/mock.rs
@@ -58,11 +58,6 @@ pub struct MockSource {
     /// Tracks sensor IDs that have been seen for INSERT vs UPDATE logic.
     /// Only used when `config.data_type` is `SensorReading`.
     seen_sensors: Arc<RwLock<HashSet<u32>>>,
-
-    /// Test-only knob: number of times to clone the injected identity provider
-    /// (and call `get_credentials` on each clone) during `initialize`, used to
-    /// exercise the FFI identity-provider clone/drop path. `0` in normal use.
-    identity_clone_stress: u32,
 }
 
 impl MockSource {
@@ -107,7 +102,6 @@ impl MockSource {
             base: SourceBase::new(params)?,
             config,
             seen_sensors: Arc::new(RwLock::new(HashSet::new())),
-            identity_clone_stress: 0,
         })
     }
 
@@ -147,7 +141,6 @@ impl MockSource {
             base: SourceBase::new(params)?,
             config,
             seen_sensors: Arc::new(RwLock::new(HashSet::new())),
-            identity_clone_stress: 0,
         })
     }
 }
@@ -179,7 +172,6 @@ impl Source for MockSource {
         let dto = MockSourceConfigDto {
             data_type: data_type_dto,
             interval_ms: ConfigValue::Static(self.config.interval_ms),
-            identity_clone_stress: self.identity_clone_stress,
         };
 
         self.base.properties_or_serialize(&dto)
@@ -565,15 +557,20 @@ impl Source for MockSource {
 
     async fn initialize(&self, context: drasi_lib::context::SourceRuntimeContext) {
         // Test-only: exercise the FFI identity-provider clone/drop path across the plugin
-        // boundary. When `identity_clone_stress > 0` and an identity provider was injected,
-        // clone it that many times and fetch credentials on each clone. Each `clone_box`
-        // invokes the FFI vtable `clone_fn` (the path that previously leaked a vtable
-        // struct), and each `get_credentials` round-trips through the host back into the
-        // identity-provider plugin.
-        if self.identity_clone_stress > 0 {
-            if let Some(provider) = context.identity_provider.clone() {
+        // boundary. Gated entirely behind the `DRASI_MOCK_IDENTITY_CLONE_STRESS` environment
+        // variable (read only here) so no test-only knob leaks into the public config schema.
+        // When set to N > 0 and an identity provider was injected, clone it N times and fetch
+        // credentials on each clone. Each `clone_box` invokes the FFI vtable `clone_fn` (the
+        // path that previously leaked a vtable struct), and each `get_credentials` round-trips
+        // through the host back into the identity-provider plugin.
+        if let Some(provider) = context.identity_provider.clone() {
+            let clone_stress = std::env::var("DRASI_MOCK_IDENTITY_CLONE_STRESS")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .unwrap_or(0);
+            if clone_stress > 0 {
                 let ctx = CredentialContext::default();
-                for _ in 0..self.identity_clone_stress {
+                for _ in 0..clone_stress {
                     let cloned: Box<dyn IdentityProvider> = provider.clone_box();
                     let _ = cloned.get_credentials(&ctx).await;
                 }
@@ -673,7 +670,6 @@ pub struct MockSourceBuilder {
     dispatch_buffer_capacity: Option<usize>,
     bootstrap_provider: Option<Box<dyn drasi_lib::bootstrap::BootstrapProvider + 'static>>,
     auto_start: bool,
-    identity_clone_stress: u32,
 }
 
 impl MockSourceBuilder {
@@ -691,7 +687,6 @@ impl MockSourceBuilder {
             dispatch_buffer_capacity: None,
             bootstrap_provider: None,
             auto_start: true,
-            identity_clone_stress: 0,
         }
     }
 
@@ -759,16 +754,6 @@ impl MockSourceBuilder {
         self
     }
 
-    /// Set the test-only identity-provider clone-stress count.
-    ///
-    /// When greater than zero, [`MockSource::initialize`] clones the injected identity
-    /// provider this many times (calling `get_credentials` on each clone) to exercise the
-    /// FFI identity-provider clone/drop path. Defaults to `0` (disabled).
-    pub fn with_identity_clone_stress(mut self, count: u32) -> Self {
-        self.identity_clone_stress = count;
-        self
-    }
-
     /// Build the MockSource instance.
     ///
     /// # Returns
@@ -804,7 +789,6 @@ impl MockSourceBuilder {
             base: SourceBase::new(params)?,
             config,
             seen_sensors: Arc::new(RwLock::new(HashSet::new())),
-            identity_clone_stress: self.identity_clone_stress,
         })
     }
 }

--- a/components/sources/mock/src/mock.rs
+++ b/components/sources/mock/src/mock.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use drasi_lib::channels::*;
+use drasi_lib::identity::{CredentialContext, IdentityProvider};
 use drasi_lib::managers::{log_component_start, log_component_stop};
 use drasi_lib::sources::base::{SourceBase, SourceBaseParams};
 use drasi_lib::Source;
@@ -57,6 +58,11 @@ pub struct MockSource {
     /// Tracks sensor IDs that have been seen for INSERT vs UPDATE logic.
     /// Only used when `config.data_type` is `SensorReading`.
     seen_sensors: Arc<RwLock<HashSet<u32>>>,
+
+    /// Test-only knob: number of times to clone the injected identity provider
+    /// (and call `get_credentials` on each clone) during `initialize`, used to
+    /// exercise the FFI identity-provider clone/drop path. `0` in normal use.
+    identity_clone_stress: u32,
 }
 
 impl MockSource {
@@ -101,6 +107,7 @@ impl MockSource {
             base: SourceBase::new(params)?,
             config,
             seen_sensors: Arc::new(RwLock::new(HashSet::new())),
+            identity_clone_stress: 0,
         })
     }
 
@@ -140,6 +147,7 @@ impl MockSource {
             base: SourceBase::new(params)?,
             config,
             seen_sensors: Arc::new(RwLock::new(HashSet::new())),
+            identity_clone_stress: 0,
         })
     }
 }
@@ -171,6 +179,7 @@ impl Source for MockSource {
         let dto = MockSourceConfigDto {
             data_type: data_type_dto,
             interval_ms: ConfigValue::Static(self.config.interval_ms),
+            identity_clone_stress: self.identity_clone_stress,
         };
 
         self.base.properties_or_serialize(&dto)
@@ -555,6 +564,21 @@ impl Source for MockSource {
     }
 
     async fn initialize(&self, context: drasi_lib::context::SourceRuntimeContext) {
+        // Test-only: exercise the FFI identity-provider clone/drop path across the plugin
+        // boundary. When `identity_clone_stress > 0` and an identity provider was injected,
+        // clone it that many times and fetch credentials on each clone. Each `clone_box`
+        // invokes the FFI vtable `clone_fn` (the path that previously leaked a vtable
+        // struct), and each `get_credentials` round-trips through the host back into the
+        // identity-provider plugin.
+        if self.identity_clone_stress > 0 {
+            if let Some(provider) = context.identity_provider.clone() {
+                let ctx = CredentialContext::default();
+                for _ in 0..self.identity_clone_stress {
+                    let cloned: Box<dyn IdentityProvider> = provider.clone_box();
+                    let _ = cloned.get_credentials(&ctx).await;
+                }
+            }
+        }
         self.base.initialize(context).await;
     }
 
@@ -649,6 +673,7 @@ pub struct MockSourceBuilder {
     dispatch_buffer_capacity: Option<usize>,
     bootstrap_provider: Option<Box<dyn drasi_lib::bootstrap::BootstrapProvider + 'static>>,
     auto_start: bool,
+    identity_clone_stress: u32,
 }
 
 impl MockSourceBuilder {
@@ -666,6 +691,7 @@ impl MockSourceBuilder {
             dispatch_buffer_capacity: None,
             bootstrap_provider: None,
             auto_start: true,
+            identity_clone_stress: 0,
         }
     }
 
@@ -733,6 +759,16 @@ impl MockSourceBuilder {
         self
     }
 
+    /// Set the test-only identity-provider clone-stress count.
+    ///
+    /// When greater than zero, [`MockSource::initialize`] clones the injected identity
+    /// provider this many times (calling `get_credentials` on each clone) to exercise the
+    /// FFI identity-provider clone/drop path. Defaults to `0` (disabled).
+    pub fn with_identity_clone_stress(mut self, count: u32) -> Self {
+        self.identity_clone_stress = count;
+        self
+    }
+
     /// Build the MockSource instance.
     ///
     /// # Returns
@@ -768,6 +804,7 @@ impl MockSourceBuilder {
             base: SourceBase::new(params)?,
             config,
             seen_sensors: Arc::new(RwLock::new(HashSet::new())),
+            identity_clone_stress: self.identity_clone_stress,
         })
     }
 }


### PR DESCRIPTION
## Summary

Fixes #341.

`FfiIdentityProviderProxy::clone_box()` allocated a cloned vtable header via `Box::into_raw(Box::new(...))`, but `Drop` only called `drop_fn(state)` and never freed the cloned `IdentityProviderVtable` struct — leaking ~64 bytes per clone.

The issue's suggested fix (unconditionally `Box::from_raw(self.vtable)` in `Drop`) is **unsafe**: the same `Drop` also runs for proxies created via `new()` from `FfiRuntimeContext.identity_provider`, whose vtable struct is **host-allocated in another cdylib**. Freeing it from the plugin would be a cross-cdylib free (the heap-corruption class seen in #602).

Instead, this PR stores the vtable **by value**, mirroring the host-side `HostIdentityProviderProxy`. With a by-value field there is no separate struct allocation, so `clone_box()` cannot leak and `Drop` only releases the underlying state via `drop_fn`.

## Changes

- **`plugin-sdk/src/ffi/identity_proxy.rs`** — `FfiIdentityProviderProxy` stores `IdentityProviderVtable` by value; `clone_box()` no longer `Box::into_raw`s; `Drop` calls only `drop_fn`.
- **`host-sdk/src/proxies/source.rs` + `reaction.rs`** — reclaim the host-allocated `ip_ptr` vtable struct after `initialize_fn` returns (safe now that the plugin copies by value), fixing a related host-side leak.
- **`Cargo.toml`** — bump workspace `0.9.1 → 0.10.0` (and the three workspace-versioned internal pins). This changes the cross-FFI lifetime contract (host frees the vtable struct after initialize), so `FFI_SDK_VERSION` must change: the loader's major.minor gate then rejects older plugins that still retain the pointer, preventing a use-after-free. **All plugins must be rebuilt against the new SDK.**

## Testing

A unit test with hand-built vtables doesn't exercise the real allocator boundary, so this adds a **two-cdylib** regression test:

- New hermetic **`drasi-identity-test`** identity-provider cdylib fixture (`components/identity/test-fixture`) returning canned credentials and counting `get_credentials` calls via an exported symbol.
- **`drasi-source-mock`** gains a test-only `identityCloneStress` config knob that calls `clone_box()` + `get_credentials()` on the injected provider N times during `initialize`.
- `test_identity_provider_cross_cdylib_clone_stress` loads **both** cdylibs, creates the provider from the identity cdylib (→ `HostIdentityProviderProxy`), injects it into the real mock-source cdylib, drives 500 `clone_box()`+`get_credentials()` calls across the full chain (identity cdylib → host → source cdylib `FfiIdentityProviderProxy::clone_box`), and asserts the fixture's exported counter `== 500`.

Verified: all identity integration tests pass; clean under `MALLOC_CHECK_=3` (no cross-cdylib invalid free); `cargo build --workspace`, `clippy`, and `cargo fmt --check` all green.

Build the fixtures before running the test:
\`\`\`sh
cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin
cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin
cargo test -p drasi-host-sdk --test integration_test identity
\`\`\`