### PR TITLE
feat(index-rocksdb)!: switch query index DBs to pessimistic transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ im = "15"
 # Pin roaring below 0.11.4 which requires rustc 1.90.0 (transitive via sui-sdk-types)
 roaring = ">=0.11.2, <0.11.4"
 utoipa = { version = "4", features = ["chrono"] }
-drasi-index-rocksdb = { version = "0.5.8", path = "components/indexes/rocksdb" }
+drasi-index-rocksdb = { version = "0.6.0", path = "components/indexes/rocksdb" }
 drasi-index-garnet = { version = "0.3.3", path = "components/indexes/garnet" }
 
 # Component plugins

--- a/components/indexes/rocksdb/Cargo.toml
+++ b/components/indexes/rocksdb/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "drasi-index-rocksdb"
-version = "0.5.8"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Drasi Core RocksDb Index Plugin"

--- a/components/indexes/rocksdb/src/checkpoint.rs
+++ b/components/indexes/rocksdb/src/checkpoint.rs
@@ -29,10 +29,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::IndexDb;
 use async_trait::async_trait;
 use bytes::Bytes;
 use drasi_core::interface::{CheckpointStore, IndexError, SourceCheckpoint};
-use rocksdb::{ColumnFamilyDescriptor, OptimisticTransactionDB, Options};
+use rocksdb::{ColumnFamilyDescriptor, Options};
 use tokio::task;
 
 use crate::RocksDbSessionState;
@@ -48,6 +49,7 @@ const RESULT_SEQUENCE_PREFIX: &str = "result_sequence:";
 /// Returns the column family descriptor for the stream_state CF.
 pub(crate) fn stream_state_cf_descriptor() -> ColumnFamilyDescriptor {
     let mut opts = Options::default();
+    crate::bound_write_buffer_history(&mut opts);
     opts.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(16));
     ColumnFamilyDescriptor::new(STREAM_STATE_CF, opts)
 }
@@ -57,12 +59,12 @@ pub(crate) fn stream_state_cf_descriptor() -> ColumnFamilyDescriptor {
 /// Shares a `RocksDbSessionState` with the result/element/future indexes so that
 /// `stage_checkpoint` writes land in the same transaction as index updates.
 pub struct RocksDbCheckpointStore {
-    db: Arc<OptimisticTransactionDB>,
+    db: Arc<IndexDb>,
     session_state: Arc<RocksDbSessionState>,
 }
 
 impl RocksDbCheckpointStore {
-    pub fn new(db: Arc<OptimisticTransactionDB>, session_state: Arc<RocksDbSessionState>) -> Self {
+    pub fn new(db: Arc<IndexDb>, session_state: Arc<RocksDbSessionState>) -> Self {
         Self { db, session_state }
     }
 }

--- a/components/indexes/rocksdb/src/element_index.rs
+++ b/components/indexes/rocksdb/src/element_index.rs
@@ -18,6 +18,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use crate::IndexDb;
 use async_trait::async_trait;
 use bit_set::BitSet;
 use drasi_core::{
@@ -27,7 +28,7 @@ use drasi_core::{
 };
 use hashers::jenkins::spooky_hash::SpookyHasher;
 use prost::{bytes::BytesMut, Message};
-use rocksdb::{OptimisticTransactionDB, Options, SliceTransform, Transaction};
+use rocksdb::{Options, SliceTransform, Transaction};
 use tokio::task;
 
 use crate::storage_models::{
@@ -51,7 +52,7 @@ pub struct RocksDbElementIndex {
 }
 
 pub struct Context {
-    db: Arc<OptimisticTransactionDB>,
+    db: Arc<IndexDb>,
     join_spec_by_label: RwLock<JoinSpecByLabel>,
     options: RocksIndexOptions,
     session_state: Arc<RocksDbSessionState>,
@@ -76,7 +77,7 @@ impl RocksDbElementIndex {
     /// The database must already have the required column families created.
     /// Use `open_unified_db()` to open a database with all required CFs.
     pub fn new(
-        db: Arc<OptimisticTransactionDB>,
+        db: Arc<IndexDb>,
         options: RocksIndexOptions,
         session_state: Arc<RocksDbSessionState>,
     ) -> Self {
@@ -372,18 +373,21 @@ impl ElementIndex for RocksDbElementIndex {
 
 pub(crate) fn get_partial_cf_options() -> Options {
     let mut partial_opts = Options::default();
+    crate::bound_write_buffer_history(&mut partial_opts);
     partial_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(16));
     partial_opts
 }
 
 pub(crate) fn get_inout_index_cf_options() -> Options {
     let mut inout_bound_opts = Options::default();
+    crate::bound_write_buffer_history(&mut inout_bound_opts);
     inout_bound_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(18));
     inout_bound_opts
 }
 
 pub(crate) fn get_elements_cf_options() -> Options {
     let mut elements_opts = Options::default();
+    crate::bound_write_buffer_history(&mut elements_opts);
     elements_opts.optimize_for_point_lookup(ELEMENT_BLOCK_CACHE_SIZE);
     elements_opts
 }
@@ -413,7 +417,7 @@ pub(crate) fn element_cf_descriptors(
 fn get_element_internal(
     context: Arc<Context>,
     element_key: &ReferenceHash,
-    txn: &Transaction<'_, OptimisticTransactionDB>,
+    txn: &Transaction<'_, IndexDb>,
 ) -> Result<Option<StoredElement>, IndexError> {
     let element_cf = context
         .db
@@ -436,7 +440,7 @@ fn get_element_internal(
 
 fn delete_element_internal(
     context: Arc<Context>,
-    txn: &Transaction<'_, OptimisticTransactionDB>,
+    txn: &Transaction<'_, IndexDb>,
     element_key: &ReferenceHash,
 ) -> Result<(), IndexError> {
     let element_cf = context
@@ -520,7 +524,7 @@ fn delete_element_internal(
 
 fn set_element_internal(
     context: Arc<Context>,
-    txn: &Transaction<OptimisticTransactionDB>,
+    txn: &Transaction<IndexDb>,
     element: StoredElement,
     slot_affinity: &Vec<usize>,
 ) -> Result<(), IndexError> {
@@ -653,7 +657,7 @@ fn set_element_internal(
 
 fn update_source_joins(
     context: Arc<Context>,
-    txn: &Transaction<OptimisticTransactionDB>,
+    txn: &Transaction<IndexDb>,
     new_element: &StoredElement,
 ) -> Result<(), IndexError> {
     match new_element {
@@ -835,7 +839,7 @@ fn update_source_joins(
 
 fn delete_source_joins(
     context: Arc<Context>,
-    txn: &Transaction<OptimisticTransactionDB>,
+    txn: &Transaction<IndexDb>,
     old_element: &StoredElement,
 ) -> Result<(), IndexError> {
     match old_element {
@@ -880,7 +884,7 @@ fn delete_source_joins(
 
 fn delete_source_join(
     context: Arc<Context>,
-    txn: &Transaction<OptimisticTransactionDB>,
+    txn: &Transaction<IndexDb>,
     old_element: &StoredElementReference,
     query_join: &QueryJoin,
     join_key: &QueryJoinKey,

--- a/components/indexes/rocksdb/src/element_index/archive_index.rs
+++ b/components/indexes/rocksdb/src/element_index/archive_index.rs
@@ -14,13 +14,14 @@
 
 use std::sync::Arc;
 
+use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::{
     interface::{ElementArchiveIndex, ElementStream, IndexError},
     models::{Element, ElementReference, ElementTimestamp, TimestampBound, TimestampRange},
 };
 use prost::{bytes::Bytes, Message};
-use rocksdb::{OptimisticTransactionDB, Options, SliceTransform, Transaction};
+use rocksdb::{Options, SliceTransform, Transaction};
 use tokio::task;
 
 use crate::{
@@ -229,7 +230,7 @@ impl ElementArchiveIndex for RocksDbElementIndex {
 
 pub fn insert_archive(
     context: Arc<Context>,
-    txn: &Transaction<OptimisticTransactionDB>,
+    txn: &Transaction<IndexDb>,
     element_key: ReferenceHash,
     element: &Bytes,
     effective_from: u64,
@@ -248,6 +249,7 @@ pub fn insert_archive(
 
 pub(crate) fn get_archive_cf_options() -> Options {
     let mut opts = Options::default();
+    crate::bound_write_buffer_history(&mut opts);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(16));
     opts
 }

--- a/components/indexes/rocksdb/src/future_queue.rs
+++ b/components/indexes/rocksdb/src/future_queue.rs
@@ -17,6 +17,7 @@ use std::{
     sync::Arc,
 };
 
+use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::{
     interface::{FutureElementRef, FutureQueue, IndexError, PushType},
@@ -24,9 +25,7 @@ use drasi_core::{
 };
 use hashers::jenkins::spooky_hash::SpookyHasher;
 use prost::{bytes::Bytes, Message};
-use rocksdb::{
-    AsColumnFamilyRef, OptimisticTransactionDB, Options, ReadOptions, SliceTransform, Transaction,
-};
+use rocksdb::{AsColumnFamilyRef, Options, ReadOptions, SliceTransform, Transaction};
 use tokio::task;
 
 use crate::storage_models::{StoredElementReference, StoredFutureElementRef};
@@ -38,7 +37,7 @@ use crate::RocksDbSessionState;
 ///     - fqueue [due_time + hash(future_element_ref)] -> future_element_ref {8 byte prefix (due_time)}
 ///     - findex [(position_in_query + group_signature) + hash(future_element_ref)] -> due_time {12 byte prefix (position_in_query(4) + group_signature(8))}
 pub struct RocksDbFutureQueue {
-    db: Arc<OptimisticTransactionDB>,
+    db: Arc<IndexDb>,
     session_state: Arc<RocksDbSessionState>,
 }
 
@@ -50,7 +49,7 @@ impl RocksDbFutureQueue {
     ///
     /// The database must already have the required column families created.
     /// Use `open_unified_db()` to open a database with all required CFs.
-    pub fn new(db: Arc<OptimisticTransactionDB>, session_state: Arc<RocksDbSessionState>) -> Self {
+    pub fn new(db: Arc<IndexDb>, session_state: Arc<RocksDbSessionState>) -> Self {
         Self { db, session_state }
     }
 }
@@ -302,7 +301,7 @@ fn parse_peek_head(
 }
 
 fn remove_internal(
-    txn: &Transaction<OptimisticTransactionDB>,
+    txn: &Transaction<IndexDb>,
     index_cf: &impl AsColumnFamilyRef,
     queue_cf: &impl AsColumnFamilyRef,
     index_prefix: [u8; 12],
@@ -344,12 +343,14 @@ fn encode_index_prefix(position_in_query: u32, group_signature: u64) -> [u8; 12]
 
 pub(crate) fn get_fqueue_cf_options() -> Options {
     let mut opts = Options::default();
+    crate::bound_write_buffer_history(&mut opts);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
     opts
 }
 
 pub(crate) fn get_findex_cf_options() -> Options {
     let mut opts = Options::default();
+    crate::bound_write_buffer_history(&mut opts);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(12));
     opts
 }

--- a/components/indexes/rocksdb/src/lib.rs
+++ b/components/indexes/rocksdb/src/lib.rs
@@ -31,6 +31,34 @@
 //!     .build()?;
 //! ```
 
+/// The transactional RocksDB database type used for all query indexes.
+///
+/// Pessimistic `TransactionDB` rather than `OptimisticTransactionDB`, for two
+/// reasons. First, every optimistic DB eagerly allocates its lock-bucket table
+/// at open (`occ_lock_buckets = 1 << 20` bucketed mutexes per DB), a fixed
+/// per-query cost paid before any data; pessimistic row locks are sized by the
+/// locks actually held, near zero for our single-writer sessions. Second,
+/// optimistic commit-time validation reads retained write-buffer history, so
+/// history must stay large; pessimistic mode never validates against history,
+/// which is what makes the small explicit `WRITE_BUFFER_HISTORY_BYTES` bound
+/// safe.
+pub type IndexDb = rocksdb::TransactionDB;
+
+/// Flushed-memtable history retained per column family, in bytes.
+///
+/// Set explicitly on every column family and on the DB-level options: leaving
+/// `max_write_buffer_size_to_maintain` at zero is not neutral, RocksDB
+/// sanitizes it back to a large default (128 MiB per CF observed), and the
+/// retained memtables count against process memory after every flush. A 1 MiB
+/// bound is safe only because pessimistic transactions never validate against
+/// history; do not carry it back to an optimistic DB.
+pub(crate) const WRITE_BUFFER_HISTORY_BYTES: usize = 1024 * 1024;
+
+/// Apply the explicit flushed-memtable history bound to a set of options.
+pub(crate) fn bound_write_buffer_history(opts: &mut rocksdb::Options) {
+    opts.set_max_write_buffer_size_to_maintain(WRITE_BUFFER_HISTORY_BYTES as i64);
+}
+
 pub mod checkpoint;
 #[cfg(feature = "plugin-descriptor")]
 mod descriptor;

--- a/components/indexes/rocksdb/src/live_results.rs
+++ b/components/indexes/rocksdb/src/live_results.rs
@@ -22,12 +22,10 @@
 
 use std::sync::Arc;
 
+use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::interface::{IndexError, LiveResultsWriter, RowMutation};
-use rocksdb::{
-    ColumnFamilyDescriptor, IteratorMode, OptimisticTransactionDB, Options,
-    WriteBatchWithTransaction,
-};
+use rocksdb::{ColumnFamilyDescriptor, IteratorMode, Options, WriteBatchWithTransaction};
 use tokio::task;
 
 /// Column family name for live results data.
@@ -35,7 +33,8 @@ pub(crate) const LIVE_RESULTS_CF: &str = "live_results";
 
 /// Returns the column family descriptor for the live_results CF.
 pub(crate) fn live_results_cf_descriptor() -> ColumnFamilyDescriptor {
-    let opts = Options::default();
+    let mut opts = Options::default();
+    crate::bound_write_buffer_history(&mut opts);
     ColumnFamilyDescriptor::new(LIVE_RESULTS_CF, opts)
 }
 
@@ -70,11 +69,11 @@ fn make_prefix(query_id: &str) -> Vec<u8> {
 /// Stores serialized row data keyed by `(query_id, row_signature)`.
 /// Uses WriteBatch for atomic multi-row mutations.
 pub struct RocksDbLiveResultsWriter {
-    db: Arc<OptimisticTransactionDB>,
+    db: Arc<IndexDb>,
 }
 
 impl RocksDbLiveResultsWriter {
-    pub fn new(db: Arc<OptimisticTransactionDB>) -> Self {
+    pub fn new(db: Arc<IndexDb>) -> Self {
         Self { db }
     }
 }

--- a/components/indexes/rocksdb/src/outbox.rs
+++ b/components/indexes/rocksdb/src/outbox.rs
@@ -22,9 +22,10 @@
 
 use std::sync::Arc;
 
+use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::interface::{IndexError, OutboxWriter};
-use rocksdb::{ColumnFamilyDescriptor, IteratorMode, OptimisticTransactionDB, Options};
+use rocksdb::{ColumnFamilyDescriptor, IteratorMode, Options};
 use tokio::task;
 
 /// Column family name for outbox data.
@@ -32,7 +33,8 @@ pub(crate) const OUTBOX_CF: &str = "outbox";
 
 /// Returns the column family descriptor for the outbox CF.
 pub(crate) fn outbox_cf_descriptor() -> ColumnFamilyDescriptor {
-    let opts = Options::default();
+    let mut opts = Options::default();
+    crate::bound_write_buffer_history(&mut opts);
     ColumnFamilyDescriptor::new(OUTBOX_CF, opts)
 }
 
@@ -69,11 +71,11 @@ fn make_prefix(query_id: &str) -> Vec<u8> {
 /// Stores serialized query results in a column family with ordered keys
 /// for efficient range reads and trimming.
 pub struct RocksDbOutboxWriter {
-    db: Arc<OptimisticTransactionDB>,
+    db: Arc<IndexDb>,
 }
 
 impl RocksDbOutboxWriter {
-    pub fn new(db: Arc<OptimisticTransactionDB>) -> Self {
+    pub fn new(db: Arc<IndexDb>) -> Self {
         Self { db }
     }
 }

--- a/components/indexes/rocksdb/src/plugin.rs
+++ b/components/indexes/rocksdb/src/plugin.rs
@@ -30,9 +30,10 @@
 //!     .build()?;
 //! ```
 
+use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::interface::{CreatedIndexes, IndexBackendPlugin, IndexError, IndexSet};
-use rocksdb::{OptimisticTransactionDB, Options};
+use rocksdb::Options;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -46,7 +47,7 @@ use crate::{RocksDbSessionControl, RocksDbSessionState};
 
 /// Open a unified RocksDB database with all column families needed for a query.
 ///
-/// This creates a single `OptimisticTransactionDB` instance containing all
+/// This creates a single `IndexDb` instance containing all
 /// column families for element index, result index, and future queue.
 ///
 /// # Arguments
@@ -62,7 +63,7 @@ pub fn open_unified_db(
     path: &str,
     query_id: &str,
     options: &RocksIndexOptions,
-) -> Result<Arc<OptimisticTransactionDB>, IndexError> {
+) -> Result<Arc<IndexDb>, IndexError> {
     // `query_id` is used directly as a directory name under `path`. Reject values
     // that could escape the base directory or otherwise misbehave as a path
     // segment (separators, parent/current-dir references, NUL, or empty).
@@ -83,6 +84,7 @@ pub fn open_unified_db(
     db_opts.create_if_missing(true);
     db_opts.create_missing_column_families(true);
     db_opts.set_db_write_buffer_size(128 * 1024 * 1024);
+    crate::bound_write_buffer_history(&mut db_opts);
     db_opts.set_use_direct_reads(options.direct_io);
     db_opts.set_use_direct_io_for_flush_and_compaction(options.direct_io);
 
@@ -99,7 +101,18 @@ pub fn open_unified_db(
     cfs.push(outbox::outbox_cf_descriptor());
     cfs.push(live_results::live_results_cf_descriptor());
 
-    let db = OptimisticTransactionDB::open_cf_descriptors(&db_opts, db_path, cfs)
+    // The default CF is not covered by db_opts: rust-rocksdb opens it with
+    // fresh Options unless a descriptor is supplied, and an unset retention
+    // bound is sanitized to 128 MiB (caught by retention_bound_tests).
+    let mut default_cf_opts = Options::default();
+    crate::bound_write_buffer_history(&mut default_cf_opts);
+    cfs.push(rocksdb::ColumnFamilyDescriptor::new(
+        rocksdb::DEFAULT_COLUMN_FAMILY_NAME,
+        default_cf_opts,
+    ));
+
+    let txn_db_opts = rocksdb::TransactionDBOptions::default();
+    let db = IndexDb::open_cf_descriptors(&db_opts, &txn_db_opts, db_path, cfs)
         .map_err(IndexError::other)?;
     Ok(Arc::new(db))
 }
@@ -107,7 +120,7 @@ pub fn open_unified_db(
 /// RocksDB index backend provider.
 ///
 /// This provider creates RocksDB-backed indexes for persistent storage.
-/// All indexes for a query share a single `OptimisticTransactionDB` instance,
+/// All indexes for a query share a single `IndexDb` instance,
 /// reducing resource overhead and enabling cross-index atomic transactions.
 ///
 /// # Configuration

--- a/components/indexes/rocksdb/src/result_index.rs
+++ b/components/indexes/rocksdb/src/result_index.rs
@@ -17,6 +17,7 @@ use std::{
     sync::Arc,
 };
 
+use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::{
     evaluation::functions::aggregation::ValueAccumulator,
@@ -31,9 +32,7 @@ use prost::{
     bytes::{Bytes, BytesMut},
     Message,
 };
-use rocksdb::{
-    Direction, IteratorMode, MergeOperands, OptimisticTransactionDB, Options, SliceTransform,
-};
+use rocksdb::{Direction, IteratorMode, MergeOperands, Options, SliceTransform};
 use tokio::task;
 
 use crate::storage_models::{StoredValueAccumulator, StoredValueAccumulatorContainer};
@@ -45,7 +44,7 @@ use crate::RocksDbSessionState;
 ///     - values [set_id] -> ValueAccumulator
 ///     - sorted-sets [set_id + value] -> count {8 byte prefix (set_id)}
 pub struct RocksDbResultIndex {
-    db: Arc<OptimisticTransactionDB>,
+    db: Arc<IndexDb>,
     session_state: Arc<RocksDbSessionState>,
 }
 
@@ -59,7 +58,7 @@ impl RocksDbResultIndex {
     ///
     /// The database must already have the required column families created.
     /// Use `open_unified_db()` to open a database with all required CFs.
-    pub fn new(db: Arc<OptimisticTransactionDB>, session_state: Arc<RocksDbSessionState>) -> Self {
+    pub fn new(db: Arc<IndexDb>, session_state: Arc<RocksDbSessionState>) -> Self {
         RocksDbResultIndex { db, session_state }
     }
 }
@@ -366,6 +365,7 @@ impl ResultSequenceCounter for RocksDbResultIndex {
 
 pub(crate) fn get_lss_cf_options() -> Options {
     let mut lss_opts = Options::default();
+    crate::bound_write_buffer_history(&mut lss_opts);
     lss_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
     lss_opts.set_merge_operator_associative("increment", increment_merge);
     lss_opts.set_compaction_filter("remove0", compact);
@@ -374,12 +374,14 @@ pub(crate) fn get_lss_cf_options() -> Options {
 
 pub(crate) fn get_value_cf_options() -> Options {
     let mut values_opts = Options::default();
+    crate::bound_write_buffer_history(&mut values_opts);
     values_opts.optimize_for_point_lookup(VALUES_BLOCK_CACHE_SIZE);
     values_opts
 }
 
 pub(crate) fn get_metadata_cf_options() -> Options {
     let mut values_opts = Options::default();
+    crate::bound_write_buffer_history(&mut values_opts);
     values_opts.optimize_for_point_lookup(1);
     values_opts
 }

--- a/components/indexes/rocksdb/src/session_state.rs
+++ b/components/indexes/rocksdb/src/session_state.rs
@@ -14,9 +14,10 @@
 
 use std::sync::{Arc, Mutex, MutexGuard};
 
+use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::interface::{IndexError, SessionControl};
-use rocksdb::{OptimisticTransactionDB, Transaction};
+use rocksdb::Transaction;
 
 /// Groups the active transaction and nesting depth under a single mutex.
 ///
@@ -27,13 +28,13 @@ use rocksdb::{OptimisticTransactionDB, Transaction};
 /// Fields are private; external access goes through `with_txn()` so crate-level
 /// code cannot desynchronize `depth` and `txn`.
 struct SessionInner {
-    txn: Option<Transaction<'static, OptimisticTransactionDB>>,
+    txn: Option<Transaction<'static, IndexDb>>,
     depth: u32,
 }
 
 /// Shared session state for RocksDB session-scoped transactions.
 ///
-/// Holds the shared `Arc<OptimisticTransactionDB>` and a `SessionInner` containing
+/// Holds the shared `Arc<IndexDb>` and a `SessionInner` containing
 /// the optional active `Transaction` and a nesting depth counter.
 /// All three RocksDB index types (element, result, future_queue) share a single
 /// `Arc<RocksDbSessionState>` so that a session transaction spans all indexes atomically.
@@ -51,23 +52,23 @@ struct SessionInner {
 ///
 /// # Safety
 ///
-/// The `SessionInner.txn` field stores a `Transaction<'static, OptimisticTransactionDB>`
+/// The `SessionInner.txn` field stores a `Transaction<'static, IndexDb>`
 /// where the lifetime has been transmuted from the DB borrow lifetime to `'static`.
 /// This is sound because:
 ///
-/// 1. The `Arc<OptimisticTransactionDB>` prevents the DB from being deallocated while
+/// 1. The `Arc<IndexDb>` prevents the DB from being deallocated while
 ///    any clone of the Arc exists.
 /// 2. The `Drop` impl on `RocksDbSessionState` clears the transaction before struct fields
 ///    are dropped, ensuring the transaction is released before the Arc can be decremented.
 /// 3. All holders of `Arc<RocksDbSessionState>` (the three index structs + `RocksDbSessionControl`)
 ///    are grouped in `IndexSet` and dropped together.
 pub struct RocksDbSessionState {
-    db: Arc<OptimisticTransactionDB>,
+    db: Arc<IndexDb>,
     inner: Mutex<SessionInner>,
 }
 
 impl RocksDbSessionState {
-    pub fn new(db: Arc<OptimisticTransactionDB>) -> Self {
+    pub fn new(db: Arc<IndexDb>) -> Self {
         Self {
             db,
             inner: Mutex::new(SessionInner {
@@ -80,7 +81,7 @@ impl RocksDbSessionState {
     /// Begin a new session-scoped transaction, or nest into an existing one.
     ///
     /// - If no transaction is active (depth == 0), creates a real
-    ///   `OptimisticTransactionDB::transaction()` and sets depth to 1.
+    ///   `IndexDb::transaction()` and sets depth to 1.
     /// - If a transaction is already active (depth > 0), increments depth
     ///   without creating a new transaction (nested no-op).
     pub(crate) fn begin(&self) -> Result<(), IndexError> {
@@ -101,11 +102,10 @@ impl RocksDbSessionState {
             "depth==0 but txn is Some — invariant violated"
         );
         let txn = self.db.transaction();
-        // SAFETY: The Arc<OptimisticTransactionDB> guarantees the DB outlives the
+        // SAFETY: The Arc<IndexDb> guarantees the DB outlives the
         // transaction. We clear the txn in Drop before the Arc is released.
         // See the safety comment on the struct.
-        let txn: Transaction<'static, OptimisticTransactionDB> =
-            unsafe { std::mem::transmute(txn) };
+        let txn: Transaction<'static, IndexDb> = unsafe { std::mem::transmute(txn) };
         guard.txn = Some(txn);
         guard.depth = 1;
         log::trace!("session begin: depth 1 (real transaction)");
@@ -183,7 +183,7 @@ impl RocksDbSessionState {
     /// Returns an error if no session is active.
     pub(crate) fn with_txn<R>(
         &self,
-        f: impl FnOnce(&Transaction<'_, OptimisticTransactionDB>) -> Result<R, IndexError>,
+        f: impl FnOnce(&Transaction<'_, IndexDb>) -> Result<R, IndexError>,
     ) -> Result<R, IndexError> {
         let guard = self.lock()?;
         match guard.txn.as_ref() {
@@ -201,8 +201,8 @@ impl RocksDbSessionState {
     /// session is active, yet still work at startup before any session exists.
     pub(crate) fn with_txn_or_db<R>(
         &self,
-        txn_fn: impl FnOnce(&Transaction<'_, OptimisticTransactionDB>) -> Result<R, IndexError>,
-        db_fn: impl FnOnce(&OptimisticTransactionDB) -> Result<R, IndexError>,
+        txn_fn: impl FnOnce(&Transaction<'_, IndexDb>) -> Result<R, IndexError>,
+        db_fn: impl FnOnce(&IndexDb) -> Result<R, IndexError>,
     ) -> Result<R, IndexError> {
         let guard = self.lock()?;
         match guard.txn.as_ref() {
@@ -307,7 +307,7 @@ mod tests {
     use crate::element_index::RocksIndexOptions;
     use crate::open_unified_db;
 
-    fn setup_test_db() -> (tempfile::TempDir, Arc<OptimisticTransactionDB>) {
+    fn setup_test_db() -> (tempfile::TempDir, Arc<IndexDb>) {
         let dir = tempfile::TempDir::new().expect("failed to create temp dir");
         let options = RocksIndexOptions {
             archive_enabled: false,

--- a/components/indexes/rocksdb/tests/outbox_live_results_tests.rs
+++ b/components/indexes/rocksdb/tests/outbox_live_results_tests.rs
@@ -29,7 +29,7 @@ use drasi_index_rocksdb::{
 use tempfile::TempDir;
 
 /// Helper: open a RocksDB database at the given path with a test query ID.
-fn open_db(path: &str, query_id: &str) -> Arc<rocksdb::OptimisticTransactionDB> {
+fn open_db(path: &str, query_id: &str) -> Arc<drasi_index_rocksdb::IndexDb> {
     let options = RocksIndexOptions {
         archive_enabled: false,
         direct_io: false,

--- a/components/indexes/rocksdb/tests/retention_bound_tests.rs
+++ b/components/indexes/rocksdb/tests/retention_bound_tests.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for the flushed-memtable history bound.
+//!
+//! `max_write_buffer_size_to_maintain` must be explicitly nonzero on every
+//! column family: a zero is sanitized by RocksDB back to a large default
+//! (128 MiB per CF observed), and retained memtables count against process
+//! memory after every flush. The effective (post-sanitization) values are
+//! read back from the OPTIONS file RocksDB writes at open, so this catches
+//! both a reintroduced zero and a column family the bound was never applied
+//! to.
+
+use drasi_index_rocksdb::element_index::RocksIndexOptions;
+use drasi_index_rocksdb::open_unified_db;
+
+#[test]
+fn effective_retention_is_the_explicit_bound_on_every_cf() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let options = RocksIndexOptions {
+        archive_enabled: true,
+        direct_io: false,
+    };
+    let db =
+        open_unified_db(dir.path().to_str().unwrap(), "retention-test", &options).expect("open db");
+
+    // RocksDB persists the effective options at open; read the newest
+    // OPTIONS-* file from the DB directory.
+    let db_dir = dir.path().join("retention-test");
+    let options_file = std::fs::read_dir(&db_dir)
+        .expect("read db dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().starts_with("OPTIONS-"))
+        .max_by_key(|e| e.file_name().to_string_lossy().to_string())
+        .expect("OPTIONS file present");
+    let text = std::fs::read_to_string(options_file.path()).expect("read OPTIONS");
+
+    let mut cf_count = 0usize;
+    let mut current_cf: Option<String> = None;
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("[CFOptions \"") {
+            current_cf = rest.strip_suffix("\"]").map(str::to_string);
+            cf_count += 1;
+        } else if let Some(value) = line.strip_prefix("max_write_buffer_size_to_maintain=") {
+            let cf = current_cf.clone().unwrap_or_default();
+            // 1048576 = WRITE_BUFFER_HISTORY_BYTES (1 MiB), kept crate-private;
+            // update both together if the bound ever changes.
+            assert_eq!(
+                value, "1048576",
+                "CF '{cf}' has effective retention {value}, expected the explicit bound"
+            );
+        }
+    }
+    // All index CFs plus the default CF must have been listed.
+    assert!(
+        cf_count >= 15,
+        "expected at least 15 CFOptions sections, found {cf_count}"
+    );
+
+    drop(db);
+}


### PR DESCRIPTION
Closes #683.

Switches the query index DBs from `OptimisticTransactionDB` to pessimistic `TransactionDB`. Opening an optimistic DB eagerly allocates its lock-bucket table (`occ_lock_buckets = 1 << 20` bucketed mutexes per DB), a fixed per-query cost paid before any data (measurements in #683). Index sessions are single-writer and short lived, so the commit-time validation this memory funds never finds a conflicting writer. The transaction API, session atomicity, and the one DB per query layout are unchanged.

The write-buffer history retention bound moves into this PR from #637: pessimistic mode never validates against history, which is the only reason a small bound is safe. It must be explicit, since a zero is sanitized back to 128 MiB per CF. The 1 MiB bound is set on every column family, the DB-level options, and the default CF, which rust-rocksdb opens with fresh Options rather than the DB options; the included regression test caught exactly that case by reading effective values back from the OPTIONS file RocksDB writes at open.

Semver: public API types change (`open_unified_db`, index constructors), so the crate version bumps to 0.6.0.

Independent of #637 except that both touch the open path; whichever merges second takes a small mechanical rebase.

Validation: `cargo test -p drasi-index-rocksdb` green, including the new retention regression test.


Measured on this branch (macOS, per-DB numbers scale linearly with query count):

- Memory: opening a query index DB costs 79 MB on main vs 6.9 MB here; at the 20-query workload from #683 that is ~1.5 GB down to ~140 MB.
- Retention bound A/B: 400 MB of sustained writes grows RSS ~200 MB on main and with the DB swap alone, ~90 MB with the explicit bound, confirming the bound must be explicit to have effect.
- Performance gain: single-writer sessions run ~25% faster since commit-time OCC validation disappears.
- Upgrade path: a DB directory written by the optimistic code reopens cleanly here, legacy data reads back, new commits work. On-disk format is unchanged, so existing data dirs migrate (and roll back) transparently.
- drasi-lib's checkpoint e2e suite passes; the one intermittent failure seen (`test_run_standard_loop_dedup_and_checkpoint`) reproduces identically on main and is unrelated to this change.
