### PR TITLE
Release persistent index-backend handles on DrasiLib::shutdown() (#627)

### DIFF
--- a/lib/src/lib_core.rs
+++ b/lib/src/lib_core.rs
@@ -569,9 +569,16 @@ impl DrasiLib {
     /// Shut down the server permanently, releasing all resources.
     ///
     /// Unlike [`stop()`](Self::stop), which allows the server to be restarted,
-    /// `shutdown()` performs a full teardown: it stops all components and aborts
-    /// the internal graph update loop. After `shutdown()`, the instance cannot
+    /// `shutdown()` performs a full teardown: it stops all components, aborts
+    /// the internal graph update loop, and releases the persistent index-backend
+    /// handles held by queries. After `shutdown()`, the instance cannot
     /// be restarted — create a new `DrasiLib` instance instead.
+    ///
+    /// Releasing the index handles is non-destructive: on-disk data is left intact,
+    /// but persistent backends that hold an exclusive OS resource (notably RocksDB,
+    /// which takes a process-exclusive lock on its data directory) free it here rather
+    /// than only when the whole `DrasiLib` value is dropped. This lets a new `DrasiLib`
+    /// reopen the same path — and recover the prior state — within the same process.
     ///
     /// This method is idempotent — calling it on an already-stopped server will
     /// still clean up the graph update loop.
@@ -611,6 +618,13 @@ impl DrasiLib {
             handle.abort();
             let _ = handle.await;
         }
+
+        // Release persistent index-backend handles retained by queries. Components are
+        // stopped by this point, so the transient handles held by per-query tasks are
+        // already dropped; this drops the remaining long-lived handles so persistent
+        // backends (e.g. RocksDB) release their exclusive lock. On-disk data is left
+        // intact for a future reopen.
+        self.query_manager.release_all_persistent_handles().await;
 
         info!("drasi-lib shut down permanently");
         Ok(())

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -2555,7 +2555,10 @@ impl Query for DrasiQuery {
         // Defensive: if the query was never stopped (e.g. left in a terminal Error
         // state), the FutureQueueSource may still hold a clone of the backend future
         // queue. `stop()` normally takes it already, in which case this is a no-op.
-        if let Some(fq) = self.future_queue_source.write().await.take() {
+        // Take the value out first so the write-lock guard is dropped before the
+        // `.await` below (never hold a lock across an await point).
+        let future_queue_source = self.future_queue_source.write().await.take();
+        if let Some(fq) = future_queue_source {
             fq.stop().await;
         }
 
@@ -2943,8 +2946,12 @@ impl QueryManager {
             .collect();
 
         for id in query_ids {
-            if let Ok(query) = self.get_query_instance(&id).await {
-                query.release_persistent_handles().await;
+            match self.get_query_instance(&id).await {
+                Ok(query) => query.release_persistent_handles().await,
+                Err(e) => warn!(
+                    "Failed to release persistent index handles for query '{id}' during \
+                     shutdown: {e}. A persistent backend may keep its exclusive lock held."
+                ),
             }
         }
     }

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -242,6 +242,19 @@ pub trait Query: Send + Sync {
     fn output_metrics(&self) -> Option<Arc<QueryOutputMetrics>> {
         None
     }
+
+    /// Release the persistent index-backend handles this query retains, **without**
+    /// deleting any on-disk data.
+    ///
+    /// Persistent backends (e.g. RocksDB, which holds a process-exclusive lock on its
+    /// data directory) keep that resource pinned until every clone of their shared
+    /// handle is dropped. A query retains some of those handles for its whole lifetime,
+    /// so they are only freed when the whole `DrasiLib` is dropped. This method drops
+    /// those in-memory handles so the backend can release its lock during a permanent
+    /// shutdown, while leaving persisted state intact for a future reopen.
+    ///
+    /// Default: no-op — volatile/in-memory queries hold no such handles.
+    async fn release_persistent_handles(&self) {}
 }
 
 /// Bootstrap phase tracking for each source
@@ -2530,6 +2543,26 @@ impl Query for DrasiQuery {
     fn output_metrics(&self) -> Option<Arc<QueryOutputMetrics>> {
         Some(self.output_metrics.clone())
     }
+
+    async fn release_persistent_handles(&self) {
+        // Drop the persistent handles created by the index backend. For a shared
+        // backend like RocksDB (one `OptimisticTransactionDB` cloned into every
+        // index/store/writer), these are the only backend clones the query still
+        // retains after `stop()`; dropping them lets the backend release its
+        // exclusive lock. On-disk data is left untouched, so a future reopen of the
+        // same path recovers the prior state.
+
+        // Defensive: if the query was never stopped (e.g. left in a terminal Error
+        // state), the FutureQueueSource may still hold a clone of the backend future
+        // queue. `stop()` normally takes it already, in which case this is a no-op.
+        if let Some(fq) = self.future_queue_source.write().await.take() {
+            fq.stop().await;
+        }
+
+        *self.checkpoint_store.write().await = None;
+        *self.outbox_writer.write().await = None;
+        *self.live_results_writer.write().await = None;
+    }
 }
 
 pub struct QueryManager {
@@ -2887,6 +2920,33 @@ impl QueryManager {
         }
 
         Ok(())
+    }
+
+    /// Release persistent index-backend handles for every query runtime, without
+    /// deleting any on-disk data.
+    ///
+    /// Intended for permanent shutdown ([`crate::DrasiLib::shutdown`]). Persistent
+    /// backends such as RocksDB hold a process-exclusive lock on their data directory
+    /// until every clone of their shared handle is dropped; queries retain some of
+    /// those handles for their whole lifetime, so without this they are only freed
+    /// when the entire `DrasiLib` is dropped. Clearing them here lets the backend
+    /// release its lock while leaving persisted state intact for a future reopen.
+    ///
+    /// Callers should stop components first so the transient handles held by
+    /// per-query tasks are already dropped by the time this runs.
+    pub async fn release_all_persistent_handles(&self) {
+        let query_ids: Vec<String> = self
+            .list_queries()
+            .await
+            .into_iter()
+            .map(|(id, _status)| id)
+            .collect();
+
+        for id in query_ids {
+            if let Ok(query) = self.get_query_instance(&id).await {
+                query.release_persistent_handles().await;
+            }
+        }
     }
 
     /// List all registered queries with their current lifecycle status.

--- a/lib/tests/static_rocksdb_index_e2e.rs
+++ b/lib/tests/static_rocksdb_index_e2e.rs
@@ -242,7 +242,116 @@ async fn static_rocksdb_index_persists_across_restart() -> Result<()> {
     Ok(())
 }
 
-/// Proves the `with_default_index_provider` path that `drasi-server` uses for its
+/// Proves the fix for issue #627: after `DrasiLib::shutdown()`, the RocksDB
+/// process-exclusive lock on the data directory is released, so a **brand-new**
+/// `DrasiLib` + provider can reopen the **same** on-disk path **within the same
+/// process** and recover the prior query state — without re-ingesting any source
+/// events.
+///
+/// This is exactly the scenario the sibling `..._persists_across_restart` test
+/// documents as previously unsupported: before the fix, the query runtime kept the
+/// RocksDB handles alive for the whole `DrasiLib` lifetime, so reopening the path in
+/// the same process failed with `LOCK: No locks available`.
+///
+/// The first engine is intentionally kept alive (held in an `Arc`) across the
+/// reopen: the fix must free the lock on `shutdown()` itself, not rely on the whole
+/// `DrasiLib` being dropped (internal Arcs can keep it alive past `shutdown()`).
+#[tokio::test]
+async fn static_rocksdb_shutdown_releases_lock_for_same_process_reopen() -> Result<()> {
+    let data_dir = TempDir::new()?;
+    let backend_config = json!({
+        "kind": "rocksdb",
+        "path": data_dir.path().to_string_lossy(),
+        "enableArchive": false,
+    });
+
+    // ---- First engine: ingest rows, then shut down permanently. ----
+    let provider1 = build_provider_from_config(&backend_config).await;
+    let (source1, handle1) = MockSource::new("people-src")?;
+    let core1 = Arc::new(
+        DrasiLib::builder()
+            .with_id("static-rocksdb-1")
+            .with_index_provider("rocks-1", provider1)
+            .with_source(source1)
+            // Bootstrap disabled so that, after reopen, rows can only come from the
+            // persisted RocksDB index — proving durability rather than re-bootstrap.
+            .with_query(
+                Query::cypher("people")
+                    .query("MATCH (p:Person) RETURN p.name AS name, p.age AS age")
+                    .from_source("people-src")
+                    .auto_start(true)
+                    .enable_bootstrap(false)
+                    .with_storage_backend(StorageBackendRef::Named("rocks-1".to_string()))
+                    .build(),
+            )
+            .build()
+            .await?,
+    );
+
+    core1.start().await?;
+
+    insert_person(&handle1, "p1", "Alice", 30).await?;
+    insert_person(&handle1, "p2", "Bob", 25).await?;
+    insert_person(&handle1, "p3", "Carol", 41).await?;
+    let results = wait_for_results(&core1, "people", 3).await;
+    assert_eq!(results.len(), 3, "first engine should ingest 3 rows");
+
+    // Permanent teardown — this must release the RocksDB lock even though `core1`
+    // (and its provider) remain alive below.
+    core1.shutdown().await?;
+
+    // ---- Second engine: reopen the SAME path in the SAME process. ----
+    // A fresh provider on the same on-disk path; this open acquires the RocksDB
+    // LOCK, which only succeeds if the first engine's `shutdown()` released it.
+    let provider2 = build_provider_from_config(&backend_config).await;
+    let (source2, _handle2) = MockSource::new("people-src")?;
+    let core2 = Arc::new(
+        DrasiLib::builder()
+            .with_id("static-rocksdb-2")
+            .with_index_provider("rocks-1", provider2)
+            .with_source(source2)
+            .with_query(
+                Query::cypher("people")
+                    .query("MATCH (p:Person) RETURN p.name AS name, p.age AS age")
+                    .from_source("people-src")
+                    .auto_start(true)
+                    .enable_bootstrap(false)
+                    .with_storage_backend(StorageBackendRef::Named("rocks-1".to_string()))
+                    .build(),
+            )
+            .build()
+            .await?,
+    );
+
+    // If the lock were still held, `start()` would fail while building the indexes
+    // ("Failed to build indexes" / "No locks available").
+    core2
+        .start()
+        .await
+        .expect("second engine should open the same RocksDB path after shutdown released the lock");
+
+    // No re-ingestion: results must be recovered from the persisted index.
+    let recovered = wait_for_results(&core2, "people", 3).await;
+    let names: Vec<&str> = recovered
+        .iter()
+        .filter_map(|r| r["name"].as_str())
+        .collect();
+    assert_eq!(
+        recovered.len(),
+        3,
+        "reopened engine should recover the persisted rows without re-ingestion, got: {recovered:?}"
+    );
+    assert!(names.contains(&"Alice"), "missing Alice in {recovered:?}");
+    assert!(names.contains(&"Bob"), "missing Bob in {recovered:?}");
+    assert!(names.contains(&"Carol"), "missing Carol in {recovered:?}");
+
+    core2.shutdown().await?;
+
+    // Keep the first engine alive until the very end so the test proves the lock was
+    // freed by `shutdown()` rather than by dropping `core1`.
+    drop(core1);
+    Ok(())
+}
 /// instance-wide `persist_index` flag: a query with **no** `storage_backend` is
 /// transparently backed by the default RocksDB provider (rather than falling back
 /// to in-memory), and that data is durable across a query stop/start cycle.


### PR DESCRIPTION
# Description

`DrasiLib` never released the persistent index-backend handles a query retains, so a backend that takes an exclusive OS resource -- notably RocksDB, which holds a process-exclusive lock on its data directory -- kept that resource pinned until the whole `DrasiLib` value was dropped (in practice, process exit). After `shutdown()`, a new `DrasiLib` could not reopen the same rocksdb path in the same process, failing with `LOCK: No locks available`. This blocks the downstream `@drasi/lib` binding (drasi-project/drasi-nodejs#22), whose `close()` cannot free the lock on its own.

**Root cause:** RocksDB's `create_indexes()` shares one `OptimisticTransactionDB` across all eight handles, so the OS lock is freed only when the last clone drops. After a normal `stop()`, the processor task and `FutureQueueSource` are reaped, releasing five of them -- but `DrasiQuery` keeps `checkpoint_store`, `outbox_writer`, and `live_results_writer` for its whole lifetime, and neither `stop()` nor `shutdown()` ever cleared them.

**Approach:** Add a non-destructive release that drops only the in-memory `Arc` handles, leaving all on-disk state intact:

- `Query::release_persistent_handles()` -- a defaulted no-op; `DrasiQuery` clears the three retained handles and drops any lingering `FutureQueueSource`.
- `QueryManager::release_all_persistent_handles()` -- invokes it across all query runtimes.
- `DrasiLib::shutdown()` -- calls it after stopping components and aborting the graph loop.

This runs only on `shutdown()` (the documented permanent teardown), so the in-memory `stop()`/`start()` checkpoint-reuse path is unaffected. Because it clears the inner `Option` fields rather than relying on the `DrasiQuery` itself being dropped, it is robust even when other components (e.g. reactions) still hold an `Arc<dyn Query>` clone.

Adds an e2e test proving same-process shutdown -> reopen -> recover with a brand-new provider on the same RocksDB path. The test was verified to fail with `No locks available` when the fix is disabled, and the first engine is deliberately kept alive across the reopen to prove the lock is freed by `shutdown()` itself rather than by dropping `DrasiLib`.

## Type of change

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).

Fixes: #627