### PR TITLE
Fix #664: restore source sequence counter on resume so restart doesn't drop the first K changes

### DIFF
--- a/components/ffi-primitives/src/lib.rs
+++ b/components/ffi-primitives/src/lib.rs
@@ -37,6 +37,8 @@
 //! - [`impl_vtable_proxy!`] — Generate proxy structs that wrap vtables into method calls
 
 pub mod macros;
+pub mod marshal;
 pub mod types;
 
+pub use marshal::{decode_optional_u64, encode_optional_u64};
 pub use types::*;

--- a/components/ffi-primitives/src/marshal.rs
+++ b/components/ffi-primitives/src/marshal.rs
@@ -1,0 +1,66 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helpers for marshalling Rust `Option`s across the C ABI, which cannot carry
+//! `Option<T>` directly.
+//!
+//! An `Option<u64>` is encoded as a `(value, present)` pair: when `present` is
+//! `false` the `value` is meaningless and decodes back to `None`. Host and
+//! plugin sides share these two functions so the encoding can never drift.
+
+/// Encode an `Option<u64>` as a `(value, present)` pair for the C ABI.
+///
+/// `None` becomes `(0, false)`; `Some(v)` becomes `(v, true)`.
+#[inline]
+pub fn encode_optional_u64(opt: Option<u64>) -> (u64, bool) {
+    match opt {
+        Some(v) => (v, true),
+        None => (0, false),
+    }
+}
+
+/// Decode a `(value, present)` pair received across the C ABI back into an
+/// `Option<u64>`. `value` is ignored when `present` is `false`.
+#[inline]
+pub fn decode_optional_u64(value: u64, present: bool) -> Option<u64> {
+    present.then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_round_trips() {
+        let (value, present) = encode_optional_u64(None);
+        assert!(!present);
+        assert_eq!(decode_optional_u64(value, present), None);
+    }
+
+    #[test]
+    fn some_round_trips() {
+        for v in [0u64, 1, 5, 42, u64::MAX] {
+            let (value, present) = encode_optional_u64(Some(v));
+            assert!(present);
+            assert_eq!(value, v);
+            assert_eq!(decode_optional_u64(value, present), Some(v));
+        }
+    }
+
+    #[test]
+    fn decode_ignores_value_when_absent() {
+        // A non-zero value with present=false must still decode to None.
+        assert_eq!(decode_optional_u64(999, false), None);
+    }
+}

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -212,24 +212,13 @@ impl Source for SourceProxy {
             None => (std::ptr::null(), 0u32),
         };
 
-        // The FFI subscribe ABI does not yet marshal `resume_sequence`, so a
-        // dynamically-loaded plugin source cannot advance its in-memory sequence
-        // counter above the query's dedup high-water mark on resume. When the
-        // source also has no durable `resume_from` position of its own, the first
-        // `resume_sequence` post-restart events would be stamped 1..=seq and
-        // silently deduplicated away (issue #664). Surface the gap in logs until
-        // the ABI is extended to carry the checkpoint sequence.
-        if let Some(seq) = settings.resume_sequence {
-            if settings.resume_from.is_none() {
-                log::warn!(
-                    "SourceProxy::subscribe('{}') for query '{}': FFI ABI does not marshal \
-                     resume_sequence ({seq}); this dynamically-loaded source may silently drop \
-                     the first {seq} post-restart events. Pending an ABI extension.",
-                    settings.source_id,
-                    settings.query_id,
-                );
-            }
-        }
+        // Marshal the optional checkpoint sequence as (value, present) since the
+        // ABI cannot carry `Option<u64>` directly. This lets a resuming plugin
+        // source advance its in-memory sequence counter above the query's dedup
+        // high-water mark, so the first K post-restart events are not silently
+        // deduplicated away — closing issue #664 for FFI-loaded sources too.
+        let (resume_sequence, resume_sequence_present) =
+            drasi_ffi_primitives::encode_optional_u64(settings.resume_sequence);
 
         let resp_ptr = (self.vtable.subscribe_fn)(
             self.vtable.state,
@@ -241,6 +230,8 @@ impl Source for SourceProxy {
             resume_from_ptr,
             resume_from_len,
             settings.request_position_handle,
+            resume_sequence,
+            resume_sequence_present,
         );
 
         if resp_ptr.is_null() {

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -212,6 +212,25 @@ impl Source for SourceProxy {
             None => (std::ptr::null(), 0u32),
         };
 
+        // The FFI subscribe ABI does not yet marshal `resume_sequence`, so a
+        // dynamically-loaded plugin source cannot advance its in-memory sequence
+        // counter above the query's dedup high-water mark on resume. When the
+        // source also has no durable `resume_from` position of its own, the first
+        // `resume_sequence` post-restart events would be stamped 1..=seq and
+        // silently deduplicated away (issue #664). Surface the gap in logs until
+        // the ABI is extended to carry the checkpoint sequence.
+        if let Some(seq) = settings.resume_sequence {
+            if settings.resume_from.is_none() {
+                log::warn!(
+                    "SourceProxy::subscribe('{}') for query '{}': FFI ABI does not marshal \
+                     resume_sequence ({seq}); this dynamically-loaded source may silently drop \
+                     the first {seq} post-restart events. Pending an ABI extension.",
+                    settings.source_id,
+                    settings.query_id,
+                );
+            }
+        }
+
         let resp_ptr = (self.vtable.subscribe_fn)(
             self.vtable.state,
             source_id_ffi,

--- a/components/host-sdk/tests/ffi_layout_mismatch_test.rs
+++ b/components/host-sdk/tests/ffi_layout_mismatch_test.rs
@@ -122,6 +122,7 @@ async fn mock_source_change_stream_survives_layout_mismatch() {
         relations: HashSet::new(),
         resume_from: None,
         request_position_handle: false,
+        resume_sequence: None,
     };
     let sub = source.subscribe(settings).await.expect("Should subscribe");
     let mut receiver = sub.receiver;
@@ -219,6 +220,7 @@ async fn mock_source_bootstrap_stream_survives_layout_mismatch() {
         relations: HashSet::new(),
         resume_from: None,
         request_position_handle: false,
+        resume_sequence: None,
     };
     let sub = source.subscribe(settings).await.expect("Should subscribe");
     let mut bootstrap_receiver = sub

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -2858,6 +2858,7 @@ async fn test_cdylib_source_dispatches_events() {
         relations: std::collections::HashSet::new(),
         resume_from: None,
         request_position_handle: false,
+        resume_sequence: None,
     };
     let sub = source.subscribe(settings).await.expect("Should subscribe");
     let receiver = sub.receiver;
@@ -2938,6 +2939,7 @@ async fn test_stress_rapid_subscribe_drop_under_load() {
             relations: std::collections::HashSet::new(),
             resume_from: None,
             request_position_handle: false,
+            resume_sequence: None,
         };
         let sub = source.subscribe(settings).await.expect("Should subscribe");
         let mut receiver = sub.receiver;
@@ -3072,6 +3074,7 @@ async fn test_ffi_subscribe_position_handle() {
         relations: std::collections::HashSet::new(),
         resume_from: None,
         request_position_handle: true,
+        resume_sequence: None,
     };
     let sub = source
         .subscribe(settings_with)
@@ -3105,6 +3108,7 @@ async fn test_ffi_subscribe_position_handle() {
         relations: std::collections::HashSet::new(),
         resume_from: None,
         request_position_handle: false,
+        resume_sequence: None,
     };
     let sub2 = source
         .subscribe(settings_without)
@@ -3141,6 +3145,7 @@ async fn test_ffi_resume_from_skips_bootstrap() {
         relations: std::collections::HashSet::new(),
         resume_from: Some(resume_bytes),
         request_position_handle: true,
+        resume_sequence: None,
     };
     let sub = source
         .subscribe(settings)
@@ -3219,6 +3224,7 @@ async fn test_ffi_bootstrap_result_receiver_delivers_result() {
         relations: std::collections::HashSet::new(),
         resume_from: None,
         request_position_handle: true,
+        resume_sequence: None,
     };
     let sub = source
         .subscribe(settings)
@@ -3370,6 +3376,7 @@ async fn test_ffi_checkpoint_persist_and_resume_from() {
         relations: std::collections::HashSet::new(),
         resume_from: None,
         request_position_handle: true,
+        resume_sequence: None,
     };
     let sub = source2
         .subscribe(settings)

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -3173,6 +3173,52 @@ async fn test_ffi_resume_from_skips_bootstrap() {
     source.stop().await.expect("Should stop");
 }
 
+/// Verify the optional checkpoint `resume_sequence` is marshalled across the FFI
+/// subscribe ABI (host encodes `(value, present)`, plugin decodes it back). This
+/// is the FFI counterpart of the in-process fix for issue #664: without the
+/// marshalling, a dynamically-loaded source resuming from a checkpoint would
+/// restart its sequence counter at 1 and silently drop the first K post-restart
+/// events. Exercises the full host→plugin path at runtime; the round-trip
+/// encoding itself is unit-tested in `drasi-ffi-primitives`.
+#[tokio::test]
+#[serial]
+#[ignore = "requires cdylib: cargo build --lib -p drasi-source-mock --features dynamic-plugin"]
+async fn test_ffi_resume_sequence_marshalled() {
+    if !plugin_exists("drasi-source-mock") {
+        panic!("SKIP: drasi-source-mock not built as cdylib");
+    }
+    let (_plugin, source, _rx) = create_started_mock_source("resume-seq-test").await;
+
+    // Subscribe with a checkpoint sequence but no durable position — exactly the
+    // case that regressed in #664 for FFI sources. The subscribe must round-trip
+    // the value across the boundary without error.
+    let settings = drasi_lib::config::SourceSubscriptionSettings {
+        source_id: "resume-seq-test".to_string(),
+        enable_bootstrap: false,
+        query_id: "resume-seq-query".to_string(),
+        nodes: std::collections::HashSet::new(),
+        relations: std::collections::HashSet::new(),
+        resume_from: None,
+        request_position_handle: true,
+        resume_sequence: Some(7),
+    };
+    let sub = source
+        .subscribe(settings)
+        .await
+        .expect("subscribe with resume_sequence should succeed across FFI");
+
+    // A position handle is still returned; the key assertion is that the
+    // resume_sequence-carrying subscribe completed without a marshalling error.
+    assert!(
+        sub.position_handle.is_some(),
+        "position_handle should be returned when request_position_handle is set"
+    );
+
+    source.remove_position_handle("resume-seq-query").await;
+    drop(sub);
+    source.stop().await.expect("Should stop");
+}
+
 /// A trivial bootstrap provider that returns a fixed BootstrapResult with
 /// source_position, without sending any bootstrap events.
 struct TestBootstrapProvider {

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -34,7 +34,12 @@ use super::types::FfiStr;
 ///   `KeyedSnapshotRow { k: <row_signature>, v: <row> }` JSON envelope instead
 ///   of a bare row, so the engine's canonical `row_signature` survives FFI
 ///   (fixes #605 duplicate dashboard rows on the plugin path).
-pub const FFI_SDK_VERSION: &str = "0.11.0";
+/// - `0.12.0`: `SourceVtable::subscribe_fn` gained `resume_sequence: u64` +
+///   `resume_sequence_present: bool` params so a resuming source can advance its
+///   sequence counter above the query's dedup high-water mark (fixes #664 on the
+///   FFI path). This widens the function-pointer signature, so an older cdylib
+///   must be rejected rather than called through the new signature.
+pub const FFI_SDK_VERSION: &str = "0.12.0";
 
 /// The target triple this crate was compiled for.
 pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -748,6 +748,8 @@ pub fn build_source_vtable<T: Source + 'static>(
         resume_from_ptr: *const u8,
         resume_from_len: u32,
         request_position_handle: bool,
+        resume_sequence: u64,
+        resume_sequence_present: bool,
     ) -> *mut FfiSubscriptionResponse {
         let w = unsafe { &*(state as *const SourceWrapper<T>) };
         let source_id_str = unsafe { source_id.to_string() };
@@ -780,12 +782,14 @@ pub fn build_source_vtable<T: Source + 'static>(
             relations,
             resume_from,
             request_position_handle,
-            // The FFI vtable does not (yet) marshal the checkpoint sequence, so
-            // dynamically-loaded plugins default to None here. In-process sources
-            // that delegate to `SourceBase::subscribe_with_bootstrap` receive it
-            // via the native path. The host proxy logs a warning when it has to
-            // drop a `resume_sequence` here (see host-sdk SourceProxy::subscribe).
-            resume_sequence: None,
+            // Reconstruct the optional checkpoint sequence from its (value,
+            // present) marshalling so a resuming source delegating to
+            // `SourceBase::subscribe_with_bootstrap` advances its counter above
+            // the query's dedup high-water mark (issue #664).
+            resume_sequence: drasi_ffi_primitives::decode_optional_u64(
+                resume_sequence,
+                resume_sequence_present,
+            ),
         };
 
         let handle = (w.runtime_handle)().handle().clone();
@@ -1144,6 +1148,8 @@ pub fn build_source_vtable_from_boxed(
         resume_from_ptr: *const u8,
         resume_from_len: u32,
         request_position_handle: bool,
+        resume_sequence: u64,
+        resume_sequence_present: bool,
     ) -> *mut FfiSubscriptionResponse {
         let w = unsafe { &*(state as *const DynSourceWrapper) };
         let source_id_str = unsafe { source_id.to_string() };
@@ -1176,12 +1182,14 @@ pub fn build_source_vtable_from_boxed(
             relations,
             resume_from,
             request_position_handle,
-            // The FFI vtable does not (yet) marshal the checkpoint sequence, so
-            // dynamically-loaded plugins default to None here. In-process sources
-            // that delegate to `SourceBase::subscribe_with_bootstrap` receive it
-            // via the native path. The host proxy logs a warning when it has to
-            // drop a `resume_sequence` here (see host-sdk SourceProxy::subscribe).
-            resume_sequence: None,
+            // Reconstruct the optional checkpoint sequence from its (value,
+            // present) marshalling so a resuming source delegating to
+            // `SourceBase::subscribe_with_bootstrap` advances its counter above
+            // the query's dedup high-water mark (issue #664).
+            resume_sequence: drasi_ffi_primitives::decode_optional_u64(
+                resume_sequence,
+                resume_sequence_present,
+            ),
         };
 
         let handle = (w.runtime_handle)().handle().clone();

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -780,6 +780,11 @@ pub fn build_source_vtable<T: Source + 'static>(
             relations,
             resume_from,
             request_position_handle,
+            // The FFI vtable does not (yet) marshal the checkpoint sequence, so
+            // dynamically-loaded plugins default to None here. In-process sources
+            // that delegate to `SourceBase::subscribe_with_bootstrap` receive it
+            // via the native path.
+            resume_sequence: None,
         };
 
         let handle = (w.runtime_handle)().handle().clone();
@@ -1170,6 +1175,11 @@ pub fn build_source_vtable_from_boxed(
             relations,
             resume_from,
             request_position_handle,
+            // The FFI vtable does not (yet) marshal the checkpoint sequence, so
+            // dynamically-loaded plugins default to None here. In-process sources
+            // that delegate to `SourceBase::subscribe_with_bootstrap` receive it
+            // via the native path.
+            resume_sequence: None,
         };
 
         let handle = (w.runtime_handle)().handle().clone();

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -783,7 +783,8 @@ pub fn build_source_vtable<T: Source + 'static>(
             // The FFI vtable does not (yet) marshal the checkpoint sequence, so
             // dynamically-loaded plugins default to None here. In-process sources
             // that delegate to `SourceBase::subscribe_with_bootstrap` receive it
-            // via the native path.
+            // via the native path. The host proxy logs a warning when it has to
+            // drop a `resume_sequence` here (see host-sdk SourceProxy::subscribe).
             resume_sequence: None,
         };
 
@@ -1178,7 +1179,8 @@ pub fn build_source_vtable_from_boxed(
             // The FFI vtable does not (yet) marshal the checkpoint sequence, so
             // dynamically-loaded plugins default to None here. In-process sources
             // that delegate to `SourceBase::subscribe_with_bootstrap` receive it
-            // via the native path.
+            // via the native path. The host proxy logs a warning when it has to
+            // drop a `resume_sequence` here (see host-sdk SourceProxy::subscribe).
             resume_sequence: None,
         };
 

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -339,9 +339,14 @@ drasi_ffi_primitives::ffi_vtable! {
         fn initialize_fn(state: *mut, ctx: *const FfiRuntimeContext),
 
         // Subscriptions
-        /// Subscribe with query_id, node_labels JSON, relation_labels JSON, and
-        /// optional resume_from position bytes.
-        fn subscribe_fn(state: *mut, source_id: FfiStr, enable_bootstrap: bool, query_id: FfiStr, nodes_json: FfiStr, relations_json: FfiStr, resume_from_ptr: *const u8, resume_from_len: u32, request_position_handle: bool) -> *mut FfiSubscriptionResponse,
+        /// Subscribe with query_id, node_labels JSON, relation_labels JSON,
+        /// optional resume_from position bytes, and the optional checkpoint
+        /// `resume_sequence` (carried as a value + present flag, since the ABI
+        /// cannot pass `Option<u64>` directly). `resume_sequence` lets a resuming
+        /// source advance its monotonic sequence counter above the query's dedup
+        /// high-water mark so the first post-restart events are not silently
+        /// dropped (issue #664).
+        fn subscribe_fn(state: *mut, source_id: FfiStr, enable_bootstrap: bool, query_id: FfiStr, nodes_json: FfiStr, relations_json: FfiStr, resume_from_ptr: *const u8, resume_from_len: u32, request_position_handle: bool, resume_sequence: u64, resume_sequence_present: bool) -> *mut FfiSubscriptionResponse,
 
         /// Host calls this to inject an external bootstrap provider (from another plugin).
         fn set_bootstrap_provider_fn(state: *mut, provider: *mut BootstrapProviderVtable),

--- a/components/sources/application/tests/wal_integration.rs
+++ b/components/sources/application/tests/wal_integration.rs
@@ -82,6 +82,7 @@ fn fresh_settings(source_id: &str, query_id: &str) -> SourceSubscriptionSettings
         relations: HashSet::new(),
         request_position_handle: true,
         resume_from: None,
+        resume_sequence: None,
     }
 }
 
@@ -95,6 +96,7 @@ fn resume_settings(source_id: &str, query_id: &str, resume_seq: u64) -> SourceSu
         relations: HashSet::new(),
         request_position_handle: true,
         resume_from: Some(bytes::Bytes::from(resume_seq.to_be_bytes().to_vec())),
+        resume_sequence: None,
     }
 }
 
@@ -530,6 +532,7 @@ async fn test_resume_from_position_end_to_end() {
         relations: HashSet::new(),
         request_position_handle: true,
         resume_from: None,
+        resume_sequence: None,
     };
     let resp = source.subscribe(settings).await.unwrap();
     let mut rx = resp.receiver;

--- a/components/sources/grpc/tests/wal_integration.rs
+++ b/components/sources/grpc/tests/wal_integration.rs
@@ -182,6 +182,7 @@ async fn test_grpc_crash_recovery_resumes_sequence() {
         relations: HashSet::new(),
         request_position_handle: true,
         resume_from: Some(bytes::Bytes::from(3u64.to_be_bytes().to_vec())),
+        resume_sequence: None,
     };
     let resp = source.subscribe(settings).await.unwrap();
     let mut rx = resp.receiver;

--- a/components/sources/http/tests/wal_integration.rs
+++ b/components/sources/http/tests/wal_integration.rs
@@ -71,6 +71,7 @@ fn fresh_settings(source_id: &str) -> SourceSubscriptionSettings {
         relations: HashSet::new(),
         request_position_handle: true,
         resume_from: None,
+        resume_sequence: None,
     }
 }
 
@@ -84,6 +85,7 @@ fn resume_settings(source_id: &str, resume_seq: u64) -> SourceSubscriptionSettin
         relations: HashSet::new(),
         request_position_handle: true,
         resume_from: Some(bytes::Bytes::from(resume_seq.to_be_bytes().to_vec())),
+        resume_sequence: None,
     }
 }
 

--- a/components/sources/kafka/tests/integration.rs
+++ b/components/sources/kafka/tests/integration.rs
@@ -472,6 +472,7 @@ async fn test_kafka_bootstrap_source_overlap_handover() {
         relations: HashSet::new(),
         resume_from: None,
         request_position_handle: true,
+        resume_sequence: None,
     };
     let response = source.subscribe(settings).await.unwrap();
     let mut bootstrap_rx = response

--- a/components/sources/mock/src/tests.rs
+++ b/components/sources/mock/src/tests.rs
@@ -1483,6 +1483,7 @@ mod source_trait {
             relations: HashSet::new(),
             resume_from: None,
             request_position_handle: false,
+            resume_sequence: None,
         };
 
         let result = source.subscribe(settings).await;

--- a/components/sources/mssql/tests/integration_test.rs
+++ b/components/sources/mssql/tests/integration_test.rs
@@ -408,6 +408,7 @@ async fn test_mssql_bootstrap_cdc_overlap_handover() -> Result<()> {
             relations: HashSet::new(),
             resume_from: None,
             request_position_handle: true,
+            resume_sequence: None,
         };
         let response = source
             .subscribe(settings)
@@ -2011,6 +2012,7 @@ async fn subscribe_direct(
         relations: HashSet::new(),
         resume_from: None,
         request_position_handle: true,
+        resume_sequence: None,
     };
     let response = source
         .subscribe(settings)

--- a/components/sources/mysql/tests/integration_test.rs
+++ b/components/sources/mysql/tests/integration_test.rs
@@ -553,6 +553,7 @@ async fn test_mysql_bootstrap_cdc_overlap_handover_no_duplicates_or_gaps() {
             relations: HashSet::new(),
             resume_from: None,
             request_position_handle: true,
+            resume_sequence: None,
         };
         let response = source.subscribe(settings).await.unwrap();
         let mut bootstrap_rx = response

--- a/components/sources/oracle/tests/integration_test.rs
+++ b/components/sources/oracle/tests/integration_test.rs
@@ -905,6 +905,7 @@ async fn test_oracle_bootstrap_cdc_overlap_handover_no_duplicates_or_gaps() -> R
             relations: HashSet::new(),
             resume_from: None,
             request_position_handle: true,
+            resume_sequence: None,
         };
         let response = source
             .subscribe(settings)

--- a/components/sources/postgres/src/lib.rs
+++ b/components/sources/postgres/src/lib.rs
@@ -1670,6 +1670,7 @@ mod tests {
                 relations: HashSet::new(),
                 resume_from: Some(bad_position),
                 request_position_handle: false,
+                resume_sequence: None,
             };
 
             let result = source.subscribe(settings).await;

--- a/components/sources/postgres/tests/integration_tests.rs
+++ b/components/sources/postgres/tests/integration_tests.rs
@@ -1270,6 +1270,7 @@ fn subscription_settings(
         relations: HashSet::new(),
         resume_from,
         request_position_handle,
+        resume_sequence: None,
     }
 }
 

--- a/components/sources/sqlite/tests/integration_test.rs
+++ b/components/sources/sqlite/tests/integration_test.rs
@@ -376,6 +376,7 @@ async fn sqlite_bootstrap_loads_existing_rows() {
         relations: HashSet::new(),
         resume_from: None,
         request_position_handle: false,
+        resume_sequence: None,
     };
 
     let response = source.subscribe(settings).await.unwrap();

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -774,6 +774,7 @@ mod tests {
             relations: HashSet::new(),
             resume_from: Some(position_bytes.clone()),
             request_position_handle: true,
+            resume_sequence: None,
         };
         assert_eq!(settings.resume_from, Some(position_bytes));
         assert!(settings.request_position_handle);

--- a/lib/src/config/schema.rs
+++ b/lib/src/config/schema.rs
@@ -160,6 +160,7 @@ pub struct SourceSubscriptionConfig {
 ///     relations: ["PLACED_BY"].iter().map(|s| s.to_string()).collect(),
 ///     resume_from: None,
 ///     request_position_handle: false,
+///     resume_sequence: None,
 /// };
 /// ```
 #[derive(Debug, Clone)]
@@ -176,6 +177,15 @@ pub struct SourceSubscriptionSettings {
     /// If true, the query requests a shared `Arc<AtomicU64>` position handle in the
     /// `SubscriptionResponse` for reporting its durably-processed position back to the source.
     pub request_position_handle: bool,
+    /// If set, the resuming query has a dedup high-water mark at this sequence and
+    /// will discard any event with `sequence <= resume_sequence`. Sources that
+    /// restart their monotonic sequence counter from scratch in a new process
+    /// (e.g. those with no durable `source_position` of their own) must advance
+    /// their counter above this value so post-restart events are not silently
+    /// deduplicated away. `SourceBase::subscribe_with_bootstrap_context` honours
+    /// this automatically; unlike `resume_from`, it is populated whenever a
+    /// checkpoint exists, independent of whether a durable position was stored.
+    pub resume_sequence: Option<u64>,
 }
 
 /// Root configuration for drasi-lib

--- a/lib/src/queries/checkpoint_tests.rs
+++ b/lib/src/queries/checkpoint_tests.rs
@@ -329,6 +329,7 @@ mod tests {
             relations: std::collections::HashSet::new(),
             resume_from: None,
             request_position_handle: false,
+            resume_sequence: None,
         };
         let sub = source.subscribe(settings).await.unwrap();
         let mut receiver = sub.receiver;
@@ -394,6 +395,7 @@ mod tests {
             relations: std::collections::HashSet::new(),
             resume_from: None,
             request_position_handle: false,
+            resume_sequence: None,
         };
         let sub = source.subscribe(settings).await.unwrap();
         let mut receiver = sub.receiver;
@@ -916,6 +918,7 @@ mod tests {
             relations: std::collections::HashSet::new(),
             resume_from: None,
             request_position_handle: false,
+            resume_sequence: None,
         };
         let sub = source.subscribe(settings).await.unwrap();
         let mut receiver = sub.receiver;
@@ -2405,6 +2408,266 @@ mod tests {
             stored_hash,
             Some(99999),
             "Old config hash should remain when clear_checkpoints fails on mismatch"
+        );
+    }
+
+    // ========================================================================
+    // Regression test for #664 — restart with a persistent index must not
+    // silently drop the first K changes when the source has no durable position.
+    // ========================================================================
+
+    /// A source that emits events with **no** `source_position` (so its
+    /// checkpoints carry a sequence but no durable position bytes) and delegates
+    /// its `subscribe` to [`SourceBase::subscribe_with_bootstrap`] so the
+    /// framework's sequence-counter recovery runs.
+    ///
+    /// [`Self::simulate_process_restart`] resets the monotonic counter to its
+    /// initial value, emulating a fresh process where the in-memory counter is
+    /// lost while the query's persistent checkpoint survives.
+    struct NoPositionTestSource {
+        base: SourceBase,
+    }
+
+    impl NoPositionTestSource {
+        fn new(id: &str) -> anyhow::Result<Self> {
+            Ok(Self {
+                base: SourceBase::new(SourceBaseParams::new(id))?,
+            })
+        }
+
+        /// Dispatch a Person insert with **no** `source_position`.
+        async fn inject(&self, key: &str) -> anyhow::Result<()> {
+            let change = drasi_core::models::SourceChange::Insert {
+                element: drasi_core::models::Element::Node {
+                    metadata: drasi_core::models::ElementMetadata {
+                        reference: drasi_core::models::ElementReference::new(
+                            self.base.get_id(),
+                            key,
+                        ),
+                        labels: Arc::new([Arc::from("Person")]),
+                        effective_from: 0,
+                    },
+                    properties: drasi_core::models::ElementPropertyMap::from(
+                        vec![(
+                            "name".to_string(),
+                            drasi_core::evaluation::variable_value::VariableValue::String(
+                                key.to_string(),
+                            ),
+                        )]
+                        .into_iter()
+                        .collect::<std::collections::BTreeMap<_, _>>(),
+                    ),
+                },
+            };
+            // Deliberately no source_position — this source has no durable
+            // position of its own.
+            let wrapper = SourceEventWrapper::new(
+                self.base.get_id().to_string(),
+                SourceEvent::Change(change),
+                chrono::Utc::now(),
+            );
+            self.base.dispatch_event(wrapper).await
+        }
+
+        /// Emulate a process restart: the in-memory sequence counter is lost and
+        /// restarts at 1 (the next dispatched event would be seq 1 again).
+        fn simulate_process_restart(&self) {
+            self.base.set_next_sequence(0);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Source for NoPositionTestSource {
+        fn id(&self) -> &str {
+            self.base.get_id()
+        }
+
+        fn type_name(&self) -> &str {
+            "no-position-test"
+        }
+
+        fn properties(&self) -> std::collections::HashMap<String, serde_json::Value> {
+            std::collections::HashMap::new()
+        }
+
+        fn auto_start(&self) -> bool {
+            self.base.get_auto_start()
+        }
+
+        async fn start(&self) -> anyhow::Result<()> {
+            self.base
+                .set_status(ComponentStatus::Starting, Some("Starting".to_string()))
+                .await;
+            self.base
+                .set_status(ComponentStatus::Running, Some("Running".to_string()))
+                .await;
+            Ok(())
+        }
+
+        async fn stop(&self) -> anyhow::Result<()> {
+            self.base
+                .set_status(ComponentStatus::Stopping, Some("Stopping".to_string()))
+                .await;
+            self.base
+                .set_status(ComponentStatus::Stopped, Some("Stopped".to_string()))
+                .await;
+            Ok(())
+        }
+
+        async fn status(&self) -> ComponentStatus {
+            self.base.status_handle().get_status().await
+        }
+
+        async fn subscribe(
+            &self,
+            settings: crate::config::SourceSubscriptionSettings,
+        ) -> anyhow::Result<SubscriptionResponse> {
+            // Delegate to the base helper so the framework's checkpoint-restore
+            // sequence bump (driven by settings.resume_sequence) is exercised.
+            self.base
+                .subscribe_with_bootstrap(&settings, "no-position-test")
+                .await
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        async fn initialize(&self, context: crate::context::SourceRuntimeContext) {
+            self.base.initialize(context).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_no_durable_position_source_not_dropped_after_restart() {
+        const K: usize = 3;
+
+        let (query_manager, source_manager, graph) =
+            create_test_env_with_persistent_backend().await;
+        let mut event_rx = graph.read().await.subscribe();
+
+        let source = NoPositionTestSource::new("nopos-src").unwrap();
+        add_source(&source_manager, &graph, source).await.unwrap();
+        source_manager
+            .start_source("nopos-src".to_string())
+            .await
+            .unwrap();
+        wait_for_component_status(
+            &mut event_rx,
+            "nopos-src",
+            ComponentStatus::Running,
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+
+        let config = create_persistent_query_config("nopos-query", vec!["nopos-src".to_string()]);
+        add_query(&query_manager, &graph, config).await.unwrap();
+        query_manager
+            .start_query("nopos-query".to_string())
+            .await
+            .unwrap();
+        wait_for_component_status(
+            &mut event_rx,
+            "nopos-query",
+            ComponentStatus::Running,
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let source_instance = source_manager
+            .get_source_instance("nopos-src")
+            .await
+            .unwrap();
+        let test_source = source_instance
+            .as_any()
+            .downcast_ref::<NoPositionTestSource>()
+            .unwrap();
+
+        // Push K events — the framework stamps them seq 1..=K. Checkpoint -> K.
+        for i in 0..K {
+            test_source.inject(&format!("a{i}")).await.unwrap();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let query_instance = query_manager
+            .get_query_instance("nopos-query")
+            .await
+            .unwrap();
+        let cp_store = query_instance
+            .as_any()
+            .downcast_ref::<DrasiQuery>()
+            .unwrap()
+            .get_checkpoint_store()
+            .await
+            .expect("query should have a checkpoint store");
+        let cp = cp_store
+            .read_checkpoint("nopos-src")
+            .await
+            .unwrap()
+            .expect("checkpoint should exist after processing K events");
+        assert_eq!(
+            cp.sequence, K as u64,
+            "checkpoint should reach K before restart"
+        );
+        assert!(
+            cp.source_position.is_none(),
+            "this source stores no durable position"
+        );
+
+        // Stop the query.
+        query_manager
+            .stop_query("nopos-query".to_string())
+            .await
+            .unwrap();
+        wait_for_component_status(
+            &mut event_rx,
+            "nopos-query",
+            ComponentStatus::Stopped,
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+
+        // Emulate a process restart: the source's in-memory sequence counter
+        // resets to 1 while the persistent checkpoint (seq=K) survives.
+        test_source.simulate_process_restart();
+
+        // Restart the query. It restores its dedup high-water mark (K) and, via
+        // the fix, hands `resume_sequence=K` to the source so the counter is
+        // bumped above K on subscribe.
+        query_manager
+            .start_query("nopos-query".to_string())
+            .await
+            .unwrap();
+        wait_for_component_status(
+            &mut event_rx,
+            "nopos-query",
+            ComponentStatus::Running,
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Push K brand-new events. Before the fix these would be stamped 1..=K and
+        // silently dropped by the dedup filter; with the fix they are stamped
+        // (K+1)..=2K and all land.
+        for i in 0..K {
+            test_source.inject(&format!("b{i}")).await.unwrap();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let cp_after = cp_store
+            .read_checkpoint("nopos-src")
+            .await
+            .unwrap()
+            .expect("checkpoint should still exist after restart");
+        assert_eq!(
+            cp_after.sequence,
+            (2 * K) as u64,
+            "all {K} post-restart events must be processed (checkpoint should advance to {}), \
+             got seq {}. A lower value means the first K post-restart events were silently dropped.",
+            2 * K,
+            cp_after.sequence
         );
     }
 }

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -1106,6 +1106,13 @@ impl Query for DrasiQuery {
                                 checkpoint_sequences_per_source
                                     .insert(settings.source_id.clone(), cp.sequence);
                                 settings.request_position_handle = true;
+                                // Always hand the source the checkpoint sequence so a
+                                // source that restarts its counter from scratch in a new
+                                // process (no durable `source_position` of its own) can
+                                // advance it above the query's dedup high-water mark.
+                                // Without this the first `cp.sequence` post-restart events
+                                // get sequences `1..=cp.sequence` and are silently dropped.
+                                settings.resume_sequence = Some(cp.sequence);
                                 if let Some(pos) = &cp.source_position {
                                     settings.resume_from = Some(pos.clone());
                                 }
@@ -1278,6 +1285,7 @@ impl Query for DrasiQuery {
                 );
                 for (_, _, settings) in &mut sources_to_subscribe {
                     settings.resume_from = None;
+                    settings.resume_sequence = None;
                     settings.request_position_handle = has_persistent_backend;
                 }
                 // Reset per-loop accumulators

--- a/lib/src/queries/subscription_builder.rs
+++ b/lib/src/queries/subscription_builder.rs
@@ -38,6 +38,7 @@ impl SubscriptionSettingsBuilder {
                 relations: source_config.relations.iter().cloned().collect(),
                 resume_from: None,
                 request_position_handle: false,
+                resume_sequence: None,
             })
             .collect();
 

--- a/lib/src/sources/base.rs
+++ b/lib/src/sources/base.rs
@@ -582,6 +582,25 @@ impl SourceBase {
             .store(sequence.saturating_add(1), Ordering::Relaxed);
     }
 
+    /// Ensure the monotonic sequence counter is strictly above `sequence` so the
+    /// next dispatched event receives a sequence greater than it.
+    ///
+    /// Unlike [`set_next_sequence`](Self::set_next_sequence), which
+    /// unconditionally stores `sequence + 1`, this uses `fetch_max` and therefore
+    /// never lowers the counter. That makes it safe to call from multiple
+    /// concurrent subscribers resuming from different checkpoints, and safe to
+    /// call on a source that has already advanced its counter past `sequence`.
+    ///
+    /// This closes the checkpoint-restore gap: a resuming query restores its
+    /// dedup high-water mark (which discards events with `sequence <= mark`), but
+    /// a source with no durable position of its own restarts this counter at 1 in
+    /// every process. Without this bump the first `mark` post-restart events would
+    /// be stamped `1..=mark` and silently deduplicated away.
+    pub fn ensure_next_sequence_above(&self, sequence: u64) {
+        self.next_sequence
+            .fetch_max(sequence.saturating_add(1), Ordering::Relaxed);
+    }
+
     /// Returns whether a bootstrap provider is configured for this source.
     ///
     /// CDC sources use this to decide whether their start task should
@@ -819,6 +838,17 @@ impl SourceBase {
             settings.request_position_handle
         );
 
+        // Close the checkpoint-restore sequence gap. A resuming subscriber's dedup
+        // high-water mark survives the restart, but this source's monotonic
+        // sequence counter restarts at 1 in every process. Bump the counter above
+        // the checkpoint sequence so post-restart events are stamped with
+        // sequences greater than the mark and are not silently deduplicated away.
+        // `fetch_max` keeps this safe across multiple subscribers and never
+        // rewinds a counter the source has already advanced (e.g. a durable source
+        // that restored its own position).
+        if let Some(resume_seq) = settings.resume_sequence {
+            self.ensure_next_sequence_above(resume_seq);
+        }
         // Record that an initial bootstrap was requested so each CDC source's
         // start task knows to wait for the snapshot boundary. Set *before* the
         // dispatcher is registered below so it is visible once the task's
@@ -1809,6 +1839,7 @@ mod tests {
             relations: HashSet::new(),
             resume_from,
             request_position_handle,
+            resume_sequence: None,
         }
     }
 
@@ -2155,6 +2186,122 @@ mod tests {
 
         assert_eq!(s2, s1 + 1, "sequences must be monotonically increasing");
         assert_eq!(s3, s2 + 1, "sequences must be monotonically increasing");
+    }
+
+    // =========================================================================
+    // Sequence-counter recovery on subscribe (issue #664)
+    //
+    // A source with no durable position of its own restarts `next_sequence` at 1
+    // in every process. When a query resumes from a checkpoint, its dedup
+    // high-water mark survives the restart and discards events with
+    // `sequence <= mark`. `subscribe_with_bootstrap` must advance the counter
+    // above `settings.resume_sequence` so post-restart events are not dropped.
+    // =========================================================================
+
+    #[tokio::test]
+    async fn subscribe_with_resume_sequence_bumps_counter_above_checkpoint() {
+        let params = SourceBaseParams::new("resume-seq").with_dispatch_mode(DispatchMode::Channel);
+        let base = SourceBase::new(params).unwrap();
+
+        // Simulate resuming a query whose dedup high-water mark is 5.
+        let mut settings = make_settings("q1", false, None, false);
+        settings.resume_sequence = Some(5);
+
+        let response = base
+            .subscribe_with_bootstrap(&settings, "test")
+            .await
+            .unwrap();
+        let mut receiver = response.receiver;
+
+        // The first post-restart event must be stamped 6 (> 5), not 1.
+        base.dispatch_event(make_event("resume-seq", None))
+            .await
+            .unwrap();
+        let ev = receiver.recv().await.unwrap();
+        assert_eq!(
+            ev.sequence,
+            Some(6),
+            "first event after resuming at checkpoint 5 must be seq 6, not <= 5"
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_without_resume_sequence_starts_counter_at_one() {
+        let params = SourceBaseParams::new("fresh-seq").with_dispatch_mode(DispatchMode::Channel);
+        let base = SourceBase::new(params).unwrap();
+
+        // No checkpoint to resume from — counter stays at its initial value.
+        let settings = make_settings("q1", false, None, false);
+        assert!(settings.resume_sequence.is_none());
+
+        let response = base
+            .subscribe_with_bootstrap(&settings, "test")
+            .await
+            .unwrap();
+        let mut receiver = response.receiver;
+
+        base.dispatch_event(make_event("fresh-seq", None))
+            .await
+            .unwrap();
+        let ev = receiver.recv().await.unwrap();
+        assert_eq!(ev.sequence, Some(1), "a fresh source must start at seq 1");
+    }
+
+    #[tokio::test]
+    async fn resume_sequence_bump_never_lowers_across_subscribers() {
+        let params = SourceBaseParams::new("multi-sub").with_dispatch_mode(DispatchMode::Channel);
+        let base = SourceBase::new(params).unwrap();
+
+        // First subscriber resumes at 5 -> counter bumped to 6.
+        let mut s1 = make_settings("q1", false, None, false);
+        s1.resume_sequence = Some(5);
+        let mut rx1 = base
+            .subscribe_with_bootstrap(&s1, "test")
+            .await
+            .unwrap()
+            .receiver;
+
+        // Second subscriber resumes at a *lower* checkpoint (2). `fetch_max` must
+        // not rewind the counter below where the first subscriber left it.
+        let mut s2 = make_settings("q2", false, None, false);
+        s2.resume_sequence = Some(2);
+        let _rx2 = base.subscribe_with_bootstrap(&s2, "test").await.unwrap();
+
+        base.dispatch_event(make_event("multi-sub", None))
+            .await
+            .unwrap();
+        let ev = rx1.recv().await.unwrap();
+        assert_eq!(
+            ev.sequence,
+            Some(6),
+            "a later lower-checkpoint subscriber must not rewind the counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_next_sequence_above_uses_fetch_max_semantics() {
+        let params = SourceBaseParams::new("fetch-max").with_dispatch_mode(DispatchMode::Channel);
+        let base = SourceBase::new(params).unwrap();
+        let mut receiver = base.create_streaming_receiver().await.unwrap();
+
+        base.ensure_next_sequence_above(10);
+        base.dispatch_event(make_event("fetch-max", None))
+            .await
+            .unwrap();
+        let ev = receiver.recv().await.unwrap();
+        assert_eq!(ev.sequence, Some(11), "counter must advance above 10");
+
+        // A lower target must be ignored (never lowers the counter).
+        base.ensure_next_sequence_above(3);
+        base.dispatch_event(make_event("fetch-max", None))
+            .await
+            .unwrap();
+        let ev = receiver.recv().await.unwrap();
+        assert_eq!(
+            ev.sequence,
+            Some(12),
+            "a lower target must not rewind the counter"
+        );
     }
 
     #[tokio::test]
@@ -2627,6 +2774,7 @@ mod tests {
             request_position_handle: true,
             nodes: Default::default(),
             relations: Default::default(),
+            resume_sequence: None,
         };
 
         let response = base
@@ -2655,6 +2803,7 @@ mod tests {
             request_position_handle: true,
             nodes: Default::default(),
             relations: Default::default(),
+            resume_sequence: None,
         };
 
         let response = base

--- a/lib/src/sources/traits.rs
+++ b/lib/src/sources/traits.rs
@@ -249,7 +249,11 @@ pub trait Source: Send + Sync {
     /// or the native `resume_from` position). Delegating to
     /// [`SourceBase::subscribe_with_replay()`](crate::sources::base::SourceBase::subscribe_with_replay)
     /// or [`SourceBase::subscribe_with_bootstrap()`](crate::sources::base::SourceBase::subscribe_with_bootstrap)
-    /// handles the base-level bookkeeping automatically.
+    /// handles the base-level bookkeeping automatically. In particular, a source
+    /// with no durable position of its own does not need to do anything: when the
+    /// query resumes from a checkpoint, `subscribe_with_bootstrap()` reads
+    /// `settings.resume_sequence` and advances the counter above the query's dedup
+    /// high-water mark so the first post-restart events are not silently dropped.
     ///
     /// # Arguments
     /// * `settings` - Subscription settings including query ID, text, and labels of interest


### PR DESCRIPTION
## Summary

Fixes #664.

When a query has a persistent index/checkpoint store, the first *K* source changes pushed after a **process restart** were silently discarded, where *K* is the checkpoint sequence reached before the restart. This affected any source that does not report a durable `source_position`.

### Root cause

On resume, the query records `cp.sequence` into its dedup high-water mark **unconditionally** and drops events with `sequence <= K`. But `resume_from` is only set when `cp.source_position` is `Some`, and `SourceBase.next_sequence` is constructed as `AtomicU64::new(1)` — the counter restarts at 1 in every process. So the dedup mark (K) survives the restart, but the counter it is compared against does not: post-restart events get seq `1..=K` and are all silently deduplicated away.

### Fix (issue's recommended Option 1)

Thread the checkpoint sequence to the source on subscribe (independent of `source_position`) so `SourceBase` advances its own counter above the dedup mark:

- Add `resume_sequence: Option<u64>` to `SourceSubscriptionSettings`.
- Populate it from `cp.sequence` **unconditionally** on resume in the query manager (and clear it on the auto-reset retry path).
- Add `SourceBase::ensure_next_sequence_above` (uses `fetch_max`, so it never lowers the counter — safe with multiple subscribers and already-advanced counters) and call it in `subscribe_with_bootstrap_context` when `resume_sequence` is set.

This fixes every source that delegates to the base helper with **no plugin-author changes**, and keeps dedup seeding unconditional (still required so durable/WAL sources filter genuinely-replayed events). The WAL replay path is intentionally left untouched — those sources restore their own counter.

### FFI-loaded plugin sources

Sources loaded as dynamic cdylibs cross the FFI subscribe boundary. This also carries `resume_sequence` so they get the same counter bump — **including durable DB sources** (e.g. postgres): they resume to the correct LSN via `resume_from`, but their `next_sequence` still restarts at 1 in a new process, so without this they'd lose the first K post-restart changes too (thanks @amansinghoriginal for catching this).

- `SourceVtable::subscribe_fn` gains `resume_sequence` + `resume_sequence_present` params (mirroring how `resume_from` is passed as ptr+len).
- The host proxy encodes `settings.resume_sequence`; both plugin-side reconstruction sites decode it back so the plugin's `subscribe_with_bootstrap` runs `ensure_next_sequence_above`.
- The `(value, present)` encoding of the `Option<u64>` lives in one shared, unit-tested helper in `ffi-primitives` (`encode_optional_u64` / `decode_optional_u64`) so host and plugin can't drift.

### Notes

- Adding a field to the public `SourceSubscriptionSettings` is a breaking literal change; all construction sites across the workspace are updated (mechanical `resume_sequence: None`).

## Tests

- **Unit** (`sources/base.rs`): `resume_sequence: Some(K)` makes the next dispatched event seq `K+1`; without it the first event is seq `1`; `fetch_max` never lowers across subscribers.
- **E2E regression** (`queries/checkpoint_tests.rs`): persistent backend + a source with no durable position; push K events, simulate a process restart (reset the source counter), push K new events, assert all are processed (checkpoint advances to `2K`). Verified to **fail before** the fix (checkpoint stuck at K) and **pass after**.
- **FFI marshalling**: round-trip unit tests for `encode_optional_u64`/`decode_optional_u64` in `ffi-primitives`, plus a cdylib integration test (`test_ffi_resume_sequence_marshalled`) exercising the full host→plugin subscribe path at runtime.

All 879 `drasi-lib` lib tests pass; `cargo clippy --workspace --all-targets` and `cargo fmt --check` are clean; the full workspace builds with `--all-targets`.
