### PR TITLE
fix(source-postgres): auto-detect primary keys for stable CDC element IDs

### DIFF
--- a/components/sources/postgres/README.md
+++ b/components/sources/postgres/README.md
@@ -458,9 +458,14 @@ The source handles connection failures gracefully:
 
 ### Primary Key Detection
 
-During WAL streaming, the source uses primary key information from the relation metadata provided by PostgreSQL's logical replication protocol. For bootstrap, the configured bootstrap provider is responsible for primary key detection.
+On connect, the streaming source queries the PostgreSQL system catalogs to
+auto-detect each table's primary key columns, then derives a stable,
+primary-key-based element id for every CDC change. This means INSERT, UPDATE, and
+DELETE events for the same row share the same element id and correlate correctly,
+even without any `table_keys` configuration. The bootstrap provider performs the
+same catalog lookup, so bootstrap and CDC element ids agree.
 
-When using `PostgresBootstrapProvider`, it queries PostgreSQL system catalogs:
+The catalog query used for detection is:
 ```sql
 SELECT n.nspname, c.relname, a.attname
 FROM pg_constraint con
@@ -472,7 +477,9 @@ WHERE con.contype = 'p'
 ORDER BY n.nspname, c.relname, array_position(con.conkey, a.attnum)
 ```
 
-User-configured `table_keys` override automatically detected primary keys in both streaming and bootstrap.
+User-configured `table_keys` override automatically detected primary keys in both
+streaming and bootstrap. A random UUID element id is used only as a last resort
+for tables that have no primary key and no configured `table_keys`.
 
 ## Troubleshooting
 

--- a/components/sources/postgres/src/lib.rs
+++ b/components/sources/postgres/src/lib.rs
@@ -102,7 +102,13 @@
 //!
 //! ## Node Mapping
 //!
-//! - **Element ID**: `{schema}:{table}:{primary_key_value}` (e.g., `public:users:123`)
+//! - **Element ID**: `{table}:{primary_key_value}` (e.g., `users:123`). For
+//!   composite keys the values are joined with `_` (e.g., `order_items:1_5`), and
+//!   tables outside the `public` schema are qualified as
+//!   `{schema}.{table}:{primary_key_value}`. Primary keys are auto-detected from
+//!   the PostgreSQL system catalogs on connect; `table_keys` config overrides the
+//!   detected keys, and a random UUID is used only as a last resort for keyless
+//!   tables.
 //! - **Labels**: `[{table_name}]` (e.g., `["users"]`)
 //! - **Properties**: All columns from the row (column names become property keys)
 //!
@@ -136,7 +142,7 @@
 //!     "type": "Insert",
 //!     "element": {
 //!         "metadata": {
-//!             "element_id": "public:users:1",
+//!             "element_id": "users:1",
 //!             "source_id": "pg-source",
 //!             "labels": ["users"],
 //!             "effective_from": 1699900000000000
@@ -319,11 +325,13 @@ fn postgres_type_to_property_type(data_type: &str) -> Option<PropertyType> {
     }
 }
 
-async fn introspect_postgres_schema(config: &PostgresSourceConfig) -> Result<Option<SourceSchema>> {
-    if config.tables.is_empty() {
-        return Ok(None);
-    }
-
+/// Establish a regular (non-replication) libpq connection to PostgreSQL using
+/// the source configuration's SSL settings.
+///
+/// The replication-protocol connection used for streaming WAL cannot run
+/// ordinary SQL queries, so schema introspection and primary-key detection use
+/// a separate standard connection created here.
+async fn connect_pg_client(config: &PostgresSourceConfig) -> Result<tokio_postgres::Client> {
     let mut pg_config = tokio_postgres::Config::new();
     pg_config.host(&config.host);
     pg_config.port(config.port);
@@ -333,7 +341,7 @@ async fn introspect_postgres_schema(config: &PostgresSourceConfig) -> Result<Opt
         pg_config.password(&config.password);
     }
 
-    let client = match config.ssl_mode {
+    match config.ssl_mode {
         SslMode::Require => {
             pg_config.ssl_mode(tokio_postgres::config::SslMode::Require);
             let tls_connector = native_tls::TlsConnector::builder()
@@ -343,14 +351,14 @@ async fn introspect_postgres_schema(config: &PostgresSourceConfig) -> Result<Opt
                 .map_err(|e| anyhow!("Failed to create TLS connector: {e}"))?;
             let connector = MakeTlsConnector::new(tls_connector);
 
-            debug!("Schema introspection: connecting with SSL (require)");
+            debug!("PostgreSQL query connection: connecting with SSL (require)");
             let (client, connection) = pg_config.connect(connector).await?;
             tokio::spawn(async move {
                 if let Err(e) = connection.await {
-                    log::warn!("PostgreSQL schema introspection connection closed: {e}");
+                    log::warn!("PostgreSQL query connection closed: {e}");
                 }
             });
-            client
+            Ok(client)
         }
         SslMode::Prefer => {
             // Try TLS first, fall back to plaintext
@@ -362,26 +370,85 @@ async fn introspect_postgres_schema(config: &PostgresSourceConfig) -> Result<Opt
             let connector = MakeTlsConnector::new(tls_connector);
 
             pg_config.ssl_mode(tokio_postgres::config::SslMode::Prefer);
-            debug!("Schema introspection: connecting with SSL (prefer)");
+            debug!("PostgreSQL query connection: connecting with SSL (prefer)");
             let (client, connection) = pg_config.connect(connector).await?;
             tokio::spawn(async move {
                 if let Err(e) = connection.await {
-                    log::warn!("PostgreSQL schema introspection connection closed: {e}");
+                    log::warn!("PostgreSQL query connection closed: {e}");
                 }
             });
-            client
+            Ok(client)
         }
         SslMode::Disable => {
-            debug!("Schema introspection: connecting without SSL");
+            debug!("PostgreSQL query connection: connecting without SSL");
             let (client, connection) = pg_config.connect(tokio_postgres::NoTls).await?;
             tokio::spawn(async move {
                 if let Err(e) = connection.await {
-                    log::warn!("PostgreSQL schema introspection connection closed: {e}");
+                    log::warn!("PostgreSQL query connection closed: {e}");
                 }
             });
-            client
+            Ok(client)
         }
-    };
+    }
+}
+
+/// Query primary-key columns for all user tables from the PostgreSQL system
+/// catalogs.
+///
+/// The returned map is keyed by table name using the same convention the CDC
+/// stream uses when generating element IDs: the bare relation name for tables in
+/// the `public` schema, and `{schema}.{table}` otherwise. Column order follows
+/// the primary-key definition order.
+///
+/// This lets the replication stream generate stable, primary-key-derived element
+/// IDs without requiring explicit `table_keys` configuration, so INSERT / UPDATE
+/// / DELETE events for the same row correlate to the same node.
+pub(crate) async fn query_table_primary_keys(
+    config: &PostgresSourceConfig,
+) -> Result<HashMap<String, Vec<String>>> {
+    let client = connect_pg_client(config).await?;
+
+    // pg_constraint-based lookup (matches the bootstrap provider) so that the CDC
+    // and bootstrap element-id encodings agree.
+    let query = "SELECT \
+            n.nspname AS schema_name, \
+            c.relname AS table_name, \
+            a.attname AS column_name \
+         FROM pg_constraint con \
+         JOIN pg_class c ON con.conrelid = c.oid \
+         JOIN pg_namespace n ON c.relnamespace = n.oid \
+         JOIN pg_attribute a ON a.attrelid = c.oid \
+         WHERE con.contype = 'p' \
+             AND a.attnum = ANY(con.conkey) \
+             AND n.nspname NOT IN ('pg_catalog', 'information_schema') \
+         ORDER BY n.nspname, c.relname, array_position(con.conkey, a.attnum)";
+
+    let rows = client.query(query, &[]).await?;
+
+    let mut primary_keys: HashMap<String, Vec<String>> = HashMap::new();
+    for row in rows {
+        let schema: String = row.get(0);
+        let table: String = row.get(1);
+        let column: String = row.get(2);
+
+        let table_key = if schema == "public" {
+            table
+        } else {
+            format!("{schema}.{table}")
+        };
+
+        primary_keys.entry(table_key).or_default().push(column);
+    }
+
+    Ok(primary_keys)
+}
+
+async fn introspect_postgres_schema(config: &PostgresSourceConfig) -> Result<Option<SourceSchema>> {
+    if config.tables.is_empty() {
+        return Ok(None);
+    }
+
+    let client = connect_pg_client(config).await?;
 
     let mut nodes = Vec::new();
 

--- a/components/sources/postgres/src/stream.rs
+++ b/components/sources/postgres/src/stream.rs
@@ -83,9 +83,10 @@ impl ReplicationStream {
         }
     }
 
-    // Note: table_primary_keys is initialized empty and remains so.
-    // Element IDs are generated from configured table_keys (in config.table_keys),
-    // or fall back to using all column values if no keys are configured.
+    // `table_primary_keys` is populated on connect by querying the PostgreSQL
+    // system catalogs (see `connect_and_setup`). Element IDs are generated from
+    // configured `table_keys` first, then these auto-detected primary keys, and
+    // finally fall back to a random UUID only for keyless tables.
 
     pub async fn run(
         &mut self,
@@ -161,6 +162,30 @@ impl ReplicationStream {
 
     async fn connect_and_setup(&mut self) -> Result<()> {
         info!("Connecting to PostgreSQL for replication");
+
+        // Auto-detect primary keys so CDC element IDs are stable across
+        // INSERT/UPDATE/DELETE for the same row without requiring explicit
+        // `table_keys` configuration. Best-effort: if the lookup fails we keep
+        // any previously detected keys and fall back to configured `table_keys`
+        // (or a random UUID) rather than aborting replication.
+        match super::query_table_primary_keys(&self.config).await {
+            Ok(primary_keys) => {
+                let table_count = primary_keys.len();
+                {
+                    let mut guard = self.table_primary_keys.write().await;
+                    *guard = primary_keys;
+                }
+                info!(
+                    "Auto-detected primary keys for {table_count} table(s) for element-id generation"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    "Failed to auto-detect primary keys ({error:#}); CDC element IDs will use \
+                     configured 'table_keys' or fall back to random UUIDs"
+                );
+            }
+        }
 
         // Create connection
         let mut conn = ReplicationConnection::connect(

--- a/components/sources/postgres/tests/integration_tests.rs
+++ b/components/sources/postgres/tests/integration_tests.rs
@@ -101,6 +101,17 @@ async fn build_core(
     config: &postgres_helpers::ReplicationPostgresConfig,
     slot_name: String,
 ) -> Result<(Arc<DrasiLib>, ApplicationReactionHandle)> {
+    build_core_inner(config, slot_name, true).await
+}
+
+/// Build a test core. When `configure_table_keys` is false, no `table_keys` are
+/// configured on either the source or bootstrap provider, forcing element IDs to
+/// come from auto-detected primary keys (regression coverage for issue #654).
+async fn build_core_inner(
+    config: &postgres_helpers::ReplicationPostgresConfig,
+    slot_name: String,
+    configure_table_keys: bool,
+) -> Result<(Arc<DrasiLib>, ApplicationReactionHandle)> {
     let source_config = PostgresSourceConfig {
         host: config.host.clone(),
         port: config.port,
@@ -111,10 +122,14 @@ async fn build_core(
         slot_name,
         publication_name: TEST_PUBLICATION.to_string(),
         ssl_mode: SslMode::Disable,
-        table_keys: vec![TableKeyConfig {
-            table: TEST_TABLE.to_string(),
-            key_columns: vec!["id".to_string()],
-        }],
+        table_keys: if configure_table_keys {
+            vec![TableKeyConfig {
+                table: TEST_TABLE.to_string(),
+                key_columns: vec!["id".to_string()],
+            }]
+        } else {
+            vec![]
+        },
     };
 
     let bootstrap_config = PostgresBootstrapConfig {
@@ -127,10 +142,14 @@ async fn build_core(
         slot_name: source_config.slot_name.clone(),
         publication_name: source_config.publication_name.clone(),
         ssl_mode: BootstrapSslMode::Disable,
-        table_keys: vec![BootstrapTableKeyConfig {
-            table: TEST_TABLE.to_string(),
-            key_columns: vec!["id".to_string()],
-        }],
+        table_keys: if configure_table_keys {
+            vec![BootstrapTableKeyConfig {
+                table: TEST_TABLE.to_string(),
+                key_columns: vec!["id".to_string()],
+            }]
+        } else {
+            vec![]
+        },
     };
 
     let bootstrap_provider = PostgresBootstrapProvider::new(bootstrap_config);
@@ -576,7 +595,64 @@ async fn test_full_crud_cycle() -> Result<()> {
     Ok(())
 }
 
-/// Extract the trailing integer primary key from an element id of the form
+/// Regression test for issue #654: without any `table_keys` configuration, CDC
+/// change events must derive a **stable** element id from the auto-detected
+/// primary key so that INSERT/UPDATE/DELETE correlate to the same node.
+///
+/// Before the fix, `table_primary_keys` was never populated, so every change fell
+/// through to a random UUID element id. An UPDATE then looked like a brand-new
+/// node (leaving a phantom "before" row in the result set) and a DELETE referenced
+/// an id that was never added (removing nothing). This test fails on that old
+/// behavior because it asserts the result set collapses to a single updated row
+/// and then to empty.
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn test_cdc_autodetected_primary_key_correlates_update_and_delete() -> Result<()> {
+    init_logging();
+
+    let pg = setup_replication_postgres().await;
+    let client = pg.get_client().await?;
+
+    grant_replication(&client, "postgres").await?;
+    create_test_table(&client, TEST_TABLE).await?;
+    grant_table_access(&client, TEST_TABLE, "postgres").await?;
+    create_publication(&client, TEST_PUBLICATION, &[TEST_TABLE.to_string()]).await?;
+
+    let slot_name = slot_name();
+    create_logical_replication_slot(&client, &slot_name).await?;
+
+    // Note: no `table_keys` configured — element IDs must come from the
+    // auto-detected `id` primary key.
+    let (core, _handle) = build_core_inner(pg.config(), slot_name, false).await?;
+    core.start().await?;
+
+    insert_test_row(&client, TEST_TABLE, 1, "Alice").await?;
+    wait_for_query_results(&core, "test-query", |results| {
+        results
+            .iter()
+            .any(|row| row.get("name") == Some(&"Alice".into()))
+    })
+    .await?;
+
+    // The UPDATE must mutate the existing node in place: exactly one row with the
+    // new name, not a phantom pair of {Alice, Alice Updated}.
+    update_test_row(&client, TEST_TABLE, 1, "Alice Updated").await?;
+    wait_for_query_results(&core, "test-query", |results| {
+        results.len() == 1 && results[0].get("name") == Some(&"Alice Updated".into())
+    })
+    .await?;
+
+    // The DELETE must reference the same element id and remove the node.
+    delete_test_row(&client, TEST_TABLE, 1).await?;
+    wait_for_query_results(&core, "test-query", |results| results.is_empty()).await?;
+
+    core.stop().await?;
+    pg.cleanup().await;
+
+    Ok(())
+}
+
 /// `table:pk` (e.g. `users:42` → 42).
 fn element_id_int(element_id: &str) -> Option<i64> {
     element_id.rsplit(':').next()?.parse::<i64>().ok()
@@ -726,9 +802,8 @@ async fn test_bootstrap_cdc_handover_has_no_overlap_or_gap() -> Result<()> {
     }
 
     // No gap: every post-boundary change was delivered exactly once. The
-    // concurrent insert's decoded key is not asserted here because the
-    // Postgres CDC element-id encoding for newly inserted integer keys differs
-    // from the bootstrap encoding; the structural counts below are what matter.
+    // concurrent insert's decoded key is not asserted here; this test focuses on
+    // structural delivery counts across the bootstrap/CDC handover boundary.
     let total_inserts: usize = inserts.values().sum();
     assert_eq!(
         total_inserts, 1,


### PR DESCRIPTION
## Summary

Fixes #654.

The PostgreSQL replication source never populated `table_primary_keys`, so tier‑2 (auto‑detected PK) of `generate_element_id` in `stream.rs` was dead code. When `tableKeys` was not configured, **every** CDC change fell through to the `Uuid::new_v4()` branch, so INSERT/UPDATE/DELETE events for the same logical row never shared an element id:

- **UPDATE** arrived with a fresh id → engine treated it as a new node → phantom "before" row left in the result set.
- **DELETE** referenced an id that was never added → nothing removed.

## Changes

- **Populate `table_primary_keys` on connect** (`stream.rs::connect_and_setup`) by querying the `pg_constraint` catalog — the same lookup the bootstrap provider (`drasi-bootstrap-postgres`) uses. Keys are stored with the same table‑name convention `generate_element_id` uses (bare name for `public`, `schema.table` otherwise), so lookups line up. Best‑effort: on failure it warns and falls back to configured `table_keys`/UUID rather than aborting replication.
- **Extract `connect_pg_client`** in `lib.rs` from `introspect_postgres_schema` and add `query_table_primary_keys`, reusing the existing SSL‑aware `tokio_postgres` connection logic (the replication‑protocol connection can't run ordinary SQL).
- **Element‑id encoding already matched** between CDC and bootstrap (`{table}:{pk}`); the module docs were stale (claimed `{schema}:{table}:{pk}` / `public:users:1`). Corrected the docs in `lib.rs` and `README.md`, and removed the now‑inaccurate "CDC encoding differs from bootstrap" note in the handover test.
- **Regression test** `test_cdc_autodetected_primary_key_correlates_update_and_delete` (ignored, needs Docker) builds a core with **no** `table_keys` and asserts the result set collapses to a single updated row on UPDATE and to empty on DELETE. Existing tests configured `table_keys`, which masked the bug.

## Verification

- `cargo build` / `cargo clippy --all-targets --all-features` / `cargo fmt --check`: clean.
- 87 unit tests + doctests pass.
- Against a real PostgreSQL (testcontainers): the new test passes with the fix, and **fails** (times out on the phantom UPDATE) when the population is disabled — confirming it catches the regression. `test_full_crud_cycle`, `test_update_detection`, `test_delete_detection` still pass.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
