### PR TITLE
Set publish_no_verify to true for release plz

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -105,17 +105,7 @@ drasi-index-rocksdb = { path = "../components/indexes/rocksdb", features = [
 ] }
 # Mirrors how drasi-server depends on the plugin SDK to drive index backends
 # through their descriptor/DTO when statically linking a backend crate.
-#
-# IMPORTANT: This is a path-only dependency (no version) on purpose. There is a
-# dependency cycle between drasi-lib and drasi-plugin-sdk:
-#   - drasi-plugin-sdk depends on drasi-lib (normal dependency)
-#   - drasi-lib depends on drasi-plugin-sdk (this dev-dependency)
-# Cargo strips path-only dev-dependencies from the published manifest, so
-# `cargo publish` of drasi-lib does NOT require drasi-plugin-sdk to exist on
-# crates.io. This breaks the publish deadlock (see issue #617) and lets
-# drasi-lib publish first, followed by drasi-plugin-sdk. Do NOT add a `version`
-# or switch back to `{ workspace = true }` here, or the release will deadlock.
-drasi-plugin-sdk = { path = "../components/plugin-sdk" }
+drasi-plugin-sdk = { workspace = true }
 
 # Additional testing dependencies
 rstest = "0.18"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -105,7 +105,17 @@ drasi-index-rocksdb = { path = "../components/indexes/rocksdb", features = [
 ] }
 # Mirrors how drasi-server depends on the plugin SDK to drive index backends
 # through their descriptor/DTO when statically linking a backend crate.
-drasi-plugin-sdk = { workspace = true }
+#
+# IMPORTANT: This is a path-only dependency (no version) on purpose. There is a
+# dependency cycle between drasi-lib and drasi-plugin-sdk:
+#   - drasi-plugin-sdk depends on drasi-lib (normal dependency)
+#   - drasi-lib depends on drasi-plugin-sdk (this dev-dependency)
+# Cargo strips path-only dev-dependencies from the published manifest, so
+# `cargo publish` of drasi-lib does NOT require drasi-plugin-sdk to exist on
+# crates.io. This breaks the publish deadlock (see issue #617) and lets
+# drasi-lib publish first, followed by drasi-plugin-sdk. Do NOT add a `version`
+# or switch back to `{ workspace = true }` here, or the release will deadlock.
+drasi-plugin-sdk = { path = "../components/plugin-sdk" }
 
 # Additional testing dependencies
 rstest = "0.18"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,6 +12,15 @@ git_release_type = "prod"
 
 # Publishing settings
 publish = true
+# Skip the isolated `cargo publish` verification build. That build re-resolves
+# the crate's full dependency graph (including dev-dependencies) from crates.io.
+# release-plz orders publishing by [dependencies]/[build-dependencies] only and
+# ignores [dev-dependencies] (they may form cycles), so a crate can be published
+# before an internal crate it only dev-depends on has landed on crates.io,
+# causing the verify build to fail with "no matching version". The whole
+# workspace is already built and tested in CI on every PR, so this verify step
+# is redundant. Matches `cargo publish --no-verify` used in publish-crate.yml.
+publish_no_verify = true
 
 # PR settings
 pr_labels = ["release"]


### PR DESCRIPTION

# Description
Fixes #617


## Summary

Publishing the workspace to crates.io was failing because `cargo publish`'s
isolated **verify build** re-resolves each crate's *entire* dependency graph —
including dev-dependencies — from crates.io. Some internal crates form
**dev-dependency cycles** (e.g. `drasi-lib` <-> `drasi-plugin-sdk`), and the
verify build tried to resolve a cyclic sibling's new version from crates.io
before it had been published. That produced `failed to select a version for the
requirement ... candidate versions found which didn't match` and aborted the
release.

This PR sets `publish_no_verify = true` in `release-plz.toml`, which skips that
redundant verify build for **all** crates.

## The problem

`cargo publish` runs an isolated verification build of the packaged crate. That
build re-resolves the full dependency graph from crates.io, **including
`[dev-dependencies]`**.

release-plz, on the other hand, computes publish order using only
`[dependencies]` / `[build-dependencies]` and deliberately **ignores
`[dev-dependencies]`** (because they are allowed to form cycles). So release-plz
will happily publish a crate before an internal crate it only *dev-depends* on
has landed on crates.io — but the verify build then fails, because it *does*
look at dev-dependencies and can't find the not-yet-published version.

This is exactly what blocked the `drasi-lib` <-> `drasi-plugin-sdk` cycle, and
the same class of failure surfaced again for other crates in the workspace.

## The fix

```toml
[workspace]
publish = true
publish_no_verify = true   # skip the isolated `cargo publish` verify build
```

Skipping the verify build removes the step that re-resolves dev-dependencies
from crates.io, so cyclic dev-dependencies can no longer block publishing. This
matches the `cargo publish --no-verify` already used in `publish-crate.yml`.

## Why this is safe

- The **entire workspace is already built and tested in CI on every PR**, so the
  isolated per-crate verify build is redundant — it re-compiles code that CI has
  already validated.
- `--no-verify` only skips the local compile check performed during packaging;
  it does **not** change the published artifact, its manifest, or how consumers
  resolve the crate.
- release-plz still orders publishing correctly via the normal
  `[dependencies]` / `[build-dependencies]` graph, so runtime dependencies are
  always published in a valid order.


## Impact

- **Downstream users of any crate** — no change. The published artifacts and
  manifests are identical; only the publisher's local verify step is skipped.
- **Release ordering** — unchanged. Still derived from runtime dependencies.
- **CI validation** — unchanged. Full workspace build + tests still run on every
  PR, which is what actually guarantees the crates compile.

## Going forward

- Cyclic dev-dependencies no longer block releases, so `{ workspace = true }`
  dev-dependencies are fine to use across the workspace.
- Correctness of published crates continues to rely on the per-PR CI build/test,
  which is the appropriate place for it.


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
