### PR TITLE
Share RocksDB memory budgets across query index DBs

### DIFF
--- a/components/indexes/rocksdb/Cargo.toml
+++ b/components/indexes/rocksdb/Cargo.toml
@@ -29,7 +29,7 @@ workspace = true
 [dependencies]
 drasi-core.workspace = true
 drasi-query-ast.workspace = true
-rocksdb = { version = "0.21.0", features = ["default", "multi-threaded-cf"] }
+rocksdb = { version = "0.22.0", features = ["default", "multi-threaded-cf"] }
 async-trait = "0.1.68"
 bytes = "1"
 hashers = "1.0.1"

--- a/components/indexes/rocksdb/src/budget_monitor.rs
+++ b/components/indexes/rocksdb/src/budget_monitor.rs
@@ -1,0 +1,109 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Saturation monitor for the shared RocksDB memory budgets.
+//!
+//! The shared `WriteBufferManager` never blocks writers (`allow_stall` is
+//! off): past the budget it applies continuous flush pressure instead, and
+//! because memtable memory is charged to the shared block cache, sustained
+//! saturation also evicts cached blocks and degrades every read. None of
+//! that is visible in RocksDB's own LOG files — from the outside it looks
+//! like the index simply got slow. This module polls the budget and logs
+//! saturation transitions so a saturated budget is an observable state
+//! rather than an inference from collapsed throughput.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocksdb::{Cache, WriteBufferManager};
+
+const MIB: usize = 1024 * 1024;
+
+/// Poll interval for the saturation check.
+const TICK_INTERVAL: Duration = Duration::from_secs(2);
+
+/// While saturated, re-log the state every this many ticks (with 2s ticks,
+/// every 30s) so long saturation windows stay visible without log spam.
+const SATURATED_RELOG_TICKS: u32 = 15;
+
+/// Handle owning the monitor thread. Held (via `Arc`) by every clone of the
+/// `RocksDbTuning` it watches; dropping the last clone stops the thread on
+/// its next tick.
+pub(crate) struct BudgetMonitor {
+    stop: Arc<AtomicBool>,
+}
+
+impl Drop for BudgetMonitor {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Spawn the saturation monitor for one shared budget.
+pub(crate) fn spawn(wbm: WriteBufferManager, cache: Cache) -> BudgetMonitor {
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = stop.clone();
+    // Monitoring is best-effort: if the thread cannot be spawned the budget
+    // still works, it is just unobserved again.
+    let _ = std::thread::Builder::new()
+        .name("rocksdb-budget-monitor".into())
+        .spawn(move || {
+            let mut saturated = false;
+            let mut ticks_since_log = 0u32;
+            loop {
+                std::thread::sleep(TICK_INTERVAL);
+                if stop_flag.load(Ordering::Relaxed) {
+                    break;
+                }
+                let usage = wbm.get_usage();
+                let budget = wbm.get_buffer_size();
+                let now_saturated = budget > 0 && usage >= budget;
+                if now_saturated && !saturated {
+                    log::warn!(
+                        "rocksdb budget saturated: memtable usage {} MiB >= budget {} MiB — \
+                         continuous flush pressure engaged; block cache usage {} MiB \
+                         (pinned {} MiB). Writes are not stalled, but index throughput \
+                         will degrade until flushes reclaim budget.",
+                        usage / MIB,
+                        budget / MIB,
+                        cache.get_usage() / MIB,
+                        cache.get_pinned_usage() / MIB,
+                    );
+                    ticks_since_log = 0;
+                } else if now_saturated {
+                    ticks_since_log += 1;
+                    if ticks_since_log >= SATURATED_RELOG_TICKS {
+                        log::warn!(
+                            "rocksdb budget still saturated: memtable usage {} MiB / budget {} MiB; \
+                             block cache usage {} MiB (pinned {} MiB)",
+                            usage / MIB,
+                            budget / MIB,
+                            cache.get_usage() / MIB,
+                            cache.get_pinned_usage() / MIB,
+                        );
+                        ticks_since_log = 0;
+                    }
+                } else if saturated {
+                    log::info!(
+                        "rocksdb budget recovered: memtable usage {} MiB back under budget {} MiB",
+                        usage / MIB,
+                        budget / MIB,
+                    );
+                }
+                saturated = now_saturated;
+            }
+        });
+    BudgetMonitor { stop }
+}

--- a/components/indexes/rocksdb/src/checkpoint.rs
+++ b/components/indexes/rocksdb/src/checkpoint.rs
@@ -46,8 +46,10 @@ const CONFIG_HASH_KEY: &str = "config_hash";
 const RESULT_SEQUENCE_PREFIX: &str = "result_sequence:";
 
 /// Returns the column family descriptor for the stream_state CF.
-pub(crate) fn stream_state_cf_descriptor() -> ColumnFamilyDescriptor {
-    let mut opts = Options::default();
+pub(crate) fn stream_state_cf_descriptor(
+    tuning: &crate::tuning::RocksDbTuning,
+) -> ColumnFamilyDescriptor {
+    let mut opts = tuning.base_cf_options(false);
     opts.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(16));
     ColumnFamilyDescriptor::new(STREAM_STATE_CF, opts)
 }

--- a/components/indexes/rocksdb/src/element_index.rs
+++ b/components/indexes/rocksdb/src/element_index.rs
@@ -34,6 +34,7 @@ use crate::storage_models::{
     StoredElement, StoredElementContainer, StoredElementMetadata, StoredElementReference,
     StoredRelation, StoredValue, StoredValueMap,
 };
+use crate::tuning::RocksDbTuning;
 use crate::RocksDbSessionState;
 
 mod archive_index;
@@ -54,6 +55,7 @@ pub struct Context {
     db: Arc<OptimisticTransactionDB>,
     join_spec_by_label: RwLock<JoinSpecByLabel>,
     options: RocksIndexOptions,
+    tuning: RocksDbTuning,
     session_state: Arc<RocksDbSessionState>,
 }
 
@@ -68,7 +70,6 @@ const SLOT_CF: &str = "slots";
 const INBOUND_CF: &str = "inbound";
 const OUTBOUND_CF: &str = "outbound";
 const PARTIAL_CF: &str = "partial";
-const ELEMENT_BLOCK_CACHE_SIZE: u64 = 32;
 
 impl RocksDbElementIndex {
     /// Create a new RocksDbElementIndex from a shared database handle.
@@ -78,6 +79,7 @@ impl RocksDbElementIndex {
     pub fn new(
         db: Arc<OptimisticTransactionDB>,
         options: RocksIndexOptions,
+        tuning: RocksDbTuning,
         session_state: Arc<RocksDbSessionState>,
     ) -> Self {
         RocksDbElementIndex {
@@ -85,6 +87,7 @@ impl RocksDbElementIndex {
                 db,
                 join_spec_by_label: RwLock::new(HashMap::new()),
                 options,
+                tuning,
                 session_state,
             }),
         }
@@ -326,30 +329,36 @@ impl ElementIndex for RocksDbElementIndex {
 
             if let Err(err) = context
                 .db
-                .create_cf(ELEMENTS_CF, &get_elements_cf_options())
-            {
-                return Err(IndexError::other(err));
-            }
-
-            if let Err(err) = context.db.create_cf(SLOT_CF, &get_elements_cf_options()) {
-                return Err(IndexError::other(err));
-            }
-
-            if let Err(err) = context
-                .db
-                .create_cf(INBOUND_CF, &get_inout_index_cf_options())
+                .create_cf(ELEMENTS_CF, &get_elements_cf_options(&context.tuning))
             {
                 return Err(IndexError::other(err));
             }
 
             if let Err(err) = context
                 .db
-                .create_cf(OUTBOUND_CF, &get_inout_index_cf_options())
+                .create_cf(SLOT_CF, &get_elements_cf_options(&context.tuning))
             {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = context.db.create_cf(PARTIAL_CF, &get_partial_cf_options()) {
+            if let Err(err) = context
+                .db
+                .create_cf(INBOUND_CF, &get_inout_index_cf_options(&context.tuning))
+            {
+                return Err(IndexError::other(err));
+            }
+
+            if let Err(err) = context
+                .db
+                .create_cf(OUTBOUND_CF, &get_inout_index_cf_options(&context.tuning))
+            {
+                return Err(IndexError::other(err));
+            }
+
+            if let Err(err) = context
+                .db
+                .create_cf(PARTIAL_CF, &get_partial_cf_options(&context.tuning))
+            {
                 return Err(IndexError::other(err));
             }
 
@@ -370,40 +379,39 @@ impl ElementIndex for RocksDbElementIndex {
     }
 }
 
-pub(crate) fn get_partial_cf_options() -> Options {
-    let mut partial_opts = Options::default();
+pub(crate) fn get_partial_cf_options(tuning: &RocksDbTuning) -> Options {
+    let mut partial_opts = tuning.base_cf_options(false);
     partial_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(16));
     partial_opts
 }
 
-pub(crate) fn get_inout_index_cf_options() -> Options {
-    let mut inout_bound_opts = Options::default();
+pub(crate) fn get_inout_index_cf_options(tuning: &RocksDbTuning) -> Options {
+    let mut inout_bound_opts = tuning.base_cf_options(true);
     inout_bound_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(18));
     inout_bound_opts
 }
 
-pub(crate) fn get_elements_cf_options() -> Options {
-    let mut elements_opts = Options::default();
-    elements_opts.optimize_for_point_lookup(ELEMENT_BLOCK_CACHE_SIZE);
-    elements_opts
+pub(crate) fn get_elements_cf_options(tuning: &RocksDbTuning) -> Options {
+    tuning.point_lookup_cf_options(true)
 }
 
 /// Collect all column family descriptors needed by the element index.
 pub(crate) fn element_cf_descriptors(
     options: &RocksIndexOptions,
+    tuning: &RocksDbTuning,
 ) -> Vec<rocksdb::ColumnFamilyDescriptor> {
     let mut cfs = vec![
-        rocksdb::ColumnFamilyDescriptor::new(ELEMENTS_CF, get_elements_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(SLOT_CF, get_elements_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(INBOUND_CF, get_inout_index_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(OUTBOUND_CF, get_inout_index_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(PARTIAL_CF, get_partial_cf_options()),
+        rocksdb::ColumnFamilyDescriptor::new(ELEMENTS_CF, get_elements_cf_options(tuning)),
+        rocksdb::ColumnFamilyDescriptor::new(SLOT_CF, get_elements_cf_options(tuning)),
+        rocksdb::ColumnFamilyDescriptor::new(INBOUND_CF, get_inout_index_cf_options(tuning)),
+        rocksdb::ColumnFamilyDescriptor::new(OUTBOUND_CF, get_inout_index_cf_options(tuning)),
+        rocksdb::ColumnFamilyDescriptor::new(PARTIAL_CF, get_partial_cf_options(tuning)),
     ];
 
     if options.archive_enabled {
         cfs.push(rocksdb::ColumnFamilyDescriptor::new(
             archive_index::ARCHIVE_CF,
-            archive_index::get_archive_cf_options(),
+            archive_index::get_archive_cf_options(tuning),
         ));
     }
 

--- a/components/indexes/rocksdb/src/element_index/archive_index.rs
+++ b/components/indexes/rocksdb/src/element_index/archive_index.rs
@@ -217,7 +217,10 @@ impl ElementArchiveIndex for RocksDbElementIndex {
                     return Err(IndexError::other(err));
                 }
             }
-            if let Err(err) = context.db.create_cf(ARCHIVE_CF, &get_archive_cf_options()) {
+            if let Err(err) = context
+                .db
+                .create_cf(ARCHIVE_CF, &get_archive_cf_options(&context.tuning))
+            {
                 return Err(IndexError::other(err));
             }
             Ok(())
@@ -246,8 +249,8 @@ pub fn insert_archive(
     }
 }
 
-pub(crate) fn get_archive_cf_options() -> Options {
-    let mut opts = Options::default();
+pub(crate) fn get_archive_cf_options(tuning: &crate::tuning::RocksDbTuning) -> Options {
+    let mut opts = tuning.base_cf_options(true);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(16));
     opts
 }

--- a/components/indexes/rocksdb/src/future_queue.rs
+++ b/components/indexes/rocksdb/src/future_queue.rs
@@ -39,6 +39,7 @@ use crate::RocksDbSessionState;
 ///     - findex [(position_in_query + group_signature) + hash(future_element_ref)] -> due_time {12 byte prefix (position_in_query(4) + group_signature(8))}
 pub struct RocksDbFutureQueue {
     db: Arc<OptimisticTransactionDB>,
+    tuning: crate::tuning::RocksDbTuning,
     session_state: Arc<RocksDbSessionState>,
 }
 
@@ -50,8 +51,16 @@ impl RocksDbFutureQueue {
     ///
     /// The database must already have the required column families created.
     /// Use `open_unified_db()` to open a database with all required CFs.
-    pub fn new(db: Arc<OptimisticTransactionDB>, session_state: Arc<RocksDbSessionState>) -> Self {
-        Self { db, session_state }
+    pub fn new(
+        db: Arc<OptimisticTransactionDB>,
+        tuning: crate::tuning::RocksDbTuning,
+        session_state: Arc<RocksDbSessionState>,
+    ) -> Self {
+        Self {
+            db,
+            tuning,
+            session_state,
+        }
     }
 }
 
@@ -256,12 +265,13 @@ impl FutureQueue for RocksDbFutureQueue {
 
     async fn clear(&self) -> Result<(), IndexError> {
         let db = self.db.clone();
+        let tuning = self.tuning.clone();
         let task = task::spawn_blocking(move || {
             if let Err(err) = db.drop_cf(QUEUE_CF) {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = db.create_cf(QUEUE_CF, &get_fqueue_cf_options()) {
+            if let Err(err) = db.create_cf(QUEUE_CF, &get_fqueue_cf_options(&tuning)) {
                 return Err(IndexError::other(err));
             }
 
@@ -269,7 +279,7 @@ impl FutureQueue for RocksDbFutureQueue {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = db.create_cf(INDEX_CF, &get_findex_cf_options()) {
+            if let Err(err) = db.create_cf(INDEX_CF, &get_findex_cf_options(&tuning)) {
                 return Err(IndexError::other(err));
             }
             Ok(())
@@ -342,22 +352,24 @@ fn encode_index_prefix(position_in_query: u32, group_signature: u64) -> [u8; 12]
     buf
 }
 
-pub(crate) fn get_fqueue_cf_options() -> Options {
-    let mut opts = Options::default();
+pub(crate) fn get_fqueue_cf_options(tuning: &crate::tuning::RocksDbTuning) -> Options {
+    let mut opts = tuning.base_cf_options(false);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
     opts
 }
 
-pub(crate) fn get_findex_cf_options() -> Options {
-    let mut opts = Options::default();
+pub(crate) fn get_findex_cf_options(tuning: &crate::tuning::RocksDbTuning) -> Options {
+    let mut opts = tuning.base_cf_options(false);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(12));
     opts
 }
 
 /// Collect all column family descriptors needed by the future queue.
-pub(crate) fn future_queue_cf_descriptors() -> Vec<rocksdb::ColumnFamilyDescriptor> {
+pub(crate) fn future_queue_cf_descriptors(
+    tuning: &crate::tuning::RocksDbTuning,
+) -> Vec<rocksdb::ColumnFamilyDescriptor> {
     vec![
-        rocksdb::ColumnFamilyDescriptor::new(QUEUE_CF, get_fqueue_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(INDEX_CF, get_findex_cf_options()),
+        rocksdb::ColumnFamilyDescriptor::new(QUEUE_CF, get_fqueue_cf_options(tuning)),
+        rocksdb::ColumnFamilyDescriptor::new(INDEX_CF, get_findex_cf_options(tuning)),
     ]
 }

--- a/components/indexes/rocksdb/src/lib.rs
+++ b/components/indexes/rocksdb/src/lib.rs
@@ -31,6 +31,7 @@
 //!     .build()?;
 //! ```
 
+mod budget_monitor;
 pub mod checkpoint;
 #[cfg(feature = "plugin-descriptor")]
 mod descriptor;
@@ -42,6 +43,7 @@ mod plugin;
 pub mod result_index;
 mod session_state;
 mod storage_models;
+pub mod tuning;
 
 // Re-export the plugin provider and unified DB opener for easy access
 pub use checkpoint::RocksDbCheckpointStore;
@@ -49,6 +51,7 @@ pub use live_results::RocksDbLiveResultsWriter;
 pub use outbox::RocksDbOutboxWriter;
 pub use plugin::open_unified_db;
 pub use plugin::RocksDbIndexProvider;
+pub use tuning::RocksDbTuning;
 
 #[cfg(feature = "plugin-descriptor")]
 pub use descriptor::{RocksDbIndexConfigDto, RocksDbIndexDescriptor};

--- a/components/indexes/rocksdb/src/live_results.rs
+++ b/components/indexes/rocksdb/src/live_results.rs
@@ -34,8 +34,10 @@ use tokio::task;
 pub(crate) const LIVE_RESULTS_CF: &str = "live_results";
 
 /// Returns the column family descriptor for the live_results CF.
-pub(crate) fn live_results_cf_descriptor() -> ColumnFamilyDescriptor {
-    let opts = Options::default();
+pub(crate) fn live_results_cf_descriptor(
+    tuning: &crate::tuning::RocksDbTuning,
+) -> ColumnFamilyDescriptor {
+    let opts = tuning.base_cf_options(false);
     ColumnFamilyDescriptor::new(LIVE_RESULTS_CF, opts)
 }
 

--- a/components/indexes/rocksdb/src/outbox.rs
+++ b/components/indexes/rocksdb/src/outbox.rs
@@ -31,8 +31,10 @@ use tokio::task;
 pub(crate) const OUTBOX_CF: &str = "outbox";
 
 /// Returns the column family descriptor for the outbox CF.
-pub(crate) fn outbox_cf_descriptor() -> ColumnFamilyDescriptor {
-    let opts = Options::default();
+pub(crate) fn outbox_cf_descriptor(
+    tuning: &crate::tuning::RocksDbTuning,
+) -> ColumnFamilyDescriptor {
+    let opts = tuning.base_cf_options(false);
     ColumnFamilyDescriptor::new(OUTBOX_CF, opts)
 }
 

--- a/components/indexes/rocksdb/src/plugin.rs
+++ b/components/indexes/rocksdb/src/plugin.rs
@@ -42,6 +42,7 @@ use crate::future_queue::{self, RocksDbFutureQueue};
 use crate::live_results::{self, RocksDbLiveResultsWriter};
 use crate::outbox::{self, RocksDbOutboxWriter};
 use crate::result_index::{self, RocksDbResultIndex};
+use crate::tuning::RocksDbTuning;
 use crate::{RocksDbSessionControl, RocksDbSessionState};
 
 /// Open a unified RocksDB database with all column families needed for a query.
@@ -62,6 +63,7 @@ pub fn open_unified_db(
     path: &str,
     query_id: &str,
     options: &RocksIndexOptions,
+    tuning: &RocksDbTuning,
 ) -> Result<Arc<OptimisticTransactionDB>, IndexError> {
     // `query_id` is used directly as a directory name under `path`. Reject values
     // that could escape the base directory or otherwise misbehave as a path
@@ -82,7 +84,10 @@ pub fn open_unified_db(
     let mut db_opts = Options::default();
     db_opts.create_if_missing(true);
     db_opts.create_missing_column_families(true);
-    db_opts.set_db_write_buffer_size(128 * 1024 * 1024);
+    // Memtable memory is bounded globally by the shared WriteBufferManager
+    // rather than a per-DB db_write_buffer_size, so the budget holds across
+    // however many query DBs share this tuning.
+    db_opts.set_write_buffer_manager(&tuning.write_buffer_manager);
     db_opts.set_use_direct_reads(options.direct_io);
     db_opts.set_use_direct_io_for_flush_and_compaction(options.direct_io);
 
@@ -92,12 +97,18 @@ pub fn open_unified_db(
         None => return Err(IndexError::NotSupported),
     };
 
-    let mut cfs = element_index::element_cf_descriptors(options);
-    cfs.extend(result_index::result_cf_descriptors());
-    cfs.extend(future_queue::future_queue_cf_descriptors());
-    cfs.push(checkpoint::stream_state_cf_descriptor());
-    cfs.push(outbox::outbox_cf_descriptor());
-    cfs.push(live_results::live_results_cf_descriptor());
+    let mut cfs = element_index::element_cf_descriptors(options, tuning);
+    cfs.extend(result_index::result_cf_descriptors(tuning));
+    cfs.extend(future_queue::future_queue_cf_descriptors(tuning));
+    cfs.push(checkpoint::stream_state_cf_descriptor(tuning));
+    cfs.push(outbox::outbox_cf_descriptor(tuning));
+    cfs.push(live_results::live_results_cf_descriptor(tuning));
+    // The default CF is created implicitly when absent; declare it explicitly
+    // so it uses the shared cache and small buffers instead of RocksDB defaults.
+    cfs.push(rocksdb::ColumnFamilyDescriptor::new(
+        "default",
+        tuning.base_cf_options(false),
+    ));
 
     let db = OptimisticTransactionDB::open_cf_descriptors(&db_opts, db_path, cfs)
         .map_err(IndexError::other)?;
@@ -127,6 +138,7 @@ pub struct RocksDbIndexProvider {
     path: PathBuf,
     enable_archive: bool,
     direct_io: bool,
+    tuning: RocksDbTuning,
 }
 
 impl RocksDbIndexProvider {
@@ -144,10 +156,26 @@ impl RocksDbIndexProvider {
     /// let provider = RocksDbIndexProvider::new("/data/drasi", true, false);
     /// ```
     pub fn new<P: Into<PathBuf>>(path: P, enable_archive: bool, direct_io: bool) -> Self {
+        Self::with_tuning(path, enable_archive, direct_io, RocksDbTuning::default())
+    }
+
+    /// Create a provider with explicit memory tuning.
+    ///
+    /// Pass clones of the same `RocksDbTuning` to several providers to share
+    /// one block cache and write buffer budget across all of them (e.g.
+    /// process-wide across instances). Archive should be left off unless
+    /// queries use the past() functions.
+    pub fn with_tuning<P: Into<PathBuf>>(
+        path: P,
+        enable_archive: bool,
+        direct_io: bool,
+        tuning: RocksDbTuning,
+    ) -> Self {
         Self {
             path: path.into(),
             enable_archive,
             direct_io,
+            tuning,
         }
     }
 
@@ -176,7 +204,7 @@ impl IndexBackendPlugin for RocksDbIndexProvider {
             direct_io: self.direct_io,
         };
 
-        let db = open_unified_db(&path, query_id, &options).map_err(|e| {
+        let db = open_unified_db(&path, query_id, &options, &self.tuning).map_err(|e| {
             log::error!(
                 "Failed to open unified RocksDB for query '{query_id}' at path '{path}': {e}"
             );
@@ -189,10 +217,19 @@ impl IndexBackendPlugin for RocksDbIndexProvider {
         let element_index = Arc::new(RocksDbElementIndex::new(
             db.clone(),
             options,
+            self.tuning.clone(),
             session_state.clone(),
         ));
-        let result_index = Arc::new(RocksDbResultIndex::new(db.clone(), session_state.clone()));
-        let future_queue = Arc::new(RocksDbFutureQueue::new(db.clone(), session_state.clone()));
+        let result_index = Arc::new(RocksDbResultIndex::new(
+            db.clone(),
+            self.tuning.clone(),
+            session_state.clone(),
+        ));
+        let future_queue = Arc::new(RocksDbFutureQueue::new(
+            db.clone(),
+            self.tuning.clone(),
+            session_state.clone(),
+        ));
         let checkpoint_store = Arc::new(RocksDbCheckpointStore::new(db.clone(), session_state));
         let outbox_writer = Arc::new(RocksDbOutboxWriter::new(db.clone()));
         let live_results_writer = Arc::new(RocksDbLiveResultsWriter::new(db));
@@ -290,7 +327,7 @@ mod tests {
         };
 
         let path = temp_dir.path().to_string_lossy().to_string();
-        let result = open_unified_db(&path, "test_query", &options);
+        let result = open_unified_db(&path, "test_query", &options, &RocksDbTuning::default());
         assert!(result.is_ok());
     }
 
@@ -304,7 +341,7 @@ mod tests {
         let path = temp_dir.path().to_string_lossy().to_string();
 
         for bad in ["", ".", "..", "a/b", "../escape", "a\\b", "with\0nul"] {
-            let result = open_unified_db(&path, bad, &options);
+            let result = open_unified_db(&path, bad, &options, &RocksDbTuning::default());
             assert!(
                 result.is_err(),
                 "query_id '{bad}' should be rejected as a path segment"

--- a/components/indexes/rocksdb/src/result_index.rs
+++ b/components/indexes/rocksdb/src/result_index.rs
@@ -37,6 +37,7 @@ use rocksdb::{
 use tokio::task;
 
 use crate::storage_models::{StoredValueAccumulator, StoredValueAccumulatorContainer};
+use crate::tuning::RocksDbTuning;
 use crate::RocksDbSessionState;
 
 /// RocksDB accumulator index store
@@ -46,21 +47,29 @@ use crate::RocksDbSessionState;
 ///     - sorted-sets [set_id + value] -> count {8 byte prefix (set_id)}
 pub struct RocksDbResultIndex {
     db: Arc<OptimisticTransactionDB>,
+    tuning: RocksDbTuning,
     session_state: Arc<RocksDbSessionState>,
 }
 
 const VALUES_CF: &str = "values";
 const SETS_CF: &str = "sorted-sets";
 const METADATA_CF: &str = "metadata";
-const VALUES_BLOCK_CACHE_SIZE: u64 = 32;
 
 impl RocksDbResultIndex {
     /// Create a new RocksDbResultIndex from a shared database handle.
     ///
     /// The database must already have the required column families created.
     /// Use `open_unified_db()` to open a database with all required CFs.
-    pub fn new(db: Arc<OptimisticTransactionDB>, session_state: Arc<RocksDbSessionState>) -> Self {
-        RocksDbResultIndex { db, session_state }
+    pub fn new(
+        db: Arc<OptimisticTransactionDB>,
+        tuning: RocksDbTuning,
+        session_state: Arc<RocksDbSessionState>,
+    ) -> Self {
+        RocksDbResultIndex {
+            db,
+            tuning,
+            session_state,
+        }
     }
 }
 
@@ -140,12 +149,13 @@ impl AccumulatorIndex for RocksDbResultIndex {
 
     async fn clear(&self) -> Result<(), IndexError> {
         let db = self.db.clone();
+        let tuning = self.tuning.clone();
         let task = task::spawn_blocking(move || {
             if let Err(err) = db.drop_cf(VALUES_CF) {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = db.create_cf(VALUES_CF, &get_value_cf_options()) {
+            if let Err(err) = db.create_cf(VALUES_CF, &get_value_cf_options(&tuning)) {
                 return Err(IndexError::other(err));
             }
 
@@ -153,7 +163,7 @@ impl AccumulatorIndex for RocksDbResultIndex {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = db.create_cf(SETS_CF, &get_lss_cf_options()) {
+            if let Err(err) = db.create_cf(SETS_CF, &get_lss_cf_options(&tuning)) {
                 return Err(IndexError::other(err));
             }
             Ok(())
@@ -364,32 +374,30 @@ impl ResultSequenceCounter for RocksDbResultIndex {
     }
 }
 
-pub(crate) fn get_lss_cf_options() -> Options {
-    let mut lss_opts = Options::default();
+pub(crate) fn get_lss_cf_options(tuning: &RocksDbTuning) -> Options {
+    let mut lss_opts = tuning.base_cf_options(false);
     lss_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
     lss_opts.set_merge_operator_associative("increment", increment_merge);
     lss_opts.set_compaction_filter("remove0", compact);
     lss_opts
 }
 
-pub(crate) fn get_value_cf_options() -> Options {
-    let mut values_opts = Options::default();
-    values_opts.optimize_for_point_lookup(VALUES_BLOCK_CACHE_SIZE);
-    values_opts
+pub(crate) fn get_value_cf_options(tuning: &RocksDbTuning) -> Options {
+    tuning.point_lookup_cf_options(true)
 }
 
-pub(crate) fn get_metadata_cf_options() -> Options {
-    let mut values_opts = Options::default();
-    values_opts.optimize_for_point_lookup(1);
-    values_opts
+pub(crate) fn get_metadata_cf_options(tuning: &RocksDbTuning) -> Options {
+    tuning.point_lookup_cf_options(false)
 }
 
 /// Collect all column family descriptors needed by the result index.
-pub(crate) fn result_cf_descriptors() -> Vec<rocksdb::ColumnFamilyDescriptor> {
+pub(crate) fn result_cf_descriptors(
+    tuning: &RocksDbTuning,
+) -> Vec<rocksdb::ColumnFamilyDescriptor> {
     vec![
-        rocksdb::ColumnFamilyDescriptor::new(VALUES_CF, get_value_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(SETS_CF, get_lss_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(METADATA_CF, get_metadata_cf_options()),
+        rocksdb::ColumnFamilyDescriptor::new(VALUES_CF, get_value_cf_options(tuning)),
+        rocksdb::ColumnFamilyDescriptor::new(SETS_CF, get_lss_cf_options(tuning)),
+        rocksdb::ColumnFamilyDescriptor::new(METADATA_CF, get_metadata_cf_options(tuning)),
     ]
 }
 

--- a/components/indexes/rocksdb/src/session_state.rs
+++ b/components/indexes/rocksdb/src/session_state.rs
@@ -306,6 +306,7 @@ mod tests {
     use super::*;
     use crate::element_index::RocksIndexOptions;
     use crate::open_unified_db;
+    use crate::tuning::RocksDbTuning;
 
     fn setup_test_db() -> (tempfile::TempDir, Arc<OptimisticTransactionDB>) {
         let dir = tempfile::TempDir::new().expect("failed to create temp dir");
@@ -313,8 +314,13 @@ mod tests {
             archive_enabled: false,
             direct_io: false,
         };
-        let db = open_unified_db(dir.path().to_str().expect("path"), "test", &options)
-            .expect("failed to open db");
+        let db = open_unified_db(
+            dir.path().to_str().expect("path"),
+            "test",
+            &options,
+            &RocksDbTuning::default(),
+        )
+        .expect("failed to open db");
         (dir, db)
     }
 

--- a/components/indexes/rocksdb/src/tuning.rs
+++ b/components/indexes/rocksdb/src/tuning.rs
@@ -1,0 +1,222 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared memory tuning for the RocksDB index backend.
+//!
+//! Every query opens its own `OptimisticTransactionDB` with 15 column families.
+//! Without shared budgets, each CF gets a private block cache and a 64 MiB
+//! write buffer, which costs ~80 MiB of RSS per query before any data
+//! (see drasi-core#634). `RocksDbTuning` holds the process- or provider-wide
+//! `Cache` and `WriteBufferManager` handles plus the per-CF sizing used by all
+//! column families.
+//!
+//! `RocksDbTuning` is `Clone`, and clones share the same underlying cache and
+//! write buffer manager. Passing one tuning value (or clones of it) to several
+//! `RocksDbIndexProvider`s makes all of their DBs draw from the same budgets.
+
+use rocksdb::{BlockBasedOptions, Cache, DataBlockIndexType, Options, WriteBufferManager};
+
+/// Default capacity of the shared block cache (all DBs/CFs).
+pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 256 * 1024 * 1024;
+
+/// Default global memtable budget, charged against the block cache.
+pub const DEFAULT_WRITE_BUFFER_BUDGET: usize = 128 * 1024 * 1024;
+
+/// Default memtable size for hot data CFs (elements, adjacency, values, archive).
+pub const DEFAULT_HOT_WRITE_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+
+/// Default memtable size for all other CFs.
+pub const DEFAULT_COLD_WRITE_BUFFER_SIZE: usize = 8 * 1024 * 1024;
+
+/// Shared memory budgets and per-CF sizing for RocksDB index databases.
+///
+/// Clones share the same `Cache` and `WriteBufferManager` handles, so the
+/// sharing scope (per provider, per instance, or process-wide) is decided by
+/// whoever constructs and distributes this value.
+#[derive(Clone)]
+pub struct RocksDbTuning {
+    /// Block cache shared by all DBs and CFs opened with this tuning.
+    pub block_cache: Cache,
+    /// Global memtable budget shared by all DBs opened with this tuning.
+    pub write_buffer_manager: WriteBufferManager,
+    /// Memtable size for hot data CFs.
+    pub hot_write_buffer_size: usize,
+    /// Memtable size for all other CFs.
+    pub cold_write_buffer_size: usize,
+    /// Keeps the budget saturation monitor alive; shared by all clones and
+    /// stopped when the last clone is dropped.
+    monitor: std::sync::Arc<crate::budget_monitor::BudgetMonitor>,
+}
+
+impl RocksDbTuning {
+    /// Create a tuning value with the given budgets.
+    ///
+    /// The write buffer budget is charged against the block cache, so
+    /// `block_cache_size` is the single number bounding both read and write
+    /// memory across every DB opened with this tuning.
+    pub fn with_budgets(block_cache_size: usize, write_buffer_budget: usize) -> Self {
+        let block_cache = Cache::new_lru_cache(block_cache_size);
+        let write_buffer_manager = WriteBufferManager::new_write_buffer_manager_with_cache(
+            write_buffer_budget,
+            false,
+            block_cache.clone(),
+        );
+        // Derive per-CF buffer sizes from the budget so a larger budget also
+        // buys fewer flushes (less write amplification), not just more cache.
+        // budget/16 keeps the defaults at a 256 MiB budget (16 MiB hot, 8 MiB
+        // cold) and caps at RocksDB's stock 64 MiB, where flush frequency
+        // stops being the bottleneck.
+        const MIB: usize = 1024 * 1024;
+        let hot = (block_cache_size / 16).clamp(8 * MIB, 64 * MIB);
+        let cold = (hot / 2).clamp(4 * MIB, 16 * MIB);
+        let monitor = std::sync::Arc::new(crate::budget_monitor::spawn(
+            write_buffer_manager.clone(),
+            block_cache.clone(),
+        ));
+        Self {
+            block_cache,
+            write_buffer_manager,
+            hot_write_buffer_size: hot,
+            cold_write_buffer_size: cold,
+            monitor,
+        }
+    }
+
+    /// The saturation monitor handle (test hook; the field itself keeps the
+    /// monitor thread alive for the lifetime of the tuning value).
+    #[cfg(test)]
+    pub(crate) fn monitor_refcount(&self) -> usize {
+        std::sync::Arc::strong_count(&self.monitor)
+    }
+
+    fn write_buffer_size(&self, hot: bool) -> usize {
+        if hot {
+            self.hot_write_buffer_size
+        } else {
+            self.cold_write_buffer_size
+        }
+    }
+
+    fn block_based_options(&self) -> BlockBasedOptions {
+        let mut bbo = BlockBasedOptions::default();
+        bbo.set_block_cache(&self.block_cache);
+        // Index/filter blocks stay in table-reader memory rather than being
+        // charged to the cache: charging them (cache_index_and_filter_blocks)
+        // measured a ~4% hit on query-perf ingest, and per-query index SSTs
+        // are small enough that the unaccounted memory is negligible.
+        bbo
+    }
+
+    fn apply_common(&self, opts: &mut Options, hot: bool) {
+        let wbs = self.write_buffer_size(hot);
+        opts.set_write_buffer_size(wbs);
+        // Memtables allocate arena memory in blocks of this size, and the first
+        // block is paid at memtable construction. The sanitized default is
+        // min(1 MiB, write_buffer_size / 8), which puts a ~1 MiB floor under
+        // every CF: with 15+ CFs per query DB that is the dominant at-rest cost.
+        // Scale the block with the buffer: small buffers get small blocks
+        // (near-free idle CFs), large buffers get 1 MiB blocks (memtable
+        // locality for write-heavy loads; benchmarked ~5% of write throughput).
+        opts.set_arena_block_size((wbs / 64).clamp(64 * 1024, 1024 * 1024));
+    }
+
+    /// Base options for a CF: shared block cache and tiered write buffer.
+    pub(crate) fn base_cf_options(&self, hot: bool) -> Options {
+        let mut opts = Options::default();
+        self.apply_common(&mut opts, hot);
+        opts.set_block_based_table_factory(&self.block_based_options());
+        opts
+    }
+
+    /// Options for point-lookup CFs. This is `Options::optimize_for_point_lookup`
+    /// unrolled so the block cache is the shared one instead of a private
+    /// per-CF cache the convenience method constructs internally.
+    pub(crate) fn point_lookup_cf_options(&self, hot: bool) -> Options {
+        let mut opts = Options::default();
+        self.apply_common(&mut opts, hot);
+        // Memtable bloom for whole-key point lookups (2% of the write buffer,
+        // matching optimize_for_point_lookup).
+        opts.set_memtable_prefix_bloom_ratio(0.02);
+        opts.set_memtable_whole_key_filtering(true);
+        let mut bbo = self.block_based_options();
+        bbo.set_data_block_index_type(DataBlockIndexType::BinaryAndHash);
+        bbo.set_data_block_hash_ratio(0.75);
+        bbo.set_bloom_filter(10.0, false);
+        opts.set_block_based_table_factory(&bbo);
+        opts
+    }
+}
+
+impl Default for RocksDbTuning {
+    fn default() -> Self {
+        Self::with_budgets(DEFAULT_BLOCK_CACHE_SIZE, DEFAULT_WRITE_BUFFER_BUDGET)
+    }
+}
+
+impl std::fmt::Debug for RocksDbTuning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RocksDbTuning")
+            .field("hot_write_buffer_size", &self.hot_write_buffer_size)
+            .field("cold_write_buffer_size", &self.cold_write_buffer_size)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_tuning_builds() {
+        let tuning = RocksDbTuning::default();
+        let _ = tuning.base_cf_options(true);
+        let _ = tuning.base_cf_options(false);
+        let _ = tuning.point_lookup_cf_options(true);
+    }
+
+    #[test]
+    fn buffer_sizes_derive_from_budget() {
+        const MIB: usize = 1024 * 1024;
+        let t = RocksDbTuning::with_budgets(256 * MIB, 128 * MIB);
+        assert_eq!(t.hot_write_buffer_size, 16 * MIB);
+        assert_eq!(t.cold_write_buffer_size, 8 * MIB);
+        let small = RocksDbTuning::with_budgets(64 * MIB, 32 * MIB);
+        assert_eq!(small.hot_write_buffer_size, 8 * MIB);
+        assert_eq!(small.cold_write_buffer_size, 4 * MIB);
+        let big = RocksDbTuning::with_budgets(4096 * MIB, 2048 * MIB);
+        assert_eq!(big.hot_write_buffer_size, 64 * MIB);
+        assert_eq!(big.cold_write_buffer_size, 16 * MIB);
+    }
+
+    #[test]
+    fn clones_share_monitor() {
+        let tuning = RocksDbTuning::default();
+        assert_eq!(tuning.monitor_refcount(), 1);
+        let clone = tuning.clone();
+        assert_eq!(tuning.monitor_refcount(), 2);
+        drop(clone);
+        assert_eq!(tuning.monitor_refcount(), 1);
+    }
+
+    #[test]
+    fn clones_share_handles() {
+        let tuning = RocksDbTuning::default();
+        let clone = tuning.clone();
+        // Both handles point at the same cache; capacity reads must agree.
+        assert_eq!(
+            tuning.block_cache.get_usage(),
+            clone.block_cache.get_usage()
+        );
+    }
+}

--- a/components/indexes/rocksdb/tests/outbox_live_results_tests.rs
+++ b/components/indexes/rocksdb/tests/outbox_live_results_tests.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use drasi_core::interface::{LiveResultsWriter, OutboxWriter, RowMutation};
 use drasi_index_rocksdb::{
     element_index::RocksIndexOptions, open_unified_db, RocksDbLiveResultsWriter,
-    RocksDbOutboxWriter,
+    RocksDbOutboxWriter, RocksDbTuning,
 };
 use tempfile::TempDir;
 
@@ -34,7 +34,8 @@ fn open_db(path: &str, query_id: &str) -> Arc<rocksdb::OptimisticTransactionDB> 
         archive_enabled: false,
         direct_io: false,
     };
-    open_unified_db(path, query_id, &options).expect("Failed to open RocksDB")
+    open_unified_db(path, query_id, &options, &RocksDbTuning::default())
+        .expect("Failed to open RocksDB")
 }
 
 // ─── OutboxWriter Tests ──────────────────────────────────────────────────────

--- a/components/indexes/rocksdb/tests/scenario_tests.rs
+++ b/components/indexes/rocksdb/tests/scenario_tests.rs
@@ -28,7 +28,7 @@ use drasi_index_rocksdb::{
     future_queue::RocksDbFutureQueue,
     open_unified_db,
     result_index::RocksDbResultIndex,
-    RocksDbSessionControl, RocksDbSessionState,
+    RocksDbSessionControl, RocksDbSessionState, RocksDbTuning,
 };
 
 struct RocksDbQueryConfig {
@@ -59,10 +59,13 @@ impl RocksDbQueryConfig {
             archive_enabled: true,
             direct_io: false,
         };
-        let db = open_unified_db(&self.url, query_id, &options).unwrap();
+        let db = open_unified_db(&self.url, query_id, &options, &RocksDbTuning::default()).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
-        (RocksDbFutureQueue::new(db, session_state), session_control)
+        (
+            RocksDbFutureQueue::new(db, RocksDbTuning::default(), session_state),
+            session_control,
+        )
     }
 }
 
@@ -85,12 +88,19 @@ impl QueryTestConfig for RocksDbQueryConfig {
             direct_io: false,
         };
 
-        let db = open_unified_db(&self.url, &query_id, &options).unwrap();
+        let db =
+            open_unified_db(&self.url, &query_id, &options, &RocksDbTuning::default()).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
 
-        let element_index = RocksDbElementIndex::new(db.clone(), options, session_state.clone());
-        let ari = RocksDbResultIndex::new(db.clone(), session_state.clone());
-        let fqi = RocksDbFutureQueue::new(db, session_state.clone());
+        let element_index = RocksDbElementIndex::new(
+            db.clone(),
+            options,
+            RocksDbTuning::default(),
+            session_state.clone(),
+        );
+        let ari =
+            RocksDbResultIndex::new(db.clone(), RocksDbTuning::default(), session_state.clone());
+        let fqi = RocksDbFutureQueue::new(db, RocksDbTuning::default(), session_state.clone());
         let session_control = Arc::new(RocksDbSessionControl::new(session_state));
 
         element_index.clear().await.unwrap();
@@ -415,7 +425,7 @@ mod session {
         future_queue::RocksDbFutureQueue,
         open_unified_db,
         result_index::RocksDbResultIndex,
-        RocksDbSessionControl, RocksDbSessionState,
+        RocksDbSessionControl, RocksDbSessionState, RocksDbTuning,
     };
     use serial_test::serial;
     use uuid::Uuid;
@@ -430,11 +440,18 @@ mod session {
             archive_enabled: true,
             direct_io: false,
         };
-        let db = open_unified_db(&url, &query_id, &options).unwrap();
+        let db = open_unified_db(&url, &query_id, &options, &RocksDbTuning::default()).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
-        let element_index = RocksDbElementIndex::new(db.clone(), options, session_state.clone());
-        let result_index = RocksDbResultIndex::new(db.clone(), session_state.clone());
-        let future_queue = RocksDbFutureQueue::new(db, session_state.clone());
+        let element_index = RocksDbElementIndex::new(
+            db.clone(),
+            options,
+            RocksDbTuning::default(),
+            session_state.clone(),
+        );
+        let result_index =
+            RocksDbResultIndex::new(db.clone(), RocksDbTuning::default(), session_state.clone());
+        let future_queue =
+            RocksDbFutureQueue::new(db, RocksDbTuning::default(), session_state.clone());
         let session_control = RocksDbSessionControl::new(session_state);
 
         element_index.clear().await.unwrap();
@@ -502,11 +519,18 @@ mod session {
             archive_enabled: true,
             direct_io: false,
         };
-        let db = open_unified_db(&url, &query_id, &options).unwrap();
+        let db = open_unified_db(&url, &query_id, &options, &RocksDbTuning::default()).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
-        let element_index = RocksDbElementIndex::new(db.clone(), options, session_state.clone());
-        let result_index = RocksDbResultIndex::new(db.clone(), session_state.clone());
-        let future_queue = RocksDbFutureQueue::new(db, session_state.clone());
+        let element_index = RocksDbElementIndex::new(
+            db.clone(),
+            options,
+            RocksDbTuning::default(),
+            session_state.clone(),
+        );
+        let result_index =
+            RocksDbResultIndex::new(db.clone(), RocksDbTuning::default(), session_state.clone());
+        let future_queue =
+            RocksDbFutureQueue::new(db, RocksDbTuning::default(), session_state.clone());
         let session_control = RocksDbSessionControl::new(session_state);
 
         element_index.clear().await.unwrap();
@@ -626,7 +650,8 @@ mod checkpoint_tests {
             archive_enabled: false,
             direct_io: false,
         };
-        let db = open_unified_db(&config.url, &query_id, &options).unwrap();
+        let db =
+            open_unified_db(&config.url, &query_id, &options, &RocksDbTuning::default()).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
         let subject = RocksDbCheckpointStore::new(db, session_state);
@@ -644,7 +669,8 @@ mod checkpoint_tests {
             archive_enabled: false,
             direct_io: false,
         };
-        let db = open_unified_db(&config.url, &query_id, &options).unwrap();
+        let db =
+            open_unified_db(&config.url, &query_id, &options, &RocksDbTuning::default()).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
         let subject = RocksDbCheckpointStore::new(db, session_state);
@@ -662,10 +688,11 @@ mod checkpoint_tests {
             archive_enabled: false,
             direct_io: false,
         };
-        let db = open_unified_db(&config.url, &query_id, &options).unwrap();
+        let db =
+            open_unified_db(&config.url, &query_id, &options, &RocksDbTuning::default()).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
-        let subject = RocksDbResultIndex::new(db, session_state);
+        let subject = RocksDbResultIndex::new(db, RocksDbTuning::default(), session_state);
 
         session_control.begin().await.unwrap();
         shared_tests::sequence_counter::result_sequence_counter(&subject).await;
@@ -686,7 +713,8 @@ mod checkpoint_tests {
             archive_enabled: false,
             direct_io: false,
         };
-        let db = open_unified_db(&config.url, &query_id, &options).unwrap();
+        let db =
+            open_unified_db(&config.url, &query_id, &options, &RocksDbTuning::default()).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
         let subject = RocksDbCheckpointStore::new(db, session_state);
@@ -761,7 +789,8 @@ mod checkpoint_tests {
             archive_enabled: false,
             direct_io: false,
         };
-        let db = open_unified_db(&config.url, &query_id, &options).unwrap();
+        let db =
+            open_unified_db(&config.url, &query_id, &options, &RocksDbTuning::default()).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
         let subject = RocksDbCheckpointStore::new(db, session_state);

--- a/query-perf/src/main.rs
+++ b/query-perf/src/main.rs
@@ -31,7 +31,7 @@ use drasi_index_rocksdb::{
     element_index::{RocksDbElementIndex, RocksIndexOptions},
     open_unified_db,
     result_index::RocksDbResultIndex,
-    RocksDbSessionControl, RocksDbSessionState,
+    RocksDbSessionControl, RocksDbSessionState, RocksDbTuning,
 };
 use drasi_query_cypher::CypherParser;
 
@@ -117,7 +117,7 @@ async fn main() {
 
         // Open shared RocksDB if either index type needs it (avoids LOCK conflict
         // from opening the same unified DB path twice)
-        let (rocks_db, rocks_session_state) = if test_run_config.element_index_type
+        let (rocks_db, rocks_session_state, rocks_tuning) = if test_run_config.element_index_type
             == IndexType::RocksDB
             || test_run_config.result_index_type == IndexType::RocksDB
         {
@@ -129,11 +129,12 @@ async fn main() {
                 Ok(p) => p,
                 Err(_) => "test-data".to_string(),
             };
-            let db = open_unified_db(&path, &query_id, &options).unwrap();
+            let tuning = RocksDbTuning::default();
+            let db = open_unified_db(&path, &query_id, &options, &tuning).unwrap();
             let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
-            (Some(db), Some(session_state))
+            (Some(db), Some(session_state), Some(tuning))
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         // Configure the correct element index
@@ -154,7 +155,12 @@ async fn main() {
 
                 let db = rocks_db.clone().unwrap();
                 let session_state = rocks_session_state.clone().unwrap();
-                let element_index = RocksDbElementIndex::new(db, options, session_state);
+                let element_index = RocksDbElementIndex::new(
+                    db,
+                    options,
+                    rocks_tuning.clone().unwrap(),
+                    session_state,
+                );
                 element_index.clear().await.unwrap();
 
                 builder.with_element_index(Arc::new(element_index))
@@ -174,7 +180,7 @@ async fn main() {
             IndexType::RocksDB => {
                 let db = rocks_db.unwrap();
                 let session_state = rocks_session_state.clone().unwrap();
-                let ari = RocksDbResultIndex::new(db, session_state);
+                let ari = RocksDbResultIndex::new(db, rocks_tuning.clone().unwrap(), session_state);
                 ari.clear().await.unwrap();
 
                 builder.with_result_index(Arc::new(ari))


### PR DESCRIPTION
Closes #634.

Each query opens its own OptimisticTransactionDB with 15 column families and nothing shared: private block caches, 64 MiB write buffers per CF, and a 128 MiB flushed-memtable retention default. Measured cost: ~80 MiB of RSS per query before any data.

This adds RocksDbTuning: one shared block cache and one shared WriteBufferManager (charged to the cache) used by every DB the provider opens, with per-CF write buffer and arena block sizes derived from the single budget. Clones share handles, so the sharing scope (provider, instance, or process) is the caller's choice. RocksDbIndexProvider::new keeps its signature; defaults are a 256 MiB cache with a 128 MiB write budget.

Requires rocksdb 0.22 for the WriteBufferManager API (the 0.21 to 0.22 engine bump itself measures about 1 percent on write throughput).

Benchmarks (20 queries x 240k events, macOS): creation RSS 694 to 552 MiB, eager memtable cost per DB 16 MiB to 28 KiB, write throughput within noise of main on the same engine, disk 1.0 GB to 624 MB.

The flushed-memtable history retention bound is not set here: it moves to the pessimistic transaction change (#684), where the small bound is actually safe. A follow-up can derive its size from the shared budget once both land.
