### PR TITLE
fix(lib): reject ignored storage backend configuration

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -541,9 +541,10 @@ By default, query indexes are held in memory. For persistent state that survives
 Persistent backends are **named bindings to injected providers**: you construct the
 provider (e.g. `RocksDbIndexProvider` from the `drasi-index-rocksdb` crate), register
 it under a name with `with_index_provider`, and reference that name from queries.
-The registration name must match the backend id or `StorageBackendRef::Named` value
-(such as `rocks` below); it does not need to match the provider kind (`rocksdb`).
-Inline specs are supported for the in-memory backend only.
+A separate backend declaration is optional. When present, its id, the provider
+registration name, and the `StorageBackendRef::Named` value must match (such as
+`rocks` below); none needs to match the provider kind (`rocksdb`). Only in-memory
+backends can be configured inline.
 
 ```rust
 use drasi_index_rocksdb::RocksDbIndexProvider;
@@ -575,7 +576,7 @@ let core = DrasiLib::builder()
 | Variant | Fields | Notes |
 |---------|--------|-------|
 | `Memory` | `enable_archive: bool` | Default. Volatile — data lost on restart. Usable inline or named. |
-| `Plugin` | `kind: String` | Optional declaration for a persistent backend (`rocksdb`, `redis`). The injected provider's registration name must match the declaration id/query reference, not `kind`. Inline plugin specs and backend-specific properties are rejected in embedded mode. |
+| `Plugin` | `kind: String` | Declares a named persistent backend (`rocksdb`, `redis`) by kind. The declaration is optional when the provider is registered directly. When present, its id must match the provider registration name and query reference, not `kind`. Plugin backends cannot be configured inline. |
 
 The provider crates define their own construction options (for RocksDB:
 data path, archive on/off, direct I/O, and a shared memory budget). Apply those

--- a/lib/README.md
+++ b/lib/README.md
@@ -202,8 +202,8 @@ let core = DrasiLib::builder()
     .with_query(query_config)                    // Add a query (see Query Builder)
     .with_priority_queue_capacity(50_000)         // Event queue depth (default: 10,000)
     .with_dispatch_buffer_capacity(5_000)         // Channel buffer size (default: 1,000)
-    .add_storage_backend(backend_config)          // Named storage backend (RocksDB, Redis)
-    .with_index_provider(index_plugin)            // Plugin for persistent indexes
+    .add_storage_backend(backend_config)          // Optional named backend declaration
+    .with_index_provider("rocks", Arc::new(index_provider)) // Configured persistent provider
     .with_state_store_provider(state_store)       // Plugin state persistence
     .build()
     .await?;
@@ -221,8 +221,9 @@ Sources and reactions are **owned by DrasiLib** after calling `with_source()` / 
 | `with_query(QueryConfig)` | Query config from `Query` builder | — |
 | `with_priority_queue_capacity(usize)` | Default event queue capacity | `10,000` |
 | `with_dispatch_buffer_capacity(usize)` | Default channel buffer size | `1,000` |
-| `add_storage_backend(StorageBackendConfig)` | Named storage backend definition | — |
-| `with_index_provider(Arc<dyn IndexBackendPlugin>)` | Persistent index plugin | In-memory |
+| `add_storage_backend(StorageBackendConfig)` | Optional named memory or plugin declaration | — |
+| `with_index_provider(name, Arc<dyn IndexBackendPlugin>)` | Register a named persistent provider | — |
+| `with_default_index_provider(name, Arc<dyn IndexBackendPlugin>)` | Register a provider as the default | In-memory |
 | `with_state_store_provider(Arc<dyn StateStoreProvider>)` | Plugin state persistence | In-memory |
 | `build() -> Result<DrasiLib>` | Validate and construct | — |
 
@@ -537,28 +538,31 @@ Query::cypher("my-query")
 
 By default, query indexes are held in memory. For persistent state that survives restarts, configure a storage backend:
 
+Persistent backends are **named bindings to injected providers**: you construct the
+provider (e.g. `RocksDbIndexProvider` from the `drasi-index-rocksdb` crate), register
+it under a name with `with_index_provider`, and reference that name from queries.
+The registration name must match the backend id or `StorageBackendRef::Named` value
+(such as `rocks` below); it does not need to match the provider kind (`rocksdb`).
+Inline specs are supported for the in-memory backend only.
+
 ```rust
-use drasi_lib::{StorageBackendConfig, StorageBackendSpec, StorageBackendRef};
+use drasi_index_rocksdb::RocksDbIndexProvider;
+use drasi_lib::{DrasiLib, Query, StorageBackendRef};
+use std::sync::Arc;
+
+let provider = RocksDbIndexProvider::new("/data/drasi-indexes", false, false)
+    .with_memory_budget_bytes(512 << 20)?;
 
 let core = DrasiLib::builder()
     .with_id("my-app")
-    // 1. Define a named backend
-    .add_storage_backend(StorageBackendConfig {
-        id: "rocks".to_string(),
-        spec: StorageBackendSpec::RocksDb {
-            path: "/data/drasi-indexes".to_string(),
-            enable_archive: false,     // Enable drasi.past() time-travel queries
-            direct_io: false,          // Bypass OS page cache
-        },
-    })
-    // 2. Provide the plugin that implements the backend
-    .with_index_provider(Arc::new(my_rocksdb_plugin))
+    // 1. Register the provider under a name
+    .with_index_provider("rocks", Arc::new(provider))
     .with_source(source)
     .with_query(
         Query::cypher("my-query")
             .query("MATCH (n:Sensor) RETURN n")
             .from_source("sensors")
-            // 3. Assign the backend to a specific query
+            // 2. Assign the backend to a specific query by name
             .with_storage_backend(StorageBackendRef::Named("rocks".to_string()))
             .build()
     )
@@ -570,9 +574,13 @@ let core = DrasiLib::builder()
 
 | Variant | Fields | Notes |
 |---------|--------|-------|
-| `Memory` | `enable_archive: bool` | Default. Volatile — data lost on restart. |
-| `RocksDb` | `path: String`, `enable_archive: bool`, `direct_io: bool` | Path must be absolute. |
-| `Redis` | `connection_string: String`, `cache_size: Option<usize>` | URL must start with `redis://` or `rediss://`. |
+| `Memory` | `enable_archive: bool` | Default. Volatile — data lost on restart. Usable inline or named. |
+| `Plugin` | `kind: String` | Optional declaration for a persistent backend (`rocksdb`, `redis`). The injected provider's registration name must match the declaration id/query reference, not `kind`. Inline plugin specs and backend-specific properties are rejected in embedded mode. |
+
+The provider crates define their own construction options (for RocksDB:
+data path, archive on/off, direct I/O, and a shared memory budget). Apply those
+settings when constructing the provider; `StorageBackendSpec::Plugin` does not
+configure an injected provider.
 
 ---
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -537,28 +537,27 @@ Query::cypher("my-query")
 
 By default, query indexes are held in memory. For persistent state that survives restarts, configure a storage backend:
 
+Persistent backends are **named bindings to injected providers**: you construct the
+provider (e.g. `RocksDbIndexProvider` from the `drasi-index-rocksdb` crate), register
+it under a name with `with_index_provider`, and reference that name from queries.
+Inline specs are supported for the in-memory backend only.
+
 ```rust
-use drasi_lib::{StorageBackendConfig, StorageBackendSpec, StorageBackendRef};
+use drasi_lib::StorageBackendRef;
+use drasi_index_rocksdb::RocksDbIndexProvider;
+
+let provider = RocksDbIndexProvider::new("/data/drasi-indexes", false, false);
 
 let core = DrasiLib::builder()
     .with_id("my-app")
-    // 1. Define a named backend
-    .add_storage_backend(StorageBackendConfig {
-        id: "rocks".to_string(),
-        spec: StorageBackendSpec::RocksDb {
-            path: "/data/drasi-indexes".to_string(),
-            enable_archive: false,     // Enable drasi.past() time-travel queries
-            direct_io: false,          // Bypass OS page cache
-        },
-    })
-    // 2. Provide the plugin that implements the backend
-    .with_index_provider(Arc::new(my_rocksdb_plugin))
+    // 1. Register the provider under a name
+    .with_index_provider("rocks", Arc::new(provider))
     .with_source(source)
     .with_query(
         Query::cypher("my-query")
             .query("MATCH (n:Sensor) RETURN n")
             .from_source("sensors")
-            // 3. Assign the backend to a specific query
+            // 2. Assign the backend to a specific query by name
             .with_storage_backend(StorageBackendRef::Named("rocks".to_string()))
             .build()
     )
@@ -570,9 +569,12 @@ let core = DrasiLib::builder()
 
 | Variant | Fields | Notes |
 |---------|--------|-------|
-| `Memory` | `enable_archive: bool` | Default. Volatile — data lost on restart. |
-| `RocksDb` | `path: String`, `enable_archive: bool`, `direct_io: bool` | Path must be absolute. |
-| `Redis` | `connection_string: String`, `cache_size: Option<usize>` | URL must start with `redis://` or `rediss://`. |
+| `Memory` | `enable_archive: bool` | Default. Volatile — data lost on restart. Usable inline or named. |
+| `Plugin` | `kind: String` plus an opaque payload | Persistent backends (`rocksdb`, `redis`). Declares intent only: the actual backend is the provider injected via `with_index_provider` under the same name. Inline `Plugin` specs are rejected at query start. |
+
+The provider crates define their own construction options (for RocksDB:
+data path, archive on/off, direct I/O, memory tuning). Backend behavior is
+controlled there, not through the spec payload.
 
 ---
 

--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -1330,7 +1330,7 @@ mod tests {
             id: "rocks".to_string(),
             spec: StorageBackendSpec::Plugin {
                 kind: "rocksdb".to_string(),
-                config: serde_json::json!({ "path": "/data/drasi" }),
+                config: serde_json::json!({}),
             },
         };
         let query = Query::cypher("q")
@@ -1348,6 +1348,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_builder_rejects_ignored_plugin_config() {
+        use crate::indexes::config::{StorageBackendConfig, StorageBackendSpec};
+
+        let backend = StorageBackendConfig {
+            id: "rocks".to_string(),
+            spec: StorageBackendSpec::Plugin {
+                kind: "rocksdb".to_string(),
+                config: serde_json::json!({ "path": "/data/drasi" }),
+            },
+        };
+        let err = DrasiLibBuilder::new()
+            .add_storage_backend(backend)
+            .build()
+            .await
+            .map(|_| ())
+            .expect_err("ignored plugin configuration should fail validation");
+        assert!(err.to_string().contains("ignored in embedded mode"));
+    }
+
+    #[tokio::test]
     async fn test_builder_inline_plugin_backend_errors() {
         use crate::indexes::config::{StorageBackendRef, StorageBackendSpec};
 
@@ -1355,7 +1375,7 @@ mod tests {
             .query("MATCH (n) RETURN n")
             .with_storage_backend(StorageBackendRef::Inline(StorageBackendSpec::Plugin {
                 kind: "rocksdb".to_string(),
-                config: serde_json::json!({ "path": "/data/drasi" }),
+                config: serde_json::json!({}),
             }))
             .build();
         let err = DrasiLibBuilder::new()

--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -518,7 +518,7 @@ impl DrasiLibBuilder {
                     StorageBackendSpec::Memory { .. } => {
                         declared_memory.insert(b.id.as_str());
                     }
-                    StorageBackendSpec::Plugin { kind, .. } => {
+                    StorageBackendSpec::Plugin { kind } => {
                         declared_plugin.insert(b.id.as_str(), kind.as_str());
                     }
                 }
@@ -559,9 +559,7 @@ impl DrasiLibBuilder {
                             )));
                         }
                     }
-                    Some(StorageBackendRef::Inline(StorageBackendSpec::Plugin {
-                        kind, ..
-                    })) => {
+                    Some(StorageBackendRef::Inline(StorageBackendSpec::Plugin { kind })) => {
                         return Err(DrasiError::validation(format!(
                             "Query '{}' uses an inline '{}' storage backend, which is not \
                              supported in embedded mode. Declare a named storage backend and \
@@ -1330,7 +1328,6 @@ mod tests {
             id: "rocks".to_string(),
             spec: StorageBackendSpec::Plugin {
                 kind: "rocksdb".to_string(),
-                config: serde_json::json!({}),
             },
         };
         let query = Query::cypher("q")
@@ -1348,26 +1345,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_builder_rejects_ignored_plugin_config() {
-        use crate::indexes::config::{StorageBackendConfig, StorageBackendSpec};
-
-        let backend = StorageBackendConfig {
-            id: "rocks".to_string(),
-            spec: StorageBackendSpec::Plugin {
-                kind: "rocksdb".to_string(),
-                config: serde_json::json!({ "path": "/data/drasi" }),
-            },
-        };
-        let err = DrasiLibBuilder::new()
-            .add_storage_backend(backend)
-            .build()
-            .await
-            .map(|_| ())
-            .expect_err("ignored plugin configuration should fail validation");
-        assert!(err.to_string().contains("ignored in embedded mode"));
-    }
-
-    #[tokio::test]
     async fn test_builder_inline_plugin_backend_errors() {
         use crate::indexes::config::{StorageBackendRef, StorageBackendSpec};
 
@@ -1375,7 +1352,6 @@ mod tests {
             .query("MATCH (n) RETURN n")
             .with_storage_backend(StorageBackendRef::Inline(StorageBackendSpec::Plugin {
                 kind: "rocksdb".to_string(),
-                config: serde_json::json!({}),
             }))
             .build();
         let err = DrasiLibBuilder::new()

--- a/lib/src/indexes/config.rs
+++ b/lib/src/indexes/config.rs
@@ -26,13 +26,11 @@ pub struct StorageBackendConfig {
 
 /// Storage backend specification defining the type and parameters.
 ///
-/// In-memory storage is handled natively by drasi-lib. All persistent backends
-/// (e.g. `rocksdb`, `redis`) are first-class config plugins: drasi-lib does not
-/// carry backend-specific serialization for them. Instead a persistent backend is
-/// declared generically by its `kind` plus an opaque `config` payload, and the
-/// concrete provider is supplied at runtime via
-/// `DrasiLibBuilder::with_index_provider(name, provider)` (the provider name must
-/// match the backend id / referenced name).
+/// In-memory storage is handled natively by drasi-lib. Persistent backends
+/// (e.g. `rocksdb`, `redis`) are declared by `kind`, then supplied as configured
+/// provider instances through `DrasiLibBuilder::with_index_provider(name, provider)`.
+/// Backend-specific settings belong to the provider constructor, not this
+/// specification.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all_fields = "camelCase")]
 pub enum StorageBackendSpec {
@@ -53,21 +51,22 @@ pub enum StorageBackendSpec {
     /// A pluggable persistent storage backend identified by `kind`
     /// (e.g. `rocksdb`, `redis`).
     ///
-    /// The `config` payload is opaque to drasi-lib and is interpreted by the
-    /// backend's config plugin / injected provider. In embedded mode the backend
-    /// is satisfied by a named provider injected via `with_index_provider`.
+    /// In embedded mode the backend is satisfied by a named provider injected via
+    /// `with_index_provider`. Additional configuration properties are rejected
+    /// because drasi-lib cannot apply them to an already-constructed provider.
     ///
     /// # Example
     /// ```yaml
     /// kind: rocksdb
-    /// path: /data/drasi
-    /// enableArchive: true
     /// ```
     #[serde(untagged)]
     Plugin {
         /// Backend kind discriminator (e.g. "rocksdb", "redis")
         kind: String,
-        /// Opaque, backend-specific configuration payload
+        /// Flattened backend properties retained for serialization compatibility.
+        ///
+        /// This must be empty in embedded mode. Configure the injected provider
+        /// directly instead.
         #[serde(flatten)]
         config: serde_json::Value,
     },
@@ -88,9 +87,17 @@ impl StorageBackendSpec {
     pub fn validate(&self) -> Result<(), String> {
         match self {
             StorageBackendSpec::Memory { .. } => Ok(()),
-            StorageBackendSpec::Plugin { kind, .. } => {
+            StorageBackendSpec::Plugin { kind, config } => {
                 if kind.trim().is_empty() {
                     return Err("Storage backend 'kind' must not be empty".to_string());
+                }
+                if !matches!(config, serde_json::Value::Null)
+                    && !config.as_object().is_some_and(serde_json::Map::is_empty)
+                {
+                    return Err(format!(
+                        "Storage backend kind '{kind}' includes backend-specific properties that \
+                         are ignored in embedded mode; configure the injected provider directly"
+                    ));
                 }
                 Ok(())
             }
@@ -205,6 +212,19 @@ directIo: false
     }
 
     #[test]
+    fn test_plugin_without_config_serde() {
+        let spec: StorageBackendSpec = serde_yaml::from_str("kind: rocksdb").unwrap();
+        match &spec {
+            StorageBackendSpec::Plugin { kind, config } => {
+                assert_eq!(kind, "rocksdb");
+                assert_eq!(config, &serde_json::json!({}));
+            }
+            _ => panic!("Expected Plugin variant"),
+        }
+        assert!(spec.validate().is_ok());
+    }
+
+    #[test]
     fn test_plugin_redis_serde() {
         let yaml = r#"
 kind: redis
@@ -296,12 +316,23 @@ enableArchive: false
     }
 
     #[test]
-    fn test_validate_plugin_ok() {
+    fn test_validate_plugin_without_config() {
+        let spec = StorageBackendSpec::Plugin {
+            kind: "rocksdb".to_string(),
+            config: serde_json::json!({}),
+        };
+        assert!(spec.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_plugin_rejects_ignored_config() {
         let spec = StorageBackendSpec::Plugin {
             kind: "rocksdb".to_string(),
             config: serde_json::json!({ "path": "/data/drasi" }),
         };
-        assert!(spec.validate().is_ok());
+        let err = spec.validate().unwrap_err();
+        assert!(err.contains("ignored in embedded mode"));
+        assert!(err.contains("configure the injected provider directly"));
     }
 
     #[test]

--- a/lib/src/indexes/config.rs
+++ b/lib/src/indexes/config.rs
@@ -32,7 +32,7 @@ pub struct StorageBackendConfig {
 /// Backend-specific settings belong to the provider constructor, not this
 /// specification.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all_fields = "camelCase")]
+#[serde(tag = "kind", rename_all_fields = "camelCase", deny_unknown_fields)]
 pub enum StorageBackendSpec {
     /// In-memory storage backend (volatile, fast, no persistence)
     ///
@@ -63,12 +63,6 @@ pub enum StorageBackendSpec {
     Plugin {
         /// Backend kind discriminator (e.g. "rocksdb", "redis")
         kind: String,
-        /// Flattened backend properties retained for serialization compatibility.
-        ///
-        /// This must be empty in embedded mode. Configure the injected provider
-        /// directly instead.
-        #[serde(flatten)]
-        config: serde_json::Value,
     },
 }
 
@@ -87,17 +81,15 @@ impl StorageBackendSpec {
     pub fn validate(&self) -> Result<(), String> {
         match self {
             StorageBackendSpec::Memory { .. } => Ok(()),
-            StorageBackendSpec::Plugin { kind, config } => {
+            StorageBackendSpec::Plugin { kind } => {
                 if kind.trim().is_empty() {
                     return Err("Storage backend 'kind' must not be empty".to_string());
                 }
-                if !matches!(config, serde_json::Value::Null)
-                    && !config.as_object().is_some_and(serde_json::Map::is_empty)
-                {
-                    return Err(format!(
-                        "Storage backend kind '{kind}' includes backend-specific properties that \
-                         are ignored in embedded mode; configure the injected provider directly"
-                    ));
+                if kind.trim() == "memory" {
+                    return Err(
+                        "Storage backend kind 'memory' is reserved for the in-memory backend"
+                            .to_string(),
+                    );
                 }
                 Ok(())
             }
@@ -137,20 +129,11 @@ mod tests {
 
         let plugin = StorageBackendSpec::Plugin {
             kind: "rocksdb".to_string(),
-            config: serde_json::json!({
-                "path": "/data/drasi",
-                "enableArchive": true,
-            }),
         };
         let plugin_value = serde_json::to_value(&plugin).unwrap();
-        assert_eq!(plugin_value["kind"], "rocksdb");
-        assert_eq!(plugin_value["path"], "/data/drasi");
+        assert_eq!(plugin_value, serde_json::json!({ "kind": "rocksdb" }));
         match serde_json::from_value::<StorageBackendSpec>(plugin_value).unwrap() {
-            StorageBackendSpec::Plugin { kind, config } => {
-                assert_eq!(kind, "rocksdb");
-                assert_eq!(config["path"], "/data/drasi");
-                assert_eq!(config["enableArchive"], true);
-            }
+            StorageBackendSpec::Plugin { kind } => assert_eq!(kind, "rocksdb"),
             _ => panic!("Expected Plugin variant after JSON round-trip"),
         }
     }
@@ -181,65 +164,32 @@ enableArchive: true
     }
 
     #[test]
-    fn test_plugin_rocksdb_serde() {
+    fn test_plugin_properties_rejected() {
         let yaml = r#"
+id: rocks
 kind: rocksdb
 path: /data/drasi
 enableArchive: true
 directIo: false
 "#;
-        let spec: StorageBackendSpec = serde_yaml::from_str(yaml).unwrap();
-        match &spec {
-            StorageBackendSpec::Plugin { kind, config } => {
-                assert_eq!(kind, "rocksdb");
-                assert_eq!(config["path"], "/data/drasi");
-                assert_eq!(config["enableArchive"], true);
-                assert_eq!(config["directIo"], false);
-            }
-            _ => panic!("Expected Plugin variant"),
-        }
+        assert!(serde_yaml::from_str::<StorageBackendConfig>(yaml).is_err());
 
-        // Round-trip: Plugin variant preserves kind + opaque config
-        let serialized = serde_yaml::to_string(&spec).unwrap();
-        let deserialized: StorageBackendSpec = serde_yaml::from_str(&serialized).unwrap();
-        match deserialized {
-            StorageBackendSpec::Plugin { kind, config } => {
-                assert_eq!(kind, "rocksdb");
-                assert_eq!(config["path"], "/data/drasi");
-            }
-            _ => panic!("Expected Plugin variant after round-trip"),
-        }
+        let json = serde_json::json!({
+            "id": "rocks",
+            "kind": "rocksdb",
+            "path": "/data/drasi"
+        });
+        assert!(serde_json::from_value::<StorageBackendConfig>(json).is_err());
     }
 
     #[test]
     fn test_plugin_without_config_serde() {
         let spec: StorageBackendSpec = serde_yaml::from_str("kind: rocksdb").unwrap();
         match &spec {
-            StorageBackendSpec::Plugin { kind, config } => {
-                assert_eq!(kind, "rocksdb");
-                assert_eq!(config, &serde_json::json!({}));
-            }
+            StorageBackendSpec::Plugin { kind } => assert_eq!(kind, "rocksdb"),
             _ => panic!("Expected Plugin variant"),
         }
         assert!(spec.validate().is_ok());
-    }
-
-    #[test]
-    fn test_plugin_redis_serde() {
-        let yaml = r#"
-kind: redis
-connectionString: "redis://localhost:6379"
-cacheSize: 10000
-"#;
-        let spec: StorageBackendSpec = serde_yaml::from_str(yaml).unwrap();
-        match spec {
-            StorageBackendSpec::Plugin { kind, config } => {
-                assert_eq!(kind, "redis");
-                assert_eq!(config["connectionString"], "redis://localhost:6379");
-                assert_eq!(config["cacheSize"], 10000);
-            }
-            _ => panic!("Expected Plugin variant"),
-        }
     }
 
     #[test]
@@ -247,17 +197,11 @@ cacheSize: 10000
         let yaml = r#"
 id: rocks_persistent
 kind: rocksdb
-path: /data/drasi
-enableArchive: true
 "#;
         let config: StorageBackendConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.id, "rocks_persistent");
         match config.spec {
-            StorageBackendSpec::Plugin { kind, config } => {
-                assert_eq!(kind, "rocksdb");
-                assert_eq!(config["path"], "/data/drasi");
-                assert_eq!(config["enableArchive"], true);
-            }
+            StorageBackendSpec::Plugin { kind } => assert_eq!(kind, "rocksdb"),
             _ => panic!("Expected Plugin variant"),
         }
     }
@@ -319,27 +263,23 @@ enableArchive: false
     fn test_validate_plugin_without_config() {
         let spec = StorageBackendSpec::Plugin {
             kind: "rocksdb".to_string(),
-            config: serde_json::json!({}),
         };
         assert!(spec.validate().is_ok());
     }
 
     #[test]
-    fn test_validate_plugin_rejects_ignored_config() {
+    fn test_validate_plugin_memory_kind() {
         let spec = StorageBackendSpec::Plugin {
-            kind: "rocksdb".to_string(),
-            config: serde_json::json!({ "path": "/data/drasi" }),
+            kind: "memory".to_string(),
         };
         let err = spec.validate().unwrap_err();
-        assert!(err.contains("ignored in embedded mode"));
-        assert!(err.contains("configure the injected provider directly"));
+        assert!(err.contains("reserved"));
     }
 
     #[test]
     fn test_validate_plugin_empty_kind() {
         let spec = StorageBackendSpec::Plugin {
             kind: "   ".to_string(),
-            config: serde_json::json!({}),
         };
         assert!(spec.validate().is_err());
         let err = spec.validate().unwrap_err();
@@ -352,10 +292,8 @@ enableArchive: false
             enable_archive: false,
         };
         assert!(memory_spec.is_volatile());
-
         let plugin_spec = StorageBackendSpec::Plugin {
             kind: "rocksdb".to_string(),
-            config: serde_json::json!({ "path": "/data/drasi" }),
         };
         assert!(!plugin_spec.is_volatile());
     }

--- a/lib/src/indexes/factory.rs
+++ b/lib/src/indexes/factory.rs
@@ -356,7 +356,7 @@ mod tests {
                 id: "rocks_test".to_string(),
                 spec: StorageBackendSpec::Plugin {
                     kind: "rocksdb".to_string(),
-                    config: serde_json::json!({ "path": "/tmp/test" }),
+                    config: serde_json::json!({}),
                 },
             },
         ];
@@ -420,7 +420,7 @@ mod tests {
             id: "rocks".to_string(),
             spec: StorageBackendSpec::Plugin {
                 kind: "rocksdb".to_string(),
-                config: serde_json::json!({ "path": "/data/test" }),
+                config: serde_json::json!({}),
             },
         }];
         let factory = IndexFactory::new(backends, HashMap::new());
@@ -453,7 +453,7 @@ mod tests {
         let factory = IndexFactory::new(vec![], providers_with("rocks", false));
         let backend_ref = StorageBackendRef::Inline(StorageBackendSpec::Plugin {
             kind: "rocksdb".to_string(),
-            config: serde_json::json!({ "path": "/data/test" }),
+            config: serde_json::json!({}),
         });
         let result = factory.build(&backend_ref, "test_query").await;
 
@@ -497,7 +497,7 @@ mod tests {
             id: "rocks".to_string(),
             spec: StorageBackendSpec::Plugin {
                 kind: "rocksdb".to_string(),
-                config: serde_json::json!({ "path": "/data/test" }),
+                config: serde_json::json!({}),
             },
         }];
         let factory = IndexFactory::new(backends, HashMap::new());
@@ -516,7 +516,7 @@ mod tests {
 
         let backend_ref = StorageBackendRef::Inline(StorageBackendSpec::Plugin {
             kind: "rocksdb".to_string(),
-            config: serde_json::json!({ "path": "/data/test" }),
+            config: serde_json::json!({}),
         });
         assert!(!factory.is_volatile(&backend_ref));
     }

--- a/lib/src/indexes/factory.rs
+++ b/lib/src/indexes/factory.rs
@@ -157,7 +157,7 @@ impl IndexFactory {
                 StorageBackendSpec::Memory { enable_archive } => {
                     memory_backends.insert(b.id, enable_archive);
                 }
-                StorageBackendSpec::Plugin { kind, .. } => {
+                StorageBackendSpec::Plugin { kind } => {
                     plugin_backends.insert(b.id, kind);
                 }
             }
@@ -210,7 +210,7 @@ impl IndexFactory {
             StorageBackendRef::Inline(StorageBackendSpec::Memory { enable_archive }) => {
                 self.build_memory_indexes(*enable_archive)
             }
-            StorageBackendRef::Inline(StorageBackendSpec::Plugin { kind, .. }) => {
+            StorageBackendRef::Inline(StorageBackendSpec::Plugin { kind }) => {
                 Err(IndexError::InitializationFailed(format!(
                     "Inline plugin storage backend (kind '{kind}') is not supported in embedded mode. \
                      Declare a named storage backend and inject a provider via \
@@ -356,7 +356,6 @@ mod tests {
                 id: "rocks_test".to_string(),
                 spec: StorageBackendSpec::Plugin {
                     kind: "rocksdb".to_string(),
-                    config: serde_json::json!({}),
                 },
             },
         ];
@@ -420,7 +419,6 @@ mod tests {
             id: "rocks".to_string(),
             spec: StorageBackendSpec::Plugin {
                 kind: "rocksdb".to_string(),
-                config: serde_json::json!({}),
             },
         }];
         let factory = IndexFactory::new(backends, HashMap::new());
@@ -453,7 +451,6 @@ mod tests {
         let factory = IndexFactory::new(vec![], providers_with("rocks", false));
         let backend_ref = StorageBackendRef::Inline(StorageBackendSpec::Plugin {
             kind: "rocksdb".to_string(),
-            config: serde_json::json!({}),
         });
         let result = factory.build(&backend_ref, "test_query").await;
 
@@ -497,7 +494,6 @@ mod tests {
             id: "rocks".to_string(),
             spec: StorageBackendSpec::Plugin {
                 kind: "rocksdb".to_string(),
-                config: serde_json::json!({}),
             },
         }];
         let factory = IndexFactory::new(backends, HashMap::new());
@@ -516,7 +512,6 @@ mod tests {
 
         let backend_ref = StorageBackendRef::Inline(StorageBackendSpec::Plugin {
             kind: "rocksdb".to_string(),
-            config: serde_json::json!({}),
         });
         assert!(!factory.is_volatile(&backend_ref));
     }

--- a/lib/src/indexes/mod.rs
+++ b/lib/src/indexes/mod.rs
@@ -22,14 +22,14 @@
 //!
 //! - **Memory**: In-memory storage (volatile, fast, no persistence). Fully self-contained.
 //! - **Plugin** (`kind: rocksdb`, `kind: redis`, ...): Persistent storage provided by an
-//!   index backend plugin. The backend is selected by `kind` and carries its own
-//!   plugin-specific config (e.g. `path`, `connectionString`).
+//!   index backend plugin. The declaration identifies the provider kind; backend-specific
+//!   settings are applied when constructing the provider.
 //!
 //! ## Configuration
 //!
-//! Storage backends can be declared globally and referenced by id, or configured inline
-//! on a single query. Both use a `kind` discriminator and camelCase fields, consistent
-//! with every other DrasiLib component DTO.
+//! In-memory backends can be declared globally and referenced by id, or configured inline
+//! on a single query. Persistent backends may be declared globally by id and kind, but
+//! require a configured provider injected under the same id.
 //!
 //! ### Named Backends (Global Declaration)
 //!
@@ -37,9 +37,6 @@
 //! storage_backends:
 //!   - id: rocks_persistent
 //!     kind: rocksdb
-//!     path: /data/drasi
-//!     enableArchive: true
-//!     directIo: false
 //!
 //! queries:
 //!   - id: my_query
@@ -72,7 +69,8 @@
 //! use drasi_lib::{DrasiLib, Query, StorageBackendRef};
 //! use std::sync::Arc;
 //!
-//! let provider = RocksDbIndexProvider::new("/data/drasi", true, false);
+//! let provider = RocksDbIndexProvider::new("/data/drasi", true, false)
+//!     .with_memory_budget_bytes(512 << 20)?;
 //! let query = Query::cypher("my_query")
 //!     .query("MATCH (n) RETURN n")
 //!     .from_source("my_source")
@@ -86,7 +84,8 @@
 //! ```
 //!
 //! Only in-memory backends can be instantiated purely from configuration in embedded
-//! mode; a plugin backend always requires a matching injected provider.
+//! mode. A plugin backend always requires a matching injected provider, and its settings
+//! must be applied when constructing that provider.
 //!
 //! ## Performance Characteristics
 //!


### PR DESCRIPTION
Closes #636.

- Correct all stale `drasi-lib` README examples and builder signatures for named provider injection.
- Document provider-owned RocksDB settings, including `with_memory_budget_bytes`.
- Reject non-empty `StorageBackendSpec::Plugin` payloads in embedded mode instead of silently ignoring them.
- Keep empty kind-only plugin declarations for matching configured providers by name.