### PR TITLE
Restore backpressure on the bootstrap FFI bridge (#686)

### DIFF
--- a/components/host-sdk/src/proxies/bootstrap_provider.rs
+++ b/components/host-sdk/src/proxies/bootstrap_provider.rs
@@ -61,70 +61,76 @@ impl BootstrapProvider for BootstrapProviderProxy {
         event_tx: BootstrapEventSender,
         _settings: Option<&SourceSubscriptionSettings>,
     ) -> anyhow::Result<BootstrapResult> {
-        // Build FfiStr arrays for node/relation labels
         let node_label_strs: Vec<String> = request.node_labels.clone();
         let rel_label_strs: Vec<String> = request.relation_labels.clone();
-        let node_ffi: Vec<FfiStr> = node_label_strs
-            .iter()
-            .map(|s| FfiStr::from_str(s))
-            .collect();
-        let rel_ffi: Vec<FfiStr> = rel_label_strs.iter().map(|s| FfiStr::from_str(s)).collect();
+        let query_id = request.query_id.clone();
+        let request_id = request.request_id.clone();
+        let server_id = context.server_id.clone();
+        let source_id = context.source_id.clone();
 
-        let query_id_ffi = FfiStr::from_str(&request.query_id);
-        let request_id_ffi = FfiStr::from_str(&request.request_id);
-        let server_id_ffi = FfiStr::from_str(&context.server_id);
-        let source_id_ffi = FfiStr::from_str(&context.source_id);
-
-        // Build the FfiBootstrapSender that forwards events into the tokio channel
-        let sender = build_ffi_bootstrap_sender(event_tx);
-        let sender_ptr = Box::into_raw(Box::new(sender));
-
-        let state = self.vtable.state;
+        let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
         let bootstrap_fn = self.vtable.bootstrap_fn;
-        let node_labels_ptr = node_ffi.as_ptr();
-        let node_labels_count = node_ffi.len();
-        let rel_labels_ptr = rel_ffi.as_ptr();
-        let rel_labels_count = rel_ffi.len();
 
-        let result_ptr = (bootstrap_fn)(
-            state,
-            query_id_ffi,
-            node_labels_ptr,
-            node_labels_count,
-            rel_labels_ptr,
-            rel_labels_count,
-            request_id_ffi,
-            server_id_ffi,
-            source_id_ffi,
-            sender_ptr,
-        );
+        // The FFI call runs the plugin's entire bootstrap and only returns when
+        // the snapshot is fully sent. With the bounded bridge below, its
+        // duration is governed by the query-side consumer, so it MUST run on
+        // the blocking pool: on a core worker, N concurrent bootstraps pin N
+        // workers while the consumers that would drain them wait for a worker,
+        // deadlocking the whole runtime once N reaches the worker count
+        // (observed: 28 query bootstraps froze at 35/65 streams with the REST
+        // API unresponsive).
+        tokio::task::spawn_blocking(move || {
+            let state = state;
+            let node_ffi: Vec<FfiStr> = node_label_strs
+                .iter()
+                .map(|s| FfiStr::from_str(s))
+                .collect();
+            let rel_ffi: Vec<FfiStr> = rel_label_strs.iter().map(|s| FfiStr::from_str(s)).collect();
 
-        // Reclaim the FfiBootstrapSender so its drop_fn runs, which drops the
-        // std::sync::mpsc::Sender, causing the forwarding thread to exit and
-        // the tokio mpsc Sender (event_tx) to be dropped. Without this, the
-        // query's bootstrap_rx.recv() would never return None and the query
-        // would stay in Starting state forever.
-        unsafe {
-            let sender = Box::from_raw(sender_ptr);
-            (sender.drop_fn)(sender.state);
-        }
+            // Build the FfiBootstrapSender that forwards events into the tokio channel
+            let sender = build_ffi_bootstrap_sender(event_tx);
+            let sender_ptr = Box::into_raw(Box::new(sender));
 
-        // Extract handover metadata from the FfiBootstrapResult
-        if result_ptr.is_null() {
-            return Err(anyhow::anyhow!("Bootstrap failed: null result"));
-        }
+            let result_ptr = (bootstrap_fn)(
+                state.0,
+                FfiStr::from_str(&query_id),
+                node_ffi.as_ptr(),
+                node_ffi.len(),
+                rel_ffi.as_ptr(),
+                rel_ffi.len(),
+                FfiStr::from_str(&request_id),
+                FfiStr::from_str(&server_id),
+                FfiStr::from_str(&source_id),
+                sender_ptr,
+            );
 
-        let ffi_result = unsafe { *Box::from_raw(result_ptr) };
+            // Reclaim the FfiBootstrapSender so its drop_fn runs, which drops the
+            // std::sync::mpsc::SyncSender, causing the forwarding thread to exit and
+            // the tokio mpsc Sender (event_tx) to be dropped. Without this, the
+            // query's bootstrap_rx.recv() would never return None and the query
+            // would stay in Starting state forever.
+            unsafe {
+                let sender = Box::from_raw(sender_ptr);
+                (sender.drop_fn)(sender.state);
+            }
 
-        if ffi_result.event_count < 0 {
-            return Err(anyhow::anyhow!(
-                "Bootstrap failed with code {}",
-                ffi_result.event_count
-            ));
-        }
+            // Extract handover metadata from the FfiBootstrapResult
+            if result_ptr.is_null() {
+                return Err(anyhow::anyhow!("Bootstrap failed: null result"));
+            }
 
-        let source_position =
-            if !ffi_result.source_position_ptr.is_null() && ffi_result.source_position_len > 0 {
+            let ffi_result = unsafe { *Box::from_raw(result_ptr) };
+
+            if ffi_result.event_count < 0 {
+                return Err(anyhow::anyhow!(
+                    "Bootstrap failed with code {}",
+                    ffi_result.event_count
+                ));
+            }
+
+            let source_position = if !ffi_result.source_position_ptr.is_null()
+                && ffi_result.source_position_len > 0
+            {
                 let bytes = unsafe {
                     std::slice::from_raw_parts(
                         ffi_result.source_position_ptr,
@@ -144,10 +150,13 @@ impl BootstrapProvider for BootstrapProviderProxy {
                 None
             };
 
-        Ok(BootstrapResult {
-            event_count: ffi_result.event_count as usize,
-            source_position,
+            Ok(BootstrapResult {
+                event_count: ffi_result.event_count as usize,
+                source_position,
+            })
         })
+        .await
+        .map_err(|e| anyhow::anyhow!("bootstrap blocking task failed: {e}"))?
     }
 }
 
@@ -159,13 +168,24 @@ impl Drop for BootstrapProviderProxy {
     }
 }
 
+/// Capacity of the std bridge between the plugin's `send_fn` and the host
+/// forwarding thread. Bounded so that a slow or stalled query propagates
+/// backpressure into the plugin (`send_fn` blocks when full) instead of the
+/// bridge buffering an entire snapshot in host memory; mirrors the
+/// `sync_channel(256)` used by `ChangeReceiverProxy` / `BootstrapReceiverProxy`.
+const BOOTSTRAP_BRIDGE_CAPACITY: usize = 256;
+
 /// Build an `FfiBootstrapSender` that forwards bootstrap events into a tokio mpsc sender.
 ///
-/// Uses a std::sync::mpsc channel + forwarding thread to avoid blocking the plugin's
-/// tokio runtime (the same pattern proven in the PoC's cross-plugin bootstrap).
+/// Uses a bounded std::sync::mpsc channel + forwarding thread so the plugin's
+/// tokio runtime never has to touch the host runtime directly, while the
+/// bounded capacity keeps end-to-end backpressure intact: when the query-side
+/// bootstrap channel is full, the forwarding thread blocks, the bridge fills,
+/// and the plugin's `send_fn` blocks until the consumer drains.
 fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSender {
-    // Create a std::sync channel for the plugin to send on (sync-safe)
-    let (std_tx, std_rx) = std::sync::mpsc::channel::<BootstrapEvent>();
+    // Bounded sync channel for the plugin to send on (sync-safe, blocking).
+    let (std_tx, std_rx) =
+        std::sync::mpsc::sync_channel::<BootstrapEvent>(BOOTSTRAP_BRIDGE_CAPACITY);
 
     // Spawn a thread that forwards from std channel → tokio channel
     std::thread::spawn(move || {
@@ -184,7 +204,7 @@ fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSen
 
     extern "C" fn send_fn(state: *mut c_void, event: *mut FfiBootstrapEvent) -> i32 {
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let tx = unsafe { &*(state as *const std::sync::mpsc::Sender<BootstrapEvent>) };
+            let tx = unsafe { &*(state as *const std::sync::mpsc::SyncSender<BootstrapEvent>) };
             if event.is_null() {
                 return -1;
             }
@@ -200,6 +220,8 @@ fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSen
                 // Undecodable payload: skip this event, keep the stream alive.
                 return 0;
             };
+            // Blocks when the bridge is full — this is the backpressure path:
+            // the plugin's sending thread waits until the host consumer drains.
             match tx.send(bootstrap_event) {
                 Ok(()) => 0,
                 Err(_) => -1,
@@ -211,7 +233,7 @@ fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSen
     extern "C" fn drop_fn(state: *mut c_void) {
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
             drop(Box::from_raw(
-                state as *mut std::sync::mpsc::Sender<BootstrapEvent>,
+                state as *mut std::sync::mpsc::SyncSender<BootstrapEvent>,
             ))
         }));
     }


### PR DESCRIPTION
Closes #686.

Bounds the bootstrap FFI bridge with a small sync channel, mirroring the CDC change bridge, so a full bridge blocks the plugin's send and backpressure reaches the producer. The synchronous bootstrap FFI call moves to the blocking pool: with the bound in place its duration is set by the consumer, and on an async worker enough concurrent bootstraps deadlock the runtime.

Verified on a 20-query workload bootstrapping all queries concurrently: every stream completes with the API responsive throughout.

Independent of the other open memory PRs; touches only the bootstrap proxy in host-sdk.
