### PR TITLE
Add state machine as a query-consuming source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
   "components/sources/platform",
   "components/sources/application",
   "components/sources/mock",
+  "components/sources/state-machine",
   "components/sources/ris-live",
   "components/sources/mssql",
   "components/sources/dataverse",

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ build-test-plugins:
 	cargo build --lib -p drasi-reaction-sse --features drasi-reaction-sse/dynamic-plugin
 	cargo build --lib -p drasi-reaction-snapshot-test
 	cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin
+	cargo build --lib -p drasi-source-state-machine --features drasi-source-state-machine/dynamic-plugin
 	@mkdir -p $(PLUGIN_OUT_DIR)
 	@echo "=== Copying plugins to $(PLUGIN_OUT_DIR) ==="
 	@for ext in dylib so dll; do \
@@ -59,11 +60,13 @@ build-test-plugins:
 		         target/debug/libdrasi_reaction_sse.$$ext \
 		         target/debug/libdrasi_reaction_snapshot_test.$$ext \
 		         target/debug/libdrasi_identity_test.$$ext \
+		         target/debug/libdrasi_source_state_machine.$$ext \
 		         target/debug/drasi_source_mock.$$ext \
 		         target/debug/drasi_reaction_log.$$ext \
 		         target/debug/drasi_reaction_sse.$$ext \
 		         target/debug/drasi_reaction_snapshot_test.$$ext \
-		         target/debug/drasi_identity_test.$$ext; do \
+		         target/debug/drasi_identity_test.$$ext \
+		         target/debug/drasi_source_state_machine.$$ext; do \
 			[ -f "$$f" ] && cp "$$f" $(PLUGIN_OUT_DIR)/ || true; \
 		done; \
 	done
@@ -73,6 +76,7 @@ build-test-plugins:
 test-host-sdk: build-test-plugins
 	@echo "=== Running host-sdk integration tests ==="
 	cargo test -p drasi-host-sdk --test integration_test -- --test-threads=1
+	cargo test -p drasi-host-sdk --test source_query_subscription_e2e -- --test-threads=1
 	@echo "=== host-sdk integration tests passed ==="
 
 # Deterministic cross-cdylib layout-mismatch regression for issue #602.

--- a/components/host-sdk/Cargo.toml
+++ b/components/host-sdk/Cargo.toml
@@ -62,3 +62,7 @@ serial_test = "3"
 im = "15"
 tokio-stream = "0.1"
 async-stream = "0.3"
+# End-to-end dynamic source query-subscription test dependencies
+drasi-source-application = { path = "../sources/application" }
+drasi-reaction-application = { path = "../reactions/application" }
+drasi-state-store-redb = { path = "../state_stores/redb" }

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -28,9 +28,10 @@ use drasi_lib::schema::SourceSchema;
 use drasi_lib::sources::Source;
 use drasi_lib::{ComponentStatus, DispatchMode, SourceRuntimeContext};
 use drasi_plugin_sdk::descriptor::SourcePluginDescriptor;
+use drasi_plugin_sdk::ffi::payload::encode_query_result;
 use drasi_plugin_sdk::ffi::{
-    FfiComponentStatus, FfiDispatchMode, FfiRuntimeContext, FfiStr, SourcePluginVtable,
-    SourceVtable,
+    FfiComponentStatus, FfiDispatchMode, FfiQueryResult, FfiResultPushCallbackFn,
+    FfiRuntimeContext, FfiStr, SourcePluginVtable, SourceVtable,
 };
 use libloading::Library;
 
@@ -68,6 +69,93 @@ extern "C" fn host_executor(future_ptr: *mut c_void) -> *mut c_void {
     .unwrap_or(std::ptr::null_mut())
 }
 
+/// Context for the push-based query-result callback used to feed a
+/// query-consuming source's `enqueue_query_result` across the FFI boundary.
+///
+/// Mirrors the equivalent machinery in the reaction proxy: the host holds the
+/// receiving end of a channel; the plugin's forwarder task pulls each
+/// `QueryResult` via [`result_push_callback`], which blocks on `rx.recv()`.
+struct ResultPushContext {
+    rx: std::sync::Mutex<Option<std::sync::mpsc::Receiver<drasi_lib::channels::QueryResult>>>,
+    /// Signaled when the plugin-side forwarder task has fully exited its loop and
+    /// will no longer access the source wrapper. The forwarder signals this by
+    /// calling the callback one final time with a non-null sentinel parameter.
+    forwarder_done: std::sync::Mutex<bool>,
+    forwarder_done_cv: std::sync::Condvar,
+}
+
+fn signal_forwarder_done(context: &ResultPushContext) {
+    if let Ok(mut done) = context.forwarder_done.lock() {
+        *done = true;
+        context.forwarder_done_cv.notify_all();
+    }
+}
+
+/// Frees a serialized `QueryResult` byte buffer produced by the host in
+/// [`result_push_callback_inner`]. Called by the consuming plugin after it has
+/// deserialized its own copy.
+extern "C" fn drop_query_result_bytes(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() && len > 0 {
+        unsafe {
+            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
+        }
+    }
+}
+
+/// Callback invoked by the plugin's forwarder task to receive the next
+/// `QueryResult`. Blocks until a result is available. Returns null on channel
+/// close (shutdown). A non-null `sentinel` signals that the forwarder has fully
+/// exited and will not access the source wrapper again.
+///
+/// Wrapped in `catch_unwind` because this is `extern "C"` — panics unwinding
+/// across the FFI boundary are undefined behavior.
+extern "C" fn result_push_callback(ctx: *mut c_void, sentinel: *mut c_void) -> *mut c_void {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        result_push_callback_inner(ctx, sentinel)
+    }))
+    .unwrap_or_else(|_| {
+        let context = unsafe { &*(ctx as *const ResultPushContext) };
+        signal_forwarder_done(context);
+        std::ptr::null_mut()
+    })
+}
+
+fn result_push_callback_inner(ctx: *mut c_void, sentinel: *mut c_void) -> *mut c_void {
+    let context = unsafe { &*(ctx as *const ResultPushContext) };
+
+    // Sentinel call: the forwarder has exited its loop.
+    if !sentinel.is_null() {
+        signal_forwarder_done(context);
+        return std::ptr::null_mut();
+    }
+
+    let guard = context
+        .rx
+        .lock()
+        .expect("result_push_callback lock poisoned");
+    if let Some(ref rx) = *guard {
+        match rx.recv() {
+            Ok(result) => {
+                // Serialize the QueryResult for cross-cdylib transfer — never hand
+                // the plugin a reinterpreted `repr(Rust)` pointer (issue #602).
+                let bytes = encode_query_result(&result);
+                let payload_len = bytes.len();
+                let payload_ptr = Box::into_raw(bytes.into_boxed_slice()) as *const u8;
+                Box::into_raw(Box::new(FfiQueryResult {
+                    payload_ptr,
+                    payload_len,
+                    payload_drop_fn: Some(drop_query_result_bytes),
+                })) as *mut c_void
+            }
+            // Channel closed — return null so the forwarder breaks and then sends
+            // the sentinel.
+            Err(_) => std::ptr::null_mut(),
+        }
+    } else {
+        std::ptr::null_mut()
+    }
+}
+
 /// Wraps a `SourceVtable` into a DrasiLib `Source` trait implementation.
 ///
 /// The host creates this proxy when the plugin factory produces a `SourceVtable`.
@@ -79,6 +167,12 @@ pub struct SourceProxy {
     cached_type_name: String,
     /// Keeps the per-instance callback context alive for the lifetime of this proxy.
     _callback_ctx: std::sync::Mutex<Option<Arc<crate::callbacks::InstanceCallbackContext>>>,
+    /// Channel for push-based query-result delivery. Created on start, closed on
+    /// stop/drop. Only used by query-consuming sources.
+    result_tx:
+        std::sync::Mutex<Option<std::sync::mpsc::SyncSender<drasi_lib::channels::QueryResult>>>,
+    /// Keeps the push callback context alive for the lifetime of the forwarder.
+    _push_ctx: std::sync::Mutex<Option<Arc<ResultPushContext>>>,
     /// Per-source identity provider set programmatically via
     /// [`Source::set_identity_provider`]. When present, it takes precedence over
     /// any instance-wide provider supplied via
@@ -100,6 +194,8 @@ impl SourceProxy {
             cached_id,
             cached_type_name,
             _callback_ctx: std::sync::Mutex::new(None),
+            result_tx: std::sync::Mutex::new(None),
+            _push_ctx: std::sync::Mutex::new(None),
             identity_provider: std::sync::Mutex::new(None),
         }
     }
@@ -162,6 +258,30 @@ impl Source for SourceProxy {
     }
 
     async fn start(&self) -> anyhow::Result<()> {
+        // For query-consuming sources, set up push-based result delivery before
+        // starting the source, so query results forwarded by the host reach the
+        // plugin's `enqueue_query_result` across the FFI boundary. Ordinary
+        // sources (no subscribed queries) skip this entirely.
+        if !self.subscribed_query_ids().is_empty() {
+            let (tx, rx) = std::sync::mpsc::sync_channel::<drasi_lib::channels::QueryResult>(256);
+            {
+                let mut guard = self.result_tx.lock().expect("result_tx lock poisoned");
+                *guard = Some(tx);
+            }
+            let push_ctx = Arc::new(ResultPushContext {
+                rx: std::sync::Mutex::new(Some(rx)),
+                forwarder_done: std::sync::Mutex::new(false),
+                forwarder_done_cv: std::sync::Condvar::new(),
+            });
+            // Use Arc::as_ptr — the Arc stays alive in _push_ctx for the proxy's life.
+            let ctx_ptr = Arc::as_ptr(&push_ctx) as *mut c_void;
+            {
+                let mut guard = self._push_ctx.lock().expect("_push_ctx lock poisoned");
+                *guard = Some(push_ctx);
+            }
+            (self.vtable.start_result_push_fn)(self.vtable.state, result_push_callback, ctx_ptr);
+        }
+
         let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
         let start_fn = self.vtable.start_fn;
         let result = std::thread::spawn(move || (start_fn)(state.as_ptr()))
@@ -171,12 +291,42 @@ impl Source for SourceProxy {
     }
 
     async fn stop(&self) -> anyhow::Result<()> {
+        // Close the result channel sender to unblock the plugin forwarder's
+        // callback (its rx.recv() returns Err, the callback returns null, and the
+        // forwarder breaks out of its loop). The forwarder task is joined in Drop
+        // via the sentinel signal before the wrapper is freed.
+        {
+            let mut guard = self.result_tx.lock().expect("result_tx lock poisoned");
+            *guard = None;
+        }
+
         let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
         let stop_fn = self.vtable.stop_fn;
         let result = std::thread::spawn(move || (stop_fn)(state.as_ptr()))
             .join()
             .map_err(|_| anyhow::anyhow!("Thread panicked"))?;
         unsafe { result.into_result().map_err(|e| anyhow::anyhow!(e)) }
+    }
+
+    fn subscribed_query_ids(&self) -> Vec<String> {
+        let arr = (self.vtable.subscribed_query_ids_fn)(self.vtable.state as *const c_void);
+        unsafe { arr.into_vec() }
+    }
+
+    async fn enqueue_query_result(
+        &self,
+        result: drasi_lib::channels::QueryResult,
+    ) -> anyhow::Result<()> {
+        let guard = self.result_tx.lock().expect("result_tx lock poisoned");
+        if let Some(ref tx) = *guard {
+            tx.send(result)
+                .map_err(|_| anyhow::anyhow!("Result channel closed"))?;
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Source not started — result channel not initialized"
+            ))
+        }
     }
 
     async fn status(&self) -> ComponentStatus {
@@ -547,11 +697,54 @@ impl Source for SourceProxy {
 
 impl Drop for SourceProxy {
     fn drop(&mut self) {
-        // Run plugin drop on the shared worker thread to avoid TLS destructor
-        // races on macOS arm64 (see drop_worker module for details).
-        let drop_fn = self.vtable.drop_fn;
-        let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
-        super::drop_worker::execute_drop_fn(drop_fn, state);
+        // Close the result channel to unblock the plugin forwarder (if any), then
+        // wait for it to fully exit before freeing the wrapper. This mirrors the
+        // ReactionProxy coordination: the plugin forwarder references the wrapper
+        // through a raw pointer, so drop_fn must not run until the forwarder has
+        // signalled (via the sentinel callback) that it will no longer touch it.
+        {
+            if let Ok(mut guard) = self.result_tx.lock() {
+                *guard = None;
+            }
+        }
+
+        let forwarder_exited = if let Ok(guard) = self._push_ctx.lock() {
+            if let Some(ref ctx) = *guard {
+                let done = ctx.forwarder_done.lock().expect("forwarder_done lock");
+                let (done, timeout) = ctx
+                    .forwarder_done_cv
+                    .wait_timeout_while(done, std::time::Duration::from_secs(5), |done| !*done)
+                    .expect("forwarder_done condvar wait");
+                !timeout.timed_out() && *done
+            } else {
+                true // No push context → forwarder was never started
+            }
+        } else {
+            false // Lock poisoned
+        };
+
+        if forwarder_exited {
+            // Run plugin drop on the shared worker thread to avoid TLS destructor
+            // races on macOS arm64 (see drop_worker module for details).
+            let drop_fn = self.vtable.drop_fn;
+            let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
+            super::drop_worker::execute_drop_fn(drop_fn, state);
+        } else {
+            // Timeout or error — leak the source wrapper rather than risk a
+            // use-after-free while the forwarder may still be running.
+            log::warn!(
+                "SourceProxy::drop: forwarder did not exit within timeout; \
+                 leaking source wrapper to prevent use-after-free"
+            );
+        }
+
+        // Leak the push context Arc so the forwarder's in-flight spawn_blocking
+        // callback (on the timeout path) cannot dereference freed memory.
+        if let Ok(mut guard) = self._push_ctx.lock() {
+            if let Some(ctx) = guard.take() {
+                std::mem::forget(ctx);
+            }
+        }
 
         // Bug C fix: leak the per-instance callback context Arc unconditionally.
         // The strong reference handed to the plugin via `Arc::into_raw` in

--- a/components/host-sdk/tests/source_query_subscription_e2e.rs
+++ b/components/host-sdk/tests/source_query_subscription_e2e.rs
@@ -1,0 +1,349 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! End-to-end test for the source query-subscription FFI path.
+//!
+//! Loads the `drasi-source-state-machine` crate as a **dynamic cdylib plugin**
+//! and drives a full `DrasiLib` flow through it:
+//!
+//! ```text
+//! application source ──▶ stage queries ──▶ (dynamic) state machine source ──▶ downstream query ──▶ application reaction
+//! ```
+//!
+//! This exercises the vtable additions (`subscribed_query_ids_fn` +
+//! `start_result_push_fn`) and the `SourceProxy` push bridge: query results are
+//! forwarded across the FFI boundary into the plugin's `enqueue_query_result`,
+//! the plugin computes state transitions, and re-emits entity-state nodes that a
+//! downstream query observes.
+//!
+//! **Prerequisite**: build the plugin cdylib first:
+//!
+//! ```sh
+//! cargo build --lib -p drasi-source-state-machine --features drasi-source-state-machine/dynamic-plugin
+//! # or: cargo xtask build-plugins
+//! ```
+//!
+//! The test SKIPs (panics with a SKIP message) when the cdylib is not present.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use drasi_host_sdk::callbacks;
+use drasi_host_sdk::loader::load_plugin_from_path;
+use drasi_lib::state_store::StateStoreProvider;
+use drasi_lib::{DrasiLib, Query, Source};
+use drasi_plugin_sdk::descriptor::SourcePluginDescriptor;
+use drasi_reaction_application::ApplicationReaction;
+use drasi_source_application::{ApplicationSource, ApplicationSourceConfig, PropertyMapBuilder};
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+// ----------------------------------------------------------------------------
+// Plugin discovery helpers (mirrors integration_test.rs)
+// ----------------------------------------------------------------------------
+
+fn plugin_dir() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("Cannot find workspace root from CARGO_MANIFEST_DIR");
+    workspace_root.join("target").join("debug").join("plugins")
+}
+
+fn plugin_filename(crate_name: &str) -> String {
+    let lib_name = crate_name.replace('-', "_");
+    if cfg!(target_os = "macos") {
+        format!("lib{lib_name}.dylib")
+    } else if cfg!(target_os = "windows") {
+        format!("{lib_name}.dll")
+    } else {
+        format!("lib{lib_name}.so")
+    }
+}
+
+fn plugin_path(crate_name: &str) -> PathBuf {
+    plugin_dir().join(plugin_filename(crate_name))
+}
+
+fn plugin_exists(crate_name: &str) -> bool {
+    plugin_path(crate_name).exists()
+}
+
+// ----------------------------------------------------------------------------
+// Observation helper
+// ----------------------------------------------------------------------------
+
+#[derive(Default)]
+struct Observed {
+    latest: HashMap<String, String>,
+    history: Vec<(String, String)>,
+}
+
+type ObservedHandle = Arc<Mutex<Observed>>;
+
+async fn wait_for_state(observed: &ObservedHandle, order_id: &str, want: &str) -> bool {
+    for _ in 0..100 {
+        if observed
+            .lock()
+            .await
+            .latest
+            .get(order_id)
+            .map(|s| s == want)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+fn stage_queries() -> Vec<drasi_lib::config::QueryConfig> {
+    vec![
+        Query::cypher("draft-orders")
+            .query("MATCH (o:Order) WHERE o.is_draft = true RETURN o.id AS orderId")
+            .from_source("orders")
+            .auto_start(true)
+            .build(),
+        Query::cypher("confirmed-orders")
+            .query("MATCH (o:Order) WHERE o.is_draft = false RETURN o.id AS orderId")
+            .from_source("orders")
+            .auto_start(true)
+            .build(),
+        Query::cypher("paid-orders")
+            .query("MATCH (o:Order) WHERE o.paid = true RETURN o.id AS orderId")
+            .from_source("orders")
+            .auto_start(true)
+            .build(),
+    ]
+}
+
+/// The state machine config, exactly as it would appear in YAML/JSON. Note the
+/// three referenced queries — the dynamically-loaded source must report these via
+/// the FFI `subscribed_query_ids_fn`.
+fn state_machine_config_json() -> Value {
+    serde_json::json!({
+        "entityLabel": "OrderState",
+        "keyField": "orderId",
+        "states": [
+            {
+                "id": "NEW",
+                "enter": [
+                    { "query": "draft-orders", "previous": [], "key": "{{orderId}}", "ops": ["added"] }
+                ]
+            },
+            {
+                "id": "CONFIRMED",
+                "enter": [
+                    { "query": "confirmed-orders", "previous": ["NEW"], "key": "{{orderId}}", "ops": ["added"] }
+                ]
+            },
+            {
+                "id": "PAID",
+                "enter": [
+                    { "query": "paid-orders", "previous": ["CONFIRMED"], "key": "{{orderId}}", "ops": ["added"] }
+                ]
+            }
+        ]
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dynamic_state_machine_source_drives_transitions_over_ffi() {
+    if !plugin_exists("drasi-source-state-machine") {
+        eprintln!(
+            "SKIP: drasi-source-state-machine not built as cdylib. Build with: \
+             cargo build --lib -p drasi-source-state-machine \
+             --features drasi-source-state-machine/dynamic-plugin"
+        );
+        panic!("SKIP: drasi-source-state-machine not built as cdylib");
+    }
+
+    // ------------------------------------------------------------------
+    // 1. Load the state machine source as a dynamic cdylib plugin.
+    // ------------------------------------------------------------------
+    let path = plugin_path("drasi-source-state-machine");
+    let plugin = load_plugin_from_path(
+        &path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("load state machine source plugin");
+
+    assert_eq!(
+        plugin.source_plugins.len(),
+        1,
+        "state machine plugin should export exactly one source descriptor"
+    );
+    let descriptor = &plugin.source_plugins[0];
+    assert_eq!(descriptor.kind(), "state-machine");
+
+    // Create the source instance over FFI from the config.
+    let sm_source = descriptor
+        .create_source("order-state-source", &state_machine_config_json(), true)
+        .await
+        .expect("create dynamic state machine source");
+    assert_eq!(sm_source.id(), "order-state-source");
+    // The proxy must report the referenced queries across FFI.
+    let mut subs = sm_source.subscribed_query_ids();
+    subs.sort();
+    assert_eq!(
+        subs,
+        vec![
+            "confirmed-orders".to_string(),
+            "draft-orders".to_string(),
+            "paid-orders".to_string()
+        ],
+        "dynamic source must expose its subscribed queries via FFI"
+    );
+
+    // ------------------------------------------------------------------
+    // 2. Assemble a DrasiLib around the dynamic source.
+    // ------------------------------------------------------------------
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Arc::new(
+        drasi_state_store_redb::RedbStateStoreProvider::new(tmp.path().join("state.redb")).unwrap(),
+    );
+    let observed: ObservedHandle = Arc::new(Mutex::new(Observed::default()));
+
+    let (source, handle) = ApplicationSource::new(
+        "orders",
+        ApplicationSourceConfig {
+            properties: HashMap::new(),
+            durability: None,
+        },
+    )
+    .unwrap();
+
+    let downstream_query = Query::cypher("order-states")
+        .query("MATCH (o:OrderState) RETURN o.orderId AS orderId, o.state AS state")
+        .from_source("order-state-source")
+        .auto_start(true)
+        .build();
+
+    let (observer, obs_handle) =
+        ApplicationReaction::new("state-observer", vec!["order-states".into()]);
+    {
+        let observed = observed.clone();
+        obs_handle
+            .subscribe(move |result| {
+                let observed = observed.clone();
+                tokio::spawn(async move {
+                    let mut guard = observed.lock().await;
+                    for diff in &result.results {
+                        let row = match diff {
+                            drasi_lib::channels::ResultDiff::Add { data, .. } => Some(data.clone()),
+                            drasi_lib::channels::ResultDiff::Update { after, .. } => {
+                                Some(after.clone())
+                            }
+                            _ => None,
+                        };
+                        if let Some(Value::Object(map)) = row {
+                            if let (Some(Value::String(id)), Some(Value::String(state))) =
+                                (map.get("orderId"), map.get("state"))
+                            {
+                                guard.latest.insert(id.clone(), state.clone());
+                                guard.history.push((id.clone(), state.clone()));
+                            }
+                        }
+                    }
+                });
+            })
+            .await
+            .expect("subscribe to order-states");
+    }
+
+    let mut builder = DrasiLib::builder()
+        .with_id("dynamic-state-machine-test")
+        .with_state_store_provider(store.clone())
+        .with_source(source)
+        .with_source(sm_source) // the dynamically-loaded Box<dyn Source>
+        .with_reaction(observer)
+        .with_query(downstream_query);
+    for q in stage_queries() {
+        builder = builder.with_query(q);
+    }
+    let core = Arc::new(builder.build().await.unwrap());
+    core.start().await.unwrap();
+
+    // ------------------------------------------------------------------
+    // 3. Drive an order through the lifecycle and assert transitions.
+    // ------------------------------------------------------------------
+    handle
+        .send_node_insert(
+            "o1",
+            vec!["Order"],
+            PropertyMapBuilder::new()
+                .with_string("id", "o1")
+                .with_bool("is_draft", true)
+                .with_bool("paid", false)
+                .build(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        wait_for_state(&observed, "o1", "NEW").await,
+        "order should enter NEW via the dynamic source"
+    );
+
+    handle
+        .send_node_update(
+            "o1",
+            vec!["Order"],
+            PropertyMapBuilder::new()
+                .with_string("id", "o1")
+                .with_bool("is_draft", false)
+                .with_bool("paid", false)
+                .build(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        wait_for_state(&observed, "o1", "CONFIRMED").await,
+        "order should enter CONFIRMED via the dynamic source"
+    );
+
+    handle
+        .send_node_update(
+            "o1",
+            vec!["Order"],
+            PropertyMapBuilder::new()
+                .with_string("id", "o1")
+                .with_bool("is_draft", false)
+                .with_bool("paid", true)
+                .build(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        wait_for_state(&observed, "o1", "PAID").await,
+        "order should enter PAID via the dynamic source"
+    );
+
+    // The dynamic source persisted state through its FFI state-store bridge.
+    let persisted = store.list_keys("order-state-source").await.unwrap();
+    assert!(
+        persisted.contains(&"o1".to_string()),
+        "dynamic source should persist entity state"
+    );
+
+    core.stop().await.unwrap();
+    // Keep the loaded plugin alive until the end of the test.
+    drop(plugin);
+}

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -34,7 +34,10 @@ use super::types::FfiStr;
 ///   `KeyedSnapshotRow { k: <row_signature>, v: <row> }` JSON envelope instead
 ///   of a bare row, so the engine's canonical `row_signature` survives FFI
 ///   (fixes #605 duplicate dashboard rows on the plugin path).
-pub const FFI_SDK_VERSION: &str = "0.11.0";
+/// - `0.12.0`: `SourceVtable` gains `subscribed_query_ids_fn` and
+///   `start_result_push_fn` so sources can subscribe to continuous-query results
+///   (like reactions) across the FFI boundary.
+pub const FFI_SDK_VERSION: &str = "0.12.0";
 
 /// The target triple this crate was compiled for.
 pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -889,6 +889,72 @@ pub fn build_source_vtable<T: Source + 'static>(
         })
     }
 
+    extern "C" fn subscribed_query_ids_fn<T: Source + 'static>(
+        state: *const c_void,
+    ) -> FfiStringArray {
+        let w = unsafe { &*(state as *const SourceWrapper<T>) };
+        FfiStringArray::from_vec(w.inner.subscribed_query_ids())
+    }
+
+    extern "C" fn start_result_push_fn<T: Source + 'static>(
+        state: *mut c_void,
+        callback: FfiResultPushCallbackFn,
+        callback_ctx: *mut c_void,
+    ) {
+        // Push-based result delivery (mirrors the reaction path). The host
+        // provides a blocking callback that returns the next QueryResult pointer
+        // (or null on shutdown). The plugin spawns a forwarder that calls the
+        // callback via spawn_blocking (to avoid starving async workers), then
+        // enqueues each result into the source's priority queue.
+        let w = unsafe { &*(state as *const SourceWrapper<T>) };
+        let handle = (w.runtime_handle)().handle().clone();
+        let ctx_raw = callback_ctx as usize;
+        let ptr = SendPtr(state as *const SourceWrapper<T>);
+        handle.spawn(async move {
+            // Always signal the host (via a sentinel callback) when the forwarder
+            // stops touching the wrapper, so the host can safely free it.
+            struct SentinelOnDrop {
+                ctx_raw: usize,
+                callback: FfiResultPushCallbackFn,
+            }
+            impl Drop for SentinelOnDrop {
+                fn drop(&mut self) {
+                    let cb = self.callback;
+                    let ctx = self.ctx_raw as *mut c_void;
+                    #[allow(clippy::manual_dangling_ptr)]
+                    let sentinel = 1usize as *mut c_void;
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        cb(ctx, sentinel);
+                    }));
+                }
+            }
+            let _sentinel_guard = SentinelOnDrop { ctx_raw, callback };
+            loop {
+                let ctx_val = ctx_raw;
+                let result_ptr = tokio::task::spawn_blocking(move || {
+                    SendMutPtr(callback(ctx_val as *mut c_void, std::ptr::null_mut()))
+                })
+                .await;
+                let result_ptr = match result_ptr {
+                    Ok(p) => p.as_ptr(),
+                    Err(_) => break,
+                };
+                if result_ptr.is_null() {
+                    break;
+                }
+                let query_result =
+                    match unsafe { decode_ffi_query_result(result_ptr as *mut FfiQueryResult) } {
+                        Some(qr) => qr,
+                        None => continue,
+                    };
+                let inner = unsafe { ptr.as_ref() };
+                if let Err(e) = inner.inner.enqueue_query_result(query_result).await {
+                    log::error!("Failed to enqueue query result: {e}");
+                }
+            }
+        });
+    }
+
     let cached_id = source.id().to_string();
     let cached_type_name = source.type_name().to_string();
 
@@ -925,6 +991,8 @@ pub fn build_source_vtable<T: Source + 'static>(
         set_bootstrap_provider_fn: set_bootstrap_provider_fn::<T>,
         supports_replay_fn: supports_replay_fn::<T>,
         remove_position_handle_fn: remove_position_handle_fn::<T>,
+        subscribed_query_ids_fn: subscribed_query_ids_fn::<T>,
+        start_result_push_fn: start_result_push_fn::<T>,
         drop_fn: drop_fn::<T>,
     }
 }
@@ -1272,6 +1340,80 @@ pub fn build_source_vtable_from_boxed(
         })
     }
 
+    extern "C" fn subscribed_query_ids_fn(state: *const c_void) -> FfiStringArray {
+        let w = unsafe { &*(state as *const DynSourceWrapper) };
+        FfiStringArray::from_vec(w.inner.subscribed_query_ids())
+    }
+
+    extern "C" fn start_result_push_fn(
+        state: *mut c_void,
+        callback: FfiResultPushCallbackFn,
+        callback_ctx: *mut c_void,
+    ) {
+        ffi_guard((), || {
+            // Push-based result delivery (mirrors the reaction path). The host
+            // provides a blocking callback that returns the next QueryResult
+            // pointer (or null on shutdown). The plugin spawns a forwarder that
+            // pulls each result and enqueues it into the source's priority queue.
+            //
+            // The forwarder references the wrapper through a raw `SendPtr`; the
+            // host's `SourceProxy` guarantees the wrapper is not freed (drop_fn)
+            // until the forwarder has signalled completion via the sentinel
+            // callback, so the pointer stays valid for the forwarder's lifetime.
+            let w = unsafe { &*(state as *const DynSourceWrapper) };
+            let handle = (w.runtime_handle)().handle().clone();
+            let ctx_raw = callback_ctx as usize;
+            let ptr = SendPtr(state as *const DynSourceWrapper);
+
+            // Drop guard: always send the sentinel callback when the forwarder
+            // stops touching the wrapper — even on panic or task cancellation —
+            // so the host's Drop never blocks past its timeout.
+            struct SentinelOnDrop {
+                ctx_raw: usize,
+                callback: FfiResultPushCallbackFn,
+            }
+            impl Drop for SentinelOnDrop {
+                fn drop(&mut self) {
+                    let cb = self.callback;
+                    let ctx = self.ctx_raw as *mut c_void;
+                    #[allow(clippy::manual_dangling_ptr)]
+                    let sentinel = 1usize as *mut c_void;
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        cb(ctx, sentinel);
+                    }));
+                }
+            }
+
+            handle.spawn(async move {
+                let _sentinel_guard = SentinelOnDrop { ctx_raw, callback };
+                loop {
+                    let ctx_val = ctx_raw;
+                    let result_ptr = tokio::task::spawn_blocking(move || {
+                        SendMutPtr(callback(ctx_val as *mut c_void, std::ptr::null_mut()))
+                    })
+                    .await;
+                    let result_ptr = match result_ptr {
+                        Ok(p) => p.as_ptr(),
+                        Err(_) => break,
+                    };
+                    if result_ptr.is_null() {
+                        break;
+                    }
+                    let query_result =
+                        match unsafe { decode_ffi_query_result(result_ptr as *mut FfiQueryResult) }
+                        {
+                            Some(qr) => qr,
+                            None => continue,
+                        };
+                    let inner = unsafe { ptr.as_ref() };
+                    if let Err(e) = inner.inner.enqueue_query_result(query_result).await {
+                        log::error!("Failed to enqueue query result: {e}");
+                    }
+                }
+            });
+        });
+    }
+
     let cached_id = source.id().to_string();
     let cached_type_name = source.type_name().to_string();
 
@@ -1308,6 +1450,8 @@ pub fn build_source_vtable_from_boxed(
         set_bootstrap_provider_fn,
         supports_replay_fn,
         remove_position_handle_fn,
+        subscribed_query_ids_fn,
+        start_result_push_fn,
         drop_fn,
     }
 }

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -355,6 +355,17 @@ drasi_ffi_primitives::ffi_vtable! {
         /// handle. The source can stop tracking the resume position for this
         /// query.
         fn remove_position_handle_fn(state: *mut, query_id: FfiStr) -> FfiResult,
+
+        // Host-managed query subscription forwarding (push-based)
+        /// Returns the IDs of the continuous queries whose results feed this
+        /// source (empty for ordinary sources). Mirrors the reaction
+        /// `query_ids_fn`.
+        fn subscribed_query_ids_fn(state: *const) -> FfiStringArray,
+        /// The host calls this once to start push-based query-result delivery.
+        /// The plugin spawns a forwarder task that reads from the host callback
+        /// and calls `source.enqueue_query_result()` for each item. Mirrors the
+        /// reaction `start_result_push_fn`.
+        fn start_result_push_fn(state: *mut, callback: FfiResultPushCallbackFn, callback_ctx: *mut c_void),
     }
 }
 

--- a/components/sources/state-machine/Cargo.toml
+++ b/components/sources/state-machine/Cargo.toml
@@ -1,0 +1,55 @@
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-source-state-machine"
+version = "0.1.0"
+edition = "2021"
+authors = ["Drasi Project"]
+description = "State machine source plugin for Drasi: maps continuous-query results to per-entity state transitions and exposes each entity's live state as a source"
+license = "Apache-2.0"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi", "plugin", "source", "state-machine"]
+categories = ["database"]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+drasi-lib.workspace = true
+drasi-core.workspace = true
+drasi-plugin-sdk = { workspace = true }
+utoipa = { workspace = true }
+anyhow = "1.0"
+async-trait = "0.1"
+log = "0.4"
+tracing = "0.1"
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = "0.4"
+handlebars = "5.1"
+
+[dev-dependencies]
+drasi-source-application = { path = "../application" }
+drasi-reaction-application = { path = "../../reactions/application" }
+drasi-state-store-redb = { path = "../../state_stores/redb" }
+tempfile = "3"
+
+[features]
+# default = []
+dynamic-plugin = []

--- a/components/sources/state-machine/README.md
+++ b/components/sources/state-machine/README.md
@@ -1,0 +1,112 @@
+# Drasi State Machine Source
+
+A Drasi **source** that maps live continuous-query results to per-entity **state
+transitions** and exposes the realtime state of every entity as a Drasi source
+that downstream queries can subscribe to.
+
+Unlike an ordinary source that ingests data from an external system, the state
+machine source is driven by the results of *other continuous queries*. It uses
+the source query-subscription API — the same mechanism reactions use to consume
+query results.
+
+## How it works
+
+```text
+   input queries                 state machine source
+ ┌───────────────┐      ┌──────────────────────────────────┐
+ │ draft-orders  │─────▶│  subscribes to queries             │
+ │ paid-orders   │─────▶│  computes transitions              │──▶ downstream queries
+ │ shipped-orders│─────▶│  persists + dispatches node state  │
+ └───────────────┘      └──────────────────────────────────┘
+                                    │
+                                    └── state store (durable)
+```
+
+* The source **subscribes** to the input queries referenced by its states. Each
+  *enter condition* declares:
+  * `query` — the input query whose results drive the transition,
+  * `ops` — the result operations that trigger it (`added` / `updated` / `deleted`),
+  * `previous` — the allowed prior states (`[]` = initial entry, `["*"]` = any),
+  * `key` — a Handlebars template (e.g. `{{orderId}}`) that extracts the entity key.
+
+  When a result matches and the entity is in an allowed prior state, the entity
+  transitions. The new state is persisted to the state store and dispatched as a
+  graph node change to the source's own subscribers.
+
+* Each emitted node carries:
+  * `element_id` = the entity key,
+  * label = `entityLabel` (default `EntityState`),
+  * properties = the key field, `state`, `previousState`, `enteredAt`, plus the
+    pass-through fields from the triggering query result row.
+
+  Late-joining and downstream subscribers are bootstrapped from the durably
+  persisted state, so the source survives restarts.
+
+## IDs
+
+The source's own `id` is the id downstream queries subscribe to. There is **no**
+separate companion component — the single source both consumes upstream query
+results and produces the entity-state graph.
+
+## Usage (static / embedded)
+
+```rust
+use drasi_source_state_machine::{StateMachineSourceBuilder, config::{StateDef, EnterCondition, Op}};
+
+let source = StateMachineSourceBuilder::new("order-state-source")
+    .with_entity_label("OrderState")
+    .with_key_field("orderId")
+    .with_state(StateDef {
+        id: "NEW".to_string(),
+        enter: vec![EnterCondition {
+            query: "draft-orders".to_string(),
+            previous: vec![],
+            key: "{{orderId}}".to_string(),
+            ops: vec![Op::Added],
+        }],
+    })
+    // ... more states ...
+    .build()?;
+
+// drasi.add_source(source).await?;
+# Ok::<(), anyhow::Error>(())
+```
+
+A **durable** `StateStoreProvider` (e.g. `drasi-state-store-redb`) should be
+configured on the `DrasiLib` instance so entity state survives restarts.
+
+## Configuration (declarative / YAML)
+
+The crate exports a `state-machine` **source** descriptor (behind the
+`dynamic-plugin` feature). Declare the source and let downstream queries read
+from its id:
+
+```yaml
+sources:
+  - kind: state-machine
+    id: order-state-source
+    properties:
+      entityLabel: OrderState
+      keyField: orderId
+      states:
+        - id: NEW
+          enter:
+            - query: draft-orders
+              previous: []
+              key: "{{orderId}}"
+              ops: [added]
+        - id: CONFIRMED
+          enter:
+            - query: confirmed-orders
+              previous: [NEW]
+              key: "{{orderId}}"
+              ops: [added]
+        # ... PAID, PICKED, SHIPPED, DELIVERED ...
+```
+
+## Example
+
+See [`examples/lib/orders-state-machine`](../../../examples/lib/orders-state-machine)
+for a complete, self-driving order-lifecycle demo using a Postgres source,
+a stored-procedure reaction to advance orders, and the dashboard reaction to
+visualize the live state.

--- a/components/sources/state-machine/src/config.rs
+++ b/components/sources/state-machine/src/config.rs
@@ -1,0 +1,269 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Configuration types for the state machine source.
+//!
+//! A state machine maps live query results to per-entity state transitions. Each
+//! [`StateDef`] declares one or more [`EnterCondition`]s; when a subscribed query
+//! emits a result whose operation matches and whose entity is currently in an
+//! allowed `previous` state, the entity transitions into that state. The source's
+//! own id is the id downstream queries subscribe to — there is no separate
+//! companion component.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// The operation on a query result row that can trigger a transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[schema(as = source::state_machine::Op)]
+#[serde(rename_all = "lowercase")]
+pub enum Op {
+    /// A row was added to the query result set.
+    Added,
+    /// A row in the query result set was updated.
+    Updated,
+    /// A row was removed from the query result set.
+    Deleted,
+}
+
+/// A single condition under which an entity enters a state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[schema(as = source::state_machine::EnterCondition)]
+#[serde(rename_all = "camelCase")]
+pub struct EnterCondition {
+    /// The id of the input query whose results drive this condition.
+    pub query: String,
+    /// Allowed prior states for the transition to fire.
+    ///
+    /// * Empty (`[]`) — the condition only matches when the entity has **no**
+    ///   current state (initial entry).
+    /// * `["*"]` — matches regardless of the entity's current state.
+    /// * Otherwise — matches only when the entity's current state is one of the
+    ///   listed values.
+    #[serde(default)]
+    pub previous: Vec<String>,
+    /// Handlebars template, rendered against the query result row, that yields the
+    /// entity key (e.g. `{{orderId}}`).
+    pub key: String,
+    /// Which result operations trigger this condition.
+    pub ops: Vec<Op>,
+}
+
+/// Definition of a single state and the conditions for entering it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[schema(as = source::state_machine::StateDef)]
+#[serde(rename_all = "camelCase")]
+pub struct StateDef {
+    /// The state identifier (e.g. `PAID`).
+    pub id: String,
+    /// Conditions that cause an entity to enter this state.
+    #[serde(default)]
+    pub enter: Vec<EnterCondition>,
+}
+
+fn default_entity_label() -> String {
+    "EntityState".to_string()
+}
+
+fn default_key_field() -> String {
+    "id".to_string()
+}
+
+/// Configuration for the state machine source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[schema(as = source::state_machine::StateMachineSourceConfig)]
+#[serde(rename_all = "camelCase")]
+pub struct StateMachineSourceConfig {
+    /// Label applied to emitted entity-state nodes.
+    #[serde(default = "default_entity_label")]
+    pub entity_label: String,
+    /// Name of the node property that holds the entity key.
+    #[serde(default = "default_key_field")]
+    pub key_field: String,
+    /// The set of states and their entry conditions.
+    #[serde(default)]
+    pub states: Vec<StateDef>,
+}
+
+impl Default for StateMachineSourceConfig {
+    fn default() -> Self {
+        Self {
+            entity_label: default_entity_label(),
+            key_field: default_key_field(),
+            states: Vec::new(),
+        }
+    }
+}
+
+impl StateMachineSourceConfig {
+    /// The de-duplicated set of input query ids referenced by all enter conditions.
+    ///
+    /// This is exactly the set of queries the source subscribes to (returned from
+    /// [`Source::subscribed_query_ids`](drasi_lib::Source::subscribed_query_ids)).
+    pub fn referenced_queries(&self) -> Vec<String> {
+        let mut seen = Vec::new();
+        for state in &self.states {
+            for cond in &state.enter {
+                if !seen.contains(&cond.query) {
+                    seen.push(cond.query.clone());
+                }
+            }
+        }
+        seen
+    }
+
+    /// Validate the configuration, returning an error describing the first problem.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.entity_label.trim().is_empty() {
+            anyhow::bail!("state machine entity_label must not be empty");
+        }
+        if self.key_field.trim().is_empty() {
+            anyhow::bail!("state machine key_field must not be empty");
+        }
+        if self.states.is_empty() {
+            anyhow::bail!("state machine requires at least one state");
+        }
+
+        let mut state_ids: Vec<&str> = Vec::new();
+        for state in &self.states {
+            if state.id.trim().is_empty() {
+                anyhow::bail!("state machine state id must not be empty");
+            }
+            if state_ids.contains(&state.id.as_str()) {
+                anyhow::bail!("duplicate state id '{}'", state.id);
+            }
+            state_ids.push(&state.id);
+        }
+
+        for state in &self.states {
+            for cond in &state.enter {
+                if cond.query.trim().is_empty() {
+                    anyhow::bail!("enter condition for state '{}' has empty query", state.id);
+                }
+                if cond.key.trim().is_empty() {
+                    anyhow::bail!(
+                        "enter condition for state '{}' (query '{}') has empty key template",
+                        state.id,
+                        cond.query
+                    );
+                }
+                if cond.ops.is_empty() {
+                    anyhow::bail!(
+                        "enter condition for state '{}' (query '{}') must list at least one op",
+                        state.id,
+                        cond.query
+                    );
+                }
+                for prev in &cond.previous {
+                    if prev != "*" && !state_ids.contains(&prev.as_str()) {
+                        anyhow::bail!(
+                            "enter condition for state '{}' references unknown previous state '{}'",
+                            state.id,
+                            prev
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> StateMachineSourceConfig {
+        StateMachineSourceConfig {
+            entity_label: "OrderState".to_string(),
+            key_field: "orderId".to_string(),
+            states: vec![
+                StateDef {
+                    id: "NEW".to_string(),
+                    enter: vec![EnterCondition {
+                        query: "draft-orders".to_string(),
+                        previous: vec![],
+                        key: "{{orderId}}".to_string(),
+                        ops: vec![Op::Added],
+                    }],
+                },
+                StateDef {
+                    id: "CONFIRMED".to_string(),
+                    enter: vec![EnterCondition {
+                        query: "confirmed-orders".to_string(),
+                        previous: vec!["NEW".to_string()],
+                        key: "{{orderId}}".to_string(),
+                        ops: vec![Op::Added],
+                    }],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        sample().validate().unwrap();
+    }
+
+    #[test]
+    fn referenced_queries_dedup_and_order() {
+        assert_eq!(
+            sample().referenced_queries(),
+            vec!["draft-orders".to_string(), "confirmed-orders".to_string()]
+        );
+    }
+
+    #[test]
+    fn empty_entity_label_fails() {
+        let mut cfg = sample();
+        cfg.entity_label = String::new();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn no_states_fails() {
+        let mut cfg = sample();
+        cfg.states.clear();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn unknown_previous_state_fails() {
+        let mut cfg = sample();
+        cfg.states[1].enter[0].previous = vec!["BOGUS".to_string()];
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn wildcard_previous_is_allowed() {
+        let mut cfg = sample();
+        cfg.states[1].enter[0].previous = vec!["*".to_string()];
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn duplicate_state_fails() {
+        let mut cfg = sample();
+        cfg.states[1].id = "NEW".to_string();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn empty_ops_fails() {
+        let mut cfg = sample();
+        cfg.states[0].enter[0].ops = vec![];
+        assert!(cfg.validate().is_err());
+    }
+}

--- a/components/sources/state-machine/src/descriptor.rs
+++ b/components/sources/state-machine/src/descriptor.rs
@@ -1,0 +1,79 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Plugin descriptor for the state machine source.
+//!
+//! A single plugin crate exports one **source** descriptor (kind `state-machine`).
+//! The source config carries the `states` (with their `enter` conditions); the
+//! set of queries it subscribes to is derived from those conditions. Downstream
+//! queries subscribe to the source by its declared id.
+
+use drasi_lib::Source;
+use drasi_plugin_sdk::prelude::*;
+use utoipa::OpenApi;
+
+use crate::config::{EnterCondition, Op, StateDef, StateMachineSourceConfig};
+use crate::StateMachineSource;
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(StateMachineSourceConfig, StateDef, EnterCondition, Op)))]
+struct StateMachineSourceSchemas;
+
+/// Descriptor for the state machine source plugin.
+pub struct StateMachineSourceDescriptor;
+
+#[async_trait]
+impl SourcePluginDescriptor for StateMachineSourceDescriptor {
+    fn kind(&self) -> &str {
+        "state-machine"
+    }
+
+    fn config_version(&self) -> &str {
+        "1.0.0"
+    }
+
+    fn config_schema_name(&self) -> &str {
+        "source.state_machine.StateMachineSourceConfig"
+    }
+
+    fn config_schema_json(&self) -> String {
+        let api = StateMachineSourceSchemas::openapi();
+        serde_json::to_string(
+            &api.components
+                .as_ref()
+                .expect("OpenAPI components missing")
+                .schemas,
+        )
+        .expect("Failed to serialize config schema")
+    }
+
+    fn display_name(&self) -> &str {
+        "State Machine"
+    }
+
+    fn display_description(&self) -> &str {
+        "Maps continuous-query results to entity state transitions and exposes live entity state as a source"
+    }
+
+    async fn create_source(
+        &self,
+        id: &str,
+        config_json: &serde_json::Value,
+        auto_start: bool,
+    ) -> anyhow::Result<Box<dyn Source>> {
+        let config: StateMachineSourceConfig = serde_json::from_value(config_json.clone())?;
+        let source = StateMachineSource::create(id.to_string(), config, None, auto_start)?;
+        Ok(Box::new(source))
+    }
+}

--- a/components/sources/state-machine/src/engine.rs
+++ b/components/sources/state-machine/src/engine.rs
@@ -1,0 +1,434 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The state machine engine: pure, IO-free transition logic.
+//!
+//! The engine holds the current state of every entity and, given a
+//! [`QueryResult`], computes the set of state transitions that should occur. It
+//! performs no persistence or dispatch — those concerns live in the source
+//! component.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use drasi_lib::channels::{QueryResult, ResultDiff};
+use handlebars::Handlebars;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::config::{Op, StateMachineSourceConfig};
+
+/// A persisted, serializable record describing an entity's current state. This is
+/// both the engine's in-memory representation and the value stored in the state
+/// store; it is self-describing so the source can rebuild nodes during bootstrap
+/// without access to the full config.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EntityRecord {
+    /// The entity key (used as the graph node `element_id`).
+    pub key: String,
+    /// Name of the node property that holds the entity key.
+    pub key_field: String,
+    /// Label applied to the emitted node.
+    pub label: String,
+    /// The entity's current state id.
+    pub state: String,
+    /// The state the entity was in immediately before `state`, if any.
+    pub previous_state: Option<String>,
+    /// Wall-clock time (epoch millis) when the entity entered `state`.
+    pub entered_at: i64,
+    /// Pass-through fields from the triggering query result row.
+    #[serde(default)]
+    pub fields: Map<String, Value>,
+}
+
+impl EntityRecord {
+    /// Build the full node property object for this entity: the pass-through
+    /// fields plus the state-machine metadata (`<key_field>`, `state`,
+    /// `previousState`, `enteredAt`). Metadata keys take precedence on collision.
+    pub fn node_properties(&self) -> Value {
+        let mut props = self.fields.clone();
+        props.insert(self.key_field.clone(), Value::String(self.key.clone()));
+        props.insert("state".to_string(), Value::String(self.state.clone()));
+        props.insert(
+            "previousState".to_string(),
+            self.previous_state
+                .clone()
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        );
+        props.insert(
+            "enteredAt".to_string(),
+            Value::Number(self.entered_at.into()),
+        );
+        Value::Object(props)
+    }
+}
+
+/// A compiled enter condition with its target state resolved.
+struct CompiledCondition {
+    target_state: String,
+    query: String,
+    previous: Vec<String>,
+    ops: Vec<Op>,
+    template_name: String,
+}
+
+/// The state machine engine.
+pub struct StateMachine {
+    label: String,
+    key_field: String,
+    conditions: Vec<CompiledCondition>,
+    handlebars: Handlebars<'static>,
+    entities: HashMap<String, EntityRecord>,
+}
+
+impl StateMachine {
+    /// Build an engine from the source config, compiling all key templates.
+    pub fn new(config: &StateMachineSourceConfig) -> Result<Self> {
+        let mut handlebars = Handlebars::new();
+        handlebars.set_strict_mode(false);
+        let mut conditions = Vec::new();
+
+        for state in &config.states {
+            for (idx, cond) in state.enter.iter().enumerate() {
+                let template_name = format!("{}__{idx}", state.id);
+                handlebars
+                    .register_template_string(&template_name, &cond.key)
+                    .with_context(|| {
+                        format!(
+                            "invalid key template '{}' for state '{}'",
+                            cond.key, state.id
+                        )
+                    })?;
+                conditions.push(CompiledCondition {
+                    target_state: state.id.clone(),
+                    query: cond.query.clone(),
+                    previous: cond.previous.clone(),
+                    ops: cond.ops.clone(),
+                    template_name,
+                });
+            }
+        }
+
+        Ok(Self {
+            label: config.entity_label.clone(),
+            key_field: config.key_field.clone(),
+            conditions,
+            handlebars,
+            entities: HashMap::new(),
+        })
+    }
+
+    /// Seed the engine's in-memory state from previously persisted records.
+    pub fn load(&mut self, records: impl IntoIterator<Item = EntityRecord>) {
+        for record in records {
+            self.entities.insert(record.key.clone(), record);
+        }
+    }
+
+    /// Current number of tracked entities (primarily for testing/metrics).
+    pub fn entity_count(&self) -> usize {
+        self.entities.len()
+    }
+
+    /// Look up the current record for an entity (primarily for testing).
+    pub fn get(&self, key: &str) -> Option<&EntityRecord> {
+        self.entities.get(key)
+    }
+
+    /// Process a query result, applying any matching transitions and returning the
+    /// updated [`EntityRecord`]s (one per entity that changed state).
+    ///
+    /// Transitions are evaluated in config order, so multiple conditions in a
+    /// single result can cascade an entity through several states.
+    pub fn process(&mut self, result: &QueryResult) -> Vec<EntityRecord> {
+        let mut changed: Vec<EntityRecord> = Vec::new();
+
+        for diff in &result.results {
+            let Some((op, row)) = diff_op_and_row(diff) else {
+                continue;
+            };
+
+            for cond in &self.conditions {
+                if cond.query != result.query_id || !cond.ops.contains(&op) {
+                    continue;
+                }
+
+                let key = match self.handlebars.render(&cond.template_name, &row) {
+                    Ok(k) => k.trim().to_string(),
+                    Err(e) => {
+                        log::warn!(
+                            "state machine: failed to render key template for state '{}': {e}",
+                            cond.target_state
+                        );
+                        continue;
+                    }
+                };
+                if key.is_empty() {
+                    continue;
+                }
+
+                let current = self.entities.get(&key).map(|r| r.state.clone());
+
+                if !previous_matches(&cond.previous, current.as_deref()) {
+                    continue;
+                }
+                // Idempotent: already in the target state.
+                if current.as_deref() == Some(cond.target_state.as_str()) {
+                    continue;
+                }
+
+                // Merge pass-through fields: retain fields accumulated from earlier
+                // transitions and overlay the triggering row's fields on top. This
+                // keeps context (e.g. customer, amount captured at the first stage)
+                // available even when later stage queries return only the key.
+                let mut fields = self
+                    .entities
+                    .get(&key)
+                    .map(|r| r.fields.clone())
+                    .unwrap_or_default();
+                if let Value::Object(map) = &row {
+                    for (k, v) in map {
+                        fields.insert(k.clone(), v.clone());
+                    }
+                }
+
+                let record = EntityRecord {
+                    key: key.clone(),
+                    key_field: self.key_field.clone(),
+                    label: self.label.clone(),
+                    state: cond.target_state.clone(),
+                    previous_state: current,
+                    entered_at: chrono::Utc::now().timestamp_millis(),
+                    fields,
+                };
+
+                self.entities.insert(key, record.clone());
+
+                // Replace any earlier change for the same entity in this batch so
+                // only the final state is emitted.
+                changed.retain(|r| r.key != record.key);
+                changed.push(record);
+            }
+        }
+
+        changed
+    }
+}
+
+/// Returns whether `previous` guard allows a transition given the entity's
+/// `current` state.
+fn previous_matches(previous: &[String], current: Option<&str>) -> bool {
+    if previous.iter().any(|p| p == "*") {
+        return true;
+    }
+    match current {
+        None => previous.is_empty(),
+        Some(state) => previous.iter().any(|p| p == state),
+    }
+}
+
+/// Map a [`ResultDiff`] to its operation and the row to template against.
+fn diff_op_and_row(diff: &ResultDiff) -> Option<(Op, Value)> {
+    match diff {
+        ResultDiff::Add { data, .. } => Some((Op::Added, data.clone())),
+        ResultDiff::Update { after, .. } => Some((Op::Updated, after.clone())),
+        ResultDiff::Delete { data, .. } => Some((Op::Deleted, data.clone())),
+        ResultDiff::Aggregation { after, .. } => Some((Op::Updated, after.clone())),
+        ResultDiff::Noop => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{EnterCondition, StateDef};
+    use serde_json::json;
+
+    fn config() -> StateMachineSourceConfig {
+        StateMachineSourceConfig {
+            entity_label: "OrderState".to_string(),
+            key_field: "orderId".to_string(),
+            states: vec![
+                StateDef {
+                    id: "NEW".to_string(),
+                    enter: vec![EnterCondition {
+                        query: "draft-orders".to_string(),
+                        previous: vec![],
+                        key: "{{orderId}}".to_string(),
+                        ops: vec![Op::Added],
+                    }],
+                },
+                StateDef {
+                    id: "CONFIRMED".to_string(),
+                    enter: vec![EnterCondition {
+                        query: "confirmed-orders".to_string(),
+                        previous: vec!["NEW".to_string()],
+                        key: "{{orderId}}".to_string(),
+                        ops: vec![Op::Added],
+                    }],
+                },
+                StateDef {
+                    id: "PAID".to_string(),
+                    enter: vec![EnterCondition {
+                        query: "paid-orders".to_string(),
+                        previous: vec!["CONFIRMED".to_string()],
+                        key: "{{orderId}}".to_string(),
+                        ops: vec![Op::Added],
+                    }],
+                },
+            ],
+        }
+    }
+
+    fn result(query_id: &str, diff: ResultDiff) -> QueryResult {
+        QueryResult::new(
+            query_id.to_string(),
+            1,
+            chrono::Utc::now(),
+            vec![diff],
+            Default::default(),
+        )
+    }
+
+    fn add(data: serde_json::Value) -> ResultDiff {
+        ResultDiff::Add {
+            data,
+            row_signature: 0,
+        }
+    }
+
+    #[test]
+    fn initial_entry_from_no_state() {
+        let mut sm = StateMachine::new(&config()).unwrap();
+        let changed = sm.process(&result("draft-orders", add(json!({"orderId": "123"}))));
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].state, "NEW");
+        assert_eq!(changed[0].previous_state, None);
+        assert_eq!(changed[0].key, "123");
+        assert_eq!(changed[0].label, "OrderState");
+    }
+
+    #[test]
+    fn guarded_transition_requires_previous_state() {
+        let mut sm = StateMachine::new(&config()).unwrap();
+        // paid-orders arrives before the order is CONFIRMED -> no transition.
+        let changed = sm.process(&result("paid-orders", add(json!({"orderId": "123"}))));
+        assert!(changed.is_empty());
+        assert!(sm.get("123").is_none());
+    }
+
+    #[test]
+    fn full_progression() {
+        let mut sm = StateMachine::new(&config()).unwrap();
+        sm.process(&result("draft-orders", add(json!({"orderId": "1"}))));
+        sm.process(&result("confirmed-orders", add(json!({"orderId": "1"}))));
+        let changed = sm.process(&result("paid-orders", add(json!({"orderId": "1"}))));
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].state, "PAID");
+        assert_eq!(changed[0].previous_state.as_deref(), Some("CONFIRMED"));
+    }
+
+    #[test]
+    fn transition_is_idempotent() {
+        let mut sm = StateMachine::new(&config()).unwrap();
+        sm.process(&result("draft-orders", add(json!({"orderId": "1"}))));
+        let again = sm.process(&result("draft-orders", add(json!({"orderId": "1"}))));
+        assert!(again.is_empty());
+    }
+
+    #[test]
+    fn pass_through_fields_are_retained() {
+        let mut sm = StateMachine::new(&config()).unwrap();
+        let changed = sm.process(&result(
+            "draft-orders",
+            add(json!({"orderId": "1", "customer": "Acme", "total": 42})),
+        ));
+        let props = changed[0].node_properties();
+        assert_eq!(props["customer"], json!("Acme"));
+        assert_eq!(props["total"], json!(42));
+        assert_eq!(props["orderId"], json!("1"));
+        assert_eq!(props["state"], json!("NEW"));
+        assert_eq!(props["previousState"], Value::Null);
+        assert!(props["enteredAt"].is_number());
+    }
+
+    #[test]
+    fn fields_merge_across_transitions() {
+        let mut sm = StateMachine::new(&config()).unwrap();
+        // NEW carries customer; later stages return only the key.
+        sm.process(&result(
+            "draft-orders",
+            add(json!({"orderId": "1", "customer": "Acme"})),
+        ));
+        sm.process(&result("confirmed-orders", add(json!({"orderId": "1"}))));
+        let changed = sm.process(&result("paid-orders", add(json!({"orderId": "1"}))));
+        assert_eq!(changed[0].state, "PAID");
+        // customer captured at NEW is still present after two more transitions.
+        let props = changed[0].node_properties();
+        assert_eq!(props["customer"], json!("Acme"));
+    }
+
+    #[test]
+    fn load_seeds_state_for_guards() {
+        let mut sm = StateMachine::new(&config()).unwrap();
+        sm.load([EntityRecord {
+            key: "1".to_string(),
+            key_field: "orderId".to_string(),
+            label: "OrderState".to_string(),
+            state: "CONFIRMED".to_string(),
+            previous_state: Some("NEW".to_string()),
+            entered_at: 0,
+            fields: Map::new(),
+        }]);
+        // After reload, a paid-orders result can advance because state is CONFIRMED.
+        let changed = sm.process(&result("paid-orders", add(json!({"orderId": "1"}))));
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].state, "PAID");
+    }
+
+    #[test]
+    fn op_must_match() {
+        let mut sm = StateMachine::new(&config()).unwrap();
+        // draft-orders only triggers on `added`; a delete should not enter NEW.
+        let changed = sm.process(&result(
+            "draft-orders",
+            ResultDiff::Delete {
+                data: json!({"orderId": "1"}),
+                row_signature: 0,
+            },
+        ));
+        assert!(changed.is_empty());
+    }
+
+    #[test]
+    fn wildcard_previous_matches_any_state() {
+        let mut cfg = config();
+        cfg.states.push(StateDef {
+            id: "CANCELLED".to_string(),
+            enter: vec![EnterCondition {
+                query: "cancelled-orders".to_string(),
+                previous: vec!["*".to_string()],
+                key: "{{orderId}}".to_string(),
+                ops: vec![Op::Added],
+            }],
+        });
+        let mut sm = StateMachine::new(&cfg).unwrap();
+        sm.process(&result("draft-orders", add(json!({"orderId": "1"}))));
+        let changed = sm.process(&result("cancelled-orders", add(json!({"orderId": "1"}))));
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].state, "CANCELLED");
+        assert_eq!(changed[0].previous_state.as_deref(), Some("NEW"));
+    }
+}

--- a/components/sources/state-machine/src/lib.rs
+++ b/components/sources/state-machine/src/lib.rs
@@ -1,0 +1,154 @@
+#![allow(unexpected_cfgs)]
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # State Machine source for Drasi
+//!
+//! A Drasi **source** that maps live continuous-query results to per-entity state
+//! transitions and exposes the realtime state of every entity as a graph source
+//! that downstream queries can subscribe to.
+//!
+//! Unlike an ordinary source that ingests data from an external system, this
+//! source is driven by the results of other continuous queries. It uses the
+//! source query-subscription API — [`drasi_lib::Source::subscribed_query_ids`]
+//! and [`drasi_lib::Source::enqueue_query_result`] — the same way a reaction
+//! subscribes to query results. Each [`config::EnterCondition`] declares a
+//! query, the result `ops` that trigger it, the allowed `previous` states, and a
+//! Handlebars `key` template that extracts the entity key from the result row.
+//! When a result matches and the entity is in an allowed prior state, the entity
+//! transitions; the new state is persisted to the state store and dispatched as a
+//! node change to the source's own subscribers.
+//!
+//! Because the state machine is a single component, its own id **is** the source
+//! id downstream queries subscribe to — there is no separate companion component.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use drasi_source_state_machine::{StateMachineSourceBuilder, config::{StateDef, EnterCondition, Op}};
+//!
+//! # fn build() -> anyhow::Result<()> {
+//! let source = StateMachineSourceBuilder::new("order-state-source")
+//!     .with_entity_label("OrderState")
+//!     .with_key_field("orderId")
+//!     .with_state(StateDef {
+//!         id: "NEW".to_string(),
+//!         enter: vec![EnterCondition {
+//!             query: "draft-orders".to_string(),
+//!             previous: vec![],
+//!             key: "{{orderId}}".to_string(),
+//!             ops: vec![Op::Added],
+//!         }],
+//!     })
+//!     .build()?;
+//! // drasi.add_source(source).await?;
+//! # let _ = source;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! A **durable** `StateStoreProvider` (e.g. `drasi-state-store-redb`) should be
+//! configured on the `DrasiLib` instance so entity state survives restarts.
+
+pub mod config;
+pub mod descriptor;
+pub mod engine;
+pub mod source;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::{EnterCondition, Op, StateDef, StateMachineSourceConfig};
+pub use engine::{EntityRecord, StateMachine};
+pub use source::StateMachineSource;
+
+/// Builder for a [`StateMachineSource`].
+pub struct StateMachineSourceBuilder {
+    id: String,
+    config: StateMachineSourceConfig,
+    priority_queue_capacity: Option<usize>,
+    auto_start: bool,
+}
+
+impl StateMachineSourceBuilder {
+    /// Start building a state machine source with the given id.
+    ///
+    /// This id is the source id downstream queries subscribe to.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            config: StateMachineSourceConfig::default(),
+            priority_queue_capacity: None,
+            auto_start: true,
+        }
+    }
+
+    /// Set the label applied to emitted entity-state nodes.
+    pub fn with_entity_label(mut self, label: impl Into<String>) -> Self {
+        self.config.entity_label = label.into();
+        self
+    }
+
+    /// Set the node property name that holds the entity key.
+    pub fn with_key_field(mut self, key_field: impl Into<String>) -> Self {
+        self.config.key_field = key_field.into();
+        self
+    }
+
+    /// Add a state definition.
+    pub fn with_state(mut self, state: StateDef) -> Self {
+        self.config.states.push(state);
+        self
+    }
+
+    /// Replace the entire configuration.
+    pub fn with_config(mut self, config: StateMachineSourceConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Set the query-result priority queue capacity.
+    pub fn with_priority_queue_capacity(mut self, capacity: usize) -> Self {
+        self.priority_queue_capacity = Some(capacity);
+        self
+    }
+
+    /// Set whether the source auto-starts.
+    pub fn with_auto_start(mut self, auto_start: bool) -> Self {
+        self.auto_start = auto_start;
+        self
+    }
+
+    /// Build the source.
+    pub fn build(self) -> anyhow::Result<StateMachineSource> {
+        StateMachineSource::create(
+            self.id,
+            self.config,
+            self.priority_queue_capacity,
+            self.auto_start,
+        )
+    }
+}
+
+/// Dynamic plugin entry point. Exports the state machine source descriptor.
+#[cfg(feature = "dynamic-plugin")]
+drasi_plugin_sdk::export_plugin!(
+    plugin_id = "state-machine-source",
+    core_version = env!("CARGO_PKG_VERSION"),
+    lib_version = env!("CARGO_PKG_VERSION"),
+    plugin_version = env!("CARGO_PKG_VERSION"),
+    source_descriptors = [descriptor::StateMachineSourceDescriptor],
+    reaction_descriptors = [],
+    bootstrap_descriptors = [],
+);

--- a/components/sources/state-machine/src/source.rs
+++ b/components/sources/state-machine/src/source.rs
@@ -1,0 +1,397 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The state machine source.
+//!
+//! A single source component that:
+//! * subscribes to the continuous queries referenced by its states (via the
+//!   source query-subscription API — [`Source::subscribed_query_ids`] +
+//!   [`Source::enqueue_query_result`]),
+//! * evaluates state transitions with the pure [`StateMachine`] engine,
+//! * durably persists each entity's state to the state store, and
+//! * dispatches the resulting entity-state node changes to its own subscribers
+//!   (downstream queries), bootstrapping late joiners from persisted state.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use log::{debug, error, info, warn};
+use tokio::sync::Mutex;
+
+use drasi_core::models::{
+    Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange,
+};
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
+use drasi_lib::channels::{
+    BootstrapEvent, BootstrapEventSender, ComponentStatus, QueryResult, SubscriptionResponse,
+};
+use drasi_lib::context::SourceRuntimeContext;
+use drasi_lib::sources::base::{SourceBase, SourceBaseParams};
+use drasi_lib::state_store::StateStoreProvider;
+use drasi_lib::Source;
+
+use crate::config::StateMachineSourceConfig;
+use crate::engine::{EntityRecord, StateMachine};
+
+/// A source that maps continuous-query results to per-entity state transitions
+/// and exposes each entity's live state as a graph node.
+pub struct StateMachineSource {
+    base: SourceBase,
+    config: StateMachineSourceConfig,
+    engine: Arc<Mutex<StateMachine>>,
+}
+
+impl std::fmt::Debug for StateMachineSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StateMachineSource")
+            .field("id", &self.base.id)
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+impl StateMachineSource {
+    /// Create a new state machine source registered under `id`.
+    ///
+    /// `id` is the source id downstream queries subscribe to.
+    pub fn new(id: impl Into<String>, config: StateMachineSourceConfig) -> Result<Self> {
+        Self::create(id.into(), config, None, true)
+    }
+
+    pub(crate) fn create(
+        id: String,
+        config: StateMachineSourceConfig,
+        priority_queue_capacity: Option<usize>,
+        auto_start: bool,
+    ) -> Result<Self> {
+        config.validate()?;
+
+        let mut params = SourceBaseParams::new(id).with_auto_start(auto_start);
+        if let Some(capacity) = priority_queue_capacity {
+            params = params.with_priority_queue_capacity(capacity);
+        }
+
+        let engine = StateMachine::new(&config)?;
+
+        Ok(Self {
+            base: SourceBase::new(params)?,
+            config,
+            engine: Arc::new(Mutex::new(engine)),
+        })
+    }
+
+    /// Load persisted entity records into the engine so `previous` guards work
+    /// across restarts, then return the loaded records for reference.
+    async fn load_persisted_state(&self, store: &Arc<dyn StateStoreProvider>) -> Result<()> {
+        let records = read_all_records(store.as_ref(), &self.base.id).await?;
+        let loaded = records.len();
+        self.engine.lock().await.load(records);
+        info!(
+            "[{}] loaded {} persisted entity states",
+            self.base.id, loaded
+        );
+        Ok(())
+    }
+
+    /// Spawn the processing loop that drains the priority queue, applies
+    /// transitions, persists them, and dispatches node changes to subscribers.
+    fn spawn_processing_task(
+        &self,
+        store: Arc<dyn StateStoreProvider>,
+        mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+    ) -> tokio::task::JoinHandle<()> {
+        let base = self.base.clone_shared();
+        let engine = self.engine.clone();
+        let source_id = self.base.id.clone();
+
+        tokio::spawn(async move {
+            info!("[{source_id}] state machine processing loop started");
+            loop {
+                let query_result_arc = tokio::select! {
+                    biased;
+                    _ = &mut shutdown_rx => {
+                        info!("[{source_id}] state machine processing loop shutting down");
+                        break;
+                    }
+                    result = base.priority_queue.dequeue() => result,
+                };
+                let query_result = (*query_result_arc).clone();
+                debug!(
+                    "[{source_id}] processing result from query '{}'",
+                    query_result.query_id
+                );
+
+                let transitions = {
+                    let mut sm = engine.lock().await;
+                    sm.process(&query_result)
+                };
+
+                for record in transitions {
+                    if let Err(e) = persist_record(store.as_ref(), &source_id, &record).await {
+                        error!(
+                            "[{source_id}] failed to persist entity '{}': {e}",
+                            record.key
+                        );
+                        continue;
+                    }
+
+                    let element = record_to_node_element(&source_id, &record);
+                    let change = if record.previous_state.is_none() {
+                        SourceChange::Insert { element }
+                    } else {
+                        SourceChange::Update { element }
+                    };
+
+                    if let Err(e) = base.dispatch_source_change(change).await {
+                        debug!(
+                            "[{source_id}] could not dispatch state for '{}' (no subscribers): {e}",
+                            record.key
+                        );
+                    } else {
+                        info!(
+                            "[{source_id}] entity '{}' -> {} (was {:?})",
+                            record.key, record.state, record.previous_state
+                        );
+                    }
+                }
+            }
+        })
+    }
+}
+
+/// Read every persisted [`EntityRecord`] for a source partition.
+async fn read_all_records(
+    store: &dyn StateStoreProvider,
+    partition: &str,
+) -> Result<Vec<EntityRecord>> {
+    let keys = store
+        .list_keys(partition)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list persisted entities: {e}"))?;
+
+    let mut records = Vec::with_capacity(keys.len());
+    for key in keys {
+        if let Some(bytes) = store
+            .get(partition, &key)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to read entity '{key}': {e}"))?
+        {
+            match serde_json::from_slice::<EntityRecord>(&bytes) {
+                Ok(record) => records.push(record),
+                Err(e) => error!("[{partition}] skipping corrupt entity record '{key}': {e}"),
+            }
+        }
+    }
+    Ok(records)
+}
+
+/// Persist a single entity record to the state store, partitioned by source id.
+async fn persist_record(
+    store: &dyn StateStoreProvider,
+    source_id: &str,
+    record: &EntityRecord,
+) -> Result<()> {
+    let bytes = serde_json::to_vec(record).context("serialize entity record")?;
+    store
+        .set(source_id, &record.key, bytes)
+        .await
+        .map_err(|e| anyhow::anyhow!("state store set failed: {e}"))
+}
+
+#[async_trait]
+impl Source for StateMachineSource {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "state-machine"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        self.base.properties_or_serialize(&self.config)
+    }
+
+    fn auto_start(&self) -> bool {
+        self.base.get_auto_start()
+    }
+
+    fn supports_replay(&self) -> bool {
+        false
+    }
+
+    fn subscribed_query_ids(&self) -> Vec<String> {
+        self.config.referenced_queries()
+    }
+
+    async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+        self.base.enqueue_query_result(result).await
+    }
+
+    async fn start(&self) -> Result<()> {
+        info!("Starting StateMachineSource '{}'", self.base.id);
+        self.base
+            .set_status(
+                ComponentStatus::Starting,
+                Some("Starting state machine source".to_string()),
+            )
+            .await;
+
+        let store = self.base.state_store().await.ok_or_else(|| {
+            anyhow::anyhow!(
+                "state machine source '{}' requires a durable state store, but none is configured",
+                self.base.id
+            )
+        })?;
+        if !store.is_durable() {
+            warn!(
+                "[{}] state store is not durable; entity state will not survive restarts",
+                self.base.id
+            );
+        }
+
+        // Reload persisted state so `previous` guards work across restarts.
+        self.load_persisted_state(&store).await?;
+
+        // Install the bootstrap provider that replays persisted entity records to
+        // late/downstream subscribers.
+        let provider = StateMachineBootstrapProvider {
+            partition: self.base.id.clone(),
+            state_store: store.clone(),
+        };
+        self.base.set_bootstrap_provider(provider).await;
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        self.base.set_shutdown_tx(shutdown_tx).await;
+
+        let task = self.spawn_processing_task(store, shutdown_rx);
+        self.base.set_task_handle(task).await;
+
+        self.base
+            .set_status(ComponentStatus::Running, Some("Running".to_string()))
+            .await;
+        info!("[{}] state machine source started", self.base.id);
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        info!("Stopping StateMachineSource '{}'", self.base.id);
+        self.base
+            .set_status(
+                ComponentStatus::Stopping,
+                Some("Stopping state machine source".to_string()),
+            )
+            .await;
+
+        self.base.stop_common().await?;
+
+        self.base
+            .set_status(ComponentStatus::Stopped, Some("Stopped".to_string()))
+            .await;
+        Ok(())
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn subscribe(
+        &self,
+        settings: drasi_lib::config::SourceSubscriptionSettings,
+    ) -> Result<SubscriptionResponse> {
+        self.base
+            .subscribe_with_bootstrap(&settings, "StateMachine")
+            .await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn initialize(&self, context: SourceRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+}
+
+/// Bootstrap provider that replays persisted entity records as node inserts.
+struct StateMachineBootstrapProvider {
+    partition: String,
+    state_store: Arc<dyn StateStoreProvider>,
+}
+
+#[async_trait]
+impl BootstrapProvider for StateMachineBootstrapProvider {
+    async fn bootstrap(
+        &self,
+        request: BootstrapRequest,
+        context: &BootstrapContext,
+        event_tx: BootstrapEventSender,
+        _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
+    ) -> Result<BootstrapResult> {
+        let records = read_all_records(self.state_store.as_ref(), &self.partition).await?;
+
+        let mut count = 0usize;
+        for record in records {
+            // Filter by requested node labels (all our nodes share one label).
+            if !request.node_labels.is_empty() && !request.node_labels.contains(&record.label) {
+                continue;
+            }
+
+            let element = record_to_node_element(&self.partition, &record);
+            let sequence = context.next_sequence();
+            event_tx
+                .send(BootstrapEvent {
+                    source_id: context.source_id.clone(),
+                    change: SourceChange::Insert { element },
+                    timestamp: chrono::Utc::now(),
+                    sequence,
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to send bootstrap node: {e}"))?;
+            count += 1;
+        }
+
+        info!(
+            "StateMachineSource '{}' bootstrapped {} entity nodes for query '{}'",
+            self.partition, count, request.query_id
+        );
+
+        Ok(BootstrapResult {
+            event_count: count,
+            source_position: None,
+        })
+    }
+}
+
+/// Build a graph node [`Element`] from a persisted entity record.
+pub(crate) fn record_to_node_element(source_id: &str, record: &EntityRecord) -> Element {
+    let properties = ElementPropertyMap::from(&record.node_properties());
+    let effective_from = if record.entered_at > 0 {
+        record.entered_at as u64
+    } else {
+        chrono::Utc::now().timestamp_millis().max(0) as u64
+    };
+    Element::Node {
+        metadata: ElementMetadata {
+            reference: ElementReference::new(source_id, &record.key),
+            labels: Arc::from(vec![Arc::from(record.label.as_str())]),
+            effective_from,
+        },
+        properties,
+    }
+}

--- a/components/sources/state-machine/src/tests.rs
+++ b/components/sources/state-machine/src/tests.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Crate-level unit tests for the builder and trait wiring.
+
+use crate::config::{EnterCondition, Op, StateDef};
+use crate::{StateMachineSource, StateMachineSourceBuilder};
+use drasi_lib::Source;
+
+fn order_states() -> Vec<StateDef> {
+    vec![
+        StateDef {
+            id: "NEW".to_string(),
+            enter: vec![EnterCondition {
+                query: "draft-orders".to_string(),
+                previous: vec![],
+                key: "{{orderId}}".to_string(),
+                ops: vec![Op::Added],
+            }],
+        },
+        StateDef {
+            id: "CONFIRMED".to_string(),
+            enter: vec![EnterCondition {
+                query: "confirmed-orders".to_string(),
+                previous: vec!["NEW".to_string()],
+                key: "{{orderId}}".to_string(),
+                ops: vec![Op::Added],
+            }],
+        },
+    ]
+}
+
+fn build() -> StateMachineSource {
+    let mut builder = StateMachineSourceBuilder::new("order-state-source")
+        .with_entity_label("OrderState")
+        .with_key_field("orderId");
+    for state in order_states() {
+        builder = builder.with_state(state);
+    }
+    builder.build().expect("build source")
+}
+
+#[test]
+fn builder_produces_source() {
+    let source = build();
+    assert_eq!(source.id(), "order-state-source");
+    assert_eq!(source.type_name(), "state-machine");
+    assert!(!source.supports_replay());
+}
+
+#[test]
+fn source_subscribes_to_referenced_queries() {
+    let source = build();
+    let mut queries = source.subscribed_query_ids();
+    queries.sort();
+    assert_eq!(queries, vec!["confirmed-orders", "draft-orders"]);
+}
+
+#[test]
+fn build_fails_without_states() {
+    let result = StateMachineSourceBuilder::new("order-state-source").build();
+    assert!(result.is_err());
+}

--- a/components/sources/state-machine/tests/integration_tests.rs
+++ b/components/sources/state-machine/tests/integration_tests.rs
@@ -28,7 +28,9 @@ use drasi_lib::{DrasiLib, Query};
 use drasi_reaction_application::ApplicationReaction;
 use drasi_source_application::{ApplicationSource, ApplicationSourceConfig, PropertyMapBuilder};
 use drasi_source_state_machine::config::{EnterCondition, Op, StateDef};
-use drasi_source_state_machine::{StateMachineSource, StateMachineSourceConfig};
+use drasi_source_state_machine::{
+    StateMachineSource, StateMachineSourceBuilder, StateMachineSourceConfig,
+};
 use serde_json::Value;
 use tokio::sync::Mutex;
 
@@ -333,6 +335,118 @@ async fn fresh_subscriber_bootstraps_from_persisted_state() {
     assert!(
         found,
         "fresh subscriber should bootstrap the PAID order from persisted state"
+    );
+
+    core.stop().await.unwrap();
+}
+
+/// Regression test for the robust query-consumption engine: a query result emitted
+/// *before* the source subscribes must still be processed via **outbox catch-up**.
+///
+/// A bare live-forwarding source (the earlier design) would miss it. The shared
+/// consumption engine replays the query's outbox from the checkpoint on fresh
+/// start, so the source catches up.
+#[tokio::test]
+async fn source_catches_up_on_results_emitted_before_it_subscribes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Arc::new(
+        drasi_state_store_redb::RedbStateStoreProvider::new(tmp.path().join("state.redb")).unwrap(),
+    );
+
+    let (source, handle) = ApplicationSource::new(
+        "orders",
+        ApplicationSourceConfig {
+            properties: HashMap::new(),
+            durability: None,
+        },
+    )
+    .unwrap();
+
+    // Start with ONLY the application source + stage queries — no state machine
+    // source yet, so the draft-orders result lands in the query outbox before any
+    // state machine subscription exists.
+    let mut builder = DrasiLib::builder()
+        .with_id("sm-catchup-test")
+        .with_state_store_provider(store.clone())
+        .with_source(source);
+    for q in stage_queries() {
+        builder = builder.with_query(q);
+    }
+    let core = Arc::new(builder.build().await.unwrap());
+    core.start().await.unwrap();
+
+    // Emit a draft order BEFORE the state machine source exists/subscribes.
+    handle
+        .send_node_insert(
+            "o1",
+            vec!["Order"],
+            PropertyMapBuilder::new()
+                .with_string("id", "o1")
+                .with_bool("is_draft", true)
+                .with_bool("paid", false)
+                .build(),
+        )
+        .await
+        .unwrap();
+
+    // Wait until draft-orders has processed it (it is now in the query's outbox).
+    let mut in_query = false;
+    for _ in 0..100 {
+        if let Ok(results) = core.get_query_results("draft-orders").await {
+            if results
+                .iter()
+                .any(|r| r.get("orderId").and_then(|v| v.as_str()) == Some("o1"))
+            {
+                in_query = true;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        in_query,
+        "draft-orders should have processed o1 before the source subscribes"
+    );
+
+    // NOW add the state machine source + a downstream query and start the source.
+    // Add it with auto_start=false so wiring (and thus catch-up) happens
+    // deterministically when we call start_source below.
+    let sm_source = StateMachineSourceBuilder::new("order-state-source")
+        .with_config(state_machine_config())
+        .with_auto_start(false)
+        .build()
+        .unwrap();
+    core.add_source(sm_source).await.unwrap();
+    core.add_query(
+        Query::cypher("order-states")
+            .query("MATCH (o:OrderState) RETURN o.orderId AS orderId, o.state AS state")
+            .from_source("order-state-source")
+            .auto_start(true)
+            .build(),
+    )
+    .await
+    .unwrap();
+    core.start_source("order-state-source").await.unwrap();
+
+    // The source must catch up on the draft-orders result emitted before it
+    // subscribed, transitioning o1 to NEW. A live-only forwarder would miss it.
+    let mut found = false;
+    for _ in 0..100 {
+        if let Ok(results) = core.get_query_results("order-states").await {
+            if results.iter().any(|r| {
+                r.get("orderId").and_then(|v| v.as_str()) == Some("o1")
+                    && r.get("state").and_then(|v| v.as_str()) == Some("NEW")
+            }) {
+                found = true;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        found,
+        "state machine source should catch up on the pre-subscription draft-orders \
+         result and set o1=NEW"
     );
 
     core.stop().await.unwrap();

--- a/components/sources/state-machine/tests/integration_tests.rs
+++ b/components/sources/state-machine/tests/integration_tests.rs
@@ -1,0 +1,339 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! End-to-end tests for the state machine source.
+//!
+//! These wire a real `DrasiLib` instance: an application source feeds order data
+//! through three stage queries into the state machine source, which transitions
+//! entities and dispatches their state as node changes. A downstream query over
+//! the state machine source is observed via an application reaction.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use drasi_lib::state_store::StateStoreProvider;
+use drasi_lib::{DrasiLib, Query};
+use drasi_reaction_application::ApplicationReaction;
+use drasi_source_application::{ApplicationSource, ApplicationSourceConfig, PropertyMapBuilder};
+use drasi_source_state_machine::config::{EnterCondition, Op, StateDef};
+use drasi_source_state_machine::{StateMachineSource, StateMachineSourceConfig};
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+/// Shared record of the latest observed `state` per `orderId`, plus the full
+/// ordered history of states seen.
+#[derive(Default)]
+struct Observed {
+    latest: HashMap<String, String>,
+    history: Vec<(String, String)>,
+}
+
+type ObservedHandle = Arc<Mutex<Observed>>;
+
+fn order_states() -> Vec<StateDef> {
+    vec![
+        StateDef {
+            id: "NEW".to_string(),
+            enter: vec![EnterCondition {
+                query: "draft-orders".to_string(),
+                previous: vec![],
+                key: "{{orderId}}".to_string(),
+                ops: vec![Op::Added],
+            }],
+        },
+        StateDef {
+            id: "CONFIRMED".to_string(),
+            enter: vec![EnterCondition {
+                query: "confirmed-orders".to_string(),
+                previous: vec!["NEW".to_string()],
+                key: "{{orderId}}".to_string(),
+                ops: vec![Op::Added],
+            }],
+        },
+        StateDef {
+            id: "PAID".to_string(),
+            enter: vec![EnterCondition {
+                query: "paid-orders".to_string(),
+                previous: vec!["CONFIRMED".to_string()],
+                key: "{{orderId}}".to_string(),
+                ops: vec![Op::Added],
+            }],
+        },
+    ]
+}
+
+fn state_machine_config() -> StateMachineSourceConfig {
+    StateMachineSourceConfig {
+        entity_label: "OrderState".to_string(),
+        key_field: "orderId".to_string(),
+        states: order_states(),
+    }
+}
+
+fn stage_queries() -> Vec<drasi_lib::config::QueryConfig> {
+    vec![
+        Query::cypher("draft-orders")
+            .query("MATCH (o:Order) WHERE o.is_draft = true RETURN o.id AS orderId")
+            .from_source("orders")
+            .auto_start(true)
+            .build(),
+        Query::cypher("confirmed-orders")
+            .query("MATCH (o:Order) WHERE o.is_draft = false RETURN o.id AS orderId")
+            .from_source("orders")
+            .auto_start(true)
+            .build(),
+        Query::cypher("paid-orders")
+            .query("MATCH (o:Order) WHERE o.paid = true RETURN o.id AS orderId")
+            .from_source("orders")
+            .auto_start(true)
+            .build(),
+    ]
+}
+
+/// Build the downstream query over the state source and an application reaction
+/// that records observed `(orderId, state)` pairs into `observed`.
+async fn downstream_recorder(
+    source_id: &str,
+    observed: ObservedHandle,
+) -> (drasi_lib::config::QueryConfig, ApplicationReaction) {
+    let query = Query::cypher("order-states")
+        .query("MATCH (o:OrderState) RETURN o.orderId AS orderId, o.state AS state")
+        .from_source(source_id)
+        .auto_start(true)
+        .build();
+
+    let (reaction, handle) =
+        ApplicationReaction::new("state-observer", vec!["order-states".into()]);
+
+    handle
+        .subscribe(move |result| {
+            let observed = observed.clone();
+            // The callback is sync; spawn to record asynchronously.
+            tokio::spawn(async move {
+                let mut guard = observed.lock().await;
+                for diff in &result.results {
+                    let row = match diff {
+                        drasi_lib::channels::ResultDiff::Add { data, .. } => Some(data.clone()),
+                        drasi_lib::channels::ResultDiff::Update { after, .. } => {
+                            Some(after.clone())
+                        }
+                        _ => None,
+                    };
+                    if let Some(Value::Object(map)) = row {
+                        if let (Some(Value::String(id)), Some(Value::String(state))) =
+                            (map.get("orderId"), map.get("state"))
+                        {
+                            guard.latest.insert(id.clone(), state.clone());
+                            guard.history.push((id.clone(), state.clone()));
+                        }
+                    }
+                }
+            });
+        })
+        .await
+        .expect("subscribe to order-states");
+
+    (query, reaction)
+}
+
+async fn wait_for_state(observed: &ObservedHandle, order_id: &str, want: &str) -> bool {
+    for _ in 0..100 {
+        if observed
+            .lock()
+            .await
+            .latest
+            .get(order_id)
+            .map(|s| s == want)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+#[tokio::test]
+async fn state_machine_progresses_and_exposes_state_source() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Arc::new(
+        drasi_state_store_redb::RedbStateStoreProvider::new(tmp.path().join("state.redb")).unwrap(),
+    );
+    let observed: ObservedHandle = Arc::new(Mutex::new(Observed::default()));
+
+    let (source, handle) = ApplicationSource::new(
+        "orders",
+        ApplicationSourceConfig {
+            properties: HashMap::new(),
+            durability: None,
+        },
+    )
+    .unwrap();
+
+    let sm_source_id = "order-state-source-progress";
+    let sm_source = StateMachineSource::new(sm_source_id, state_machine_config()).unwrap();
+
+    let (downstream_query, observer) = downstream_recorder(sm_source_id, observed.clone()).await;
+
+    let mut builder = DrasiLib::builder()
+        .with_id("state-machine-test")
+        .with_state_store_provider(store.clone())
+        .with_source(source)
+        .with_source(sm_source)
+        .with_reaction(observer)
+        .with_query(downstream_query);
+    for q in stage_queries() {
+        builder = builder.with_query(q);
+    }
+    let core = Arc::new(builder.build().await.unwrap());
+    core.start().await.unwrap();
+
+    // Draft order -> NEW
+    handle
+        .send_node_insert(
+            "o1",
+            vec!["Order"],
+            PropertyMapBuilder::new()
+                .with_string("id", "o1")
+                .with_bool("is_draft", true)
+                .with_bool("paid", false)
+                .build(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        wait_for_state(&observed, "o1", "NEW").await,
+        "order should enter NEW"
+    );
+
+    // Confirm -> CONFIRMED
+    handle
+        .send_node_update(
+            "o1",
+            vec!["Order"],
+            PropertyMapBuilder::new()
+                .with_string("id", "o1")
+                .with_bool("is_draft", false)
+                .with_bool("paid", false)
+                .build(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        wait_for_state(&observed, "o1", "CONFIRMED").await,
+        "order should enter CONFIRMED"
+    );
+
+    // Pay -> PAID
+    handle
+        .send_node_update(
+            "o1",
+            vec!["Order"],
+            PropertyMapBuilder::new()
+                .with_string("id", "o1")
+                .with_bool("is_draft", false)
+                .with_bool("paid", true)
+                .build(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        wait_for_state(&observed, "o1", "PAID").await,
+        "order should enter PAID"
+    );
+
+    // Verify the progression order was observed.
+    let history: Vec<String> = observed
+        .lock()
+        .await
+        .history
+        .iter()
+        .filter(|(id, _)| id == "o1")
+        .map(|(_, s)| s.clone())
+        .collect();
+    assert!(history.contains(&"NEW".to_string()));
+    assert!(history.contains(&"CONFIRMED".to_string()));
+    assert!(history.contains(&"PAID".to_string()));
+
+    // Verify state persisted under the source partition.
+    let persisted = store.list_keys(sm_source_id).await.unwrap();
+    assert!(persisted.contains(&"o1".to_string()));
+
+    core.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn fresh_subscriber_bootstraps_from_persisted_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Arc::new(
+        drasi_state_store_redb::RedbStateStoreProvider::new(tmp.path().join("state.redb")).unwrap(),
+    );
+    let source_id = "order-state-source-bootstrap";
+
+    // Pre-seed the state store with a PAID order as a prior run would have done.
+    let record = serde_json::json!({
+        "key": "o9",
+        "key_field": "orderId",
+        "label": "OrderState",
+        "state": "PAID",
+        "previous_state": "CONFIRMED",
+        "entered_at": 1_700_000_000_000_i64,
+        "fields": { "orderId": "o9" }
+    });
+    store
+        .set(source_id, "o9", serde_json::to_vec(&record).unwrap())
+        .await
+        .unwrap();
+
+    let sm_source = StateMachineSource::new(source_id, state_machine_config()).unwrap();
+    let downstream_query = Query::cypher("order-states")
+        .query("MATCH (o:OrderState) RETURN o.orderId AS orderId, o.state AS state")
+        .from_source(source_id)
+        .auto_start(true)
+        .build();
+
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("state-machine-bootstrap-test")
+            .with_state_store_provider(store.clone())
+            .with_source(sm_source)
+            .with_query(downstream_query)
+            .build()
+            .await
+            .unwrap(),
+    );
+    core.start().await.unwrap();
+
+    // The downstream query should bootstrap the persisted PAID order from the source.
+    let mut found = false;
+    for _ in 0..100 {
+        if let Ok(results) = core.get_query_results("order-states").await {
+            if results.iter().any(|row| {
+                row.get("orderId").and_then(|v| v.as_str()) == Some("o9")
+                    && row.get("state").and_then(|v| v.as_str()) == Some("PAID")
+            }) {
+                found = true;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        found,
+        "fresh subscriber should bootstrap the PAID order from persisted state"
+    );
+
+    core.stop().await.unwrap();
+}

--- a/examples/lib/orders-state-machine/.gitignore
+++ b/examples/lib/orders-state-machine/.gitignore
@@ -1,0 +1,2 @@
+# Runtime state store (redb) created by the example at startup.
+/data/

--- a/examples/lib/orders-state-machine/Cargo.toml
+++ b/examples/lib/orders-state-machine/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "orders-state-machine-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Drasi example: a self-driving order lifecycle with the state machine source, Postgres, a stored-procedure reaction, and a dashboard"
+
+# Keep this crate independent from the parent workspace
+[workspace]
+
+[dependencies]
+drasi-lib = { path = "../../../lib" }
+drasi-source-postgres = { path = "../../../components/sources/postgres" }
+drasi-bootstrap-postgres = { path = "../../../components/bootstrappers/postgres" }
+drasi-source-state-machine = { path = "../../../components/sources/state-machine" }
+drasi-reaction-storedproc-postgres = { path = "../../../components/reactions/storedproc-postgres" }
+drasi-reaction-dashboard = { path = "../../../components/reactions/dashboard" }
+drasi-state-store-redb = { path = "../../../components/state_stores/redb" }
+
+anyhow = "1.0"
+env_logger = "0.11"
+log = "0.4"
+serde_json = "1.0"
+serde_yaml = "0.9"
+tokio = { version = "1.6", features = ["full"] }
+tokio-postgres = "0.7"
+
+[[bin]]
+name = "orders-state-machine-example"
+path = "main.rs"

--- a/examples/lib/orders-state-machine/README.md
+++ b/examples/lib/orders-state-machine/README.md
@@ -1,0 +1,130 @@
+# Orders State Machine Example
+
+A self-driving order-lifecycle demo built on the Drasi **state machine source**.
+It ties four components together and is verified end-to-end (orders animate all
+the way from NEW to DELIVERED on a live dashboard).
+
+| Component | Role |
+|-----------|------|
+| **Postgres source** (`orders-db`) | Streams changes to `orders`, `payments`, `stock_picks`, `shipments` via logical replication, with a Postgres bootstrap provider for the initial snapshot. |
+| **6 stage queries** | `draft-orders`, `confirmed-orders`, `paid-orders`, `picked-orders`, `shipped-orders`, `delivered-orders` — each a single-entity query returning the owning `order_id`. |
+| **State machine source** (`order-state-source`) | Subscribes to the stage queries and correlates them by `order_id` into the states `NEW → CONFIRMED → PAID → PICKED → SHIPPED → DELIVERED`, exposing each order's live state as its own source. |
+| **Stored-procedure reaction** (`order-advancer`) | When an order enters a stage, calls `schedule_advance(orderId)` to schedule the next step. |
+| **Dashboard reaction** | Visualizes the live order states on a web UI at `:3000`. |
+
+```text
+Postgres (orders, payments,   ──▶ orders-db ──▶ 6 stage queries ──┬──▶ state machine source (order-state-source) ──▶ dashboard queries ──▶ dashboard (:3000)
+          stock_picks, shipments)                                  └──▶ stored-proc reaction ──▶ CALL schedule_advance(...)
+       ▲                                                                                    │
+       └──────────────────── pacing driver: SELECT advance_due_orders() ◀───────────────────┘
+```
+
+## The state machine is a *source*
+
+The state machine is a single Drasi **source**. Unlike an ordinary source that
+ingests data from an external system, it is driven by the results of the six
+stage queries: it uses the source query-subscription API (the same mechanism
+reactions use to consume query results). It correlates those results into a
+per-order state, persists that state, and re-emits it as graph nodes — so its
+own id (`order-state-source`) is what the dashboard queries subscribe to. There
+is no separate companion component.
+
+## Entities (mirrors the classic Order / Payment / StockPick / Shipment model)
+
+| Stage     | Relational fact                          | Stage query |
+|-----------|------------------------------------------|-------------|
+| NEW       | `orders` row with `is_draft = 1`         | `MATCH (o:orders) WHERE o.is_draft = 1 RETURN o.id AS orderId, ...` |
+| CONFIRMED | `orders` row with `is_draft = 0`         | `MATCH (o:orders) WHERE o.is_draft = 0 RETURN o.id AS orderId` |
+| PAID      | settled `payments` row                   | `MATCH (p:payments) WHERE p.status = 'settled' RETURN p.order_id AS orderId` |
+| PICKED    | `stock_picks` row                        | `MATCH (s:stock_picks) RETURN s.order_id AS orderId` |
+| SHIPPED   | `shipments` row                          | `MATCH (h:shipments) RETURN h.order_id AS orderId` |
+| DELIVERED | `shipments` row with `delivered = 1`     | `MATCH (h:shipments) WHERE h.delivered = 1 RETURN h.order_id AS orderId` |
+
+The stages are **separate entities/tables**, exactly like the original relational
+model. Because drasi-core's Postgres source produces nodes (not foreign-key
+relationships), each stage query returns the owning `order_id` and the **state
+machine does the correlation by key** — which is precisely what it is for. Most
+advancement is INSERT-driven (settled payments, stock picks, shipments), which the
+source delivers as clean node additions.
+
+## How the self-driving loop works
+
+1. A new order is inserted (`is_draft = 1`). `draft-orders` matches → the state
+   machine sets it **NEW**; the stored-proc reaction schedules an advancement
+   (`orders.next_stage_at = now() + 1s`).
+2. The **pacing driver** (a 2 Hz loop in `main.rs`) calls `advance_due_orders()`,
+   which advances **one** due order by one stage (flip `is_draft`, or insert a
+   payment / stock pick / shipment, or set `delivered`), touching the order row at
+   most once so each CDC transaction carries a single clean change.
+3. That change flows back through Postgres CDC → the next stage query matches →
+   the state machine transitions the order and the stored-proc reaction schedules
+   the next step.
+4. Steps 2–3 repeat until the order is **DELIVERED** (~1–2 s per stage). A seeder
+   task inserts a fresh order every 8 seconds, keeping only a couple of orders in
+   flight at once.
+
+## Durability
+
+The state machine source persists each order's state to a durable
+[`redb`](../../../components/state_stores/redb) state store at `./data/state.redb`.
+On restart, state is reloaded and downstream subscribers are bootstrapped from it.
+
+## Running
+
+Requires Docker (for Postgres) and Rust.
+
+```bash
+cd examples/lib/orders-state-machine
+./run.sh
+```
+
+`run.sh` starts Postgres with logical replication, waits for it to be healthy, then
+runs the app. Open <http://localhost:3000> (or <http://127.0.0.1:3000> if your
+browser resolves `localhost` to IPv6 — the server binds IPv4) to watch orders
+progress through their lifecycle.
+
+To run the steps manually:
+
+```bash
+docker compose up -d          # Postgres on :5432
+cargo run                     # Drasi + dashboard on :3000
+docker compose down -v        # tear down the database when finished
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.rs` | Wires all components and the pacing/seeder tasks. |
+| `db/init.sql` | Orders/payments/stock_picks/shipments schema, advancement stored procedures, the `drasi_pub` publication (no seed rows). |
+| `docker-compose.yml` | Postgres 16 with `wal_level=logical`. |
+| `run.sh` | Convenience launcher. |
+
+## Notes
+
+- **The state machine is configured declaratively.** In `main.rs` the source is
+  defined as literal YAML (the `ORDER_STATE_MACHINE` constant) and deserialized into
+  the config — exactly the shape you would put in a Drasi YAML file (`entityLabel`,
+  `keyField`, and a `states` list with `enter` conditions). Note there is no
+  `sourceId`: the state machine is a single source, and its own id is what
+  downstream queries read.
+- **Integer flags, not booleans.** `orders.is_draft` and `shipments.delivered` are
+  modelled as `SMALLINT` (0/1) rather than `BOOLEAN`. The Drasi Postgres CDC source
+  currently mis-decodes streamed `BOOLEAN` values (they always decode as `true`),
+  so a boolean flag flip would not be observed on the change stream. Integers stream
+  correctly. Tracked upstream in
+  [drasi-project/drasi-core#611](https://github.com/drasi-project/drasi-core/issues/611);
+  once fixed, the flags can be plain booleans.
+- **One change per advancement.** `advance_due_orders()` advances a single order by
+  a single stage per call and touches each row at most once, so every CDC
+  transaction carries one clean change. This keeps the continuous queries reliable
+  under the self-driving load (batched multi-row updates in one transaction can be
+  collapsed on the stream).
+- **No seed data / start with a fresh DB.** The seeder inserts orders live so they
+  animate through the full lifecycle. Rows that exist before startup arrive via
+  bootstrap, which the stage queries observe, but the self-driving loop only
+  advances orders whose transitions flow through the live change stream. Use
+  `docker compose down -v` between runs to reset.
+- The Drasi Postgres source auto-creates its replication slot, so `init.sql`
+  deliberately does **not** pre-create one (doing so would replay seed rows on top
+  of the bootstrap snapshot and double the data).

--- a/examples/lib/orders-state-machine/README.md
+++ b/examples/lib/orders-state-machine/README.md
@@ -86,7 +86,7 @@ progress through their lifecycle.
 To run the steps manually:
 
 ```bash
-docker compose up -d          # Postgres on :5432
+docker compose up -d          # Postgres on host port :5442 (container 5432)
 cargo run                     # Drasi + dashboard on :3000
 docker compose down -v        # tear down the database when finished
 ```

--- a/examples/lib/orders-state-machine/README.md
+++ b/examples/lib/orders-state-machine/README.md
@@ -10,10 +10,10 @@ the way from NEW to DELIVERED on a live dashboard).
 | **6 stage queries** | `draft-orders`, `confirmed-orders`, `paid-orders`, `picked-orders`, `shipped-orders`, `delivered-orders` — each a single-entity query returning the owning `order_id`. |
 | **State machine source** (`order-state-source`) | Subscribes to the stage queries and correlates them by `order_id` into the states `NEW → CONFIRMED → PAID → PICKED → SHIPPED → DELIVERED`, exposing each order's live state as its own source. |
 | **Stored-procedure reaction** (`order-advancer`) | When an order enters a stage, calls `schedule_advance(orderId)` to schedule the next step. |
-| **Dashboard reaction** | Visualizes the live order states on a web UI at `:3000`. |
+| **Dashboard reaction** | Visualizes the live order states on a web UI at `:3002`. |
 
 ```text
-Postgres (orders, payments,   ──▶ orders-db ──▶ 6 stage queries ──┬──▶ state machine source (order-state-source) ──▶ dashboard queries ──▶ dashboard (:3000)
+Postgres (orders, payments,   ──▶ orders-db ──▶ 6 stage queries ──┬──▶ state machine source (order-state-source) ──▶ dashboard queries ──▶ dashboard (:3002)
           stock_picks, shipments)                                  └──▶ stored-proc reaction ──▶ CALL schedule_advance(...)
        ▲                                                                                    │
        └──────────────────── pacing driver: SELECT advance_due_orders() ◀───────────────────┘
@@ -79,7 +79,7 @@ cd examples/lib/orders-state-machine
 ```
 
 `run.sh` starts Postgres with logical replication, waits for it to be healthy, then
-runs the app. Open <http://localhost:3000> (or <http://127.0.0.1:3000> if your
+runs the app. Open <http://localhost:3002> (or <http://127.0.0.1:3002> if your
 browser resolves `localhost` to IPv6 — the server binds IPv4) to watch orders
 progress through their lifecycle.
 
@@ -87,7 +87,7 @@ To run the steps manually:
 
 ```bash
 docker compose up -d          # Postgres on host port :5442 (container 5432)
-cargo run                     # Drasi + dashboard on :3000
+cargo run                     # Drasi + dashboard on :3002
 docker compose down -v        # tear down the database when finished
 ```
 

--- a/examples/lib/orders-state-machine/README.md
+++ b/examples/lib/orders-state-machine/README.md
@@ -12,12 +12,62 @@ the way from NEW to DELIVERED on a live dashboard).
 | **Stored-procedure reaction** (`order-advancer`) | When an order enters a stage, calls `schedule_advance(orderId)` to schedule the next step. |
 | **Dashboard reaction** | Visualizes the live order states on a web UI at `:3002`. |
 
-```text
-Postgres (orders, payments,   ──▶ orders-db ──▶ 6 stage queries ──┬──▶ state machine source (order-state-source) ──▶ dashboard queries ──▶ dashboard (:3002)
-          stock_picks, shipments)                                  └──▶ stored-proc reaction ──▶ CALL schedule_advance(...)
-       ▲                                                                                    │
-       └──────────────────── pacing driver: SELECT advance_due_orders() ◀───────────────────┘
+The pipeline wires two sources, eight continuous queries, and two reactions
+(node colors below distinguish **sources**, **queries**, and **reactions**):
+
+```mermaid
+flowchart LR
+    pg[("Postgres<br/>orders · payments<br/>stock_picks · shipments")]
+    ui["Dashboard UI<br/>:3002"]
+    pace["pacing driver<br/>(2 Hz loop)"]
+
+    subgraph sources[Sources]
+        ordersdb["orders-db<br/>(Postgres CDC)"]
+        smsrc["order-state-source<br/>(state machine source)"]
+    end
+
+    subgraph queries[Queries]
+        subgraph stages[stage queries]
+            draft["draft-orders"]
+            confirmed["confirmed-orders"]
+            paid["paid-orders"]
+            picked["picked-orders"]
+            shipped["shipped-orders"]
+            delivered["delivered-orders"]
+        end
+        allstates["order-states-all"]
+        delstates["delivered-states"]
+    end
+
+    subgraph reactions[Reactions]
+        advancer["order-advancer<br/>(stored-proc)"]
+        dash["orders-dashboard"]
+    end
+
+    pg -->|CDC| ordersdb
+    ordersdb --> draft & confirmed & paid & picked & shipped & delivered
+    draft & confirmed & paid & picked & shipped & delivered --> smsrc
+    draft & confirmed & paid & picked & shipped & delivered --> advancer
+    smsrc --> allstates & delstates
+    allstates & delstates --> dash
+    dash --> ui
+    advancer -.->|CALL schedule_advance| pg
+    pace -.->|SELECT advance_due_orders| pg
+
+    classDef source fill:#e3f2fd,stroke:#1565c0,color:#0d1b2a;
+    classDef query fill:#f3e5f5,stroke:#6a1b9a,color:#0d1b2a;
+    classDef reaction fill:#e8f5e9,stroke:#2e7d32,color:#0d1b2a;
+    classDef ext fill:#eceff1,stroke:#455a64,color:#0d1b2a;
+    class ordersdb,smsrc source;
+    class draft,confirmed,paid,picked,shipped,delivered,allstates,delstates query;
+    class advancer,dash reaction;
+    class pg,ui,pace ext;
 ```
+
+Solid arrows are Drasi subscriptions (source → query → consumer); dashed arrows
+are the self-driving feedback loop back into Postgres (the stored-proc reaction
+schedules the next stage, and the pacing driver applies due advancements), which
+CDC then streams back in through `orders-db`.
 
 ## The state machine is a *source*
 

--- a/examples/lib/orders-state-machine/db/init.sql
+++ b/examples/lib/orders-state-machine/db/init.sql
@@ -1,0 +1,171 @@
+-- Copyright 2025 The Drasi Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- ============================================================================
+-- Orders schema (relational, mirroring the state-machine example entities)
+-- ============================================================================
+-- An order progresses through six stages, each represented by real relational
+-- data — mirroring the original example's Order / Payment / StockPick / Shipment
+-- entities:
+--
+--   NEW        an order row with is_draft = 1
+--   CONFIRMED  the order row's is_draft flipped to 0
+--   PAID       a settled `payments` row      (was: (o:Order)-[:PAID_BY]->(p:Payment))
+--   PICKED     a `stock_picks` row           (was: (o:Order)-[:RESERVED]->(:StockPick))
+--   SHIPPED    a `shipments` row             (was: (o:Order)-[:DISPATCHED]->(:Shipment))
+--   DELIVERED  the shipment row's delivered flag is 1
+--
+-- The Drasi Postgres source maps each table to graph nodes labelled by the table
+-- name. Rather than join across nodes (which would require graph relationships),
+-- each stage query returns the owning `order_id`, and the state machine correlates
+-- the stages into a per-order lifecycle by that key. Advancement is therefore
+-- mostly INSERT-driven (settled payments, stock picks, shipments), which the
+-- source delivers as clean node additions.
+--
+-- NOTE: `is_draft` and `delivered` are modelled as SMALLINT flags (0/1) rather
+-- than BOOLEAN. The Postgres CDC source currently mis-decodes streamed BOOLEAN
+-- values (they always decode as true), so a boolean flag flip would not be
+-- observed on the change stream. Integers stream correctly. See the tracking
+-- issue linked from the example README.
+
+CREATE TABLE IF NOT EXISTS orders (
+    id            TEXT PRIMARY KEY,
+    customer      TEXT NOT NULL,
+    amount        DOUBLE PRECISION NOT NULL DEFAULT 0,
+    is_draft      SMALLINT NOT NULL DEFAULT 1,
+    next_stage_at TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+    id         TEXT PRIMARY KEY,
+    order_id   TEXT NOT NULL REFERENCES orders(id),
+    status     TEXT NOT NULL DEFAULT 'settled',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS stock_picks (
+    id         TEXT PRIMARY KEY,
+    order_id   TEXT NOT NULL REFERENCES orders(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS shipments (
+    id         TEXT PRIMARY KEY,
+    order_id   TEXT NOT NULL REFERENCES orders(id),
+    delivered  SMALLINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Logical replication needs full row images for UPDATEs (is_draft, delivered).
+ALTER TABLE orders      REPLICA IDENTITY FULL;
+ALTER TABLE payments    REPLICA IDENTITY FULL;
+ALTER TABLE stock_picks REPLICA IDENTITY FULL;
+ALTER TABLE shipments   REPLICA IDENTITY FULL;
+
+-- ============================================================================
+-- Advancement procedures
+-- ============================================================================
+
+-- Schedule an order to advance to its next stage after a short delay. Called by
+-- the stored-procedure reaction whenever an order enters a stage. No-op once the
+-- order has been delivered.
+CREATE OR REPLACE PROCEDURE schedule_advance(p_order_id TEXT)
+LANGUAGE sql AS $$
+    UPDATE orders o
+       SET next_stage_at = now() + INTERVAL '1 second'
+     WHERE o.id = p_order_id
+       AND o.next_stage_at IS NULL
+       AND NOT EXISTS (
+           SELECT 1 FROM shipments s WHERE s.order_id = o.id AND s.delivered = 1
+       );
+$$;
+
+-- Apply due advancements. For each order whose next_stage_at has elapsed, perform
+-- the single mutation that moves it to the next stage, then clear the schedule.
+-- Returns the number of orders advanced. Called by the example's pacing driver.
+-- Apply one due advancement per call. Advancing a single order per call (and
+-- touching its row at most once) keeps each CDC transaction to a single change,
+-- which the change stream and continuous queries handle reliably. The pacing
+-- driver calls this frequently (see the example's 1 Hz loop). Returns 1 if an
+-- order was advanced, else 0.
+CREATE OR REPLACE FUNCTION advance_due_orders()
+RETURNS INTEGER
+LANGUAGE plpgsql AS $$
+DECLARE
+    r       RECORD;
+    n_count INTEGER := 0;
+BEGIN
+    FOR r IN
+        SELECT * FROM orders
+         WHERE next_stage_at IS NOT NULL AND next_stage_at <= now()
+         ORDER BY next_stage_at
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+    LOOP
+        -- Each branch performs the single mutation for the next stage and clears
+        -- the schedule. The orders row is touched at most once per advancement so
+        -- the CDC stream carries one clean change per stage (no collapsed
+        -- double-updates).
+        IF r.is_draft = 1 THEN
+            -- NEW -> CONFIRMED
+            UPDATE orders SET is_draft = 0, next_stage_at = NULL WHERE id = r.id;
+        ELSIF NOT EXISTS (SELECT 1 FROM payments p WHERE p.order_id = r.id) THEN
+            -- CONFIRMED -> PAID
+            INSERT INTO payments (id, order_id, status)
+            VALUES (r.id || '-pay', r.id, 'settled');
+            UPDATE orders SET next_stage_at = NULL WHERE id = r.id;
+        ELSIF NOT EXISTS (SELECT 1 FROM stock_picks sp WHERE sp.order_id = r.id) THEN
+            -- PAID -> PICKED
+            INSERT INTO stock_picks (id, order_id) VALUES (r.id || '-pick', r.id);
+            UPDATE orders SET next_stage_at = NULL WHERE id = r.id;
+        ELSIF NOT EXISTS (SELECT 1 FROM shipments s WHERE s.order_id = r.id) THEN
+            -- PICKED -> SHIPPED
+            INSERT INTO shipments (id, order_id, delivered) VALUES (r.id || '-ship', r.id, 0);
+            UPDATE orders SET next_stage_at = NULL WHERE id = r.id;
+        ELSIF NOT EXISTS (
+            SELECT 1 FROM shipments s WHERE s.order_id = r.id AND s.delivered = 1
+        ) THEN
+            -- SHIPPED -> DELIVERED
+            UPDATE shipments SET delivered = 1 WHERE order_id = r.id;
+            UPDATE orders SET next_stage_at = NULL WHERE id = r.id;
+        ELSE
+            UPDATE orders SET next_stage_at = NULL WHERE id = r.id;
+        END IF;
+
+        n_count := n_count + 1;
+    END LOOP;
+    RETURN n_count;
+END;
+$$;
+
+-- Insert a new draft order (used by the example's seeder).
+CREATE OR REPLACE PROCEDURE new_order(p_order_id TEXT, p_customer TEXT, p_amount DOUBLE PRECISION)
+LANGUAGE sql AS $$
+    INSERT INTO orders (id, customer, amount, is_draft)
+    VALUES (p_order_id, p_customer, p_amount, 1)
+    ON CONFLICT (id) DO NOTHING;
+$$;
+
+-- ============================================================================
+-- Logical replication publication
+-- ============================================================================
+-- The Drasi Postgres source auto-creates its replication slot; do NOT pre-create
+-- the slot here (doing so replays seed rows on top of the bootstrap snapshot and
+-- doubles the data). The publication, however, must exist and cover every table.
+CREATE PUBLICATION drasi_pub FOR TABLE orders, payments, stock_picks, shipments;
+
+-- No seed data: the example's seeder inserts orders live so they animate through
+-- the full lifecycle. (Rows that exist before startup arrive via bootstrap, which
+-- reactions do not observe, so they would not advance.)

--- a/examples/lib/orders-state-machine/docker-compose.yml
+++ b/examples/lib/orders-state-machine/docker-compose.yml
@@ -29,7 +29,10 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: drasi
     ports:
-      - "5432:5432"
+      # Publish on a distinctive host port (5442) to avoid colliding with a local
+      # Postgres or another container already using the default 5432 on the host.
+      # The container still listens on 5432 internally; the app connects to 5442.
+      - "5442:5432"
     volumes:
       - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:

--- a/examples/lib/orders-state-machine/docker-compose.yml
+++ b/examples/lib/orders-state-machine/docker-compose.yml
@@ -1,0 +1,39 @@
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: orders-state-machine-db
+    command:
+      - "postgres"
+      - "-c"
+      - "wal_level=logical"
+      - "-c"
+      - "max_replication_slots=4"
+      - "-c"
+      - "max_wal_senders=4"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: drasi
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d drasi"]
+      interval: 2s
+      timeout: 3s
+      retries: 20

--- a/examples/lib/orders-state-machine/main.rs
+++ b/examples/lib/orders-state-machine/main.rs
@@ -66,8 +66,15 @@ use drasi_source_postgres::{PostgresReplicationSource, TableKeyConfig};
 use drasi_source_state_machine::{StateMachineSourceBuilder, StateMachineSourceConfig};
 use drasi_state_store_redb::RedbStateStoreProvider;
 
-const PG_HOST: &str = "localhost"; // DevSkim: ignore DS137138
-const PG_PORT: u16 = 5432;
+// Connect over IPv4 explicitly. On macOS `localhost` resolves to `::1` (IPv6)
+// first, but Docker publishes the container port on IPv4 (`0.0.0.0`), so
+// connecting to `localhost` could hit `::1` where nothing is listening.
+// `127.0.0.1` forces the IPv4 address Docker exposes.
+const PG_HOST: &str = "127.0.0.1"; // DevSkim: ignore DS137138
+                                   // Host port published by docker-compose (mapped to the container's 5432). Uses a
+                                   // distinctive port so it doesn't collide with a local Postgres or another
+                                   // container already bound to 5432 on the host.
+const PG_PORT: u16 = 5442;
 const PG_DB: &str = "drasi";
 const PG_USER: &str = "postgres";
 const PG_PASSWORD: &str = "postgres";
@@ -316,7 +323,7 @@ async fn main() -> Result<()> {
     println!("│ Orders State Machine started!                 │");
     println!("├──────────────────────────────────────────────┤");
     println!("│ 🌐 Dashboard:  http://localhost:3000          │");
-    println!("│ 🗄  Postgres:   localhost:5432 (db: drasi)     │");
+    println!("│ 🗄  Postgres:   127.0.0.1:5442 (db: drasi)     │");
     println!("│ Orders advance one stage roughly every 1 s.   │");
     println!("│ A new order is seeded every 8 s.              │");
     println!("├──────────────────────────────────────────────┤");

--- a/examples/lib/orders-state-machine/main.rs
+++ b/examples/lib/orders-state-machine/main.rs
@@ -1,0 +1,460 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Orders State Machine Example
+//!
+//! A self-driving order-lifecycle demo that ties together four Drasi components:
+//!
+//! ```text
+//! Postgres (orders, payments,   ──▶ orders-db source ──▶ 6 stage queries ──┬──▶ state machine source ──▶ dashboard queries ──▶ dashboard
+//!           stock_picks, shipments)                                         └──▶ stored-proc reaction ──▶ CALL schedule_advance(...)
+//!        ▲                                                                                    │
+//!        └───────────────────── pacing driver: SELECT advance_due_orders() ◀──────────────────┘
+//! ```
+//!
+//! Each order flows NEW → CONFIRMED → PAID → PICKED → SHIPPED → DELIVERED. The
+//! stages mirror the classic Order / Payment / StockPick / Shipment entities:
+//!
+//! | Stage     | Relational fact                          | Stage query returns |
+//! |-----------|------------------------------------------|---------------------|
+//! | NEW       | `orders` row with `is_draft = 1`         | `o.id`              |
+//! | CONFIRMED | `orders` row with `is_draft = 0`         | `o.id`              |
+//! | PAID      | settled `payments` row                   | `p.order_id`        |
+//! | PICKED    | `stock_picks` row                        | `s.order_id`        |
+//! | SHIPPED   | `shipments` row                          | `h.order_id`        |
+//! | DELIVERED | `shipments` row with `delivered = 1`     | `h.order_id`        |
+//!
+//! Each stage query is a simple single-entity query returning the owning order id;
+//! the **state machine source** subscribes to those queries and correlates them
+//! into a per-order lifecycle by that key, exposing each order's live state as its
+//! own source that the dashboard queries read. The stored-procedure reaction
+//! schedules the next stage whenever an order enters a stage, and a pacing driver
+//! applies due advancements on a timer so the dashboard shows a visible
+//! progression.
+//!
+//! ## Running
+//!
+//! ```bash
+//! docker compose up -d        # start Postgres with logical replication
+//! cargo run                   # start Drasi + the dashboard on :3000
+//! ```
+//!
+//! Then open <http://localhost:3000> (use <http://127.0.0.1:3000> if your browser
+//! resolves `localhost` to IPv6).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use drasi_lib::{DrasiLib, Query};
+use drasi_reaction_dashboard::{
+    DashboardConfig, DashboardReaction, DashboardWidget, GridOptions, WidgetGrid,
+};
+use drasi_reaction_storedproc_postgres::{PostgresStoredProcReaction, QueryConfig, TemplateSpec};
+use drasi_source_postgres::{PostgresReplicationSource, TableKeyConfig};
+use drasi_source_state_machine::{StateMachineSourceBuilder, StateMachineSourceConfig};
+use drasi_state_store_redb::RedbStateStoreProvider;
+
+const PG_HOST: &str = "localhost"; // DevSkim: ignore DS137138
+const PG_PORT: u16 = 5432;
+const PG_DB: &str = "drasi";
+const PG_USER: &str = "postgres";
+const PG_PASSWORD: &str = "postgres";
+
+const SOURCE_ID: &str = "orders-db";
+const STATE_SOURCE_ID: &str = "order-state-source";
+
+/// Tables the source ingests (each becomes a node label = the table name).
+const TABLES: &[&str] = &["orders", "payments", "stock_picks", "shipments"];
+
+/// The state machine, written exactly as it would appear in YAML configuration.
+///
+/// Each state lists the query whose results cause an order to enter it, the
+/// allowed `previous` states, the Handlebars `key` that extracts the order id
+/// from the result row, and the result `ops` that trigger the transition
+/// (insert-driven stages use `added`; the is_draft / delivered flag flips also
+/// use `updated`).
+///
+/// Note there is no `sourceId`: the state machine is a single **source**, and its
+/// own id (`STATE_SOURCE_ID`, set on the builder below) is what the dashboard
+/// queries subscribe to.
+const ORDER_STATE_MACHINE: &str = r#"
+entityLabel: OrderState
+keyField: orderId
+states:
+  - id: NEW
+    enter:
+      - query: draft-orders
+        previous: []
+        key: "{{orderId}}"
+        ops: [added]
+  - id: CONFIRMED
+    enter:
+      - query: confirmed-orders
+        previous: [NEW]
+        key: "{{orderId}}"
+        ops: [added, updated]
+  - id: PAID
+    enter:
+      - query: paid-orders
+        previous: [CONFIRMED]
+        key: "{{orderId}}"
+        ops: [added]
+  - id: PICKED
+    enter:
+      - query: picked-orders
+        previous: [PAID]
+        key: "{{orderId}}"
+        ops: [added]
+  - id: SHIPPED
+    enter:
+      - query: shipped-orders
+        previous: [PICKED]
+        key: "{{orderId}}"
+        ops: [added]
+  - id: DELIVERED
+    enter:
+      - query: delivered-orders
+        previous: [SHIPPED]
+        key: "{{orderId}}"
+        ops: [added, updated]
+"#;
+
+/// The six stage queries. Each is a single-entity query returning the owning
+/// order id as `orderId`; `draft-orders` also carries `customer`/`amount`, which
+/// the state machine retains across stages.
+fn stage_queries() -> Vec<drasi_lib::config::QueryConfig> {
+    let q = |id: &str, cypher: &str| {
+        Query::cypher(id)
+            .query(cypher)
+            .from_source(SOURCE_ID)
+            .auto_start(true)
+            .build()
+    };
+    vec![
+        q(
+            "draft-orders",
+            "MATCH (o:orders) WHERE o.is_draft = 1 \
+             RETURN o.id AS orderId, o.customer AS customer, o.amount AS amount",
+        ),
+        q(
+            "confirmed-orders",
+            "MATCH (o:orders) WHERE o.is_draft = 0 RETURN o.id AS orderId",
+        ),
+        q(
+            "paid-orders",
+            "MATCH (p:payments) WHERE p.status = 'settled' RETURN p.order_id AS orderId",
+        ),
+        q(
+            "picked-orders",
+            "MATCH (s:stock_picks) RETURN s.order_id AS orderId",
+        ),
+        q(
+            "shipped-orders",
+            "MATCH (h:shipments) RETURN h.order_id AS orderId",
+        ),
+        q(
+            "delivered-orders",
+            "MATCH (h:shipments) WHERE h.delivered = 1 RETURN h.order_id AS orderId",
+        ),
+    ]
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    println!("╔══════════════════════════════════════════════╗");
+    println!("║   Drasi Orders State Machine Example          ║");
+    println!("╚══════════════════════════════════════════════╝\n");
+
+    let tables: Vec<String> = TABLES.iter().map(|t| t.to_string()).collect();
+    let table_keys: Vec<TableKeyConfig> = TABLES
+        .iter()
+        .map(|t| TableKeyConfig {
+            table: t.to_string(),
+            key_columns: vec!["id".to_string()],
+        })
+        .collect();
+
+    // -------------------------------------------------------------------------
+    // 1. Postgres source (CDC) + Postgres bootstrap provider
+    // -------------------------------------------------------------------------
+    let mut bootstrap_builder = drasi_bootstrap_postgres::PostgresBootstrapProvider::builder()
+        .with_host(PG_HOST)
+        .with_port(PG_PORT)
+        .with_database(PG_DB)
+        .with_user(PG_USER)
+        .with_password(PG_PASSWORD)
+        .with_tables(tables.clone())
+        .with_publication_name("drasi_pub");
+    for t in TABLES {
+        bootstrap_builder = bootstrap_builder.with_table_key(*t, vec!["id".to_string()]);
+    }
+    let bootstrap = bootstrap_builder.build();
+
+    let source = PostgresReplicationSource::builder(SOURCE_ID)
+        .with_host(PG_HOST)
+        .with_port(PG_PORT)
+        .with_database(PG_DB)
+        .with_user(PG_USER)
+        .with_password(PG_PASSWORD)
+        .with_tables(tables.clone())
+        .with_table_keys(table_keys)
+        .with_publication_name("drasi_pub")
+        .with_bootstrap_provider(bootstrap)
+        .build()?;
+
+    // -------------------------------------------------------------------------
+    // 2. The six stage queries
+    // -------------------------------------------------------------------------
+    let stage_queries = stage_queries();
+
+    // -------------------------------------------------------------------------
+    // 3. State machine source (order-state-source), configured declaratively
+    //    from the YAML above. It subscribes to the six stage queries and exposes
+    //    each order's live state as a source under STATE_SOURCE_ID.
+    // -------------------------------------------------------------------------
+    let order_state_machine: StateMachineSourceConfig =
+        serde_yaml::from_str(ORDER_STATE_MACHINE).expect("valid state machine config");
+    let sm_source = StateMachineSourceBuilder::new(STATE_SOURCE_ID)
+        .with_config(order_state_machine)
+        .build()?;
+
+    // -------------------------------------------------------------------------
+    // 4. Stored-procedure reaction: drives orders forward. When an order enters a
+    //    stage, schedule its next advancement.
+    // -------------------------------------------------------------------------
+    let driver = PostgresStoredProcReaction::builder("order-advancer")
+        .with_connection(PG_HOST, PG_PORT, PG_DB, PG_USER, PG_PASSWORD)
+        .with_default_template(QueryConfig {
+            added: Some(TemplateSpec::new("CALL schedule_advance(@after.orderId)")),
+            updated: Some(TemplateSpec::new("CALL schedule_advance(@after.orderId)")),
+            deleted: None,
+        })
+        .with_query("draft-orders")
+        .with_query("confirmed-orders")
+        .with_query("paid-orders")
+        .with_query("picked-orders")
+        .with_query("shipped-orders")
+        .with_query("delivered-orders")
+        .build()
+        .await?;
+
+    // -------------------------------------------------------------------------
+    // 5. Dashboard queries over the state source + dashboard reaction
+    // -------------------------------------------------------------------------
+    let all_states_query = Query::cypher("order-states-all")
+        .query(
+            "MATCH (o:OrderState) \
+             RETURN o.orderId AS orderId, o.customer AS customer, \
+                    o.state AS state, o.previousState AS previousState",
+        )
+        .from_source(STATE_SOURCE_ID)
+        .auto_start(true)
+        .build();
+
+    let delivered_query = Query::cypher("delivered-states")
+        .query("MATCH (o:OrderState) WHERE o.state = 'DELIVERED' RETURN o.orderId AS orderId")
+        .from_source(STATE_SOURCE_ID)
+        .auto_start(true)
+        .build();
+
+    let dashboard_reaction = DashboardReaction::builder("orders-dashboard")
+        .with_query("order-states-all")
+        .with_query("delivered-states")
+        // Bind all IPv4 interfaces. On WSL2 this is reachable from Windows both
+        // via the WSL2 localhost relay (http://localhost:3000) and directly via
+        // the WSL2 IP (http://<wsl-ip>:3000).
+        .with_host("0.0.0.0")
+        .with_port(3000)
+        .with_dashboard(orders_dashboard())
+        .build()?;
+
+    // -------------------------------------------------------------------------
+    // 6. Durable state store (required by the state machine source)
+    // -------------------------------------------------------------------------
+    std::fs::create_dir_all("./data")?;
+    let state_store = Arc::new(RedbStateStoreProvider::new("./data/state.redb")?);
+
+    // -------------------------------------------------------------------------
+    // 7. Assemble and start DrasiLib
+    // -------------------------------------------------------------------------
+    let mut builder = DrasiLib::builder()
+        .with_id("orders-state-machine")
+        .with_state_store_provider(state_store)
+        .with_source(source)
+        .with_source(sm_source)
+        .with_query(all_states_query)
+        .with_query(delivered_query)
+        .with_reaction(driver)
+        .with_reaction(dashboard_reaction);
+    for q in stage_queries {
+        builder = builder.with_query(q);
+    }
+    let core = Arc::new(builder.build().await?);
+    core.start().await?;
+
+    // -------------------------------------------------------------------------
+    // 8. Background tasks: pacing driver and order seeder
+    // -------------------------------------------------------------------------
+    let pacing = tokio::spawn(pacing_driver());
+    let seeder = tokio::spawn(order_seeder());
+
+    println!("\n┌──────────────────────────────────────────────┐");
+    println!("│ Orders State Machine started!                 │");
+    println!("├──────────────────────────────────────────────┤");
+    println!("│ 🌐 Dashboard:  http://localhost:3000          │");
+    println!("│ 🗄  Postgres:   localhost:5432 (db: drasi)     │");
+    println!("│ Orders advance one stage roughly every 1 s.   │");
+    println!("│ A new order is seeded every 8 s.              │");
+    println!("├──────────────────────────────────────────────┤");
+    println!("│ Press Ctrl+C to stop                          │");
+    println!("└──────────────────────────────────────────────┘\n");
+
+    tokio::signal::ctrl_c().await?;
+    println!("\n>>> Shutting down...");
+    pacing.abort();
+    seeder.abort();
+    core.stop().await?;
+    println!(">>> Shutdown complete.");
+    Ok(())
+}
+
+/// Connect to Postgres for the helper tasks below.
+async fn connect() -> Result<tokio_postgres::Client> {
+    let conn_str = format!(
+        "host={PG_HOST} port={PG_PORT} dbname={PG_DB} user={PG_USER} password={PG_PASSWORD}"
+    );
+    let (client, connection) = tokio_postgres::connect(&conn_str, tokio_postgres::NoTls).await?;
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            log::warn!("postgres helper connection error: {e}");
+        }
+    });
+    Ok(client)
+}
+
+/// Apply due stage advancements twice a second so orders progress visibly.
+async fn pacing_driver() {
+    let client = match connect().await {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("pacing driver could not connect to Postgres: {e}");
+            return;
+        }
+    };
+    let mut interval = tokio::time::interval(Duration::from_millis(500));
+    loop {
+        interval.tick().await;
+        if let Err(e) = client.execute("SELECT advance_due_orders()", &[]).await {
+            log::warn!("advance_due_orders failed: {e}");
+        }
+    }
+}
+
+/// Seed a new draft order every few seconds to keep the pipeline flowing.
+async fn order_seeder() {
+    let client = match connect().await {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("seeder could not connect to Postgres: {e}");
+            return;
+        }
+    };
+    let customers = [
+        "Acme Corp",
+        "Globex",
+        "Initech",
+        "Umbrella",
+        "Hooli",
+        "Stark Ind",
+    ];
+    let mut n = 1u64;
+    let mut interval = tokio::time::interval(Duration::from_secs(8));
+    loop {
+        interval.tick().await;
+        let id = format!("order-{n}");
+        let customer = customers[(n as usize) % customers.len()];
+        let amount = ((n * 37) % 500) as f64 + 25.0;
+        match client
+            .execute("CALL new_order($1, $2, $3)", &[&id, &customer, &amount])
+            .await
+        {
+            Ok(_) => log::info!("seeded new draft {id} for {customer}"),
+            Err(e) => log::warn!("seeding order {id} failed: {e}"),
+        }
+        n += 1;
+    }
+}
+
+/// Build the predefined dashboard: a table of order states plus KPIs.
+fn orders_dashboard() -> DashboardConfig {
+    DashboardConfig::with_id(
+        "orders-monitor",
+        "Order Lifecycle".to_string(),
+        GridOptions::default(),
+        vec![
+            DashboardWidget {
+                id: "w-table-states".to_string(),
+                widget_type: "table".to_string(),
+                title: "Order States".to_string(),
+                grid: WidgetGrid {
+                    x: 0,
+                    y: 0,
+                    w: 8,
+                    h: 6,
+                },
+                config: serde_json::json!({
+                    "queryId": "order-states-all",
+                    "columns": ["orderId", "customer", "state", "previousState"]
+                }),
+            },
+            DashboardWidget {
+                id: "w-kpi-total".to_string(),
+                widget_type: "kpi".to_string(),
+                title: "Total Orders".to_string(),
+                grid: WidgetGrid {
+                    x: 8,
+                    y: 0,
+                    w: 4,
+                    h: 3,
+                },
+                config: serde_json::json!({
+                    "queryId": "order-states-all",
+                    "valueField": "orderId",
+                    "aggregation": "count",
+                    "label": "Tracked Orders"
+                }),
+            },
+            DashboardWidget {
+                id: "w-kpi-delivered".to_string(),
+                widget_type: "kpi".to_string(),
+                title: "Delivered".to_string(),
+                grid: WidgetGrid {
+                    x: 8,
+                    y: 3,
+                    w: 4,
+                    h: 3,
+                },
+                config: serde_json::json!({
+                    "queryId": "delivered-states",
+                    "valueField": "orderId",
+                    "aggregation": "count",
+                    "label": "Delivered Orders"
+                }),
+            },
+        ],
+    )
+}

--- a/examples/lib/orders-state-machine/main.rs
+++ b/examples/lib/orders-state-machine/main.rs
@@ -47,10 +47,10 @@
 //!
 //! ```bash
 //! docker compose up -d        # start Postgres with logical replication
-//! cargo run                   # start Drasi + the dashboard on :3000
+//! cargo run                   # start Drasi + the dashboard on :3002
 //! ```
 //!
-//! Then open <http://localhost:3000> (use <http://127.0.0.1:3000> if your browser
+//! Then open <http://localhost:3002> (use <http://127.0.0.1:3002> if your browser
 //! resolves `localhost` to IPv6).
 
 use std::sync::Arc;
@@ -282,10 +282,10 @@ async fn main() -> Result<()> {
         .with_query("order-states-all")
         .with_query("delivered-states")
         // Bind all IPv4 interfaces. On WSL2 this is reachable from Windows both
-        // via the WSL2 localhost relay (http://localhost:3000) and directly via
-        // the WSL2 IP (http://<wsl-ip>:3000).
+        // via the WSL2 localhost relay (http://localhost:3002) and directly via
+        // the WSL2 IP (http://<wsl-ip>:3002).
         .with_host("0.0.0.0")
-        .with_port(3000)
+        .with_port(3002)
         .with_dashboard(orders_dashboard())
         .build()?;
 
@@ -322,7 +322,7 @@ async fn main() -> Result<()> {
     println!("\n┌──────────────────────────────────────────────┐");
     println!("│ Orders State Machine started!                 │");
     println!("├──────────────────────────────────────────────┤");
-    println!("│ 🌐 Dashboard:  http://localhost:3000          │");
+    println!("│ 🌐 Dashboard:  http://localhost:3002          │");
     println!("│ 🗄  Postgres:   127.0.0.1:5442 (db: drasi)     │");
     println!("│ Orders advance one stage roughly every 1 s.   │");
     println!("│ A new order is seeded every 8 s.              │");

--- a/examples/lib/orders-state-machine/run.sh
+++ b/examples/lib/orders-state-machine/run.sh
@@ -45,7 +45,7 @@ if [ "$reachable" != "1" ]; then
 fi
 
 echo ""
-echo "Starting Drasi + dashboard (http://localhost:3000)..."
+echo "Starting Drasi + dashboard (http://localhost:3002)..."
 echo "Press Ctrl+C to stop the app; run 'docker compose down -v' to remove the database."
 echo ""
 

--- a/examples/lib/orders-state-machine/run.sh
+++ b/examples/lib/orders-state-machine/run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2025 The Drasi Authors.
+#
+# Run the Drasi Orders State Machine example.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Starting Postgres (logical replication enabled)..."
+docker compose up -d
+
+echo "Waiting for Postgres to become healthy..."
+for i in $(seq 1 30); do
+    status="$(docker inspect -f '{{.State.Health.Status}}' orders-state-machine-db 2>/dev/null || echo starting)"
+    if [ "$status" = "healthy" ]; then
+        echo "Postgres is ready."
+        break
+    fi
+    sleep 1
+done
+
+echo ""
+echo "Starting Drasi + dashboard (http://localhost:3000)..."
+echo "Press Ctrl+C to stop the app; run 'docker compose down -v' to remove the database."
+echo ""
+
+cargo run

--- a/examples/lib/orders-state-machine/run.sh
+++ b/examples/lib/orders-state-machine/run.sh
@@ -14,11 +14,35 @@ echo "Waiting for Postgres to become healthy..."
 for i in $(seq 1 30); do
     status="$(docker inspect -f '{{.State.Health.Status}}' orders-state-machine-db 2>/dev/null || echo starting)"
     if [ "$status" = "healthy" ]; then
-        echo "Postgres is ready."
+        echo "Postgres container is healthy."
         break
     fi
     sleep 1
 done
+
+# The container healthcheck only proves Postgres is up *inside* the container. The
+# app connects from the host, so verify the published host port (5442) is actually
+# reachable. If it is not, the port was likely not published (e.g. something else
+# is already bound to it) and the app would fail with "connection refused".
+HOST_PORT=5442
+echo "Verifying Postgres is reachable on 127.0.0.1:${HOST_PORT}..."
+reachable=0
+for i in $(seq 1 20); do
+    if (exec 3<>/dev/tcp/127.0.0.1/${HOST_PORT}) 2>/dev/null; then
+        exec 3>&- 3<&-
+        reachable=1
+        echo "Postgres is reachable on 127.0.0.1:${HOST_PORT}."
+        break
+    fi
+    sleep 1
+done
+if [ "$reachable" != "1" ]; then
+    echo "ERROR: Postgres is not reachable on 127.0.0.1:${HOST_PORT}." >&2
+    echo "       The container is running but its port is not published to the host." >&2
+    echo "       Another process/container may already be using host port ${HOST_PORT}." >&2
+    echo "       Check with: docker ps  |  lsof -nP -iTCP:${HOST_PORT}" >&2
+    exit 1
+fi
 
 echo ""
 echo "Starting Drasi + dashboard (http://localhost:3000)..."

--- a/lib/src/consumption/adapters.rs
+++ b/lib/src/consumption/adapters.rs
@@ -1,0 +1,75 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::channels::QueryResult;
+use crate::reactions::Reaction;
+use crate::recovery::ReactionRecoveryPolicy;
+use crate::sources::Source;
+
+use super::{CatchupContext, QueryConsumer};
+
+pub struct ReactionConsumer(pub Arc<dyn Reaction>);
+
+#[async_trait]
+impl QueryConsumer for ReactionConsumer {
+    fn consumer_id(&self) -> &str {
+        self.0.id()
+    }
+
+    fn consumed_query_ids(&self) -> Vec<String> {
+        self.0.query_ids()
+    }
+
+    async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+        self.0.enqueue_query_result(result).await
+    }
+
+    fn is_durable(&self) -> bool {
+        self.0.is_durable()
+    }
+
+    fn needs_snapshot_on_fresh_start(&self) -> bool {
+        self.0.needs_snapshot_on_fresh_start()
+    }
+
+    fn default_recovery_policy(&self) -> ReactionRecoveryPolicy {
+        self.0.default_recovery_policy()
+    }
+
+    async fn catch_up(&self, ctx: CatchupContext) -> Result<()> {
+        self.0.bootstrap(ctx).await
+    }
+}
+
+pub struct SourceConsumer(pub Arc<dyn Source>);
+
+#[async_trait]
+impl QueryConsumer for SourceConsumer {
+    fn consumer_id(&self) -> &str {
+        self.0.id()
+    }
+
+    fn consumed_query_ids(&self) -> Vec<String> {
+        self.0.subscribed_query_ids()
+    }
+
+    async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+        self.0.enqueue_query_result(result).await
+    }
+}

--- a/lib/src/consumption/engine.rs
+++ b/lib/src/consumption/engine.rs
@@ -1,0 +1,989 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use log::{info, warn};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::Instrument;
+
+use crate::channels::*;
+use crate::component_graph::ComponentGraph;
+use crate::metrics::{LifecycleMetrics, ReactionMetrics, RecoveryPolicyKind};
+use crate::queries::output_state::FetchError;
+use crate::queries::Query;
+use crate::reactions::bootstrap_context::BootstrapContext;
+use crate::reactions::checkpoint::ReactionCheckpoint;
+use crate::reactions::QueryProvider;
+use crate::recovery::ReactionRecoveryPolicy;
+use crate::state_store::StateStoreProvider;
+
+use super::QueryConsumer;
+
+/// Key for per-consumer per-query metrics: `(consumer_id, query_id)`.
+pub type MetricsKey = (String, String);
+
+/// Convert a domain recovery policy to the metrics-level kind enum.
+fn to_policy_kind(policy: &ReactionRecoveryPolicy) -> RecoveryPolicyKind {
+    match policy {
+        ReactionRecoveryPolicy::Strict => RecoveryPolicyKind::Strict,
+        ReactionRecoveryPolicy::AutoReset => RecoveryPolicyKind::AutoReset,
+        ReactionRecoveryPolicy::AutoSkipGap => RecoveryPolicyKind::AutoSkipGap,
+    }
+}
+
+/// Context passed to `handle_broadcast_gap` to avoid excessive parameter counts.
+///
+/// Groups the shared forwarder-task state that the recovery function needs.
+pub(crate) struct BroadcastGapContext<'a> {
+    pub(crate) reaction_id: &'a str,
+    pub(crate) query_id: &'a str,
+    pub(crate) consumer: &'a Arc<dyn QueryConsumer>,
+    pub(crate) query: &'a Arc<dyn Query>,
+    pub(crate) policy: ReactionRecoveryPolicy,
+    pub(crate) state_store: &'a Option<Arc<dyn StateStoreProvider>>,
+    pub(crate) checkpoints: &'a Arc<RwLock<HashMap<String, ReactionCheckpoint>>>,
+    pub(crate) bootstrap_mutex: &'a Arc<tokio::sync::Mutex<()>>,
+    pub(crate) metrics: &'a Arc<ReactionMetrics>,
+}
+
+#[derive(Clone)]
+pub struct ConsumptionEngine {
+    instance_id: String,
+    query_provider: Arc<RwLock<Option<Arc<dyn QueryProvider>>>>,
+    state_store: Arc<RwLock<Option<Arc<dyn StateStoreProvider>>>>,
+    subscription_tasks: Arc<RwLock<HashMap<String, Vec<tokio::task::AbortHandle>>>>,
+    graph: Arc<RwLock<ComponentGraph>>,
+    metrics: Arc<RwLock<HashMap<MetricsKey, Arc<ReactionMetrics>>>>,
+    lifecycle_metrics: Arc<LifecycleMetrics>,
+}
+
+impl ConsumptionEngine {
+    pub fn new(
+        instance_id: impl Into<String>,
+        graph: Arc<RwLock<ComponentGraph>>,
+        query_provider: Arc<RwLock<Option<Arc<dyn QueryProvider>>>>,
+        state_store: Arc<RwLock<Option<Arc<dyn StateStoreProvider>>>>,
+        subscription_tasks: Arc<RwLock<HashMap<String, Vec<tokio::task::AbortHandle>>>>,
+        metrics: Arc<RwLock<HashMap<MetricsKey, Arc<ReactionMetrics>>>>,
+        lifecycle_metrics: Arc<LifecycleMetrics>,
+    ) -> Self {
+        Self {
+            instance_id: instance_id.into(),
+            query_provider,
+            state_store,
+            subscription_tasks,
+            graph,
+            metrics,
+            lifecycle_metrics,
+        }
+    }
+
+    pub fn metrics(&self) -> &Arc<RwLock<HashMap<MetricsKey, Arc<ReactionMetrics>>>> {
+        &self.metrics
+    }
+
+    pub fn lifecycle_metrics(&self) -> &Arc<LifecycleMetrics> {
+        &self.lifecycle_metrics
+    }
+
+    pub fn subscription_tasks(
+        &self,
+    ) -> &Arc<RwLock<HashMap<String, Vec<tokio::task::AbortHandle>>>> {
+        &self.subscription_tasks
+    }
+
+    pub async fn inject_query_provider(&self, qp: Arc<dyn QueryProvider>) {
+        *self.query_provider.write().await = Some(qp);
+    }
+
+    pub async fn inject_state_store(&self, state_store: Arc<dyn StateStoreProvider>) {
+        *self.state_store.write().await = Some(state_store);
+    }
+
+    /// Wire live subscriptions, then perform per-query bootstrap.
+    ///
+    /// 1. Wire subscriptions first (forwarders wait on gate, events buffer in broadcast channel)
+    /// 2. Read checkpoints from state store
+    /// 3. For each query, run the per-query startup flowchart (§5)
+    /// 4. Invoke `consumer.catch_up()` if any query needed a full reset
+    ///
+    /// The bootstrap gate is NOT opened here — the caller opens it after this returns.
+    pub async fn subscribe_and_bootstrap(
+        &self,
+        reaction_id: &str,
+        consumer: Arc<dyn QueryConsumer>,
+        gate: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<()> {
+        let query_ids = consumer.consumed_query_ids();
+        if query_ids.is_empty() {
+            return Ok(());
+        }
+
+        // Clone the query provider Arc and release the RwLock guard immediately.
+        let query_provider = self.query_provider.read().await.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "QueryProvider not injected - was ReactionManager initialized properly?"
+            )
+        })?;
+
+        let state_store = self.state_store.read().await.clone();
+        let policy = consumer.default_recovery_policy();
+
+        // Shared checkpoint map — populated during bootstrap, read by forwarders after gate opens.
+        let shared_checkpoints: Arc<RwLock<HashMap<String, ReactionCheckpoint>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+
+        // 1. Wire subscriptions FIRST so events buffer in broadcast channels
+        //    while bootstrap runs. Forwarders wait on gate before processing.
+        self.wire_subscriptions(
+            reaction_id,
+            &consumer,
+            &query_provider,
+            &query_ids,
+            shared_checkpoints.clone(),
+            gate,
+        )
+        .await?;
+
+        // 2. Read existing checkpoints from the state store (batch).
+        let existing_checkpoints = match state_store.as_ref() {
+            Some(store) => {
+                crate::reactions::checkpoint::read_checkpoints_batch(
+                    store.as_ref(),
+                    reaction_id,
+                    &query_ids,
+                )
+                .await?
+            }
+            None => HashMap::new(),
+        };
+
+        // 3. Per-query bootstrap: build the initial checkpoint map and collect
+        //    any queries that need a full bootstrap hook call.
+        let mut initial_checkpoints: HashMap<String, ReactionCheckpoint> = HashMap::new();
+        let mut bootstrap_queries: Vec<(String, Arc<dyn Query>)> = Vec::new();
+
+        for query_id in &query_ids {
+            let query = query_provider.get_query_instance(query_id).await?;
+
+            // Pre-create the metrics entry for this (reaction, query) pair so all
+            // bootstrap methods can instrument without acquiring the write lock.
+            let metrics_key = (reaction_id.to_string(), query_id.clone());
+            let per_query_metrics = {
+                let mut metrics_map = self.metrics.write().await;
+                metrics_map
+                    .entry(metrics_key)
+                    .or_insert_with(|| Arc::new(ReactionMetrics::new()))
+                    .clone()
+            };
+
+            match existing_checkpoints.get(query_id) {
+                None => {
+                    // No checkpoint — fresh start for this query.
+                    let cp = self
+                        .handle_fresh_start(
+                            reaction_id,
+                            query_id,
+                            &consumer,
+                            &query,
+                            &state_store,
+                            &mut bootstrap_queries,
+                            &per_query_metrics,
+                        )
+                        .await?;
+                    initial_checkpoints.insert(query_id.clone(), cp);
+                }
+                Some(cp) => {
+                    // Checkpoint exists — check config hash.
+                    let current_config_hash =
+                        crate::queries::compute_config_hash(query.get_config());
+                    if cp.config_hash != current_config_hash {
+                        // Hash mismatch → treat as gap → apply recovery policy.
+                        self.lifecycle_metrics.record_hash_mismatch();
+                        info!(
+                            "[{reaction_id}] Config hash mismatch for query '{query_id}': \
+                             checkpoint={}, current={}",
+                            cp.config_hash, current_config_hash
+                        );
+                        let new_cp = self
+                            .apply_recovery_policy(
+                                reaction_id,
+                                query_id,
+                                &consumer,
+                                &query,
+                                policy,
+                                &state_store,
+                                &mut bootstrap_queries,
+                                &per_query_metrics,
+                            )
+                            .await?;
+                        initial_checkpoints.insert(query_id.clone(), new_cp);
+                    } else {
+                        // Hash matches — try to catch up via outbox.
+                        let new_cp = self
+                            .handle_outbox_catchup(
+                                reaction_id,
+                                query_id,
+                                cp,
+                                &consumer,
+                                &query,
+                                policy,
+                                &state_store,
+                                &mut bootstrap_queries,
+                                &per_query_metrics,
+                            )
+                            .await?;
+                        initial_checkpoints.insert(query_id.clone(), new_cp);
+                    }
+                }
+            }
+        }
+
+        // 4. Invoke the bootstrap hook if any queries triggered a reset.
+        if !bootstrap_queries.is_empty() {
+            for (query_id, query) in &bootstrap_queries {
+                let is_reset = existing_checkpoints.contains_key(query_id);
+                let ctx = BootstrapContext::new(
+                    query_id.clone(),
+                    is_reset,
+                    query.clone(),
+                    reaction_id.to_string(),
+                    state_store.clone(),
+                );
+                consumer.catch_up(ctx).await?;
+            }
+        }
+
+        // 5. Persist checkpoints AFTER bootstrap succeeds — a crash before this
+        //    point will re-trigger bootstrap on next start (safe).
+        if let Some(store) = state_store.as_ref() {
+            for (query_id, cp) in &initial_checkpoints {
+                if let Err(e) = crate::reactions::checkpoint::write_checkpoint(
+                    store.as_ref(),
+                    reaction_id,
+                    query_id,
+                    cp,
+                )
+                .await
+                {
+                    log::warn!(
+                        "[{reaction_id}] Failed to persist checkpoint for query '{query_id}' \
+                         at seq={}: {e}",
+                        cp.sequence
+                    );
+                }
+            }
+        }
+
+        // Publish the computed checkpoints so forwarders can filter stale events.
+        *shared_checkpoints.write().await = initial_checkpoints;
+
+        Ok(())
+    }
+
+    /// Handle a fresh start for a query subscription (no existing checkpoint).
+    ///
+    /// If `needs_snapshot_on_fresh_start`, fetches snapshot and sets checkpoint.
+    /// Otherwise, fetches outbox(0) to get the current sequence.
+    async fn handle_fresh_start(
+        &self,
+        reaction_id: &str,
+        query_id: &str,
+        consumer: &Arc<dyn QueryConsumer>,
+        query: &Arc<dyn Query>,
+        state_store: &Option<Arc<dyn StateStoreProvider>>,
+        bootstrap_queries: &mut Vec<(String, Arc<dyn Query>)>,
+        metrics: &Arc<ReactionMetrics>,
+    ) -> Result<ReactionCheckpoint> {
+        let config_hash = crate::queries::compute_config_hash(query.get_config());
+
+        if consumer.needs_snapshot_on_fresh_start() {
+            info!("[{reaction_id}] Fresh start for query '{query_id}' — fetching snapshot");
+            metrics.record_fetch_snapshot();
+            let snapshot = query.fetch_snapshot().await.map_err(|e| {
+                anyhow::anyhow!("Failed to fetch snapshot for query '{query_id}': {e}")
+            })?;
+
+            let cp = ReactionCheckpoint {
+                sequence: snapshot.as_of_sequence,
+                config_hash,
+            };
+
+            bootstrap_queries.push((query_id.to_string(), query.clone()));
+            Ok(cp)
+        } else {
+            // No snapshot needed — replay any outbox entries produced during this
+            // startup cycle (e.g., from source replay) and record the checkpoint.
+            // Without this replay, results produced before the reaction subscribes
+            // to the broadcast channel would be silently skipped.
+            metrics.record_fetch_outbox();
+            let seq = match query.fetch_outbox(0).await {
+                Ok(resp) => {
+                    if resp.results.is_empty() {
+                        info!(
+                            "[{reaction_id}] Fresh start for query '{query_id}' — fetch_outbox(0) returned latest_seq={}",
+                            resp.latest_sequence
+                        );
+                    } else {
+                        info!(
+                            "[{reaction_id}] Fresh start for query '{query_id}' — replaying {} outbox entries (latest_seq={})",
+                            resp.results.len(),
+                            resp.latest_sequence
+                        );
+                        let mut last_ok_seq = 0u64;
+                        for entry in &resp.results {
+                            let result = (*entry).as_ref().clone();
+                            match consumer.enqueue_query_result(result).await {
+                                Ok(()) => last_ok_seq = entry.sequence,
+                                Err(e) => {
+                                    warn!(
+                                        "[{reaction_id}] Failed to replay outbox entry for query \
+                                         '{query_id}' seq={}: {e}",
+                                        entry.sequence
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                        if last_ok_seq != resp.latest_sequence {
+                            info!(
+                                "[{reaction_id}] Partial outbox replay for query '{query_id}' — \
+                                 replayed up to seq={last_ok_seq}, latest_seq={}",
+                                resp.latest_sequence
+                            );
+                        }
+                    }
+                    resp.latest_sequence
+                }
+                Err(FetchError::OutboxGap(gap)) => {
+                    info!(
+                        "[{reaction_id}] Fresh start for query '{query_id}' — outbox gap, latest_seq={}",
+                        gap.latest_sequence
+                    );
+                    gap.latest_sequence
+                }
+                Err(FetchError::NotRunning { .. } | FetchError::TimedOut) => {
+                    info!(
+                        "[{reaction_id}] Fresh start for query '{query_id}' — \
+                         query not yet running, starting from sequence 0"
+                    );
+                    0
+                }
+            };
+
+            let cp = ReactionCheckpoint {
+                sequence: seq,
+                config_hash,
+            };
+
+            if let Some(store) = state_store.as_ref() {
+                crate::reactions::checkpoint::write_checkpoint(
+                    store.as_ref(),
+                    reaction_id,
+                    query_id,
+                    &cp,
+                )
+                .await?;
+            }
+
+            Ok(cp)
+        }
+    }
+
+    /// Handle outbox catchup when a checkpoint exists and hash matches.
+    ///
+    /// Fetches outbox entries after the checkpoint sequence. If the outbox
+    /// returns a gap, applies the recovery policy.
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_outbox_catchup(
+        &self,
+        reaction_id: &str,
+        query_id: &str,
+        checkpoint: &ReactionCheckpoint,
+        consumer: &Arc<dyn QueryConsumer>,
+        query: &Arc<dyn Query>,
+        policy: ReactionRecoveryPolicy,
+        state_store: &Option<Arc<dyn StateStoreProvider>>,
+        bootstrap_queries: &mut Vec<(String, Arc<dyn Query>)>,
+        metrics: &Arc<ReactionMetrics>,
+    ) -> Result<ReactionCheckpoint> {
+        metrics.record_fetch_outbox();
+        match query.fetch_outbox(checkpoint.sequence).await {
+            Ok(outbox_resp) => {
+                // Replay outbox entries by enqueuing them.
+                // Track the last successfully enqueued sequence to avoid
+                // advancing the checkpoint past failed entries.
+                let mut last_ok_seq = checkpoint.sequence;
+                for entry in &outbox_resp.results {
+                    let result = (*entry).as_ref().clone();
+                    match consumer.enqueue_query_result(result).await {
+                        Ok(()) => last_ok_seq = entry.sequence,
+                        Err(e) => {
+                            warn!(
+                                "[{reaction_id}] Failed to replay outbox entry for query \
+                                 '{query_id}' seq={}: {e}",
+                                entry.sequence
+                            );
+                            break;
+                        }
+                    }
+                }
+
+                // Update checkpoint to the latest SUCCESSFULLY replayed sequence.
+                let new_seq = last_ok_seq;
+
+                let cp = ReactionCheckpoint {
+                    sequence: new_seq,
+                    config_hash: checkpoint.config_hash,
+                };
+
+                if new_seq != checkpoint.sequence {
+                    if let Some(store) = state_store.as_ref() {
+                        crate::reactions::checkpoint::write_checkpoint(
+                            store.as_ref(),
+                            reaction_id,
+                            query_id,
+                            &cp,
+                        )
+                        .await?;
+                    }
+                }
+
+                Ok(cp)
+            }
+            Err(FetchError::OutboxGap(_gap)) => {
+                info!(
+                    "[{reaction_id}] Outbox gap for query '{query_id}' — applying recovery policy"
+                );
+                self.apply_recovery_policy(
+                    reaction_id,
+                    query_id,
+                    consumer,
+                    query,
+                    policy,
+                    state_store,
+                    bootstrap_queries,
+                    metrics,
+                )
+                .await
+            }
+            Err(FetchError::NotRunning { .. } | FetchError::TimedOut) => {
+                // Query not running — keep the existing checkpoint as-is.
+                // The forwarder will pick up events once the query starts.
+                warn!(
+                    "[{reaction_id}] Query '{query_id}' not running during catchup — \
+                     keeping existing checkpoint at seq={}",
+                    checkpoint.sequence
+                );
+                Ok(checkpoint.clone())
+            }
+        }
+    }
+
+    /// Apply the recovery policy when a gap or hash mismatch is detected.
+    #[allow(clippy::too_many_arguments)]
+    async fn apply_recovery_policy(
+        &self,
+        reaction_id: &str,
+        query_id: &str,
+        _consumer: &Arc<dyn QueryConsumer>,
+        query: &Arc<dyn Query>,
+        policy: ReactionRecoveryPolicy,
+        state_store: &Option<Arc<dyn StateStoreProvider>>,
+        bootstrap_queries: &mut Vec<(String, Arc<dyn Query>)>,
+        metrics: &Arc<ReactionMetrics>,
+    ) -> Result<ReactionCheckpoint> {
+        let config_hash = crate::queries::compute_config_hash(query.get_config());
+
+        match policy {
+            ReactionRecoveryPolicy::Strict => Err(anyhow::anyhow!(
+                "Reaction '{reaction_id}': Strict recovery policy — cannot recover from \
+                     gap/mismatch for query '{query_id}'. Manual intervention required."
+            )),
+            ReactionRecoveryPolicy::AutoReset => {
+                info!(
+                    "[{reaction_id}] AutoReset for query '{query_id}' — \
+                     fetching fresh snapshot"
+                );
+                metrics.record_fetch_snapshot();
+                let snapshot = query.fetch_snapshot().await.map_err(|e| {
+                    anyhow::anyhow!(
+                        "AutoReset: failed to fetch snapshot for query '{query_id}': {e}"
+                    )
+                })?;
+
+                let cp = ReactionCheckpoint {
+                    sequence: snapshot.as_of_sequence,
+                    config_hash,
+                };
+
+                // Record successful auto-reset in lifecycle metrics
+                self.lifecycle_metrics.record_auto_reset_completion();
+
+                bootstrap_queries.push((query_id.to_string(), query.clone()));
+                Ok(cp)
+            }
+            ReactionRecoveryPolicy::AutoSkipGap => {
+                info!(
+                    "[{reaction_id}] AutoSkipGap for query '{query_id}' — \
+                     jumping to current sequence"
+                );
+
+                // Get current sequence from the query.
+                metrics.record_fetch_outbox();
+                let current_seq = match query.fetch_outbox(0).await {
+                    Ok(resp) => resp.latest_sequence,
+                    Err(FetchError::OutboxGap(gap)) => gap.latest_sequence,
+                    Err(e) => {
+                        return Err(anyhow::anyhow!(
+                            "AutoSkipGap: failed to determine current sequence \
+                             for query '{query_id}': {e}"
+                        ));
+                    }
+                };
+
+                let cp = ReactionCheckpoint {
+                    sequence: current_seq,
+                    config_hash,
+                };
+
+                if let Some(store) = state_store.as_ref() {
+                    crate::reactions::checkpoint::write_checkpoint(
+                        store.as_ref(),
+                        reaction_id,
+                        query_id,
+                        &cp,
+                    )
+                    .await?;
+                }
+
+                Ok(cp)
+            }
+        }
+    }
+
+    /// Wire live broadcast subscriptions with gap detection (§6) and bootstrap gate.
+    ///
+    /// For each query:
+    /// 1. Subscribe to the query's result broadcast channel
+    /// 2. Spawn a forwarder task that waits on the bootstrap gate, then drains events
+    /// 3. On `RecvError::Lagged`, apply the recovery policy
+    async fn wire_subscriptions(
+        &self,
+        reaction_id: &str,
+        consumer: &Arc<dyn QueryConsumer>,
+        query_provider: &Arc<dyn QueryProvider>,
+        query_ids: &[String],
+        shared_checkpoints: Arc<RwLock<HashMap<String, ReactionCheckpoint>>>,
+        gate: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<()> {
+        let instance_id = self.instance_id.clone();
+        let policy = consumer.default_recovery_policy();
+        let state_store = self.state_store.read().await.clone();
+        let mut abort_handles: Vec<tokio::task::AbortHandle> = Vec::new();
+        let mut join_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+
+        // Mutex to serialize concurrent bootstrap calls (§9 — multi-query gap recovery).
+        let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
+
+        for query_id in query_ids {
+            let query = query_provider.get_query_instance(query_id).await?;
+
+            let subscription = query.subscribe(reaction_id.to_string()).await?;
+            let mut receiver = subscription.receiver;
+
+            // Create or retrieve per-(reaction, query) metrics
+            let metrics_key = (reaction_id.to_string(), query_id.clone());
+            let forwarder_metrics = {
+                let mut metrics_map = self.metrics.write().await;
+                metrics_map
+                    .entry(metrics_key)
+                    .or_insert_with(|| Arc::new(ReactionMetrics::new()))
+                    .clone()
+            };
+
+            let consumer = consumer.clone();
+            let query_id_clone = query_id.clone();
+            let reaction_id_owned = reaction_id.to_string();
+            let mut gate_rx = gate.clone();
+            let query_clone = query.clone();
+            let state_store_clone = state_store.clone();
+            let checkpoints = shared_checkpoints.clone();
+            let bootstrap_mutex = bootstrap_mutex.clone();
+
+            let span = tracing::info_span!(
+                "reaction_forwarder",
+                instance_id = %instance_id,
+                component_id = %reaction_id_owned,
+                component_type = "reaction"
+            );
+
+            let forwarder_task = tokio::spawn(
+                async move {
+                    // Wait for the bootstrap gate to open before processing.
+                    // watch::wait_for retains the value, so even late subscribers see it.
+                    // If the sender is dropped (bootstrap failed), exit immediately.
+                    if gate_rx.wait_for(|v| *v).await.is_err() {
+                        log::debug!(
+                            "[{reaction_id_owned}] Gate sender dropped for query '{query_id_clone}' \
+                             — exiting forwarder (bootstrap likely failed)"
+                        );
+                        return;
+                    }
+
+                    // Read the initial checkpoint sequence so we can skip stale events
+                    // that were buffered in the broadcast channel during bootstrap.
+                    let initial_seq = {
+                        let cps = checkpoints.read().await;
+                        cps.get(&query_id_clone).map(|cp| cp.sequence).unwrap_or(0)
+                    };
+
+                    // Track the last forwarded sequence for gap detection.
+                    let mut last_forwarded_seq = initial_seq;
+
+                    log::debug!(
+                        "[{reaction_id_owned}] Started result forwarder for query '{query_id_clone}' \
+                         (initial_seq={initial_seq})"
+                    );
+
+                    loop {
+                        match receiver.recv().await {
+                            Ok(query_result) => {
+                                // Skip events already covered by the bootstrap snapshot/outbox catchup.
+                                if query_result.sequence <= initial_seq {
+                                    forwarder_metrics.record_dedup_skip();
+                                    log::debug!(
+                                        "[{reaction_id_owned}] Skipping seq={} <= last_forwarded={last_forwarded_seq} for query '{query_id_clone}'",
+                                        query_result.sequence
+                                    );
+                                    continue;
+                                }
+
+                                // §6: Detect sequence gaps (incoming seq > expected next).
+                                // This catches drops that don't manifest as broadcast lag
+                                // (e.g., outbox overflow while reaction was stopping).
+                                if last_forwarded_seq > 0
+                                    && query_result.sequence > last_forwarded_seq.saturating_add(1)
+                                {
+                                    forwarder_metrics.record_gap_detection();
+                                    forwarder_metrics.record_recovery_trigger(to_policy_kind(&policy));
+                                    log::warn!(
+                                        "[{reaction_id_owned}] Sequence gap for query '{query_id_clone}': \
+                                         expected seq={}, got seq={}",
+                                        last_forwarded_seq.saturating_add(1),
+                                        query_result.sequence
+                                    );
+                                    let gap_ctx = BroadcastGapContext {
+                                        reaction_id: &reaction_id_owned,
+                                        query_id: &query_id_clone,
+                                        consumer: &consumer,
+                                        query: &query_clone,
+                                        policy,
+                                        state_store: &state_store_clone,
+                                        checkpoints: &checkpoints,
+                                        bootstrap_mutex: &bootstrap_mutex,
+                                        metrics: &forwarder_metrics,
+                                    };
+                                    match Self::handle_broadcast_gap(&gap_ctx)
+                                    .await
+                                    {
+                                        Ok(()) => {
+                                            // After gap recovery, update checkpoint from the shared map
+                                            // (handle_broadcast_gap updates it).
+                                            let cps = checkpoints.read().await;
+                                            last_forwarded_seq = cps
+                                                .get(&query_id_clone)
+                                                .map(|cp| cp.sequence)
+                                                .unwrap_or(last_forwarded_seq);
+                                            // Re-evaluate this event against the updated checkpoint.
+                                            if query_result.sequence <= last_forwarded_seq {
+                                                continue;
+                                            }
+                                        }
+                                        Err(e) => {
+                                            log::error!(
+                                                "[{reaction_id_owned}] Recovery failed for sequence gap \
+                                                 on query '{query_id_clone}': {e}"
+                                            );
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                last_forwarded_seq = query_result.sequence;
+                                let seq = query_result.sequence;
+                                let result = Arc::try_unwrap(query_result)
+                                    .unwrap_or_else(|arc| (*arc).clone());
+                                if let Err(e) = consumer.enqueue_query_result(result).await {
+                                    log::error!(
+                                        "[{reaction_id_owned}] Failed to enqueue result from query '{query_id_clone}': {e}"
+                                    );
+                                } else {
+                                    // Advance in-memory checkpoint so forwarder tracks
+                                    // position (skip stale events on reconnect).
+                                    // NOTE: We do NOT persist to durable storage here.
+                                    // The reaction should persist its checkpoint after
+                                    // successfully processing the event. This prevents
+                                    // permanent skipping if the process crashes between
+                                    // enqueue and handler processing.
+                                    let config_hash = {
+                                        let cps = checkpoints.read().await;
+                                        cps.get(&query_id_clone).map(|cp| cp.config_hash).unwrap_or(0)
+                                    };
+                                    let cp = ReactionCheckpoint { sequence: seq, config_hash };
+                                    checkpoints.write().await.insert(query_id_clone.clone(), cp);
+
+                                    // Update reaction metrics: checkpoint position
+                                    let query_latest = query_clone
+                                        .output_metrics()
+                                        .map(|m| m.load_outbox_latest_seq())
+                                        .unwrap_or(seq);
+                                    forwarder_metrics.record_checkpoint(seq, query_latest);
+                                }
+                            }
+                            Err(e) => {
+                                let error_str = e.to_string();
+                                if error_str.contains("lagged") {
+                                    // §6: Broadcast gap detected.
+                                    forwarder_metrics.record_gap_detection();
+                                    forwarder_metrics.record_recovery_trigger(to_policy_kind(&policy));
+                                    log::warn!(
+                                        "[{reaction_id_owned}] Broadcast lag for query '{query_id_clone}': {error_str}"
+                                    );
+                                    let gap_ctx = BroadcastGapContext {
+                                        reaction_id: &reaction_id_owned,
+                                        query_id: &query_id_clone,
+                                        consumer: &consumer,
+                                        query: &query_clone,
+                                        policy,
+                                        state_store: &state_store_clone,
+                                        checkpoints: &checkpoints,
+                                        bootstrap_mutex: &bootstrap_mutex,
+                                        metrics: &forwarder_metrics,
+                                    };
+                                    match Self::handle_broadcast_gap(&gap_ctx)
+                                    .await
+                                    {
+                                        Ok(()) => continue,
+                                        Err(e) => {
+                                            log::error!(
+                                                "[{reaction_id_owned}] Recovery failed for broadcast gap on query '{query_id_clone}': {e}"
+                                            );
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    log::info!(
+                                        "[{reaction_id_owned}] Receiver closed for query '{query_id_clone}': {error_str}"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                .instrument(span),
+            );
+
+            abort_handles.push(forwarder_task.abort_handle());
+            join_handles.push(forwarder_task);
+        }
+
+        // Spawn a supervisor task that monitors all forwarder handles.
+        // When ALL forwarders exit, check if the reaction is still Running.
+        // Only transition to Error if the exits were unexpected.
+        let supervisor_reaction_id = reaction_id.to_string();
+        let supervisor_graph = self.graph.clone();
+
+        let supervisor = tokio::spawn(async move {
+            // Wait for all forwarder tasks to complete.
+            for handle in join_handles {
+                if let Err(e) = handle.await {
+                    log::warn!("[{supervisor_reaction_id}] Forwarder task failed: {e}");
+                }
+            }
+
+            // Only transition to Error if the reaction is still Running.
+            // If it's already Stopped/Stopping/Error, this was intentional.
+            let should_transition = {
+                let graph = supervisor_graph.read().await;
+                graph
+                    .get_component(&supervisor_reaction_id)
+                    .map(|n| n.status == ComponentStatus::Running)
+                    .unwrap_or(false)
+            };
+
+            if should_transition {
+                log::warn!(
+                    "[{supervisor_reaction_id}] All query subscriptions lost — \
+                     transitioning to Error"
+                );
+                let mut graph = supervisor_graph.write().await;
+                let _ = graph.validate_and_transition(
+                    &supervisor_reaction_id,
+                    ComponentStatus::Error,
+                    Some("All query subscriptions lost".to_string()),
+                );
+            }
+        });
+
+        abort_handles.push(supervisor.abort_handle());
+
+        // Store abort handles so stop_reaction/teardown can cancel everything.
+        self.subscription_tasks
+            .write()
+            .await
+            .insert(reaction_id.to_string(), abort_handles);
+
+        Ok(())
+    }
+
+    /// Handle a broadcast gap (§6): `RecvError::Lagged` in the forwarder loop.
+    ///
+    /// Applies the reaction's recovery policy:
+    /// - `Strict`: return error (forwarder will break)
+    /// - `AutoReset`: re-bootstrap from snapshot, update checkpoint (serialized via mutex)
+    /// - `AutoSkipGap`: jump to current sequence, update checkpoint
+    pub(crate) async fn handle_broadcast_gap(ctx: &BroadcastGapContext<'_>) -> Result<()> {
+        let config_hash = crate::queries::compute_config_hash(ctx.query.get_config());
+
+        match ctx.policy {
+            ReactionRecoveryPolicy::Strict => Err(anyhow::anyhow!(
+                "Strict recovery policy — broadcast lag for query '{}' \
+                     is unrecoverable",
+                ctx.query_id
+            )),
+            ReactionRecoveryPolicy::AutoReset => {
+                // Serialize bootstrap calls — multiple forwarders may hit gaps concurrently.
+                let _guard = ctx.bootstrap_mutex.lock().await;
+
+                log::info!(
+                    "[{}] AutoReset on broadcast gap for query '{}'",
+                    ctx.reaction_id,
+                    ctx.query_id
+                );
+                ctx.metrics.record_fetch_snapshot();
+                let snapshot = ctx.query.fetch_snapshot().await.map_err(|e| {
+                    anyhow::anyhow!(
+                        "AutoReset broadcast gap: failed to fetch snapshot for '{}': {e}",
+                        ctx.query_id
+                    )
+                })?;
+
+                let cp = ReactionCheckpoint {
+                    sequence: snapshot.as_of_sequence,
+                    config_hash,
+                };
+
+                // Invoke bootstrap hook BEFORE persisting checkpoint — a crash
+                // during bootstrap will re-trigger recovery on next start.
+                let bootstrap_ctx = BootstrapContext::new(
+                    ctx.query_id.to_string(),
+                    true,
+                    ctx.query.clone(),
+                    ctx.reaction_id.to_string(),
+                    ctx.state_store.clone(),
+                );
+                ctx.consumer.catch_up(bootstrap_ctx).await?;
+
+                // Bootstrap succeeded — now safe to persist checkpoint.
+                if let Some(store) = ctx.state_store.as_ref() {
+                    crate::reactions::checkpoint::write_checkpoint(
+                        store.as_ref(),
+                        ctx.reaction_id,
+                        ctx.query_id,
+                        &cp,
+                    )
+                    .await?;
+                }
+
+                ctx.checkpoints
+                    .write()
+                    .await
+                    .insert(ctx.query_id.to_string(), cp);
+
+                Ok(())
+            }
+            ReactionRecoveryPolicy::AutoSkipGap => {
+                log::info!(
+                    "[{}] AutoSkipGap on broadcast gap for query '{}'",
+                    ctx.reaction_id,
+                    ctx.query_id
+                );
+                ctx.metrics.record_fetch_outbox();
+                let current_seq = match ctx.query.fetch_outbox(0).await {
+                    Ok(resp) => resp.latest_sequence,
+                    Err(FetchError::OutboxGap(gap)) => gap.latest_sequence,
+                    Err(FetchError::NotRunning { .. } | FetchError::TimedOut) => {
+                        // Query not running — fall back to existing checkpoint sequence.
+                        let existing_seq = ctx
+                            .checkpoints
+                            .read()
+                            .await
+                            .get(ctx.query_id)
+                            .map(|cp| cp.sequence)
+                            .unwrap_or(0);
+                        log::info!(
+                            "[{}] AutoSkipGap: query '{}' not running, \
+                             keeping checkpoint at seq={existing_seq}",
+                            ctx.reaction_id,
+                            ctx.query_id
+                        );
+                        existing_seq
+                    }
+                };
+
+                let cp = ReactionCheckpoint {
+                    sequence: current_seq,
+                    config_hash,
+                };
+
+                if let Some(store) = ctx.state_store.as_ref() {
+                    crate::reactions::checkpoint::write_checkpoint(
+                        store.as_ref(),
+                        ctx.reaction_id,
+                        ctx.query_id,
+                        &cp,
+                    )
+                    .await?;
+                }
+
+                ctx.checkpoints
+                    .write()
+                    .await
+                    .insert(ctx.query_id.to_string(), cp);
+
+                Ok(())
+            }
+        }
+    }
+
+    /// Abort all subscription forwarder tasks for a reaction.
+    pub async fn abort_subscription_tasks(&self, reaction_id: &str) {
+        Self::abort_subscription_tasks_static(&self.subscription_tasks, reaction_id).await;
+    }
+
+    pub async fn abort_subscription_tasks_static(
+        tasks: &Arc<RwLock<HashMap<String, Vec<tokio::task::AbortHandle>>>>,
+        reaction_id: &str,
+    ) {
+        if let Some(handles) = tasks.write().await.remove(reaction_id) {
+            for handle in handles {
+                handle.abort();
+            }
+        }
+    }
+}

--- a/lib/src/consumption/mod.rs
+++ b/lib/src/consumption/mod.rs
@@ -1,0 +1,110 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared **query-consumption** engine.
+//!
+//! Some components consume the results of continuous queries: reactions (to act on
+//! them) and *query-consuming sources* (to derive a graph from them, e.g. a state
+//! machine). Both need the same robust consumption behavior:
+//!
+//! - **catch-up** on start: replay a query's outbox / snapshot from the last
+//!   checkpoint so results produced before the consumer subscribed are not lost;
+//! - **checkpointing**: persist the per-`(consumer, query)` position so a restart
+//!   resumes where it left off;
+//! - **gap/lag recovery**: detect broadcast lag or sequence gaps and apply a
+//!   recovery policy.
+//!
+//! This module centralizes that behavior behind the [`QueryConsumer`] trait and
+//! the shared [`engine::ConsumptionEngine`], which both `ReactionManager` and
+//! `SourceManager` embed — so reactions and query-consuming sources share **one**
+//! implementation instead of divergent copies. Components adapt to the engine via
+//! thin wrappers ([`ReactionConsumer`], [`SourceConsumer`]), leaving the
+//! `Reaction`/`Source` traits and their base types unchanged.
+//!
+//! # Terminology: "catch-up" vs "bootstrap"
+//!
+//! For a source these are two *different* things, so this module deliberately uses
+//! **catch-up** for the consumption/input side:
+//!
+//! - **catch-up** (this module, [`CatchupContext`]): upstream query → consumer.
+//!   "When I start consuming a query, replay its snapshot/outbox to my checkpoint."
+//! - **bootstrap** ([`crate::bootstrap::BootstrapProvider`]): source → downstream
+//!   query. "When a query subscribes to me, seed it with my current graph."
+//!
+//! Reactions keep the public method name [`crate::Reaction::bootstrap`] as a thin
+//! alias — a reaction's [`QueryConsumer::catch_up`] delegates to it — so the
+//! reaction API and its FFI stay unchanged.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::channels::QueryResult;
+use crate::recovery::ReactionRecoveryPolicy;
+
+mod adapters;
+pub mod engine;
+
+pub use adapters::{ReactionConsumer, SourceConsumer};
+pub use engine::ConsumptionEngine;
+
+/// The context handed to [`QueryConsumer::catch_up`], exposing the query's
+/// `fetch_snapshot()` / `fetch_outbox()` and checkpoint read/write.
+///
+/// This is the same type reactions receive from [`crate::Reaction::bootstrap`];
+/// it is re-exported here under the consumption-side name. (Kept as an alias to
+/// avoid churning the reaction API and FFI — see the module docs.)
+pub use crate::reactions::bootstrap_context::BootstrapContext as CatchupContext;
+
+/// A component that consumes continuous-query results (a reaction, or a
+/// query-consuming source).
+///
+/// The shared consumption engine drives any `QueryConsumer`: it subscribes to the
+/// consumed queries, catches up from the checkpoint, forwards live results into
+/// [`Self::enqueue_query_result`], and recovers from gaps per
+/// [`Self::default_recovery_policy`].
+#[async_trait]
+pub trait QueryConsumer: Send + Sync {
+    /// Unique id of the consuming component (used as the checkpoint partition key).
+    fn consumer_id(&self) -> &str;
+
+    /// The query IDs whose results this component consumes.
+    fn consumed_query_ids(&self) -> Vec<String>;
+
+    /// Enqueue a query result for processing (typically delegates to the
+    /// component's [`QueryConsumerCore::enqueue_query_result`]).
+    async fn enqueue_query_result(&self, result: QueryResult) -> Result<()>;
+
+    /// Whether this consumer requires a durable state store for its checkpoints.
+    fn is_durable(&self) -> bool {
+        false
+    }
+
+    /// Whether this consumer needs a full snapshot on a fresh start (no prior
+    /// checkpoint), rather than just replaying the outbox.
+    fn needs_snapshot_on_fresh_start(&self) -> bool {
+        false
+    }
+
+    /// The default recovery policy for this consumer.
+    fn default_recovery_policy(&self) -> ReactionRecoveryPolicy {
+        ReactionRecoveryPolicy::Strict
+    }
+
+    /// Catch up on a query subscription (fresh start or gap recovery). The
+    /// [`CatchupContext`] provides `fetch_snapshot`/`fetch_outbox` and checkpoint
+    /// read/write. Default is a no-op (outbox replay is handled by the engine).
+    async fn catch_up(&self, _ctx: CatchupContext) -> Result<()> {
+        Ok(())
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -58,6 +58,8 @@ pub mod identity;
 /// Recovery policy and error types for checkpoint-based recovery
 pub mod recovery;
 
+pub mod consumption;
+
 // ============================================================================
 // Internal Modules (crate-private, but visible to integration tests)
 // ============================================================================

--- a/lib/src/lib_core.rs
+++ b/lib/src/lib_core.rs
@@ -407,6 +407,15 @@ impl DrasiLib {
             )
             .await;
 
+        // Inject QueryManager into SourceManager as well, so query-consuming
+        // sources (those returning a non-empty `subscribed_query_ids()`) can
+        // subscribe to continuous-query results.
+        self.source_manager
+            .inject_query_provider(
+                Arc::clone(&self.query_manager) as Arc<dyn crate::reactions::QueryProvider>
+            )
+            .await;
+
         // Inject StateStoreProvider into SourceManager and ReactionManager
         // This allows sources and reactions to persist state
         let state_store = self.config.state_store_provider.clone();

--- a/lib/src/lifecycle.rs
+++ b/lib/src/lifecycle.rs
@@ -129,6 +129,12 @@ impl LifecycleManager {
             info!("All auto-start queries started successfully");
         }
 
+        // Now that queries are running, wire up any query-consuming sources
+        // (those returning a non-empty `subscribed_query_ids()`) so they begin
+        // receiving continuous-query results. Downstream queries that read from
+        // such a source already subscribed to it during the Queries phase.
+        self.source_manager.wire_all_query_subscriptions().await;
+
         // Notify sources that all initial subscriptions are done. Sources that
         // held back upstream feedback (e.g., Postgres flush-fence) can now
         // resume normal advancement based on the min-watermark of all handles.

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -13,56 +13,23 @@
 // limitations under the License.
 
 use anyhow::Result;
-use log::{error, info, warn};
+use log::info;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::Instrument;
 
 use crate::channels::*;
 use crate::component_graph::{ComponentGraph, ComponentKind, ComponentUpdateSender};
 use crate::config::ReactionRuntime;
+use crate::consumption::{ConsumptionEngine, QueryConsumer, ReactionConsumer};
 use crate::context::ReactionRuntimeContext;
 use crate::identity::IdentityProvider;
-use crate::managers::{log_component_error, ComponentLogKey, ComponentLogRegistry};
-use crate::metrics::{
-    LifecycleMetrics, ReactionMetrics, RecoveryPolicyKind, StartupRejectionReason,
-};
-use crate::queries::output_state::FetchError;
-use crate::queries::Query;
-use crate::reactions::bootstrap_context::BootstrapContext;
-use crate::reactions::checkpoint::ReactionCheckpoint;
+use crate::managers::{ComponentLogKey, ComponentLogRegistry};
+use crate::metrics::{LifecycleMetrics, StartupRejectionReason};
 use crate::reactions::snapshot_fetcher::InProcessSnapshotFetcher;
 use crate::reactions::{QueryProvider, Reaction};
 use crate::recovery::ReactionRecoveryPolicy;
 use crate::state_store::StateStoreProvider;
-
-/// Key for per-reaction per-query metrics: `(reaction_id, query_id)`.
-type MetricsKey = (String, String);
-
-/// Convert a domain recovery policy to the metrics-level kind enum.
-fn to_policy_kind(policy: &ReactionRecoveryPolicy) -> RecoveryPolicyKind {
-    match policy {
-        ReactionRecoveryPolicy::Strict => RecoveryPolicyKind::Strict,
-        ReactionRecoveryPolicy::AutoReset => RecoveryPolicyKind::AutoReset,
-        ReactionRecoveryPolicy::AutoSkipGap => RecoveryPolicyKind::AutoSkipGap,
-    }
-}
-
-/// Context passed to `handle_broadcast_gap` to avoid excessive parameter counts.
-///
-/// Groups the shared forwarder-task state that the recovery function needs.
-struct BroadcastGapContext<'a> {
-    reaction_id: &'a str,
-    query_id: &'a str,
-    reaction: &'a Arc<dyn Reaction>,
-    query: &'a Arc<dyn Query>,
-    policy: ReactionRecoveryPolicy,
-    state_store: &'a Option<Arc<dyn StateStoreProvider>>,
-    checkpoints: &'a Arc<RwLock<HashMap<String, ReactionCheckpoint>>>,
-    bootstrap_mutex: &'a Arc<tokio::sync::Mutex<()>>,
-    metrics: &'a Arc<ReactionMetrics>,
-}
 
 pub struct ReactionManager {
     instance_id: String,
@@ -74,8 +41,6 @@ pub struct ReactionManager {
     identity_provider: Arc<RwLock<Option<Arc<dyn IdentityProvider>>>>,
     /// Log registry for component log streaming
     log_registry: Arc<ComponentLogRegistry>,
-    /// Abort handles to subscription forwarder + supervisor tasks per reaction
-    subscription_tasks: Arc<RwLock<HashMap<String, Vec<tokio::task::AbortHandle>>>>,
     /// Shared component graph — the single source of truth for component metadata,
     /// state, relationships, runtime instances, AND event history.
     graph: Arc<RwLock<ComponentGraph>>,
@@ -83,10 +48,7 @@ pub struct ReactionManager {
     /// Managers send transitional states (Starting, Stopping, Reconfiguring) here;
     /// the loop applies them to the graph and records events automatically.
     update_tx: ComponentUpdateSender,
-    /// Per-(reaction, query) metrics for observability.
-    reaction_metrics: Arc<RwLock<HashMap<MetricsKey, Arc<ReactionMetrics>>>>,
-    /// Global lifecycle metrics shared across all reactions.
-    lifecycle_metrics: Arc<LifecycleMetrics>,
+    engine: ConsumptionEngine,
 }
 
 impl ReactionManager {
@@ -102,17 +64,31 @@ impl ReactionManager {
         graph: Arc<RwLock<ComponentGraph>>,
         update_tx: ComponentUpdateSender,
     ) -> Self {
+        let instance_id = instance_id.into();
+        let query_provider = Arc::new(RwLock::new(None));
+        let state_store = Arc::new(RwLock::new(None));
+        let subscription_tasks = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(RwLock::new(HashMap::new()));
+        let lifecycle_metrics = Arc::new(LifecycleMetrics::new());
+        let engine = ConsumptionEngine::new(
+            instance_id.clone(),
+            graph.clone(),
+            query_provider.clone(),
+            state_store.clone(),
+            subscription_tasks.clone(),
+            metrics,
+            lifecycle_metrics,
+        );
+
         Self {
-            instance_id: instance_id.into(),
-            query_provider: Arc::new(RwLock::new(None)),
-            state_store: Arc::new(RwLock::new(None)),
+            instance_id,
+            query_provider,
+            state_store,
             identity_provider: Arc::new(RwLock::new(None)),
             log_registry,
-            subscription_tasks: Arc::new(RwLock::new(HashMap::new())),
             graph,
             update_tx,
-            reaction_metrics: Arc::new(RwLock::new(HashMap::new())),
-            lifecycle_metrics: Arc::new(LifecycleMetrics::new()),
+            engine,
         }
     }
 
@@ -120,14 +96,14 @@ impl ReactionManager {
     ///
     /// This allows the ReactionManager to provide query access to reactions.
     pub async fn inject_query_provider(&self, qp: Arc<dyn QueryProvider>) {
-        *self.query_provider.write().await = Some(qp);
+        self.engine.inject_query_provider(qp).await;
     }
 
     /// Inject the state store provider (called after DrasiLib is fully constructed)
     ///
     /// This allows reactions to access the state store when they are added.
     pub async fn inject_state_store(&self, state_store: Arc<dyn StateStoreProvider>) {
-        *self.state_store.write().await = Some(state_store);
+        self.engine.inject_state_store(state_store).await;
     }
 
     /// Inject the identity provider (called after DrasiLib is fully constructed)
@@ -225,12 +201,14 @@ impl ReactionManager {
         // and cannot miss the notification.
         let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
 
+        let consumer = Arc::new(ReactionConsumer(reaction.clone())) as Arc<dyn QueryConsumer>;
         if let Err(e) = self
-            .subscribe_and_bootstrap(&id, reaction.clone(), gate_rx)
+            .engine
+            .subscribe_and_bootstrap(&id, consumer, gate_rx)
             .await
         {
             // Abort any forwarder/supervisor tasks spawned during wire_subscriptions.
-            Self::abort_subscription_tasks_static(&self.subscription_tasks, &id).await;
+            self.engine.abort_subscription_tasks(&id).await;
 
             // Revert to Error since the reaction can't receive data without subscriptions
             let mut graph = self.graph.write().await;
@@ -264,7 +242,8 @@ impl ReactionManager {
             let store = self.state_store.read().await;
             match store.as_ref() {
                 None => {
-                    self.lifecycle_metrics
+                    self.engine
+                        .lifecycle_metrics()
                         .record_startup_rejection(StartupRejectionReason::DurableNoStore);
                     return Err(anyhow::anyhow!(
                         "Reaction '{}' requires a durable state store (is_durable=true), \
@@ -273,7 +252,8 @@ impl ReactionManager {
                     ));
                 }
                 Some(s) if !s.is_durable() => {
-                    self.lifecycle_metrics
+                    self.engine
+                        .lifecycle_metrics()
                         .record_startup_rejection(StartupRejectionReason::DurableOnVolatile);
                     return Err(anyhow::anyhow!(
                         "Reaction '{}' requires a durable state store (is_durable=true), \
@@ -287,7 +267,8 @@ impl ReactionManager {
 
         // Rule 2: snapshot + AutoSkipGap is contradictory
         if needs_snapshot && policy == ReactionRecoveryPolicy::AutoSkipGap {
-            self.lifecycle_metrics
+            self.engine
+                .lifecycle_metrics()
                 .record_startup_rejection(StartupRejectionReason::SnapshotSkipGap);
             return Err(anyhow::anyhow!(
                 "Reaction '{}': needs_snapshot_on_fresh_start=true is incompatible with \
@@ -298,7 +279,8 @@ impl ReactionManager {
 
         // Rule 3: !snapshot + AutoReset is contradictory
         if !needs_snapshot && policy == ReactionRecoveryPolicy::AutoReset {
-            self.lifecycle_metrics
+            self.engine
+                .lifecycle_metrics()
                 .record_startup_rejection(StartupRejectionReason::NoSnapshotAutoReset);
             return Err(anyhow::anyhow!(
                 "Reaction '{}': needs_snapshot_on_fresh_start=false is incompatible with \
@@ -308,468 +290,6 @@ impl ReactionManager {
         }
 
         Ok(())
-    }
-
-    /// Wire live subscriptions, then perform per-query bootstrap.
-    ///
-    /// 1. Wire subscriptions first (forwarders wait on gate, events buffer in broadcast channel)
-    /// 2. Read checkpoints from state store
-    /// 3. For each query, run the per-query startup flowchart (§5)
-    /// 4. Invoke `reaction.bootstrap()` if any query needed a full reset
-    ///
-    /// The bootstrap gate is NOT opened here — the caller opens it after this returns.
-    async fn subscribe_and_bootstrap(
-        &self,
-        reaction_id: &str,
-        reaction: Arc<dyn Reaction>,
-        gate: tokio::sync::watch::Receiver<bool>,
-    ) -> Result<()> {
-        let query_ids = reaction.query_ids();
-        if query_ids.is_empty() {
-            return Ok(());
-        }
-
-        // Clone the query provider Arc and release the RwLock guard immediately.
-        let query_provider = self.query_provider.read().await.clone().ok_or_else(|| {
-            anyhow::anyhow!(
-                "QueryProvider not injected - was ReactionManager initialized properly?"
-            )
-        })?;
-
-        let state_store = self.state_store.read().await.clone();
-        let policy = reaction.default_recovery_policy();
-
-        // Shared checkpoint map — populated during bootstrap, read by forwarders after gate opens.
-        let shared_checkpoints: Arc<RwLock<HashMap<String, ReactionCheckpoint>>> =
-            Arc::new(RwLock::new(HashMap::new()));
-
-        // 1. Wire subscriptions FIRST so events buffer in broadcast channels
-        //    while bootstrap runs. Forwarders wait on gate before processing.
-        self.wire_subscriptions(
-            reaction_id,
-            &reaction,
-            &query_provider,
-            &query_ids,
-            shared_checkpoints.clone(),
-            gate,
-        )
-        .await?;
-
-        // 2. Read existing checkpoints from the state store (batch).
-        let existing_checkpoints = match state_store.as_ref() {
-            Some(store) => {
-                crate::reactions::checkpoint::read_checkpoints_batch(
-                    store.as_ref(),
-                    reaction_id,
-                    &query_ids,
-                )
-                .await?
-            }
-            None => HashMap::new(),
-        };
-
-        // 3. Per-query bootstrap: build the initial checkpoint map and collect
-        //    any queries that need a full bootstrap hook call.
-        let mut initial_checkpoints: HashMap<String, ReactionCheckpoint> = HashMap::new();
-        let mut bootstrap_queries: Vec<(String, Arc<dyn Query>)> = Vec::new();
-
-        for query_id in &query_ids {
-            let query = query_provider.get_query_instance(query_id).await?;
-
-            // Pre-create the metrics entry for this (reaction, query) pair so all
-            // bootstrap methods can instrument without acquiring the write lock.
-            let metrics_key = (reaction_id.to_string(), query_id.clone());
-            let per_query_metrics = {
-                let mut metrics_map = self.reaction_metrics.write().await;
-                metrics_map
-                    .entry(metrics_key)
-                    .or_insert_with(|| Arc::new(ReactionMetrics::new()))
-                    .clone()
-            };
-
-            match existing_checkpoints.get(query_id) {
-                None => {
-                    // No checkpoint — fresh start for this query.
-                    let cp = self
-                        .handle_fresh_start(
-                            reaction_id,
-                            query_id,
-                            &reaction,
-                            &query,
-                            &state_store,
-                            &mut bootstrap_queries,
-                            &per_query_metrics,
-                        )
-                        .await?;
-                    initial_checkpoints.insert(query_id.clone(), cp);
-                }
-                Some(cp) => {
-                    // Checkpoint exists — check config hash.
-                    let current_config_hash =
-                        crate::queries::compute_config_hash(query.get_config());
-                    if cp.config_hash != current_config_hash {
-                        // Hash mismatch → treat as gap → apply recovery policy.
-                        self.lifecycle_metrics.record_hash_mismatch();
-                        info!(
-                            "[{reaction_id}] Config hash mismatch for query '{query_id}': \
-                             checkpoint={}, current={}",
-                            cp.config_hash, current_config_hash
-                        );
-                        let new_cp = self
-                            .apply_recovery_policy(
-                                reaction_id,
-                                query_id,
-                                &reaction,
-                                &query,
-                                policy,
-                                &state_store,
-                                &mut bootstrap_queries,
-                                &per_query_metrics,
-                            )
-                            .await?;
-                        initial_checkpoints.insert(query_id.clone(), new_cp);
-                    } else {
-                        // Hash matches — try to catch up via outbox.
-                        let new_cp = self
-                            .handle_outbox_catchup(
-                                reaction_id,
-                                query_id,
-                                cp,
-                                &reaction,
-                                &query,
-                                policy,
-                                &state_store,
-                                &mut bootstrap_queries,
-                                &per_query_metrics,
-                            )
-                            .await?;
-                        initial_checkpoints.insert(query_id.clone(), new_cp);
-                    }
-                }
-            }
-        }
-
-        // 4. Invoke the bootstrap hook if any queries triggered a reset.
-        if !bootstrap_queries.is_empty() {
-            for (query_id, query) in &bootstrap_queries {
-                let is_reset = existing_checkpoints.contains_key(query_id);
-                let ctx = BootstrapContext::new(
-                    query_id.clone(),
-                    is_reset,
-                    query.clone(),
-                    reaction_id.to_string(),
-                    state_store.clone(),
-                );
-                reaction.bootstrap(ctx).await?;
-            }
-        }
-
-        // 5. Persist checkpoints AFTER bootstrap succeeds — a crash before this
-        //    point will re-trigger bootstrap on next start (safe).
-        if let Some(store) = state_store.as_ref() {
-            for (query_id, cp) in &initial_checkpoints {
-                if let Err(e) = crate::reactions::checkpoint::write_checkpoint(
-                    store.as_ref(),
-                    reaction_id,
-                    query_id,
-                    cp,
-                )
-                .await
-                {
-                    log::warn!(
-                        "[{reaction_id}] Failed to persist checkpoint for query '{query_id}' \
-                         at seq={}: {e}",
-                        cp.sequence
-                    );
-                }
-            }
-        }
-
-        // Publish the computed checkpoints so forwarders can filter stale events.
-        *shared_checkpoints.write().await = initial_checkpoints;
-
-        Ok(())
-    }
-
-    /// Handle a fresh start for a query subscription (no existing checkpoint).
-    ///
-    /// If `needs_snapshot_on_fresh_start`, fetches snapshot and sets checkpoint.
-    /// Otherwise, fetches outbox(0) to get the current sequence.
-    async fn handle_fresh_start(
-        &self,
-        reaction_id: &str,
-        query_id: &str,
-        reaction: &Arc<dyn Reaction>,
-        query: &Arc<dyn Query>,
-        state_store: &Option<Arc<dyn StateStoreProvider>>,
-        bootstrap_queries: &mut Vec<(String, Arc<dyn Query>)>,
-        metrics: &Arc<ReactionMetrics>,
-    ) -> Result<ReactionCheckpoint> {
-        let config_hash = crate::queries::compute_config_hash(query.get_config());
-
-        if reaction.needs_snapshot_on_fresh_start() {
-            info!("[{reaction_id}] Fresh start for query '{query_id}' — fetching snapshot");
-            metrics.record_fetch_snapshot();
-            let snapshot = query.fetch_snapshot().await.map_err(|e| {
-                anyhow::anyhow!("Failed to fetch snapshot for query '{query_id}': {e}")
-            })?;
-
-            let cp = ReactionCheckpoint {
-                sequence: snapshot.as_of_sequence,
-                config_hash,
-            };
-
-            bootstrap_queries.push((query_id.to_string(), query.clone()));
-            Ok(cp)
-        } else {
-            // No snapshot needed — replay any outbox entries produced during this
-            // startup cycle (e.g., from source replay) and record the checkpoint.
-            // Without this replay, results produced before the reaction subscribes
-            // to the broadcast channel would be silently skipped.
-            metrics.record_fetch_outbox();
-            let seq = match query.fetch_outbox(0).await {
-                Ok(resp) => {
-                    if resp.results.is_empty() {
-                        info!(
-                            "[{reaction_id}] Fresh start for query '{query_id}' — fetch_outbox(0) returned latest_seq={}",
-                            resp.latest_sequence
-                        );
-                    } else {
-                        info!(
-                            "[{reaction_id}] Fresh start for query '{query_id}' — replaying {} outbox entries (latest_seq={})",
-                            resp.results.len(),
-                            resp.latest_sequence
-                        );
-                        let mut last_ok_seq = 0u64;
-                        for entry in &resp.results {
-                            let result = (*entry).as_ref().clone();
-                            match reaction.enqueue_query_result(result).await {
-                                Ok(()) => last_ok_seq = entry.sequence,
-                                Err(e) => {
-                                    warn!(
-                                        "[{reaction_id}] Failed to replay outbox entry for query \
-                                         '{query_id}' seq={}: {e}",
-                                        entry.sequence
-                                    );
-                                    break;
-                                }
-                            }
-                        }
-                        if last_ok_seq != resp.latest_sequence {
-                            info!(
-                                "[{reaction_id}] Partial outbox replay for query '{query_id}' — \
-                                 replayed up to seq={last_ok_seq}, latest_seq={}",
-                                resp.latest_sequence
-                            );
-                        }
-                    }
-                    resp.latest_sequence
-                }
-                Err(FetchError::OutboxGap(gap)) => {
-                    info!(
-                        "[{reaction_id}] Fresh start for query '{query_id}' — outbox gap, latest_seq={}",
-                        gap.latest_sequence
-                    );
-                    gap.latest_sequence
-                }
-                Err(FetchError::NotRunning { .. } | FetchError::TimedOut) => {
-                    info!(
-                        "[{reaction_id}] Fresh start for query '{query_id}' — \
-                         query not yet running, starting from sequence 0"
-                    );
-                    0
-                }
-            };
-
-            let cp = ReactionCheckpoint {
-                sequence: seq,
-                config_hash,
-            };
-
-            if let Some(store) = state_store.as_ref() {
-                crate::reactions::checkpoint::write_checkpoint(
-                    store.as_ref(),
-                    reaction_id,
-                    query_id,
-                    &cp,
-                )
-                .await?;
-            }
-
-            Ok(cp)
-        }
-    }
-
-    /// Handle outbox catchup when a checkpoint exists and hash matches.
-    ///
-    /// Fetches outbox entries after the checkpoint sequence. If the outbox
-    /// returns a gap, applies the recovery policy.
-    #[allow(clippy::too_many_arguments)]
-    async fn handle_outbox_catchup(
-        &self,
-        reaction_id: &str,
-        query_id: &str,
-        checkpoint: &ReactionCheckpoint,
-        reaction: &Arc<dyn Reaction>,
-        query: &Arc<dyn Query>,
-        policy: ReactionRecoveryPolicy,
-        state_store: &Option<Arc<dyn StateStoreProvider>>,
-        bootstrap_queries: &mut Vec<(String, Arc<dyn Query>)>,
-        metrics: &Arc<ReactionMetrics>,
-    ) -> Result<ReactionCheckpoint> {
-        metrics.record_fetch_outbox();
-        match query.fetch_outbox(checkpoint.sequence).await {
-            Ok(outbox_resp) => {
-                // Replay outbox entries by enqueuing them.
-                // Track the last successfully enqueued sequence to avoid
-                // advancing the checkpoint past failed entries.
-                let mut last_ok_seq = checkpoint.sequence;
-                for entry in &outbox_resp.results {
-                    let result = (*entry).as_ref().clone();
-                    match reaction.enqueue_query_result(result).await {
-                        Ok(()) => last_ok_seq = entry.sequence,
-                        Err(e) => {
-                            warn!(
-                                "[{reaction_id}] Failed to replay outbox entry for query \
-                                 '{query_id}' seq={}: {e}",
-                                entry.sequence
-                            );
-                            break;
-                        }
-                    }
-                }
-
-                // Update checkpoint to the latest SUCCESSFULLY replayed sequence.
-                let new_seq = last_ok_seq;
-
-                let cp = ReactionCheckpoint {
-                    sequence: new_seq,
-                    config_hash: checkpoint.config_hash,
-                };
-
-                if new_seq != checkpoint.sequence {
-                    if let Some(store) = state_store.as_ref() {
-                        crate::reactions::checkpoint::write_checkpoint(
-                            store.as_ref(),
-                            reaction_id,
-                            query_id,
-                            &cp,
-                        )
-                        .await?;
-                    }
-                }
-
-                Ok(cp)
-            }
-            Err(FetchError::OutboxGap(_gap)) => {
-                info!(
-                    "[{reaction_id}] Outbox gap for query '{query_id}' — applying recovery policy"
-                );
-                self.apply_recovery_policy(
-                    reaction_id,
-                    query_id,
-                    reaction,
-                    query,
-                    policy,
-                    state_store,
-                    bootstrap_queries,
-                    metrics,
-                )
-                .await
-            }
-            Err(FetchError::NotRunning { .. } | FetchError::TimedOut) => {
-                // Query not running — keep the existing checkpoint as-is.
-                // The forwarder will pick up events once the query starts.
-                warn!(
-                    "[{reaction_id}] Query '{query_id}' not running during catchup — \
-                     keeping existing checkpoint at seq={}",
-                    checkpoint.sequence
-                );
-                Ok(checkpoint.clone())
-            }
-        }
-    }
-
-    /// Apply the recovery policy when a gap or hash mismatch is detected.
-    #[allow(clippy::too_many_arguments)]
-    async fn apply_recovery_policy(
-        &self,
-        reaction_id: &str,
-        query_id: &str,
-        _reaction: &Arc<dyn Reaction>,
-        query: &Arc<dyn Query>,
-        policy: ReactionRecoveryPolicy,
-        state_store: &Option<Arc<dyn StateStoreProvider>>,
-        bootstrap_queries: &mut Vec<(String, Arc<dyn Query>)>,
-        metrics: &Arc<ReactionMetrics>,
-    ) -> Result<ReactionCheckpoint> {
-        let config_hash = crate::queries::compute_config_hash(query.get_config());
-
-        match policy {
-            ReactionRecoveryPolicy::Strict => Err(anyhow::anyhow!(
-                "Reaction '{reaction_id}': Strict recovery policy — cannot recover from \
-                     gap/mismatch for query '{query_id}'. Manual intervention required."
-            )),
-            ReactionRecoveryPolicy::AutoReset => {
-                info!(
-                    "[{reaction_id}] AutoReset for query '{query_id}' — \
-                     fetching fresh snapshot"
-                );
-                metrics.record_fetch_snapshot();
-                let snapshot = query.fetch_snapshot().await.map_err(|e| {
-                    anyhow::anyhow!(
-                        "AutoReset: failed to fetch snapshot for query '{query_id}': {e}"
-                    )
-                })?;
-
-                let cp = ReactionCheckpoint {
-                    sequence: snapshot.as_of_sequence,
-                    config_hash,
-                };
-
-                // Record successful auto-reset in lifecycle metrics
-                self.lifecycle_metrics.record_auto_reset_completion();
-
-                bootstrap_queries.push((query_id.to_string(), query.clone()));
-                Ok(cp)
-            }
-            ReactionRecoveryPolicy::AutoSkipGap => {
-                info!(
-                    "[{reaction_id}] AutoSkipGap for query '{query_id}' — \
-                     jumping to current sequence"
-                );
-
-                // Get current sequence from the query.
-                metrics.record_fetch_outbox();
-                let current_seq = match query.fetch_outbox(0).await {
-                    Ok(resp) => resp.latest_sequence,
-                    Err(FetchError::OutboxGap(gap)) => gap.latest_sequence,
-                    Err(e) => {
-                        return Err(anyhow::anyhow!(
-                            "AutoSkipGap: failed to determine current sequence \
-                             for query '{query_id}': {e}"
-                        ));
-                    }
-                };
-
-                let cp = ReactionCheckpoint {
-                    sequence: current_seq,
-                    config_hash,
-                };
-
-                if let Some(store) = state_store.as_ref() {
-                    crate::reactions::checkpoint::write_checkpoint(
-                        store.as_ref(),
-                        reaction_id,
-                        query_id,
-                        &cp,
-                    )
-                    .await?;
-                }
-
-                Ok(cp)
-            }
-        }
     }
 
     /// Stop a running reaction and abort its subscription forwarder tasks.
@@ -863,7 +383,7 @@ impl ReactionManager {
     /// The caller should validate dependencies via `graph.can_remove()` before calling this.
     pub async fn teardown_reaction(&self, id: String, cleanup: bool) -> Result<()> {
         let id_clone = id.clone();
-        let sub_tasks = self.subscription_tasks.clone();
+        let engine = self.engine.clone();
         crate::managers::lifecycle_helpers::teardown_component::<Arc<dyn Reaction>, _, _>(
             &self.graph,
             &id,
@@ -872,7 +392,7 @@ impl ReactionManager {
             &self.instance_id,
             &self.log_registry,
             cleanup,
-            || Self::abort_subscription_tasks_static(&sub_tasks, &id_clone),
+            || engine.abort_subscription_tasks(&id_clone),
         )
         .await?;
 
@@ -881,7 +401,7 @@ impl ReactionManager {
 
         // Remove metrics entries for this reaction to prevent unbounded memory growth
         {
-            let mut metrics_map = self.reaction_metrics.write().await;
+            let mut metrics_map = self.engine.metrics().write().await;
             metrics_map.retain(|(rid, _), _| rid != &id);
         }
 
@@ -1064,417 +584,9 @@ impl ReactionManager {
         graph.subscribe_events(id)
     }
 
-    /// Wire live broadcast subscriptions with gap detection (§6) and bootstrap gate.
-    ///
-    /// For each query:
-    /// 1. Subscribe to the query's result broadcast channel
-    /// 2. Spawn a forwarder task that waits on the bootstrap gate, then drains events
-    /// 3. On `RecvError::Lagged`, apply the recovery policy
-    async fn wire_subscriptions(
-        &self,
-        reaction_id: &str,
-        reaction: &Arc<dyn Reaction>,
-        query_provider: &Arc<dyn QueryProvider>,
-        query_ids: &[String],
-        shared_checkpoints: Arc<RwLock<HashMap<String, ReactionCheckpoint>>>,
-        gate: tokio::sync::watch::Receiver<bool>,
-    ) -> Result<()> {
-        let instance_id = self.instance_id.clone();
-        let policy = reaction.default_recovery_policy();
-        let state_store = self.state_store.read().await.clone();
-        let mut abort_handles: Vec<tokio::task::AbortHandle> = Vec::new();
-        let mut join_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
-
-        // Mutex to serialize concurrent bootstrap calls (§9 — multi-query gap recovery).
-        let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
-
-        for query_id in query_ids {
-            let query = query_provider.get_query_instance(query_id).await?;
-
-            let subscription = query.subscribe(reaction_id.to_string()).await?;
-            let mut receiver = subscription.receiver;
-
-            // Create or retrieve per-(reaction, query) metrics
-            let metrics_key = (reaction_id.to_string(), query_id.clone());
-            let forwarder_metrics = {
-                let mut metrics_map = self.reaction_metrics.write().await;
-                metrics_map
-                    .entry(metrics_key)
-                    .or_insert_with(|| Arc::new(ReactionMetrics::new()))
-                    .clone()
-            };
-
-            let reaction = reaction.clone();
-            let query_id_clone = query_id.clone();
-            let reaction_id_owned = reaction_id.to_string();
-            let mut gate_rx = gate.clone();
-            let query_clone = query.clone();
-            let state_store_clone = state_store.clone();
-            let checkpoints = shared_checkpoints.clone();
-            let bootstrap_mutex = bootstrap_mutex.clone();
-            let lifecycle_metrics = self.lifecycle_metrics.clone();
-
-            let span = tracing::info_span!(
-                "reaction_forwarder",
-                instance_id = %instance_id,
-                component_id = %reaction_id_owned,
-                component_type = "reaction"
-            );
-
-            let forwarder_task = tokio::spawn(
-                async move {
-                    // Wait for the bootstrap gate to open before processing.
-                    // watch::wait_for retains the value, so even late subscribers see it.
-                    // If the sender is dropped (bootstrap failed), exit immediately.
-                    if gate_rx.wait_for(|v| *v).await.is_err() {
-                        log::debug!(
-                            "[{reaction_id_owned}] Gate sender dropped for query '{query_id_clone}' \
-                             — exiting forwarder (bootstrap likely failed)"
-                        );
-                        return;
-                    }
-
-                    // Read the initial checkpoint sequence so we can skip stale events
-                    // that were buffered in the broadcast channel during bootstrap.
-                    let initial_seq = {
-                        let cps = checkpoints.read().await;
-                        cps.get(&query_id_clone).map(|cp| cp.sequence).unwrap_or(0)
-                    };
-
-                    // Track the last forwarded sequence for gap detection.
-                    let mut last_forwarded_seq = initial_seq;
-
-                    log::debug!(
-                        "[{reaction_id_owned}] Started result forwarder for query '{query_id_clone}' \
-                         (initial_seq={initial_seq})"
-                    );
-
-                    loop {
-                        match receiver.recv().await {
-                            Ok(query_result) => {
-                                // Skip events already covered by the bootstrap snapshot/outbox catchup.
-                                if query_result.sequence <= initial_seq {
-                                    forwarder_metrics.record_dedup_skip();
-                                    log::debug!(
-                                        "[{reaction_id_owned}] Skipping seq={} <= last_forwarded={last_forwarded_seq} for query '{query_id_clone}'",
-                                        query_result.sequence
-                                    );
-                                    continue;
-                                }
-
-                                // §6: Detect sequence gaps (incoming seq > expected next).
-                                // This catches drops that don't manifest as broadcast lag
-                                // (e.g., outbox overflow while reaction was stopping).
-                                if last_forwarded_seq > 0
-                                    && query_result.sequence > last_forwarded_seq.saturating_add(1)
-                                {
-                                    forwarder_metrics.record_gap_detection();
-                                    forwarder_metrics.record_recovery_trigger(to_policy_kind(&policy));
-                                    log::warn!(
-                                        "[{reaction_id_owned}] Sequence gap for query '{query_id_clone}': \
-                                         expected seq={}, got seq={}",
-                                        last_forwarded_seq.saturating_add(1),
-                                        query_result.sequence
-                                    );
-                                    let gap_ctx = BroadcastGapContext {
-                                        reaction_id: &reaction_id_owned,
-                                        query_id: &query_id_clone,
-                                        reaction: &reaction,
-                                        query: &query_clone,
-                                        policy,
-                                        state_store: &state_store_clone,
-                                        checkpoints: &checkpoints,
-                                        bootstrap_mutex: &bootstrap_mutex,
-                                        metrics: &forwarder_metrics,
-                                    };
-                                    match Self::handle_broadcast_gap(&gap_ctx)
-                                    .await
-                                    {
-                                        Ok(()) => {
-                                            // After gap recovery, update checkpoint from the shared map
-                                            // (handle_broadcast_gap updates it).
-                                            let cps = checkpoints.read().await;
-                                            last_forwarded_seq = cps
-                                                .get(&query_id_clone)
-                                                .map(|cp| cp.sequence)
-                                                .unwrap_or(last_forwarded_seq);
-                                            // Re-evaluate this event against the updated checkpoint.
-                                            if query_result.sequence <= last_forwarded_seq {
-                                                continue;
-                                            }
-                                        }
-                                        Err(e) => {
-                                            log::error!(
-                                                "[{reaction_id_owned}] Recovery failed for sequence gap \
-                                                 on query '{query_id_clone}': {e}"
-                                            );
-                                            break;
-                                        }
-                                    }
-                                }
-
-                                last_forwarded_seq = query_result.sequence;
-                                let seq = query_result.sequence;
-                                let result = Arc::try_unwrap(query_result)
-                                    .unwrap_or_else(|arc| (*arc).clone());
-                                if let Err(e) = reaction.enqueue_query_result(result).await {
-                                    log::error!(
-                                        "[{reaction_id_owned}] Failed to enqueue result from query '{query_id_clone}': {e}"
-                                    );
-                                } else {
-                                    // Advance in-memory checkpoint so forwarder tracks
-                                    // position (skip stale events on reconnect).
-                                    // NOTE: We do NOT persist to durable storage here.
-                                    // The reaction should persist its checkpoint after
-                                    // successfully processing the event. This prevents
-                                    // permanent skipping if the process crashes between
-                                    // enqueue and handler processing.
-                                    let config_hash = {
-                                        let cps = checkpoints.read().await;
-                                        cps.get(&query_id_clone).map(|cp| cp.config_hash).unwrap_or(0)
-                                    };
-                                    let cp = ReactionCheckpoint { sequence: seq, config_hash };
-                                    checkpoints.write().await.insert(query_id_clone.clone(), cp);
-
-                                    // Update reaction metrics: checkpoint position
-                                    let query_latest = query_clone
-                                        .output_metrics()
-                                        .map(|m| m.load_outbox_latest_seq())
-                                        .unwrap_or(seq);
-                                    forwarder_metrics.record_checkpoint(seq, query_latest);
-                                }
-                            }
-                            Err(e) => {
-                                let error_str = e.to_string();
-                                if error_str.contains("lagged") {
-                                    // §6: Broadcast gap detected.
-                                    forwarder_metrics.record_gap_detection();
-                                    forwarder_metrics.record_recovery_trigger(to_policy_kind(&policy));
-                                    log::warn!(
-                                        "[{reaction_id_owned}] Broadcast lag for query '{query_id_clone}': {error_str}"
-                                    );
-                                    let gap_ctx = BroadcastGapContext {
-                                        reaction_id: &reaction_id_owned,
-                                        query_id: &query_id_clone,
-                                        reaction: &reaction,
-                                        query: &query_clone,
-                                        policy,
-                                        state_store: &state_store_clone,
-                                        checkpoints: &checkpoints,
-                                        bootstrap_mutex: &bootstrap_mutex,
-                                        metrics: &forwarder_metrics,
-                                    };
-                                    match Self::handle_broadcast_gap(&gap_ctx)
-                                    .await
-                                    {
-                                        Ok(()) => continue,
-                                        Err(e) => {
-                                            log::error!(
-                                                "[{reaction_id_owned}] Recovery failed for broadcast gap on query '{query_id_clone}': {e}"
-                                            );
-                                            break;
-                                        }
-                                    }
-                                } else {
-                                    log::info!(
-                                        "[{reaction_id_owned}] Receiver closed for query '{query_id_clone}': {error_str}"
-                                    );
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                .instrument(span),
-            );
-
-            abort_handles.push(forwarder_task.abort_handle());
-            join_handles.push(forwarder_task);
-        }
-
-        // Spawn a supervisor task that monitors all forwarder handles.
-        // When ALL forwarders exit, check if the reaction is still Running.
-        // Only transition to Error if the exits were unexpected.
-        let supervisor_reaction_id = reaction_id.to_string();
-        let supervisor_graph = self.graph.clone();
-
-        let supervisor = tokio::spawn(async move {
-            // Wait for all forwarder tasks to complete.
-            for handle in join_handles {
-                if let Err(e) = handle.await {
-                    log::warn!("[{supervisor_reaction_id}] Forwarder task failed: {e}");
-                }
-            }
-
-            // Only transition to Error if the reaction is still Running.
-            // If it's already Stopped/Stopping/Error, this was intentional.
-            let should_transition = {
-                let graph = supervisor_graph.read().await;
-                graph
-                    .get_component(&supervisor_reaction_id)
-                    .map(|n| n.status == ComponentStatus::Running)
-                    .unwrap_or(false)
-            };
-
-            if should_transition {
-                log::warn!(
-                    "[{supervisor_reaction_id}] All query subscriptions lost — \
-                     transitioning to Error"
-                );
-                let mut graph = supervisor_graph.write().await;
-                let _ = graph.validate_and_transition(
-                    &supervisor_reaction_id,
-                    ComponentStatus::Error,
-                    Some("All query subscriptions lost".to_string()),
-                );
-            }
-        });
-
-        abort_handles.push(supervisor.abort_handle());
-
-        // Store abort handles so stop_reaction/teardown can cancel everything.
-        self.subscription_tasks
-            .write()
-            .await
-            .insert(reaction_id.to_string(), abort_handles);
-
-        Ok(())
-    }
-
-    /// Handle a broadcast gap (§6): `RecvError::Lagged` in the forwarder loop.
-    ///
-    /// Applies the reaction's recovery policy:
-    /// - `Strict`: return error (forwarder will break)
-    /// - `AutoReset`: re-bootstrap from snapshot, update checkpoint (serialized via mutex)
-    /// - `AutoSkipGap`: jump to current sequence, update checkpoint
-    async fn handle_broadcast_gap(ctx: &BroadcastGapContext<'_>) -> Result<()> {
-        let config_hash = crate::queries::compute_config_hash(ctx.query.get_config());
-
-        match ctx.policy {
-            ReactionRecoveryPolicy::Strict => Err(anyhow::anyhow!(
-                "Strict recovery policy — broadcast lag for query '{}' \
-                     is unrecoverable",
-                ctx.query_id
-            )),
-            ReactionRecoveryPolicy::AutoReset => {
-                // Serialize bootstrap calls — multiple forwarders may hit gaps concurrently.
-                let _guard = ctx.bootstrap_mutex.lock().await;
-
-                log::info!(
-                    "[{}] AutoReset on broadcast gap for query '{}'",
-                    ctx.reaction_id,
-                    ctx.query_id
-                );
-                ctx.metrics.record_fetch_snapshot();
-                let snapshot = ctx.query.fetch_snapshot().await.map_err(|e| {
-                    anyhow::anyhow!(
-                        "AutoReset broadcast gap: failed to fetch snapshot for '{}': {e}",
-                        ctx.query_id
-                    )
-                })?;
-
-                let cp = ReactionCheckpoint {
-                    sequence: snapshot.as_of_sequence,
-                    config_hash,
-                };
-
-                // Invoke bootstrap hook BEFORE persisting checkpoint — a crash
-                // during bootstrap will re-trigger recovery on next start.
-                let bootstrap_ctx = BootstrapContext::new(
-                    ctx.query_id.to_string(),
-                    true,
-                    ctx.query.clone(),
-                    ctx.reaction_id.to_string(),
-                    ctx.state_store.clone(),
-                );
-                ctx.reaction.bootstrap(bootstrap_ctx).await?;
-
-                // Bootstrap succeeded — now safe to persist checkpoint.
-                if let Some(store) = ctx.state_store.as_ref() {
-                    crate::reactions::checkpoint::write_checkpoint(
-                        store.as_ref(),
-                        ctx.reaction_id,
-                        ctx.query_id,
-                        &cp,
-                    )
-                    .await?;
-                }
-
-                ctx.checkpoints
-                    .write()
-                    .await
-                    .insert(ctx.query_id.to_string(), cp);
-
-                Ok(())
-            }
-            ReactionRecoveryPolicy::AutoSkipGap => {
-                log::info!(
-                    "[{}] AutoSkipGap on broadcast gap for query '{}'",
-                    ctx.reaction_id,
-                    ctx.query_id
-                );
-                ctx.metrics.record_fetch_outbox();
-                let current_seq = match ctx.query.fetch_outbox(0).await {
-                    Ok(resp) => resp.latest_sequence,
-                    Err(FetchError::OutboxGap(gap)) => gap.latest_sequence,
-                    Err(FetchError::NotRunning { .. } | FetchError::TimedOut) => {
-                        // Query not running — fall back to existing checkpoint sequence.
-                        let existing_seq = ctx
-                            .checkpoints
-                            .read()
-                            .await
-                            .get(ctx.query_id)
-                            .map(|cp| cp.sequence)
-                            .unwrap_or(0);
-                        log::info!(
-                            "[{}] AutoSkipGap: query '{}' not running, \
-                             keeping checkpoint at seq={existing_seq}",
-                            ctx.reaction_id,
-                            ctx.query_id
-                        );
-                        existing_seq
-                    }
-                };
-
-                let cp = ReactionCheckpoint {
-                    sequence: current_seq,
-                    config_hash,
-                };
-
-                if let Some(store) = ctx.state_store.as_ref() {
-                    crate::reactions::checkpoint::write_checkpoint(
-                        store.as_ref(),
-                        ctx.reaction_id,
-                        ctx.query_id,
-                        &cp,
-                    )
-                    .await?;
-                }
-
-                ctx.checkpoints
-                    .write()
-                    .await
-                    .insert(ctx.query_id.to_string(), cp);
-
-                Ok(())
-            }
-        }
-    }
-
     /// Abort all subscription forwarder tasks for a reaction.
     async fn abort_subscription_tasks(&self, reaction_id: &str) {
-        Self::abort_subscription_tasks_static(&self.subscription_tasks, reaction_id).await;
-    }
-
-    async fn abort_subscription_tasks_static(
-        tasks: &Arc<RwLock<HashMap<String, Vec<tokio::task::AbortHandle>>>>,
-        reaction_id: &str,
-    ) {
-        if let Some(handles) = tasks.write().await.remove(reaction_id) {
-            for handle in handles {
-                handle.abort();
-            }
-        }
+        self.engine.abort_subscription_tasks(reaction_id).await;
     }
 
     /// Get the per-(reaction, query) metrics for a specific reaction.
@@ -1497,7 +609,7 @@ impl ReactionManager {
         }
         drop(graph);
 
-        let metrics = self.reaction_metrics.read().await;
+        let metrics = self.engine.metrics().read().await;
         Ok(metrics
             .iter()
             .filter(|((rid, _), _)| rid == reaction_id)
@@ -1507,7 +619,7 @@ impl ReactionManager {
 
     /// Get the global lifecycle metrics.
     pub fn lifecycle_metrics(&self) -> &Arc<LifecycleMetrics> {
-        &self.lifecycle_metrics
+        self.engine.lifecycle_metrics()
     }
 }
 
@@ -1517,7 +629,11 @@ mod tests {
     use crate::channels::QuerySubscriptionResponse;
     use crate::component_graph::ComponentStatusHandle;
     use crate::config::schema::QueryConfig;
-    use crate::queries::output_state::{OutboxResponse, SnapshotResponse};
+    use crate::consumption::engine::{BroadcastGapContext, ConsumptionEngine};
+    use crate::consumption::{QueryConsumer, ReactionConsumer};
+    use crate::metrics::ReactionMetrics;
+    use crate::queries::output_state::{FetchError, OutboxResponse, SnapshotResponse};
+    use crate::reactions::checkpoint::ReactionCheckpoint;
     use crate::sources::tests::TestMockSource;
     use async_trait::async_trait;
     use drasi_core::models::{Element, ElementMetadata, ElementPropertyMap, ElementReference};
@@ -2059,13 +1175,14 @@ mod tests {
     async fn broadcast_gap_strict_returns_error() {
         let query: Arc<dyn crate::queries::Query> = Arc::new(MockQuery::new(42, 10));
         let reaction: Arc<dyn Reaction> = Arc::new(MockReaction::new("r1", vec!["q1".into()]));
+        let consumer: Arc<dyn QueryConsumer> = Arc::new(ReactionConsumer(reaction.clone()));
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
 
-        let result = ReactionManager::handle_broadcast_gap(&BroadcastGapContext {
+        let result = ConsumptionEngine::handle_broadcast_gap(&BroadcastGapContext {
             reaction_id: "r1",
             query_id: "q1",
-            reaction: &reaction,
+            consumer: &consumer,
             query: &query,
             policy: ReactionRecoveryPolicy::Strict,
             state_store: &None,
@@ -2093,13 +1210,14 @@ mod tests {
                 .with_policy(ReactionRecoveryPolicy::AutoReset),
         );
         let reaction_trait: Arc<dyn Reaction> = reaction.clone();
+        let consumer: Arc<dyn QueryConsumer> = Arc::new(ReactionConsumer(reaction_trait.clone()));
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
 
-        let result = ReactionManager::handle_broadcast_gap(&BroadcastGapContext {
+        let result = ConsumptionEngine::handle_broadcast_gap(&BroadcastGapContext {
             reaction_id: "r1",
             query_id: "q1",
-            reaction: &reaction_trait,
+            consumer: &consumer,
             query: &query,
             policy: ReactionRecoveryPolicy::AutoReset,
             state_store: &None,
@@ -2143,13 +1261,14 @@ mod tests {
                 .with_policy(ReactionRecoveryPolicy::AutoSkipGap),
         );
         let reaction_trait: Arc<dyn Reaction> = reaction.clone();
+        let consumer: Arc<dyn QueryConsumer> = Arc::new(ReactionConsumer(reaction_trait.clone()));
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
 
-        let result = ReactionManager::handle_broadcast_gap(&BroadcastGapContext {
+        let result = ConsumptionEngine::handle_broadcast_gap(&BroadcastGapContext {
             reaction_id: "r1",
             query_id: "q1",
-            reaction: &reaction_trait,
+            consumer: &consumer,
             query: &query,
             policy: ReactionRecoveryPolicy::AutoSkipGap,
             state_store: &None,
@@ -2313,13 +1432,14 @@ mod tests {
                 .with_policy(ReactionRecoveryPolicy::AutoReset),
         );
         let reaction_trait: Arc<dyn Reaction> = reaction.clone();
+        let consumer: Arc<dyn QueryConsumer> = Arc::new(ReactionConsumer(reaction_trait.clone()));
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
 
-        let result = ReactionManager::handle_broadcast_gap(&BroadcastGapContext {
+        let result = ConsumptionEngine::handle_broadcast_gap(&BroadcastGapContext {
             reaction_id: "r1",
             query_id: "q1",
-            reaction: &reaction_trait,
+            consumer: &consumer,
             query: &query,
             policy: ReactionRecoveryPolicy::AutoReset,
             state_store: &None,
@@ -2441,13 +1561,14 @@ mod tests {
         let query: Arc<dyn crate::queries::Query> = Arc::new(MockQuery::new(42, 100));
         let reaction = Arc::new(FailingBootstrapReaction::new("r1", vec!["q1".into()]));
         let reaction_trait: Arc<dyn Reaction> = reaction.clone();
+        let consumer: Arc<dyn QueryConsumer> = Arc::new(ReactionConsumer(reaction_trait.clone()));
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
 
-        let result = ReactionManager::handle_broadcast_gap(&BroadcastGapContext {
+        let result = ConsumptionEngine::handle_broadcast_gap(&BroadcastGapContext {
             reaction_id: "r1",
             query_id: "q1",
-            reaction: &reaction_trait,
+            consumer: &consumer,
             query: &query,
             policy: ReactionRecoveryPolicy::AutoReset,
             state_store: &None,
@@ -2490,6 +1611,7 @@ mod tests {
                 .with_policy(ReactionRecoveryPolicy::AutoReset),
         );
         let reaction_trait: Arc<dyn Reaction> = reaction.clone();
+        let consumer: Arc<dyn QueryConsumer> = Arc::new(ReactionConsumer(reaction_trait.clone()));
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
 
@@ -2499,7 +1621,7 @@ mod tests {
         let ctx_q1 = BroadcastGapContext {
             reaction_id: "r1",
             query_id: "q1",
-            reaction: &reaction_trait,
+            consumer: &consumer,
             query: &query,
             policy: ReactionRecoveryPolicy::AutoReset,
             state_store: &None,
@@ -2510,7 +1632,7 @@ mod tests {
         let ctx_q2 = BroadcastGapContext {
             reaction_id: "r1",
             query_id: "q2",
-            reaction: &reaction_trait,
+            consumer: &consumer,
             query: &query,
             policy: ReactionRecoveryPolicy::AutoReset,
             state_store: &None,
@@ -2519,8 +1641,8 @@ mod tests {
             metrics: &metrics_q2,
         };
         let (r1, r2) = tokio::join!(
-            ReactionManager::handle_broadcast_gap(&ctx_q1),
-            ReactionManager::handle_broadcast_gap(&ctx_q2),
+            ConsumptionEngine::handle_broadcast_gap(&ctx_q1),
+            ConsumptionEngine::handle_broadcast_gap(&ctx_q2),
         );
 
         assert!(

--- a/lib/src/sources/base.rs
+++ b/lib/src/sources/base.rs
@@ -83,6 +83,11 @@ pub struct SourceBaseParams {
     pub bootstrap_provider: Option<Box<dyn BootstrapProvider + 'static>>,
     /// Whether this source should auto-start - defaults to true
     pub auto_start: bool,
+    /// Capacity of the query-result priority queue - defaults to 10000.
+    ///
+    /// Only relevant for sources that subscribe to continuous-query results
+    /// (see [`Source::subscribed_query_ids`](crate::sources::Source::subscribed_query_ids)).
+    pub priority_queue_capacity: Option<usize>,
 }
 
 impl std::fmt::Debug for SourceBaseParams {
@@ -114,6 +119,7 @@ impl SourceBaseParams {
             state_store: None,
             bootstrap_provider: None,
             auto_start: true,
+            priority_queue_capacity: None,
         }
     }
 
@@ -153,6 +159,14 @@ impl SourceBaseParams {
     /// started manually via `start_source()`.
     pub fn with_auto_start(mut self, auto_start: bool) -> Self {
         self.auto_start = auto_start;
+        self
+    }
+
+    /// Set the capacity of the query-result priority queue.
+    ///
+    /// Only relevant for sources that subscribe to continuous-query results.
+    pub fn with_priority_queue_capacity(mut self, capacity: usize) -> Self {
+        self.priority_queue_capacity = Some(capacity);
         self
     }
 }
@@ -267,6 +281,11 @@ pub struct SourceBase {
     /// [`SourceBase::take_pending_initial_bootstrap`] to decide whether to wait
     /// for the snapshot boundary. Reset by `reset_bootstrap_boundary` on start.
     pending_initial_bootstrap: Arc<AtomicBool>,
+    /// Timestamp-ordered queue of query results for sources that subscribe to
+    /// continuous queries. Populated by [`SourceBase::enqueue_query_result`]
+    /// (called by the host's forwarder) and drained by the source's own
+    /// processing loop. Unused by sources that do not subscribe to queries.
+    pub priority_queue: PriorityQueue<QueryResult>,
 }
 
 /// Publish a bootstrap-to-CDC boundary token into a `watch` sender using the
@@ -345,6 +364,7 @@ impl SourceBase {
             bootstrap_boundary: Arc::new(tokio::sync::watch::channel(None).0),
             has_bootstrap_provider: Arc::new(AtomicBool::new(has_bootstrap_provider)),
             pending_initial_bootstrap: Arc::new(AtomicBool::new(false)),
+            priority_queue: PriorityQueue::new(params.priority_queue_capacity.unwrap_or(10000)),
         })
     }
 
@@ -638,6 +658,7 @@ impl SourceBase {
             bootstrap_boundary: self.bootstrap_boundary.clone(),
             has_bootstrap_provider: self.has_bootstrap_provider.clone(),
             pending_initial_bootstrap: self.pending_initial_bootstrap.clone(),
+            priority_queue: self.priority_queue.clone(),
         }
     }
 
@@ -668,6 +689,17 @@ impl SourceBase {
     /// Get the source ID
     pub fn get_id(&self) -> &str {
         &self.id
+    }
+
+    /// Enqueue a query result for processing.
+    ///
+    /// The host calls this (via [`Source::enqueue_query_result`](crate::sources::Source::enqueue_query_result))
+    /// to forward results from the source's subscribed queries. Results are held
+    /// in a timestamp-ordered priority queue and should be drained by the source's
+    /// own processing loop via `self.base.priority_queue.dequeue()`.
+    pub async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+        self.priority_queue.enqueue_wait(Arc::new(result)).await;
+        Ok(())
     }
 
     /// Create a streaming receiver for a query subscription

--- a/lib/src/sources/manager.rs
+++ b/lib/src/sources/manager.rs
@@ -16,7 +16,6 @@ use anyhow::Result;
 use log::{info, warn};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::Instrument;
 
 // Import real Drasi Source SDK
 use drasi_core::models::{ElementPropertyMap, ElementValue};
@@ -27,9 +26,11 @@ use std::collections::BTreeMap;
 use crate::channels::*;
 use crate::component_graph::{ComponentGraph, ComponentKind, ComponentUpdateSender};
 use crate::config::SourceRuntime;
+use crate::consumption::{ConsumptionEngine, QueryConsumer, SourceConsumer};
 use crate::context::SourceRuntimeContext;
 use crate::identity::IdentityProvider;
 use crate::managers::{ComponentLogKey, ComponentLogRegistry};
+use crate::metrics::LifecycleMetrics;
 use crate::reactions::QueryProvider;
 use crate::schema::SourceSchema;
 use crate::sources::Source;
@@ -93,7 +94,8 @@ pub struct SourceManager {
     query_provider: Arc<RwLock<Option<Arc<dyn QueryProvider>>>>,
     /// Forwarder tasks that pump query results into query-consuming sources,
     /// keyed by source id. Aborted when the source stops.
-    subscription_tasks: Arc<RwLock<HashMap<String, Vec<tokio::task::JoinHandle<()>>>>>,
+    subscription_tasks: Arc<RwLock<HashMap<String, Vec<tokio::task::AbortHandle>>>>,
+    engine: ConsumptionEngine,
 }
 
 impl SourceManager {
@@ -109,16 +111,33 @@ impl SourceManager {
         graph: Arc<RwLock<ComponentGraph>>,
         update_tx: ComponentUpdateSender,
     ) -> Self {
+        let instance_id = instance_id.into();
+        let state_store = Arc::new(RwLock::new(None));
+        let query_provider = Arc::new(RwLock::new(None));
+        let subscription_tasks = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(RwLock::new(HashMap::new()));
+        let lifecycle_metrics = Arc::new(LifecycleMetrics::new());
+        let engine = ConsumptionEngine::new(
+            instance_id.clone(),
+            graph.clone(),
+            query_provider.clone(),
+            state_store.clone(),
+            subscription_tasks.clone(),
+            metrics,
+            lifecycle_metrics,
+        );
+
         Self {
-            instance_id: instance_id.into(),
-            state_store: Arc::new(RwLock::new(None)),
+            instance_id,
+            state_store,
             identity_provider: Arc::new(RwLock::new(None)),
             wal_provider: Arc::new(RwLock::new(None)),
             log_registry,
             graph,
             update_tx,
-            query_provider: Arc::new(RwLock::new(None)),
-            subscription_tasks: Arc::new(RwLock::new(HashMap::new())),
+            query_provider,
+            subscription_tasks,
+            engine,
         }
     }
 
@@ -126,7 +145,7 @@ impl SourceManager {
     ///
     /// This allows sources to access the state store when they are added.
     pub async fn inject_state_store(&self, state_store: Arc<dyn StateStoreProvider>) {
-        *self.state_store.write().await = Some(state_store);
+        self.engine.inject_state_store(state_store).await;
     }
 
     /// Inject the identity provider (called after DrasiLib is fully constructed)
@@ -178,10 +197,7 @@ impl SourceManager {
     /// Subscribe the given source to its declared queries and spawn forwarders
     /// that pump each query's results into `source.enqueue_query_result()`.
     ///
-    /// This mirrors the reaction subscription model but is intentionally simpler
-    /// (no checkpoint/recovery machinery — sources that need durability persist
-    /// their own state). Idempotent: if the source already has active forwarders,
-    /// this is a no-op.
+    /// Idempotent: if the source already has active forwarders, this is a no-op.
     pub async fn wire_query_subscriptions(&self, id: &str) -> Result<()> {
         let source = match self.get_source_instance(id).await {
             Some(s) => s,
@@ -201,63 +217,18 @@ impl SourceManager {
             }
         }
 
-        let query_provider = self.query_provider.read().await.clone().ok_or_else(|| {
-            anyhow::anyhow!("QueryProvider not injected — was SourceManager initialized properly?")
-        })?;
-
-        let instance_id = self.instance_id.clone();
-        let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
-
-        for query_id in &query_ids {
-            let query = query_provider.get_query_instance(query_id).await?;
-            let subscription = query.subscribe(id.to_string()).await?;
-            let mut receiver = subscription.receiver;
-
-            let source = source.clone();
-            let source_id = id.to_string();
-            let query_id_owned = query_id.clone();
-
-            let span = tracing::info_span!(
-                "source_query_forwarder",
-                instance_id = %instance_id,
-                component_id = %source_id,
-                component_type = "source"
-            );
-
-            let handle = tokio::spawn(
-                async move {
-                    log::debug!(
-                        "[{source_id}] started query-result forwarder for query '{query_id_owned}'"
-                    );
-                    loop {
-                        match receiver.recv().await {
-                            Ok(query_result) => {
-                                let result = std::sync::Arc::try_unwrap(query_result)
-                                    .unwrap_or_else(|arc| (*arc).clone());
-                                if let Err(e) = source.enqueue_query_result(result).await {
-                                    log::error!(
-                                        "[{source_id}] failed to enqueue result from query '{query_id_owned}': {e}"
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                log::debug!(
-                                    "[{source_id}] query-result forwarder for '{query_id_owned}' stopping: {e}"
-                                );
-                                break;
-                            }
-                        }
-                    }
-                }
-                .instrument(span),
-            );
-            handles.push(handle);
+        let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
+        let consumer = Arc::new(SourceConsumer(source.clone())) as Arc<dyn QueryConsumer>;
+        if let Err(e) = self
+            .engine
+            .subscribe_and_bootstrap(id, consumer, gate_rx)
+            .await
+        {
+            self.engine.abort_subscription_tasks(id).await;
+            return Err(e);
         }
 
-        self.subscription_tasks
-            .write()
-            .await
-            .insert(id.to_string(), handles);
+        let _ = gate_tx.send(true);
 
         info!(
             "Wired {} query subscription(s) for source '{id}'",
@@ -268,11 +239,7 @@ impl SourceManager {
 
     /// Abort and drop any query-result forwarder tasks for the given source.
     async fn abort_query_subscriptions(&self, id: &str) {
-        if let Some(handles) = self.subscription_tasks.write().await.remove(id) {
-            for handle in handles {
-                handle.abort();
-            }
-        }
+        self.engine.abort_subscription_tasks(id).await;
     }
 
     pub async fn get_source_instance(&self, id: &str) -> Option<Arc<dyn Source>> {
@@ -439,6 +406,7 @@ impl SourceManager {
     ///
     /// The caller should validate dependencies via `graph.can_remove()` before calling this.
     pub async fn teardown_source(&self, id: String, cleanup: bool) -> Result<()> {
+        let id_clone = id.clone();
         crate::managers::lifecycle_helpers::teardown_component::<Arc<dyn Source>, _, _>(
             &self.graph,
             &id,
@@ -447,7 +415,7 @@ impl SourceManager {
             &self.instance_id,
             &self.log_registry,
             cleanup,
-            || async {},
+            || self.abort_query_subscriptions(&id_clone),
         )
         .await
     }
@@ -485,7 +453,7 @@ impl SourceManager {
                 &id,
                 "source",
                 &old_source,
-                || async {},
+                || self.abort_query_subscriptions(&id),
                 || async {
                     let new_source: Arc<dyn Source> = Arc::new(new_source);
                     let mut context = SourceRuntimeContext::new(

--- a/lib/src/sources/manager.rs
+++ b/lib/src/sources/manager.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use log::{info, warn};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tracing::Instrument;
 
 // Import real Drasi Source SDK
 use drasi_core::models::{ElementPropertyMap, ElementValue};
@@ -29,10 +30,12 @@ use crate::config::SourceRuntime;
 use crate::context::SourceRuntimeContext;
 use crate::identity::IdentityProvider;
 use crate::managers::{ComponentLogKey, ComponentLogRegistry};
+use crate::reactions::QueryProvider;
 use crate::schema::SourceSchema;
 use crate::sources::Source;
 use crate::state_store::StateStoreProvider;
 use crate::wal::WalProvider;
+use std::collections::HashMap;
 
 // Convert JSON value to ElementValue
 pub fn convert_json_to_element_value(value: &Value) -> ElementValue {
@@ -85,6 +88,12 @@ pub struct SourceManager {
     /// Managers send transitional states (Starting, Stopping, Reconfiguring) here;
     /// the loop applies them to the graph and records events automatically.
     update_tx: ComponentUpdateSender,
+    /// Provider used to obtain query instances so query-consuming sources can
+    /// subscribe to continuous-query results. Injected after construction.
+    query_provider: Arc<RwLock<Option<Arc<dyn QueryProvider>>>>,
+    /// Forwarder tasks that pump query results into query-consuming sources,
+    /// keyed by source id. Aborted when the source stops.
+    subscription_tasks: Arc<RwLock<HashMap<String, Vec<tokio::task::JoinHandle<()>>>>>,
 }
 
 impl SourceManager {
@@ -108,6 +117,8 @@ impl SourceManager {
             log_registry,
             graph,
             update_tx,
+            query_provider: Arc::new(RwLock::new(None)),
+            subscription_tasks: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -131,6 +142,137 @@ impl SourceManager {
     /// for crash recovery and replay.
     pub async fn inject_wal_provider(&self, wal_provider: Arc<dyn WalProvider>) {
         *self.wal_provider.write().await = Some(wal_provider);
+    }
+
+    /// Inject the query provider (called after DrasiLib is fully constructed).
+    ///
+    /// This lets query-consuming sources (those returning a non-empty
+    /// [`Source::subscribed_query_ids`](crate::sources::Source::subscribed_query_ids))
+    /// subscribe to continuous-query results, mirroring the reaction model.
+    pub async fn inject_query_provider(&self, query_provider: Arc<dyn QueryProvider>) {
+        *self.query_provider.write().await = Some(query_provider);
+    }
+
+    /// Wire query subscriptions for every source that declares them.
+    ///
+    /// Called by the lifecycle after all queries have started, so query-consuming
+    /// sources begin receiving results. Best-effort: individual failures are
+    /// logged and do not abort the batch.
+    pub async fn wire_all_query_subscriptions(&self) {
+        let source_ids: Vec<String> = {
+            let graph = self.graph.read().await;
+            graph
+                .list_by_kind(&ComponentKind::Source)
+                .into_iter()
+                .map(|(id, _status)| id)
+                .collect()
+        };
+
+        for id in source_ids {
+            if let Err(e) = self.wire_query_subscriptions(&id).await {
+                warn!("Failed to wire query subscriptions for source '{id}': {e}");
+            }
+        }
+    }
+
+    /// Subscribe the given source to its declared queries and spawn forwarders
+    /// that pump each query's results into `source.enqueue_query_result()`.
+    ///
+    /// This mirrors the reaction subscription model but is intentionally simpler
+    /// (no checkpoint/recovery machinery — sources that need durability persist
+    /// their own state). Idempotent: if the source already has active forwarders,
+    /// this is a no-op.
+    pub async fn wire_query_subscriptions(&self, id: &str) -> Result<()> {
+        let source = match self.get_source_instance(id).await {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        let query_ids = source.subscribed_query_ids();
+        if query_ids.is_empty() {
+            return Ok(());
+        }
+
+        // Idempotency: skip if forwarders are already running for this source.
+        {
+            let tasks = self.subscription_tasks.read().await;
+            if tasks.get(id).map(|v| !v.is_empty()).unwrap_or(false) {
+                return Ok(());
+            }
+        }
+
+        let query_provider = self.query_provider.read().await.clone().ok_or_else(|| {
+            anyhow::anyhow!("QueryProvider not injected — was SourceManager initialized properly?")
+        })?;
+
+        let instance_id = self.instance_id.clone();
+        let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+
+        for query_id in &query_ids {
+            let query = query_provider.get_query_instance(query_id).await?;
+            let subscription = query.subscribe(id.to_string()).await?;
+            let mut receiver = subscription.receiver;
+
+            let source = source.clone();
+            let source_id = id.to_string();
+            let query_id_owned = query_id.clone();
+
+            let span = tracing::info_span!(
+                "source_query_forwarder",
+                instance_id = %instance_id,
+                component_id = %source_id,
+                component_type = "source"
+            );
+
+            let handle = tokio::spawn(
+                async move {
+                    log::debug!(
+                        "[{source_id}] started query-result forwarder for query '{query_id_owned}'"
+                    );
+                    loop {
+                        match receiver.recv().await {
+                            Ok(query_result) => {
+                                let result = std::sync::Arc::try_unwrap(query_result)
+                                    .unwrap_or_else(|arc| (*arc).clone());
+                                if let Err(e) = source.enqueue_query_result(result).await {
+                                    log::error!(
+                                        "[{source_id}] failed to enqueue result from query '{query_id_owned}': {e}"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                log::debug!(
+                                    "[{source_id}] query-result forwarder for '{query_id_owned}' stopping: {e}"
+                                );
+                                break;
+                            }
+                        }
+                    }
+                }
+                .instrument(span),
+            );
+            handles.push(handle);
+        }
+
+        self.subscription_tasks
+            .write()
+            .await
+            .insert(id.to_string(), handles);
+
+        info!(
+            "Wired {} query subscription(s) for source '{id}'",
+            query_ids.len()
+        );
+        Ok(())
+    }
+
+    /// Abort and drop any query-result forwarder tasks for the given source.
+    async fn abort_query_subscriptions(&self, id: &str) {
+        if let Some(handles) = self.subscription_tasks.write().await.remove(id) {
+            for handle in handles {
+                handle.abort();
+            }
+        }
     }
 
     pub async fn get_source_instance(&self, id: &str) -> Option<Arc<dyn Source>> {
@@ -193,7 +335,20 @@ impl SourceManager {
                 })?;
 
         crate::managers::lifecycle_helpers::start_component(&self.graph, &id, "source", &source)
-            .await
+            .await?;
+
+        // Wire query subscriptions for query-consuming sources. At runtime the
+        // subscribed queries are expected to already be running; during batch
+        // startup the lifecycle calls `wire_all_query_subscriptions()` after all
+        // queries have started instead (this is a no-op then, since queries may
+        // not be up yet and wiring is idempotent).
+        if !source.subscribed_query_ids().is_empty() {
+            if let Err(e) = self.wire_query_subscriptions(&id).await {
+                warn!("Failed to wire query subscriptions for source '{id}': {e}");
+            }
+        }
+
+        Ok(())
     }
 
     /// Stop a running source by ID, transitioning it to the Stopped state.
@@ -207,6 +362,9 @@ impl SourceManager {
                 .ok_or_else(|| {
                     anyhow::Error::new(crate::managers::ComponentNotFoundError::new("source", &id))
                 })?;
+
+        // Abort any query-result forwarders before stopping the source itself.
+        self.abort_query_subscriptions(&id).await;
 
         crate::managers::lifecycle_helpers::stop_component(&self.graph, &id, "source", &source)
             .await

--- a/lib/src/sources/traits.rs
+++ b/lib/src/sources/traits.rs
@@ -263,6 +263,32 @@ pub trait Source: Send + Sync {
         settings: crate::config::SourceSubscriptionSettings,
     ) -> Result<SubscriptionResponse>;
 
+    /// The IDs of continuous queries whose results feed this source.
+    ///
+    /// Most sources ingest data from an external system and return an empty
+    /// list (the default). Sources that instead derive their graph from the
+    /// results of one or more continuous queries — e.g. a state machine that
+    /// maps query results to entity-state nodes — return those query IDs here.
+    ///
+    /// After the source starts and its subscribed queries are running, the host
+    /// subscribes on the source's behalf and forwards each result via
+    /// [`enqueue_query_result`](Source::enqueue_query_result). This mirrors the
+    /// query-subscription model used by reactions.
+    fn subscribed_query_ids(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// Enqueue a query result for processing.
+    ///
+    /// The host calls this to forward query results to the source after
+    /// subscribing on its behalf (see [`subscribed_query_ids`](Source::subscribed_query_ids)).
+    /// The default implementation is a no-op. Sources that consume query results
+    /// should delegate to
+    /// [`SourceBase::enqueue_query_result`](crate::sources::base::SourceBase::enqueue_query_result).
+    async fn enqueue_query_result(&self, _result: QueryResult) -> Result<()> {
+        Ok(())
+    }
+
     /// Downcast helper for testing - allows access to concrete types
     fn as_any(&self) -> &dyn std::any::Any;
 
@@ -406,6 +432,14 @@ impl Source for Box<dyn Source + 'static> {
         settings: crate::config::SourceSubscriptionSettings,
     ) -> Result<SubscriptionResponse> {
         (**self).subscribe(settings).await
+    }
+
+    fn subscribed_query_ids(&self) -> Vec<String> {
+        (**self).subscribed_query_ids()
+    }
+
+    async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+        (**self).enqueue_query_result(result).await
     }
 
     fn as_any(&self) -> &dyn std::any::Any {


### PR DESCRIPTION
# Description

Reworks the experimental "state machine reaction" (which was awkwardly *both* a reaction and a source, linked in-process via a global registry keyed by `sourceId`) into a single **source-only** component. To make that possible, this extends the source base API so a source can subscribe to continuous-query results the same way a reaction does.

The old split was awkward: it needed two component ids, a process-global registry, and careful persistence to stay consistent across the reaction to source hop. Collapsing it into one source removes all of that: the component consumes upstream query results and emits entity-state nodes, and its own id is what downstream queries subscribe to.

## Approach

**Source API base (`drasi-lib`)** - the new capability, modelled on how reactions consume query results:
- `Source` trait gains `subscribed_query_ids()` and `enqueue_query_result()`. Both are defaulted, so every existing source is unaffected.
- `SourceBase` gains a timestamp-ordered `PriorityQueue<QueryResult>` and an `enqueue_query_result()` helper, mirroring `ReactionBase`.
- `SourceManager` subscribes query-consuming sources to their queries and forwards results into `enqueue_query_result()`; forwarders are aborted on stop. `QueryManager` is injected as the source manager's `QueryProvider`, and the lifecycle wires query to source subscriptions right after queries start (so downstream queries, which subscribed to the source during the Queries phase, and the source's own upstream subscriptions, are both satisfied).

**`drasi-source-state-machine` (new crate)**:
- Maps query results to per-entity state transitions and exposes each entity's live state as its own source.
- Persists state to the state store and bootstraps late/downstream subscribers from it, so it survives restarts.
- Ships engine/config unit tests plus an end-to-end integration test (application source -> stage queries -> state machine source -> downstream query).

**`examples/lib/orders-state-machine`**:
- Faithful port of the Postgres + dashboard + stored-procedure orders demo, swapping the old reaction+source pair for the single state machine source.

## Notes for reviewers

- The query to source forwarding is intentionally simpler than the reaction path (no checkpoint/recovery/gap-detection); the durable state store is the safety net, as it was in the experiment.
- No component-graph `Feeds` edges are added for source to query dependencies, to avoid destabilizing the existing topological ordering and shutdown. Shutdown still works: forwarders exit when upstream query dispatchers drop, and `stop_source` aborts them.
- The existing `QueryProvider` trait is reused rather than introducing a new one.

## Type of change

- This pull request adds or changes features of Drasi and has an approved issue (issue link required).

Fixes: #issue_number