### PR TITLE
Fix memory leak in InMemoryElementIndex slot maps

### DIFF
--- a/core/src/in_memory_index/in_memory_element_index.rs
+++ b/core/src/in_memory_index/in_memory_element_index.rs
@@ -104,12 +104,20 @@ impl InMemoryElementIndex {
                 let mut out_guard = self.element_by_slot_out.write().await;
 
                 for old_slot in affinity.drain() {
-                    if let Some(set) = in_guard.get_mut(&(old_slot, in_node.clone())) {
+                    let in_key = (old_slot, in_node.clone());
+                    if let Some(set) = in_guard.get_mut(&in_key) {
                         set.remove(&metadata.reference);
+                        if set.is_empty() {
+                            in_guard.remove(&in_key);
+                        }
                     }
 
-                    if let Some(set) = out_guard.get_mut(&(old_slot, out_node.clone())) {
+                    let out_key = (old_slot, out_node.clone());
+                    if let Some(set) = out_guard.get_mut(&out_key) {
                         set.remove(&metadata.reference);
+                        if set.is_empty() {
+                            out_guard.remove(&out_key);
+                        }
                     }
                 }
             }
@@ -800,6 +808,26 @@ mod tests {
         }
     }
 
+    /// Helper function to create a test relation element between two nodes
+    fn create_test_relation(
+        source_id: &str,
+        element_id: &str,
+        label: &str,
+        in_id: &str,
+        out_id: &str,
+    ) -> Element {
+        Element::Relation {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(source_id, element_id),
+                labels: Arc::from([Arc::from(label)]),
+                effective_from: 0,
+            },
+            in_node: ElementReference::new(source_id, in_id),
+            out_node: ElementReference::new(source_id, out_id),
+            properties: ElementPropertyMap::new(),
+        }
+    }
+
     #[tokio::test]
     async fn test_basic_element_operations() {
         let index = InMemoryElementIndex::new();
@@ -1159,6 +1187,7 @@ mod tests {
         }
     }
 
+<<<<<<< HEAD
     /// Regression test for issue #641: emptied partial-join containers must be
     /// pruned so `partial_joins` does not grow unbounded for high-cardinality /
     /// high-churn join values.
@@ -1283,5 +1312,96 @@ mod tests {
             )
             .await;
         assert!(versions.is_ok());
+=======
+    /// Regression test for issue #642: deleting a relation must prune the now-empty
+    /// `(slot, node)` entries from `element_by_slot_in` / `element_by_slot_out` instead
+    /// of leaving empty `HashSet`s behind, which would leak memory over time.
+    #[tokio::test]
+    async fn test_slot_maps_pruned_after_relation_delete() {
+        let index = InMemoryElementIndex::new();
+
+        // Insert two relations that share the same slot but reference distinct nodes.
+        let rel1 = create_test_relation("source1", "rel1", "KNOWS", "in1", "out1");
+        let rel2 = create_test_relation("source1", "rel2", "KNOWS", "in2", "out2");
+        index.set_element(&rel1, &vec![0]).await.unwrap();
+        index.set_element(&rel2, &vec![0]).await.unwrap();
+
+        // Both relations should be indexed by their in/out nodes.
+        assert_eq!(index.element_by_slot_in.read().await.len(), 2);
+        assert_eq!(index.element_by_slot_out.read().await.len(), 2);
+
+        // Delete the first relation; its (slot, node) entries should be removed entirely,
+        // not left as empty sets.
+        index
+            .delete_element(&ElementReference::new("source1", "rel1"))
+            .await
+            .unwrap();
+
+        {
+            let in_guard = index.element_by_slot_in.read().await;
+            let out_guard = index.element_by_slot_out.read().await;
+            assert_eq!(in_guard.len(), 1, "empty in-slot entry should be pruned");
+            assert_eq!(out_guard.len(), 1, "empty out-slot entry should be pruned");
+            assert!(!in_guard.contains_key(&(0, ElementReference::new("source1", "in1"))));
+            assert!(!out_guard.contains_key(&(0, ElementReference::new("source1", "out1"))));
+        }
+
+        // Delete the second relation; both maps should now be empty.
+        index
+            .delete_element(&ElementReference::new("source1", "rel2"))
+            .await
+            .unwrap();
+
+        assert!(
+            index.element_by_slot_in.read().await.is_empty(),
+            "element_by_slot_in should be empty after all relations are deleted"
+        );
+        assert!(
+            index.element_by_slot_out.read().await.is_empty(),
+            "element_by_slot_out should be empty after all relations are deleted"
+        );
+    }
+
+    /// Ensure pruning does not drop a shared `(slot, node)` entry while another relation
+    /// still references that node.
+    #[tokio::test]
+    async fn test_slot_maps_retain_shared_node_entry() {
+        let index = InMemoryElementIndex::new();
+
+        // Two relations sharing the same in_node and out_node.
+        let rel1 = create_test_relation("source1", "rel1", "KNOWS", "in1", "out1");
+        let rel2 = create_test_relation("source1", "rel2", "KNOWS", "in1", "out1");
+        index.set_element(&rel1, &vec![0]).await.unwrap();
+        index.set_element(&rel2, &vec![0]).await.unwrap();
+
+        let in_key = (0, ElementReference::new("source1", "in1"));
+        let out_key = (0, ElementReference::new("source1", "out1"));
+
+        // Delete one relation: the shared entries must survive with the remaining ref.
+        index
+            .delete_element(&ElementReference::new("source1", "rel1"))
+            .await
+            .unwrap();
+
+        {
+            let in_guard = index.element_by_slot_in.read().await;
+            let out_guard = index.element_by_slot_out.read().await;
+            let in_set = in_guard.get(&in_key).expect("shared in entry retained");
+            let out_set = out_guard.get(&out_key).expect("shared out entry retained");
+            assert_eq!(in_set.len(), 1);
+            assert_eq!(out_set.len(), 1);
+            assert!(in_set.contains(&ElementReference::new("source1", "rel2")));
+            assert!(out_set.contains(&ElementReference::new("source1", "rel2")));
+        }
+
+        // Delete the last relation: entries should now be pruned.
+        index
+            .delete_element(&ElementReference::new("source1", "rel2"))
+            .await
+            .unwrap();
+
+        assert!(index.element_by_slot_in.read().await.is_empty());
+        assert!(index.element_by_slot_out.read().await.is_empty());
+>>>>>>> 857010df (Fix memory leak in InMemoryElementIndex slot maps)
     }
 }

--- a/core/src/in_memory_index/in_memory_element_index.rs
+++ b/core/src/in_memory_index/in_memory_element_index.rs
@@ -81,7 +81,12 @@ impl InMemoryElementIndex {
 
     async fn clear_slot_affinity(&self, element: &Element) -> Result<(), IndexError> {
         let mut af_guard = self.slot_affinity.write().await;
-        let affinity = af_guard.entry(element.get_reference().clone()).or_default();
+        let element_ref = element.get_reference();
+        let affinity = match af_guard.get_mut(element_ref) {
+            Some(affinity) => affinity,
+            // No recorded affinity means there is nothing to clear.
+            None => return Ok(()),
+        };
 
         match element {
             Element::Node {
@@ -122,6 +127,10 @@ impl InMemoryElementIndex {
                 }
             }
         };
+
+        // The affinity set was fully drained above; remove its entry so the
+        // slot_affinity map does not retain empty sets for deleted elements.
+        af_guard.remove(element_ref);
 
         Ok(())
     }
@@ -1187,7 +1196,6 @@ mod tests {
         }
     }
 
-<<<<<<< HEAD
     /// Regression test for issue #641: emptied partial-join containers must be
     /// pruned so `partial_joins` does not grow unbounded for high-cardinality /
     /// high-churn join values.
@@ -1312,7 +1320,8 @@ mod tests {
             )
             .await;
         assert!(versions.is_ok());
-=======
+    }
+
     /// Regression test for issue #642: deleting a relation must prune the now-empty
     /// `(slot, node)` entries from `element_by_slot_in` / `element_by_slot_out` instead
     /// of leaving empty `HashSet`s behind, which would leak memory over time.
@@ -1360,6 +1369,43 @@ mod tests {
             index.element_by_slot_out.read().await.is_empty(),
             "element_by_slot_out should be empty after all relations are deleted"
         );
+        assert!(
+            index.slot_affinity.read().await.is_empty(),
+            "slot_affinity should be empty after all relations are deleted"
+        );
+    }
+
+    /// Regression test for the multi-slot case: a relation assigned to several slots must
+    /// have every `(slot, node)` entry pruned on delete, since `clear_slot_affinity`
+    /// iterates over all slots in the affinity set.
+    #[tokio::test]
+    async fn test_slot_maps_pruned_multi_slot() {
+        let index = InMemoryElementIndex::new();
+
+        let rel = create_test_relation("source1", "rel1", "KNOWS", "in1", "out1");
+        index.set_element(&rel, &vec![0, 1, 2]).await.unwrap();
+
+        // One (slot, node) entry per slot for both in and out maps.
+        assert_eq!(index.element_by_slot_in.read().await.len(), 3);
+        assert_eq!(index.element_by_slot_out.read().await.len(), 3);
+
+        index
+            .delete_element(&ElementReference::new("source1", "rel1"))
+            .await
+            .unwrap();
+
+        assert!(
+            index.element_by_slot_in.read().await.is_empty(),
+            "all in-slot entries should be pruned across every slot"
+        );
+        assert!(
+            index.element_by_slot_out.read().await.is_empty(),
+            "all out-slot entries should be pruned across every slot"
+        );
+        assert!(
+            index.slot_affinity.read().await.is_empty(),
+            "slot_affinity should be pruned for the deleted relation"
+        );
     }
 
     /// Ensure pruning does not drop a shared `(slot, node)` entry while another relation
@@ -1402,6 +1448,5 @@ mod tests {
 
         assert!(index.element_by_slot_in.read().await.is_empty());
         assert!(index.element_by_slot_out.read().await.is_empty());
->>>>>>> 857010df (Fix memory leak in InMemoryElementIndex slot maps)
     }
 }


### PR DESCRIPTION
# Description

`clear_slot_affinity()` removed a relation from the per-`(slot, node)` sets in `element_by_slot_in` / `element_by_slot_out`, but never removed the now-empty `HashSet`s or their keys. Over a workload that repeatedly adds and deletes relations referencing many distinct in/out nodes, these maps grew without bound (proportional to the number of distinct nodes ever referenced, not the live set), and were only reclaimed on a full `clear()`.

This change prunes the `(slot, node)` entry as soon as its set becomes empty, in the Relation branch of `clear_slot_affinity()`. The read paths (`get_slot_elements_by_inbound` / `by_outbound`) already treat a missing key and an empty set identically, so behavior is unchanged; only the leaked empty entries are removed.

Added two regression tests:
- `test_slot_maps_pruned_after_relation_delete` verifies empty `(slot, node)` entries are removed after deletes.
- `test_slot_maps_retain_shared_node_entry` verifies a shared entry survives while another relation still references that node, and is pruned once the last one is gone.

Verified with `cargo test -p drasi-core`, `cargo clippy --all-targets --all-features`, and `cargo fmt --check`.

## Type of change

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).

Fixes: #642