### PR TITLE
fix(ffi)!: remove plugin log capture store, filter plugin logs at the source (#685)

### DIFF
--- a/components/host-sdk/Cargo.toml
+++ b/components/host-sdk/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
+tracing = "0.1"
 tokio-stream = "0.1"
 indexmap = "2"
 chrono = "0.4"

--- a/components/host-sdk/src/callbacks.rs
+++ b/components/host-sdk/src/callbacks.rs
@@ -19,14 +19,14 @@
 //! and lifecycle events into the DrasiLib systems that the REST API reads from.
 
 use std::ffi::c_void;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 
 use drasi_lib::channels::events::{ComponentEvent, ComponentStatus, ComponentType};
 use drasi_lib::component_graph::{ComponentUpdate, ComponentUpdateSender};
 use drasi_lib::managers::{ComponentEventHistory, ComponentLogRegistry, LogLevel, LogMessage};
 use drasi_plugin_sdk::ffi::{
-    FfiLifecycleEvent, FfiLifecycleEventType, FfiLogEntry, FfiLogLevel, LifecycleCallbackFn,
-    LogCallbackFn,
+    FfiLifecycleEvent, FfiLifecycleEventType, FfiLogEntry, FfiLogLevel, FfiLogLevelFilter,
+    LifecycleCallbackFn, LogCallbackFn,
 };
 use tokio::sync::RwLock;
 
@@ -101,32 +101,56 @@ impl InstanceCallbackContext {
     }
 }
 
-/// A captured log entry from a plugin (for testing/diagnostics).
-#[derive(Debug, Clone)]
-pub struct CapturedLog {
-    pub level: FfiLogLevel,
-    pub plugin_id: String,
-    pub message: String,
-}
-
-/// A captured lifecycle event from a plugin (for testing/diagnostics).
-#[derive(Debug, Clone)]
-pub struct CapturedLifecycle {
-    pub component_id: String,
-    pub event_type: FfiLifecycleEventType,
-    pub message: String,
-}
-
-/// Access the global captured log store (for testing/diagnostics).
-pub fn captured_logs() -> &'static Mutex<Vec<CapturedLog>> {
-    static LOGS: OnceLock<Mutex<Vec<CapturedLog>>> = OnceLock::new();
-    LOGS.get_or_init(|| Mutex::new(Vec::new()))
-}
-
-/// Access the global captured lifecycle event store (for testing/diagnostics).
-pub fn captured_lifecycles() -> &'static Mutex<Vec<CapturedLifecycle>> {
-    static EVENTS: OnceLock<Mutex<Vec<CapturedLifecycle>>> = OnceLock::new();
-    EVENTS.get_or_init(|| Mutex::new(Vec::new()))
+/// Compute the host's effective log level for plugin log forwarding.
+///
+/// Passed to plugins at load time so they can drop filtered-out records
+/// before formatting them or crossing the FFI. Sources, in order:
+///
+/// 1. The tracing subscriber's max level, when a subscriber is installed.
+///    drasi-lib initializes tracing with an `EnvFilter`, so this reflects
+///    `RUST_LOG` (the `log` crate's max level does not: the LogTracer bridge
+///    pins it at `Trace`). `RUST_LOG=off` is honored: plugins are told `Off`
+///    and forward nothing.
+/// 2. The `log` crate's max level, when set to something other than `Off`
+///    (env_logger-style hosts; see the NOTE below on why `Off` cannot be
+///    honored from this source).
+/// 3. `Trace` when neither is configured (e.g. tests): forward everything.
+///
+/// The tracing max level collapses per-target directives to the most
+/// verbose one (`RUST_LOG=info,my_module=trace` reports `Trace`), so
+/// plugins may over-forward relative to the host filter but never
+/// under-forward.
+pub fn effective_host_log_level() -> FfiLogLevelFilter {
+    use tracing::level_filters::LevelFilter as TracingFilter;
+    // `LevelFilter::current()` alone cannot distinguish "no subscriber
+    // installed" from "subscriber installed with everything filtered off":
+    // both read OFF. Ask the dispatcher whether a real subscriber is active
+    // so a host configured for silence gets silence, not everything.
+    let tracing_installed =
+        tracing::dispatcher::get_default(|d| !d.is::<tracing::subscriber::NoSubscriber>());
+    if tracing_installed {
+        return match TracingFilter::current() {
+            TracingFilter::OFF => FfiLogLevelFilter::Off,
+            TracingFilter::ERROR => FfiLogLevelFilter::Error,
+            TracingFilter::WARN => FfiLogLevelFilter::Warn,
+            TracingFilter::INFO => FfiLogLevelFilter::Info,
+            TracingFilter::DEBUG => FfiLogLevelFilter::Debug,
+            _ => FfiLogLevelFilter::Trace,
+        };
+    }
+    let log_level = log::max_level();
+    if log_level != log::LevelFilter::Off {
+        return FfiLogLevelFilter::from_level_filter(log_level);
+    }
+    // NOTE: the `log` crate reads `Off` both when no logger was ever
+    // installed (the default) and when a pure-`log` host explicitly
+    // configured silence (e.g. env_logger with RUST_LOG=off); its public
+    // API cannot distinguish the two. We bias toward forwarding so
+    // unconfigured hosts and bare test binaries still see plugin logs. A
+    // `log`-only host that wants silence should call
+    // `LoadedPlugin::set_log_level(FfiLogLevelFilter::Off)` after its
+    // logging setup.
+    FfiLogLevelFilter::Trace
 }
 
 fn ffi_log_level_to_log_level(level: FfiLogLevel) -> LogLevel {
@@ -206,17 +230,6 @@ pub extern "C" fn default_log_callback(ctx: *mut c_void, entry: *const FfiLogEnt
             message
         );
 
-        // Always capture for diagnostics (use `ok()` to avoid panicking in extern "C"
-        // if the Mutex was poisoned by a prior test/thread panic — a panic here would
-        // be a non-unwinding abort since this is an extern "C" function)
-        if let Ok(mut logs) = captured_logs().lock() {
-            logs.push(CapturedLog {
-                level,
-                plugin_id: plugin_id.clone(),
-                message: message.clone(),
-            });
-        }
-
         // Route into DrasiLib's ComponentLogRegistry if we have both context and instance info
         if !ctx.is_null() && !instance_id.is_empty() && !component_id.is_empty() {
             let context = unsafe { CallbackContext::from_raw_ref(ctx) };
@@ -251,15 +264,6 @@ pub extern "C" fn default_lifecycle_callback(ctx: *mut c_void, event: *const Ffi
         let event_type = event.event_type;
 
         log::debug!("Lifecycle: {component_id} ({component_type_str}) {event_type:?} {message}");
-
-        // Always capture for diagnostics (use `ok()` to avoid panicking in extern "C")
-        if let Ok(mut events) = captured_lifecycles().lock() {
-            events.push(CapturedLifecycle {
-                component_id: component_id.clone(),
-                event_type,
-                message: message.clone(),
-            });
-        }
 
         // Route into DrasiLib's ComponentEventHistory if context is available
         if !ctx.is_null() {
@@ -339,15 +343,6 @@ pub extern "C" fn instance_log_callback(ctx: *mut c_void, entry: *const FfiLogEn
             message
         );
 
-        // Capture for diagnostics (use `ok()` to avoid panicking in extern "C")
-        if let Ok(mut logs) = captured_logs().lock() {
-            logs.push(CapturedLog {
-                level,
-                plugin_id: plugin_id.clone(),
-                message: message.clone(),
-            });
-        }
-
         // Route into ComponentLogRegistry
         if !ctx.is_null() {
             let context = unsafe { InstanceCallbackContext::from_raw_ref(ctx) };
@@ -399,15 +394,6 @@ pub extern "C" fn instance_lifecycle_callback(ctx: *mut c_void, event: *const Ff
         log::debug!(
             "Lifecycle [instance]: {component_id} ({component_type_str}) {event_type:?} {message}"
         );
-
-        // Capture for diagnostics (use `ok()` to avoid panicking in extern "C")
-        if let Ok(mut events) = captured_lifecycles().lock() {
-            events.push(CapturedLifecycle {
-                component_id: component_id.clone(),
-                event_type,
-                message: message.clone(),
-            });
-        }
 
         // Send through the component graph update channel
         if !ctx.is_null() {

--- a/components/host-sdk/src/lib.rs
+++ b/components/host-sdk/src/lib.rs
@@ -40,7 +40,7 @@ pub mod state_store_bridge;
 pub mod wal_provider_bridge;
 pub mod watcher;
 
-pub use callbacks::{CallbackContext, CapturedLifecycle, CapturedLog, InstanceCallbackContext};
+pub use callbacks::{CallbackContext, InstanceCallbackContext};
 pub use identity_bridge::IdentityProviderVtableBuilder;
 pub use loader::{
     is_plugin_binary, plugin_kind_from_filename, scan_plugin_metadata, LoadedPlugin, PluginLoader,

--- a/components/host-sdk/src/loader.rs
+++ b/components/host-sdk/src/loader.rs
@@ -22,7 +22,8 @@ use indexmap::IndexMap;
 use libloading::{Library, Symbol};
 
 use drasi_plugin_sdk::ffi::{
-    ConfigResolverFn, FfiPluginRegistration, LifecycleCallbackFn, LogCallbackFn, PluginMetadata,
+    ConfigResolverFn, FfiLogLevelFilter, FfiPluginRegistration, LifecycleCallbackFn, LogCallbackFn,
+    PluginMetadata,
 };
 
 use crate::proxies::bootstrap_provider::BootstrapPluginProxy;
@@ -58,6 +59,9 @@ pub struct LoadedPlugin {
     pub file_path: PathBuf,
     /// Config resolver injection function pointer (saved from FfiPluginRegistration).
     set_config_resolver_fn: extern "C" fn(*mut c_void, ConfigResolverFn),
+    /// Log level injection function pointer (saved from FfiPluginRegistration).
+    /// `None` for plugins built against an SDK older than 0.12.0.
+    set_log_level_fn: Option<extern "C" fn(FfiLogLevelFilter)>,
     /// Keep the library loaded.
     _library: Arc<Library>,
 }
@@ -80,6 +84,19 @@ impl LoadedPlugin {
     /// even after the `LoadedPlugin` is consumed.
     pub fn config_resolver_injection_fn(&self) -> extern "C" fn(*mut c_void, ConfigResolverFn) {
         self.set_config_resolver_fn
+    }
+
+    /// Report a log level to the plugin. Records more verbose than this level
+    /// are dropped inside the plugin before formatting or crossing the FFI.
+    ///
+    /// The loader already reports [`crate::callbacks::effective_host_log_level`]
+    /// at load time; hosts can call this to override it or to re-apply after
+    /// their logging setup changes. No-op for plugins built against an SDK
+    /// older than 0.12.0.
+    pub fn set_log_level(&self, level: FfiLogLevelFilter) {
+        if let Some(f) = self.set_log_level_fn {
+            f(level);
+        }
     }
 }
 
@@ -362,6 +379,26 @@ pub fn load_plugin_from_path(
         None
     };
 
+    // NOTE: `set_log_level` is a trailing field appended for SDK 0.12.0; gate
+    // access on the plugin's reported `sdk_version` like the identity fields
+    // above, since reading it from an older (smaller) layout is UB.
+    let set_log_level_fn: Option<extern "C" fn(FfiLogLevelFilter)> = if plugin_sdk_version
+        .as_deref()
+        .and_then(parse_semver)
+        .map(|v| v >= MIN_SDK_VERSION_WITH_SET_LOG_LEVEL)
+        .unwrap_or(false)
+    {
+        Some(registration.set_log_level)
+    } else {
+        None
+    };
+
+    // Report the host's effective log level so the plugin can drop
+    // filtered-out records before formatting or crossing the FFI.
+    if let Some(f) = set_log_level_fn {
+        f(crate::callbacks::effective_host_log_level());
+    }
+
     // Now safe to forget the registration — we own all arrays
     std::mem::forget(registration);
 
@@ -401,6 +438,7 @@ pub fn load_plugin_from_path(
         metadata_info,
         file_path: path.to_path_buf(),
         set_config_resolver_fn,
+        set_log_level_fn,
         _library: lib,
     })
 }
@@ -439,6 +477,10 @@ fn read_plugin_metadata(lib: &Library) -> Option<String> {
 /// — reading those trailing fields for such plugins would be undefined
 /// behavior, so the loader treats identity provider plugins as absent.
 const MIN_SDK_VERSION_WITH_IDENTITY_PROVIDERS: (u32, u32, u32) = (0, 6, 0);
+
+/// Minimum plugin SDK version whose `FfiPluginRegistration` carries the
+/// trailing `set_log_level` field.
+const MIN_SDK_VERSION_WITH_SET_LOG_LEVEL: (u32, u32, u32) = (0, 12, 0);
 
 /// Parse a SemVer version string into `(major, minor, patch)`, ignoring any
 /// pre-release / build metadata. Returns `None` on malformed input.

--- a/components/host-sdk/tests/effective_log_level_info_test.rs
+++ b/components/host-sdk/tests/effective_log_level_info_test.rs
@@ -1,0 +1,46 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pins the assumption producer-side log filtering rests on: with the real
+//! drasi-lib logging stack installed (registry, EnvFilter, component layer,
+//! fmt), `effective_host_log_level()` reflects `RUST_LOG`. If this ever
+//! regressed to `Trace`, plugins would silently forward everything again.
+//!
+//! Lives in its own integration-test file because it mutates process-global
+//! state (env var, global tracing subscriber); the `RUST_LOG=off` variant is
+//! a separate file for the same reason.
+
+use drasi_host_sdk::callbacks::effective_host_log_level;
+use drasi_plugin_sdk::ffi::FfiLogLevelFilter;
+
+#[test]
+fn effective_level_tracks_env_filter() {
+    // Fresh process, no subscriber, no `log` logger: forward everything so
+    // bare test hosts still see all plugin records.
+    assert_eq!(
+        effective_host_log_level(),
+        FfiLogLevelFilter::Trace,
+        "without any logging configured the host must report Trace"
+    );
+
+    std::env::set_var("RUST_LOG", "info");
+    let _registry = drasi_lib::get_or_init_global_registry();
+
+    assert_eq!(
+        effective_host_log_level(),
+        FfiLogLevelFilter::Info,
+        "with RUST_LOG=info the host must report Info, not Trace — \
+         otherwise producer-side filtering never engages in production"
+    );
+}

--- a/components/host-sdk/tests/effective_log_level_log_crate_test.rs
+++ b/components/host-sdk/tests/effective_log_level_log_crate_test.rs
@@ -1,0 +1,46 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pins `effective_host_log_level()` for `log`-crate-only hosts (env_logger
+//! style: no tracing subscriber installed). The host's `log` max level is
+//! reported as-is, except `Off`, which is indistinguishable from "no logger
+//! ever installed" at the `log` crate's public API and therefore biases
+//! toward forwarding — such hosts opt into silence via
+//! `LoadedPlugin::set_log_level(Off)` instead.
+//!
+//! Own file: depends on process-global state (no tracing subscriber may be
+//! installed, `log` max level is mutated).
+
+use drasi_host_sdk::callbacks::effective_host_log_level;
+use drasi_plugin_sdk::ffi::FfiLogLevelFilter;
+
+#[test]
+fn effective_level_falls_back_to_log_crate_level() {
+    // env_logger-style host: `log::set_max_level` called, no tracing at all.
+    log::set_max_level(log::LevelFilter::Warn);
+    assert_eq!(
+        effective_host_log_level(),
+        FfiLogLevelFilter::Warn,
+        "without a tracing subscriber the host must report the log crate's level"
+    );
+
+    // `Off` cannot be distinguished from "never configured", so it reports
+    // Trace (forward everything) rather than silencing plugins by default.
+    log::set_max_level(log::LevelFilter::Off);
+    assert_eq!(
+        effective_host_log_level(),
+        FfiLogLevelFilter::Trace,
+        "log-level Off is ambiguous with unconfigured and must bias toward forwarding"
+    );
+}

--- a/components/host-sdk/tests/effective_log_level_off_test.rs
+++ b/components/host-sdk/tests/effective_log_level_off_test.rs
@@ -1,0 +1,37 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `RUST_LOG=off` must be honored at the producer: a subscriber configured
+//! for silence reports `Off` to plugins, which then forward nothing. Without
+//! the installed-subscriber check this case is indistinguishable from "no
+//! subscriber" and falls through to the `log` crate's max level — which the
+//! host's own LogTracer bridge pins at `Trace`, making the host that wants
+//! the least logging pay for the most forwarding.
+//!
+//! Own file: mutates process-global state (env var, global subscriber).
+
+use drasi_host_sdk::callbacks::effective_host_log_level;
+use drasi_plugin_sdk::ffi::FfiLogLevelFilter;
+
+#[test]
+fn effective_level_honors_rust_log_off() {
+    std::env::set_var("RUST_LOG", "off");
+    let _registry = drasi_lib::get_or_init_global_registry();
+
+    assert_eq!(
+        effective_host_log_level(),
+        FfiLogLevelFilter::Off,
+        "with RUST_LOG=off the host must report Off so plugins forward nothing"
+    );
+}

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -84,6 +84,89 @@ fn plugin_exists(crate_name: &str) -> bool {
     dir.join(&filename).exists()
 }
 
+/// Test-owned log/lifecycle capture.
+///
+/// The log and lifecycle callbacks are parameters to `load_plugin_from_path`,
+/// so tests that need to observe what a plugin sends across the FFI install
+/// their own callbacks and assert on stores they own. The production
+/// callbacks (`default_log_callback` etc.) keep no capture state.
+mod test_capture {
+    use std::ffi::c_void;
+    use std::sync::{Mutex, OnceLock};
+
+    use drasi_plugin_sdk::ffi::{
+        FfiLifecycleEvent, FfiLifecycleEventType, FfiLogEntry, FfiLogLevel,
+    };
+
+    #[derive(Debug, Clone)]
+    pub struct TestLog {
+        pub level: FfiLogLevel,
+        #[allow(dead_code)]
+        pub plugin_id: String,
+        pub message: String,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct TestLifecycle {
+        #[allow(dead_code)]
+        pub component_id: String,
+        #[allow(dead_code)]
+        pub event_type: FfiLifecycleEventType,
+        #[allow(dead_code)]
+        pub message: String,
+    }
+
+    pub fn logs() -> &'static Mutex<Vec<TestLog>> {
+        static LOGS: OnceLock<Mutex<Vec<TestLog>>> = OnceLock::new();
+        LOGS.get_or_init(|| Mutex::new(Vec::new()))
+    }
+
+    pub fn lifecycles() -> &'static Mutex<Vec<TestLifecycle>> {
+        static EVENTS: OnceLock<Mutex<Vec<TestLifecycle>>> = OnceLock::new();
+        EVENTS.get_or_init(|| Mutex::new(Vec::new()))
+    }
+
+    pub fn clear() {
+        logs().lock().unwrap_or_else(|e| e.into_inner()).clear();
+        lifecycles()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+    }
+
+    /// Capture the entry, then forward to the production callback so the
+    /// normal host paths (log framework, registry routing) stay exercised.
+    pub extern "C" fn log_callback(ctx: *mut c_void, entry: *const FfiLogEntry) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let e = unsafe { &*entry };
+            let record = TestLog {
+                level: e.level,
+                plugin_id: unsafe { e.plugin_id.to_string() },
+                message: unsafe { e.message.to_string() },
+            };
+            if let Ok(mut logs) = logs().lock() {
+                logs.push(record);
+            }
+        }));
+        drasi_host_sdk::callbacks::default_log_callback(ctx, entry);
+    }
+
+    pub extern "C" fn lifecycle_callback(ctx: *mut c_void, event: *const FfiLifecycleEvent) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let e = unsafe { &*event };
+            let record = TestLifecycle {
+                component_id: unsafe { e.component_id.to_string() },
+                event_type: e.event_type,
+                message: unsafe { e.message.to_string() },
+            };
+            if let Ok(mut events) = lifecycles().lock() {
+                events.push(record);
+            }
+        }));
+        drasi_host_sdk::callbacks::default_lifecycle_callback(ctx, event);
+    }
+}
+
 // ============================================================================
 // Plugin Loading Tests
 // ============================================================================
@@ -669,18 +752,15 @@ async fn test_log_callback_captures_plugin_logs() {
     }
     let path = require_plugin("drasi-source-mock");
 
-    // Clear captured logs
-    callbacks::captured_logs()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .clear();
+    // Clear the test capture stores
+    test_capture::clear();
 
     let plugin = load_plugin_from_path(
         &path,
         std::ptr::null_mut(),
-        callbacks::default_log_callback_fn(),
+        test_capture::log_callback,
         std::ptr::null_mut(),
-        callbacks::default_lifecycle_callback_fn(),
+        test_capture::lifecycle_callback,
     )
     .unwrap();
 
@@ -705,12 +785,12 @@ async fn test_log_callback_captures_plugin_logs() {
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
     // Check that some logs were captured (mock source logs on start/stop)
-    let logs = callbacks::captured_logs()
+    let logs = test_capture::logs()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     // We can't guarantee specific messages, but the callback mechanism should work
     // The lifecycle callback should at least fire
-    let lifecycles = callbacks::captured_lifecycles()
+    let lifecycles = test_capture::lifecycles()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     // Either logs or lifecycle events should be captured
@@ -987,15 +1067,6 @@ async fn test_plugin_logs_routed_to_log_registry() {
         log_count > 0,
         "Expected at least one log message in ComponentLogRegistry for key {log_key:?}",
     );
-
-    // Also check the diagnostic store (captured_logs) for completeness
-    let captured = callbacks::captured_logs()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
-    assert!(
-        !captured.is_empty(),
-        "Expected at least one captured log from plugin start/stop"
-    );
 }
 
 #[tokio::test]
@@ -1105,27 +1176,14 @@ async fn test_plugin_lifecycle_events_routed_via_status_channel() {
         statuses.contains(&&ComponentStatus::Running),
         "Expected Running/Started event, got: {statuses:?}"
     );
-
-    // Also check the diagnostic store for completeness
-    let captured = callbacks::captured_lifecycles()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
-    let our_captured: Vec<_> = captured
-        .iter()
-        .filter(|e| e.component_id == "lifecycle-evt-source")
-        .collect();
-    assert!(
-        !our_captured.is_empty(),
-        "Expected lifecycle events in diagnostic store"
-    );
 }
 
 #[tokio::test]
 #[serial]
 async fn test_null_callback_context_does_not_crash() {
     //! Verify that when source.initialize() is NOT called (no per-instance callbacks),
-    //! logs still go to the diagnostic store and host log framework, and lifecycle events
-    //! go to the diagnostic store via global callbacks. No crash occurs.
+    //! logs still go to the host log framework and lifecycle events still reach the
+    //! global callbacks. No crash occurs.
     if !plugin_exists("drasi-source-mock") {
         eprintln!("SKIP: drasi-source-mock not built as cdylib");
         panic!("SKIP: drasi-source-mock not built as cdylib");
@@ -1159,14 +1217,14 @@ async fn test_null_callback_context_does_not_crash() {
 }
 
 // ============================================================================
-// Tracing bridge tests — verify log events at all levels are captured
+// Tracing bridge tests — verify log events reach the host callback
 // ============================================================================
 
 #[tokio::test]
 #[serial]
-async fn test_all_log_levels_captured_in_diagnostic_store() {
-    //! Verify that log events at all levels (info, warn, error, debug) emitted by a plugin
-    //! are captured in the diagnostic captured_logs store. The mock source emits info! during
+async fn test_plugin_logs_reach_host_callback() {
+    //! Verify that log events emitted by a plugin cross the FFI and reach the
+    //! host-provided log callback. The mock source emits info! during
     //! start/stop, verifying the tracing-log bridge works for the log crate.
     if !plugin_exists("drasi-source-mock") {
         eprintln!("SKIP: drasi-source-mock not built as cdylib");
@@ -1174,18 +1232,14 @@ async fn test_all_log_levels_captured_in_diagnostic_store() {
     }
     let path = require_plugin("drasi-source-mock");
 
-    // Clear diagnostic stores before test
-    callbacks::captured_logs()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .clear();
+    test_capture::clear();
 
     let plugin = load_plugin_from_path(
         &path,
         std::ptr::null_mut(),
-        callbacks::default_log_callback_fn(),
+        test_capture::log_callback,
         std::ptr::null_mut(),
-        callbacks::default_lifecycle_callback_fn(),
+        test_capture::lifecycle_callback,
     )
     .unwrap();
 
@@ -1204,7 +1258,7 @@ async fn test_all_log_levels_captured_in_diagnostic_store() {
     let _ = source.stop().await;
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    let logs = callbacks::captured_logs()
+    let logs = test_capture::logs()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     // We should have at least the start and stop info logs
@@ -1230,27 +1284,116 @@ async fn test_all_log_levels_captured_in_diagnostic_store() {
 
 #[tokio::test]
 #[serial]
-async fn test_logs_without_initialize_reach_global_callback() {
-    //! When a source is NOT initialized (no per-instance callbacks), logs should
-    //! still reach the global callback and be captured in the diagnostic store.
-    //! This verifies the tracing bridge's global fallback path.
+async fn test_plugin_drops_records_below_host_level() {
+    //! Verify producer-side filtering: after the host reports a Warn level via
+    //! set_log_level, the plugin's info records no longer cross the FFI at all.
+    //! Raising the level back to Trace restores them.
+    use drasi_plugin_sdk::ffi::FfiLogLevelFilter;
+
     if !plugin_exists("drasi-source-mock") {
         eprintln!("SKIP: drasi-source-mock not built as cdylib");
         panic!("SKIP: drasi-source-mock not built as cdylib");
     }
     let path = require_plugin("drasi-source-mock");
 
-    callbacks::captured_logs()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .clear();
+    test_capture::clear();
 
     let plugin = load_plugin_from_path(
         &path,
         std::ptr::null_mut(),
-        callbacks::default_log_callback_fn(),
+        test_capture::log_callback,
         std::ptr::null_mut(),
-        callbacks::default_lifecycle_callback_fn(),
+        test_capture::lifecycle_callback,
+    )
+    .unwrap();
+
+    let config = serde_json::json!({
+        "dataType": { "type": "generic" },
+        "intervalMs": 500
+    });
+
+    // Restore Trace even if an assertion below panics: the cdylib's statics
+    // are shared process-wide (dlopen refcounting), so a leaked Warn level
+    // would cascade into later tests in this serial suite.
+    struct RestoreLevel<'a>(&'a drasi_host_sdk::loader::LoadedPlugin);
+    impl Drop for RestoreLevel<'_> {
+        fn drop(&mut self) {
+            self.0.set_log_level(FfiLogLevelFilter::Trace);
+        }
+    }
+    let _restore = RestoreLevel(&plugin);
+
+    // Phase 1: Warn level — the mock source's info logs must not cross the FFI.
+    plugin.set_log_level(FfiLogLevelFilter::Warn);
+
+    let source = plugin.source_plugins[0]
+        .create_source("filter-test", &config, false)
+        .await
+        .unwrap();
+    let _ = source.start().await;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let _ = source.stop().await;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    {
+        let logs = test_capture::logs()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let leaked: Vec<_> = logs
+            .iter()
+            .filter(|l| l.message.contains("filter-test"))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "Expected no plugin logs below Warn to cross the FFI, got: {leaked:?}"
+        );
+    }
+
+    // Phase 2: Trace level — the same source's info logs cross again.
+    plugin.set_log_level(FfiLogLevelFilter::Trace);
+
+    let source2 = plugin.source_plugins[0]
+        .create_source("filter-test-open", &config, false)
+        .await
+        .unwrap();
+    let _ = source2.start().await;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let _ = source2.stop().await;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let logs = test_capture::logs()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let visible: Vec<_> = logs
+        .iter()
+        .filter(|l| l.message.contains("filter-test-open"))
+        .collect();
+    assert!(
+        !visible.is_empty(),
+        "Expected plugin logs to cross the FFI again at Trace level"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_logs_without_initialize_reach_global_callback() {
+    //! When a source is NOT initialized (no per-instance callbacks), logs should
+    //! still reach the global callback. This verifies the tracing bridge's
+    //! global fallback path.
+    if !plugin_exists("drasi-source-mock") {
+        eprintln!("SKIP: drasi-source-mock not built as cdylib");
+        panic!("SKIP: drasi-source-mock not built as cdylib");
+    }
+    let path = require_plugin("drasi-source-mock");
+
+    test_capture::clear();
+
+    let plugin = load_plugin_from_path(
+        &path,
+        std::ptr::null_mut(),
+        test_capture::log_callback,
+        std::ptr::null_mut(),
+        test_capture::lifecycle_callback,
     )
     .unwrap();
 
@@ -1270,7 +1413,7 @@ async fn test_logs_without_initialize_reach_global_callback() {
     let _ = source.stop().await;
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    let logs = callbacks::captured_logs()
+    let logs = test_capture::logs()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     let our_logs: Vec<_> = logs

--- a/components/plugin-sdk/src/ffi/callbacks.rs
+++ b/components/plugin-sdk/src/ffi/callbacks.rs
@@ -33,6 +33,78 @@ pub enum FfiLogLevel {
     Trace = 4,
 }
 
+/// Log level filter passed from the host to the plugin.
+///
+/// The host reports its effective log level through
+/// `FfiPluginRegistration::set_log_level`. Records more verbose than this
+/// level are dropped inside the plugin before they are formatted or cross
+/// the FFI boundary, so filtered-out logging costs almost nothing.
+///
+/// Discriminants order by verbosity: `Off` forwards nothing, `Trace`
+/// forwards everything.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiLogLevelFilter {
+    Off = 0,
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
+}
+
+impl FfiLogLevelFilter {
+    /// Convert to the `log` crate's `LevelFilter`.
+    pub fn to_level_filter(self) -> log::LevelFilter {
+        match self {
+            FfiLogLevelFilter::Off => log::LevelFilter::Off,
+            FfiLogLevelFilter::Error => log::LevelFilter::Error,
+            FfiLogLevelFilter::Warn => log::LevelFilter::Warn,
+            FfiLogLevelFilter::Info => log::LevelFilter::Info,
+            FfiLogLevelFilter::Debug => log::LevelFilter::Debug,
+            FfiLogLevelFilter::Trace => log::LevelFilter::Trace,
+        }
+    }
+
+    /// Convert from the `log` crate's `LevelFilter`.
+    pub fn from_level_filter(filter: log::LevelFilter) -> Self {
+        match filter {
+            log::LevelFilter::Off => FfiLogLevelFilter::Off,
+            log::LevelFilter::Error => FfiLogLevelFilter::Error,
+            log::LevelFilter::Warn => FfiLogLevelFilter::Warn,
+            log::LevelFilter::Info => FfiLogLevelFilter::Info,
+            log::LevelFilter::Debug => FfiLogLevelFilter::Debug,
+            log::LevelFilter::Trace => FfiLogLevelFilter::Trace,
+        }
+    }
+
+    /// Convert from a raw `u8` discriminant, clamping unknown values to `Trace`.
+    pub fn from_u8(value: u8) -> Self {
+        match value {
+            0 => FfiLogLevelFilter::Off,
+            1 => FfiLogLevelFilter::Error,
+            2 => FfiLogLevelFilter::Warn,
+            3 => FfiLogLevelFilter::Info,
+            4 => FfiLogLevelFilter::Debug,
+            _ => FfiLogLevelFilter::Trace,
+        }
+    }
+
+    /// Whether a record at `level` passes this filter.
+    pub fn allows(self, level: FfiLogLevel) -> bool {
+        // Exhaustive: a new FfiLogLevel variant is a compile error here
+        // rather than a silent arithmetic drift between the two enums.
+        let level_as_filter = match level {
+            FfiLogLevel::Error => FfiLogLevelFilter::Error,
+            FfiLogLevel::Warn => FfiLogLevelFilter::Warn,
+            FfiLogLevel::Info => FfiLogLevelFilter::Info,
+            FfiLogLevel::Debug => FfiLogLevelFilter::Debug,
+            FfiLogLevel::Trace => FfiLogLevelFilter::Trace,
+        };
+        (level_as_filter as u8) <= self as u8
+    }
+}
+
 /// A log entry emitted by a plugin, delivered to the host via callback.
 /// All FfiStr fields are borrowed and only valid for the duration of the callback.
 #[repr(C)]

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -34,7 +34,10 @@ use super::types::FfiStr;
 ///   `KeyedSnapshotRow { k: <row_signature>, v: <row> }` JSON envelope instead
 ///   of a bare row, so the engine's canonical `row_signature` survives FFI
 ///   (fixes #605 duplicate dashboard rows on the plugin path).
-pub const FFI_SDK_VERSION: &str = "0.11.0";
+/// - `0.12.0`: `FfiPluginRegistration` gained a trailing `set_log_level`
+///   field. The host reports its effective log level and the plugin drops
+///   more verbose records before formatting or crossing the FFI (#685).
+pub const FFI_SDK_VERSION: &str = "0.12.0";
 
 /// The target triple this crate was compiled for.
 pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");

--- a/components/plugin-sdk/src/ffi/mod.rs
+++ b/components/plugin-sdk/src/ffi/mod.rs
@@ -46,7 +46,7 @@ pub mod wal_provider_proxy;
 // Re-export commonly used types at the ffi module level
 pub use callbacks::{
     ConfigResolverFn, FfiLifecycleEvent, FfiLifecycleEventType, FfiLogEntry, FfiLogLevel,
-    LifecycleCallbackFn, LogCallbackFn,
+    FfiLogLevelFilter, LifecycleCallbackFn, LogCallbackFn,
 };
 pub use metadata::{
     PluginMetadata, BUILD_TIMESTAMP, FFI_SDK_VERSION, GIT_COMMIT_SHA, TARGET_TRIPLE,

--- a/components/plugin-sdk/src/ffi/tracing_bridge.rs
+++ b/components/plugin-sdk/src/ffi/tracing_bridge.rs
@@ -27,7 +27,7 @@
 
 use std::ffi::c_void;
 use std::fmt;
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicPtr, AtomicU8, Ordering};
 
 use tracing::field::{Field, Visit};
 use tracing::Subscriber;
@@ -35,9 +35,37 @@ use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 
-use super::callbacks::{FfiLogEntry, FfiLogLevel, LogCallbackFn};
+use super::callbacks::{FfiLogEntry, FfiLogLevel, FfiLogLevelFilter, LogCallbackFn};
 use super::types::FfiStr;
 use super::vtable_gen::{current_instance_log_ctx, InstanceLogContext};
+
+/// Maximum verbosity forwarded across the FFI, stored as the numeric value
+/// of [`FfiLogLevelFilter`]. Defaults to `Trace` (forward everything) until
+/// the host reports its effective level via `set_forward_level`.
+///
+/// `Relaxed` ordering is sufficient: this flag guards no other memory —
+/// readers compare the value and nothing else — and per-variable coherence
+/// already orders its updates. This matches `log::set_max_level` and
+/// tracing's `LevelFilter::current()`, which use `Relaxed` for the same
+/// advisory-filter pattern.
+static FORWARD_LEVEL: AtomicU8 = AtomicU8::new(FfiLogLevelFilter::Trace as u8);
+
+/// Set the maximum log level forwarded to the host.
+///
+/// Called from the `export_plugin!` macro when the host invokes
+/// `FfiPluginRegistration::set_log_level`. Besides gating the tracing layer,
+/// this sets the plugin's own `log` max level so `log` crate macros below
+/// the threshold return before formatting (the LogTracer bridge opens it at
+/// `Trace` during callback installation).
+pub fn set_forward_level(level: FfiLogLevelFilter) {
+    FORWARD_LEVEL.store(level as u8, Ordering::Relaxed);
+    log::set_max_level(level.to_level_filter());
+}
+
+/// The currently configured forwarding filter.
+pub fn forward_level() -> FfiLogLevelFilter {
+    FfiLogLevelFilter::from_u8(FORWARD_LEVEL.load(Ordering::Relaxed))
+}
 
 // Compile-time assertion that transmuting raw pointers to LogCallbackFn is safe.
 const _: () = assert!(
@@ -101,11 +129,6 @@ where
     }
 
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
-        // Extract the message from the event
-        let mut message_visitor = MessageVisitor::default();
-        event.record(&mut message_visitor);
-        let message = message_visitor.message;
-
         // Convert tracing level to FfiLogLevel
         let level = match *event.metadata().level() {
             tracing::Level::ERROR => FfiLogLevel::Error,
@@ -114,6 +137,17 @@ where
             tracing::Level::DEBUG => FfiLogLevel::Debug,
             tracing::Level::TRACE => FfiLogLevel::Trace,
         };
+
+        // Drop records more verbose than the host's effective level before
+        // doing any work: no message formatting, no FFI crossing.
+        if !forward_level().allows(level) {
+            return;
+        }
+
+        // Extract the message from the event
+        let mut message_visitor = MessageVisitor::default();
+        event.record(&mut message_visitor);
+        let message = message_visitor.message;
 
         // Extract component info from span hierarchy (set by .instrument(span))
         let span_info = ctx.event_span(event).and_then(|span| {
@@ -262,9 +296,96 @@ pub fn init_tracing_subscriber(
     // the tracing subscriber (which has span context for routing)
     let _ = tracing_log::LogTracer::init();
 
+    // LogTracer::init opens the log crate's max level at Trace. Re-apply the
+    // configured forwarding level in case the host reported it before
+    // installing the callback.
+    log::set_max_level(forward_level().to_level_filter());
+
     let layer = FfiTracingLayer::new(log_cb, log_ctx, plugin_id);
     let subscriber = tracing_subscriber::registry().with(layer);
 
     // set_global_default only affects this cdylib's tracing dispatcher
     let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static TEST_LOG_CB: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+    static TEST_LOG_CTX: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+
+    fn captured() -> &'static Mutex<Vec<(FfiLogLevel, String)>> {
+        static STORE: std::sync::OnceLock<Mutex<Vec<(FfiLogLevel, String)>>> =
+            std::sync::OnceLock::new();
+        STORE.get_or_init(|| Mutex::new(Vec::new()))
+    }
+
+    extern "C" fn capture_cb(_ctx: *mut c_void, entry: *const FfiLogEntry) {
+        let entry = unsafe { &*entry };
+        captured()
+            .lock()
+            .unwrap()
+            .push((entry.level, unsafe { entry.message.to_string() }));
+    }
+
+    #[test]
+    fn layer_drops_events_more_verbose_than_forward_level() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        TEST_LOG_CB.store(capture_cb as *mut (), Ordering::Release);
+        let layer = FfiTracingLayer::new(&TEST_LOG_CB, &TEST_LOG_CTX, "test-plugin");
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        // FORWARD_LEVEL and the `log` max level are process-global; restore
+        // them on drop so a failed assertion cannot leak state into other
+        // tests in this binary. Any future test mutating these statics must
+        // use the same guard pattern.
+        struct RestoreGlobals {
+            log_max: log::LevelFilter,
+        }
+        impl Drop for RestoreGlobals {
+            fn drop(&mut self) {
+                set_forward_level(FfiLogLevelFilter::Trace);
+                log::set_max_level(self.log_max);
+            }
+        }
+        let _restore = RestoreGlobals {
+            log_max: log::max_level(),
+        };
+
+        set_forward_level(FfiLogLevelFilter::Info);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::trace!("trace record");
+            tracing::debug!("debug record");
+            tracing::info!("info record");
+            tracing::error!("error record");
+        });
+
+        {
+            let logs = captured().lock().unwrap();
+            let levels: Vec<FfiLogLevel> = logs.iter().map(|(l, _)| *l).collect();
+            assert!(
+                !levels.contains(&FfiLogLevel::Trace) && !levels.contains(&FfiLogLevel::Debug),
+                "sub-level records must not be forwarded, got {levels:?}"
+            );
+            assert!(levels.contains(&FfiLogLevel::Info));
+            assert!(levels.contains(&FfiLogLevel::Error));
+        }
+
+        captured().lock().unwrap().clear();
+    }
+
+    #[test]
+    fn level_filter_allows_matches_verbosity_ordering() {
+        let f = FfiLogLevelFilter::Info;
+        assert!(f.allows(FfiLogLevel::Error));
+        assert!(f.allows(FfiLogLevel::Warn));
+        assert!(f.allows(FfiLogLevel::Info));
+        assert!(!f.allows(FfiLogLevel::Debug));
+        assert!(!f.allows(FfiLogLevel::Trace));
+        assert!(!FfiLogLevelFilter::Off.allows(FfiLogLevel::Error));
+        assert!(FfiLogLevelFilter::Trace.allows(FfiLogLevel::Trace));
+    }
 }

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -807,4 +807,12 @@ pub struct FfiPluginRegistration {
     /// back through the host.
     pub set_config_resolver:
         extern "C" fn(ctx: *mut ::std::ffi::c_void, callback: super::callbacks::ConfigResolverFn),
+    /// Host calls this to report its effective log level. The plugin drops
+    /// records more verbose than this level before formatting them or
+    /// forwarding them across the FFI. Until called, the plugin forwards
+    /// everything (`Trace`).
+    ///
+    /// Appended for SDK 0.12.0; hosts must gate access on the plugin's
+    /// reported `sdk_version`.
+    pub set_log_level: extern "C" fn(level: super::callbacks::FfiLogLevelFilter),
 }

--- a/components/plugin-sdk/src/lib.rs
+++ b/components/plugin-sdk/src/lib.rs
@@ -630,6 +630,10 @@ macro_rules! export_plugin {
             );
         }
 
+        extern "C" fn __set_log_level_impl(level: $crate::ffi::FfiLogLevelFilter) {
+            $crate::ffi::tracing_bridge::set_forward_level(level);
+        }
+
         // ── Config resolver callback storage ──
         static __CONFIG_RESOLVER_CB: ::std::sync::atomic::AtomicPtr<()> =
             ::std::sync::atomic::AtomicPtr::new(::std::ptr::null_mut());
@@ -781,6 +785,7 @@ macro_rules! export_plugin {
                     set_log_callback: __set_log_callback_impl,
                     set_lifecycle_callback: __set_lifecycle_callback_impl,
                     set_config_resolver: __set_config_resolver_impl,
+                    set_log_level: __set_log_level_impl,
                 });
                 // Host takes ownership of the boxed-slice allocations. It will
                 // reclaim them via `Vec::from_raw_parts(ptr, len, len)` + drop.


### PR DESCRIPTION
Closes #685.

Two changes, matching the issue.

Removes the global capture stores from host-sdk. Every plugin log record was copied into an unbounded in-memory store that nothing in production ever read, so memory grew with traffic for the life of the process. The integration tests were the only consumers. Since the log and lifecycle callbacks are already parameters to plugin loading, the tests now install their own capture callbacks and assert on stores they own, and the production callbacks are left with their real jobs: forwarding to the host log framework and routing to the component log registry.

Filters at the producer. `FfiPluginRegistration` gains a trailing `set_log_level` field, appended per the ABI evolution rule and gated on the plugin's reported sdk_version, with FFI_SDK_VERSION bumped to 0.12.0. At plugin load the host reports its effective log level and the plugin drops more verbose records before formatting them or crossing the FFI. The effective level comes from the tracing subscriber's max level when one is installed, which reflects RUST_LOG (the log crate's max level does not, since the LogTracer bridge pins it at Trace) — `RUST_LOG=off` reports `Off` — falling back to the log crate's level for env_logger style hosts, then to Trace when nothing is configured so tests still see everything. `LoadedPlugin::set_log_level` lets a host override or re-apply later.

On an info-level host, a source that logs per change event no longer pays formatting, FFI crossing, or host-side copies for debug and trace records, and nothing is retained anywhere.

Behavior note: plugin records below the host level no longer appear in the ComponentLogRegistry or the log-streaming endpoints, matching what native components already do.

Tested with the host-sdk integration suite (48 passing, including a new test that verifies info records stop crossing the FFI after `set_log_level(Warn)` and resume at `Trace`), two env-isolated tests pinning effective-level detection (`RUST_LOG=info` → Info, `RUST_LOG=off` → Off), and new plugin-sdk unit tests for the layer filter and level ordering.

