### PR TITLE
fix(ffi)!: replace blocking bootstrap provider FFI call with push-based receivers

### DIFF
--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -79,6 +79,7 @@ jobs:
           cargo build --lib -p drasi-reaction-sse --features drasi-reaction-sse/dynamic-plugin
           cargo build --lib -p drasi-reaction-snapshot-test
           cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin
+          cargo build --lib -p drasi-bootstrap-scriptfile --features drasi-bootstrap-scriptfile/dynamic-plugin
 
       - name: Copy plugins to test directory
         shell: bash
@@ -86,7 +87,7 @@ jobs:
           mkdir -p target/debug/plugins
           PREFIX="${{ matrix.lib_prefix }}"
           EXT="${{ matrix.lib_ext }}"
-          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test; do
+          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test drasi_bootstrap_scriptfile; do
             SRC="target/debug/${PREFIX}${name}.${EXT}"
             if [ -f "$SRC" ]; then
               cp "$SRC" target/debug/plugins/
@@ -102,7 +103,7 @@ jobs:
           PREFIX="${{ matrix.lib_prefix }}"
           EXT="${{ matrix.lib_ext }}"
           MISSING=0
-          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test; do
+          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test drasi_bootstrap_scriptfile; do
             FILE="target/debug/plugins/${PREFIX}${name}.${EXT}"
             if [ ! -f "$FILE" ]; then
               echo "ERROR: Expected plugin not found: $FILE"
@@ -114,7 +115,7 @@ jobs:
             ls -la target/debug/plugins/ || true
             exit 1
           fi
-          echo "All 5 test plugins verified."
+          echo "All 6 test plugins verified."
 
       - name: Run host-sdk FFI integration tests
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ build-test-plugins:
 	cargo build --lib -p drasi-reaction-sse --features drasi-reaction-sse/dynamic-plugin
 	cargo build --lib -p drasi-reaction-snapshot-test
 	cargo build --lib -p drasi-identity-test --features drasi-identity-test/dynamic-plugin
+	cargo build --lib -p drasi-bootstrap-scriptfile --features drasi-bootstrap-scriptfile/dynamic-plugin
 	@mkdir -p $(PLUGIN_OUT_DIR)
 	@echo "=== Copying plugins to $(PLUGIN_OUT_DIR) ==="
 	@for ext in dylib so dll; do \
@@ -59,11 +60,13 @@ build-test-plugins:
 		         target/debug/libdrasi_reaction_sse.$$ext \
 		         target/debug/libdrasi_reaction_snapshot_test.$$ext \
 		         target/debug/libdrasi_identity_test.$$ext \
+		         target/debug/libdrasi_bootstrap_scriptfile.$$ext \
 		         target/debug/drasi_source_mock.$$ext \
 		         target/debug/drasi_reaction_log.$$ext \
 		         target/debug/drasi_reaction_sse.$$ext \
 		         target/debug/drasi_reaction_snapshot_test.$$ext \
-		         target/debug/drasi_identity_test.$$ext; do \
+		         target/debug/drasi_identity_test.$$ext \
+		         target/debug/drasi_bootstrap_scriptfile.$$ext; do \
 			[ -f "$$f" ] && cp "$$f" $(PLUGIN_OUT_DIR)/ || true; \
 		done; \
 	done

--- a/components/host-sdk/src/proxies/bootstrap_provider.rs
+++ b/components/host-sdk/src/proxies/bootstrap_provider.rs
@@ -22,12 +22,12 @@ use async_trait::async_trait;
 use drasi_lib::bootstrap::{
     BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
 };
-use drasi_lib::channels::events::{BootstrapEvent, BootstrapEventSender};
+use drasi_lib::channels::events::BootstrapEventSender;
 use drasi_lib::config::SourceSubscriptionSettings;
 use drasi_plugin_sdk::descriptor::BootstrapPluginDescriptor;
-use drasi_plugin_sdk::ffi::payload::consume_bootstrap_event;
 use drasi_plugin_sdk::ffi::{
-    BootstrapPluginVtable, BootstrapProviderVtable, FfiBootstrapEvent, FfiBootstrapSender, FfiStr,
+    release_bootstrap_receiver, release_result_receiver, wrap_result_receiver,
+    BootstrapPluginVtable, BootstrapProviderVtable, BootstrapStreamConsumer, FfiStr,
 };
 use libloading::Library;
 
@@ -61,93 +61,95 @@ impl BootstrapProvider for BootstrapProviderProxy {
         event_tx: BootstrapEventSender,
         _settings: Option<&SourceSubscriptionSettings>,
     ) -> anyhow::Result<BootstrapResult> {
-        // Build FfiStr arrays for node/relation labels
-        let node_label_strs: Vec<String> = request.node_labels.clone();
-        let rel_label_strs: Vec<String> = request.relation_labels.clone();
-        let node_ffi: Vec<FfiStr> = node_label_strs
-            .iter()
-            .map(|s| FfiStr::from_str(s))
-            .collect();
-        let rel_ffi: Vec<FfiStr> = rel_label_strs.iter().map(|s| FfiStr::from_str(s)).collect();
+        // Start the provider and take ownership of the stream handles inside a
+        // block so no raw pointer is held across an await point. The guard
+        // keeps the result callback context alive until the result is read.
+        let (consumer, (result_rx, _result_guard)) = {
+            let node_ffi: Vec<FfiStr> = request
+                .node_labels
+                .iter()
+                .map(|s| FfiStr::from_str(s))
+                .collect();
+            let rel_ffi: Vec<FfiStr> = request
+                .relation_labels
+                .iter()
+                .map(|s| FfiStr::from_str(s))
+                .collect();
 
-        let query_id_ffi = FfiStr::from_str(&request.query_id);
-        let request_id_ffi = FfiStr::from_str(&request.request_id);
-        let server_id_ffi = FfiStr::from_str(&context.server_id);
-        let source_id_ffi = FfiStr::from_str(&context.source_id);
+            // Non-blocking: spawns the provider and returns push-based handles.
+            let stream_ptr = (self.vtable.bootstrap_fn)(
+                self.vtable.state,
+                FfiStr::from_str(&request.query_id),
+                node_ffi.as_ptr(),
+                node_ffi.len(),
+                rel_ffi.as_ptr(),
+                rel_ffi.len(),
+                FfiStr::from_str(&request.request_id),
+                FfiStr::from_str(&context.server_id),
+                FfiStr::from_str(&context.source_id),
+            );
 
-        // Build the FfiBootstrapSender that forwards events into the tokio channel
-        let sender = build_ffi_bootstrap_sender(event_tx);
-        let sender_ptr = Box::into_raw(Box::new(sender));
-
-        let state = self.vtable.state;
-        let bootstrap_fn = self.vtable.bootstrap_fn;
-        let node_labels_ptr = node_ffi.as_ptr();
-        let node_labels_count = node_ffi.len();
-        let rel_labels_ptr = rel_ffi.as_ptr();
-        let rel_labels_count = rel_ffi.len();
-
-        let result_ptr = (bootstrap_fn)(
-            state,
-            query_id_ffi,
-            node_labels_ptr,
-            node_labels_count,
-            rel_labels_ptr,
-            rel_labels_count,
-            request_id_ffi,
-            server_id_ffi,
-            source_id_ffi,
-            sender_ptr,
-        );
-
-        // Reclaim the FfiBootstrapSender so its drop_fn runs, which drops the
-        // std::sync::mpsc::Sender, causing the forwarding thread to exit and
-        // the tokio mpsc Sender (event_tx) to be dropped. Without this, the
-        // query's bootstrap_rx.recv() would never return None and the query
-        // would stay in Starting state forever.
-        unsafe {
-            let sender = Box::from_raw(sender_ptr);
-            (sender.drop_fn)(sender.state);
-        }
-
-        // Extract handover metadata from the FfiBootstrapResult
-        if result_ptr.is_null() {
-            return Err(anyhow::anyhow!("Bootstrap failed: null result"));
-        }
-
-        let ffi_result = unsafe { *Box::from_raw(result_ptr) };
-
-        if ffi_result.event_count < 0 {
-            return Err(anyhow::anyhow!(
-                "Bootstrap failed with code {}",
-                ffi_result.event_count
-            ));
-        }
-
-        let source_position =
-            if !ffi_result.source_position_ptr.is_null() && ffi_result.source_position_len > 0 {
-                let bytes = unsafe {
-                    std::slice::from_raw_parts(
-                        ffi_result.source_position_ptr,
-                        ffi_result.source_position_len,
-                    )
-                };
-                let owned = bytes::Bytes::copy_from_slice(bytes);
-                // Free the source position allocation
-                if let Some(drop_fn) = ffi_result.source_position_drop_fn {
-                    (drop_fn)(
-                        ffi_result.source_position_ptr as *mut u8,
-                        ffi_result.source_position_len,
-                    );
+            if stream_ptr.is_null() {
+                return Err(anyhow::anyhow!(
+                    "Bootstrap provider failed to start (null stream)"
+                ));
+            }
+            let stream = unsafe { *Box::from_raw(stream_ptr) };
+            if stream.events.is_null() || stream.result.is_null() {
+                // Release whichever receiver was populated so neither its
+                // state nor the provider thread blocked on it leaks.
+                if !stream.events.is_null() {
+                    release_bootstrap_receiver(unsafe { *Box::from_raw(stream.events) });
                 }
-                Some(owned)
-            } else {
-                None
-            };
+                if !stream.result.is_null() {
+                    release_result_receiver(unsafe { *Box::from_raw(stream.result) });
+                }
+                return Err(anyhow::anyhow!(
+                    "Bootstrap provider returned an incomplete stream"
+                ));
+            }
+            let events = unsafe { *Box::from_raw(stream.events) };
+            let result = unsafe { *Box::from_raw(stream.result) };
 
-        Ok(BootstrapResult {
-            event_count: ffi_result.event_count as usize,
-            source_position,
-        })
+            // Start the consumers on a dedicated thread to avoid initializing
+            // plugin TLS on the caller's thread (same rationale as the
+            // receiver proxies in SourceProxy::subscribe: on macOS, plugin TLS
+            // destructors can deadlock with the still-running plugin runtime
+            // during thread exit).
+            std::thread::spawn(move || {
+                (
+                    BootstrapStreamConsumer::new(events),
+                    wrap_result_receiver(result),
+                )
+            })
+            .join()
+            .map_err(|_| anyhow::anyhow!("Bootstrap consumer construction thread panicked"))?
+        };
+
+        // Drain every event into the query-side channel, then collect the
+        // provider's result. The consumer returns only after the producer's
+        // end-of-stream sentinel, so all events precede the result; dropping
+        // event_tx on return closes the query's bootstrap stream. Consumer
+        // backpressure propagates all the way to the provider: nothing on this
+        // path buffers without bound and nothing blocks an async worker.
+        let forwarded = consumer.forward_into(&event_tx).await;
+        let outcome = result_rx
+            .await
+            .map_err(|_| anyhow::anyhow!("Bootstrap result channel dropped without a result"))?;
+        let result = outcome?;
+
+        if result.event_count != forwarded {
+            log::warn!(
+                "Bootstrap event count mismatch: provider reported {} but {forwarded} events \
+                 were delivered",
+                result.event_count
+            );
+        }
+        log::debug!(
+            "FFI bootstrap stream complete: {forwarded} events forwarded, provider reported {}",
+            result.event_count
+        );
+        Ok(result)
     }
 }
 
@@ -156,70 +158,6 @@ impl Drop for BootstrapProviderProxy {
         let drop_fn = self.vtable.drop_fn;
         let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
         super::drop_worker::execute_drop_fn(drop_fn, state);
-    }
-}
-
-/// Build an `FfiBootstrapSender` that forwards bootstrap events into a tokio mpsc sender.
-///
-/// Uses a std::sync::mpsc channel + forwarding thread to avoid blocking the plugin's
-/// tokio runtime (the same pattern proven in the PoC's cross-plugin bootstrap).
-fn build_ffi_bootstrap_sender(event_tx: BootstrapEventSender) -> FfiBootstrapSender {
-    // Create a std::sync channel for the plugin to send on (sync-safe)
-    let (std_tx, std_rx) = std::sync::mpsc::channel::<BootstrapEvent>();
-
-    // Spawn a thread that forwards from std channel → tokio channel
-    std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("failed to build tokio runtime for bootstrap provider proxy");
-        for event in std_rx {
-            if rt.block_on(event_tx.send(event)).is_err() {
-                break;
-            }
-        }
-    });
-
-    let state = Box::into_raw(Box::new(std_tx)) as *mut c_void;
-
-    extern "C" fn send_fn(state: *mut c_void, event: *mut FfiBootstrapEvent) -> i32 {
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let tx = unsafe { &*(state as *const std::sync::mpsc::Sender<BootstrapEvent>) };
-            if event.is_null() {
-                return -1;
-            }
-            let ffi_event = unsafe { &*event };
-            // Decode the serialized payload into a host-owned BootstrapEvent and
-            // free the plugin's buffer via its own deallocator (issue #602: never
-            // reinterpret/drop the plugin's repr(Rust) memory). The canonical
-            // consumer also bounds the size and null-guards the drop fn.
-            let decoded = unsafe { consume_bootstrap_event(ffi_event) };
-            // Free the FFI envelope itself (#[repr(C)] POD).
-            unsafe { drop(Box::from_raw(event)) };
-            let Some(bootstrap_event) = decoded else {
-                // Undecodable payload: skip this event, keep the stream alive.
-                return 0;
-            };
-            match tx.send(bootstrap_event) {
-                Ok(()) => 0,
-                Err(_) => -1,
-            }
-        }))
-        .unwrap_or(-1)
-    }
-
-    extern "C" fn drop_fn(state: *mut c_void) {
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
-            drop(Box::from_raw(
-                state as *mut std::sync::mpsc::Sender<BootstrapEvent>,
-            ))
-        }));
-    }
-
-    FfiBootstrapSender {
-        state,
-        send_fn,
-        drop_fn,
     }
 }
 

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -322,11 +322,29 @@ impl Source for SourceProxy {
                         return;
                     }
                     let ffi_result = unsafe { *Box::from_raw(result) };
+                    // Extract (and free) the provider error text unconditionally
+                    // so the buffer never leaks, whichever branch we take below.
+                    let error_text = if !ffi_result.error_ptr.is_null() && ffi_result.error_len > 0
+                    {
+                        let bytes = unsafe {
+                            std::slice::from_raw_parts(ffi_result.error_ptr, ffi_result.error_len)
+                        };
+                        let text = String::from_utf8_lossy(bytes).into_owned();
+                        if let Some(drop_fn) = ffi_result.error_drop_fn {
+                            (drop_fn)(ffi_result.error_ptr as *mut u8, ffi_result.error_len);
+                        }
+                        Some(text)
+                    } else {
+                        None
+                    };
                     if ffi_result.event_count < 0 {
-                        let _ = tx.send(Err(anyhow::anyhow!(
-                            "Bootstrap failed with code {}",
-                            ffi_result.event_count
-                        )));
+                        let _ = tx.send(Err(match error_text {
+                            Some(msg) => anyhow::anyhow!("Bootstrap failed: {msg}"),
+                            None => anyhow::anyhow!(
+                                "Bootstrap failed with code {}",
+                                ffi_result.event_count
+                            ),
+                        }));
                         return;
                     }
                     let source_position = if !ffi_result.source_position_ptr.is_null()

--- a/components/host-sdk/tests/bootstrap_provider_ffi_test.rs
+++ b/components/host-sdk/tests/bootstrap_provider_ffi_test.rs
@@ -1,0 +1,616 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the push-based bootstrap provider FFI contract.
+//!
+//! These drive the real production path in-process, no cdylib required:
+//! a test `BootstrapProvider` is wrapped by `build_bootstrap_provider_vtable`
+//! (the producer side compiled into plugins) and consumed through
+//! `BootstrapProviderProxy` (the host side), exactly as drasi-lib invokes it.
+//!
+//! The key invariants under test:
+//! - backpressure reaches the provider: a stalled consumer bounds in-flight
+//!   events to the sum of the channel capacities, and the provider stalls
+//!   instead of streaming the snapshot into memory
+//! - no async worker is ever pinned: concurrent bootstraps larger than every
+//!   buffer complete on a 2-worker runtime
+//! - completion, error, and source_position handover semantics
+//! - cancellation: dropping the consuming future stops the provider
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use drasi_core::models::{Element, ElementMetadata, ElementReference, SourceChange};
+use drasi_host_sdk::BootstrapProviderProxy;
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
+use drasi_lib::channels::events::{BootstrapEvent, BootstrapEventSender};
+use drasi_plugin_sdk::ffi::{
+    build_bootstrap_provider_vtable, release_bootstrap_receiver, release_result_receiver,
+    wrap_result_receiver, BootstrapStreamConsumer, FfiBootstrapProviderProxy, FfiStr,
+    BOOTSTRAP_BRIDGE_CAPACITY, BOOTSTRAP_PROVIDER_CAPACITY,
+};
+
+/// Mirrors the query-side channel in drasi-lib sources/base.rs.
+const EVENT_CHANNEL_CAP: usize = 1000;
+/// Upper bound on in-flight events when the consumer is stalled: provider
+/// channel + consumer bridge + query channel + a small slack for events held
+/// by the forwarder threads themselves.
+const MAX_IN_FLIGHT: usize =
+    BOOTSTRAP_PROVIDER_CAPACITY + BOOTSTRAP_BRIDGE_CAPACITY + EVENT_CHANNEL_CAP + 10;
+
+fn make_node(i: usize) -> Element {
+    Element::Node {
+        metadata: ElementMetadata {
+            reference: ElementReference::new("probe-src", &format!("n{i}")),
+            labels: Arc::from(vec![Arc::from("Probe")]),
+            effective_from: 0,
+        },
+        properties: drasi_core::models::ElementPropertyMap::from(
+            serde_json::json!({"idx": i as i64}),
+        ),
+    }
+}
+
+/// Test provider that streams `n` events and tracks progress.
+struct StreamingProvider {
+    n: usize,
+    produced: Arc<AtomicUsize>,
+    done_producing: Arc<AtomicBool>,
+    cancelled: Arc<AtomicBool>,
+    fail_after: Option<usize>,
+    source_position: Option<Vec<u8>>,
+}
+
+#[async_trait]
+impl BootstrapProvider for StreamingProvider {
+    async fn bootstrap(
+        &self,
+        _request: BootstrapRequest,
+        context: &BootstrapContext,
+        event_tx: BootstrapEventSender,
+        _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
+    ) -> anyhow::Result<BootstrapResult> {
+        for i in 0..self.n {
+            if let Some(fail_at) = self.fail_after {
+                if i == fail_at {
+                    anyhow::bail!("provider failed deliberately at event {i}");
+                }
+            }
+            let event = BootstrapEvent {
+                source_id: context.source_id.clone(),
+                change: SourceChange::Insert {
+                    element: make_node(i),
+                },
+                timestamp: chrono::Utc::now(),
+                sequence: i as u64,
+            };
+            if event_tx.send(event).await.is_err() {
+                self.cancelled.store(true, Ordering::SeqCst);
+                anyhow::bail!("bootstrap event channel closed");
+            }
+            self.produced.fetch_add(1, Ordering::SeqCst);
+        }
+        self.done_producing.store(true, Ordering::SeqCst);
+        Ok(BootstrapResult {
+            event_count: self.n,
+            source_position: self.source_position.clone().map(bytes::Bytes::from),
+        })
+    }
+}
+
+/// The bootstrap path never invokes the vtable executor; return null so any
+/// future misuse surfaces as a clean null result instead of a bogus pointer.
+extern "C" fn noop_executor(_f: *mut std::ffi::c_void) -> *mut std::ffi::c_void {
+    std::ptr::null_mut()
+}
+
+struct ProviderHandles {
+    produced: Arc<AtomicUsize>,
+    done: Arc<AtomicBool>,
+    cancelled: Arc<AtomicBool>,
+}
+
+fn make_proxy(n: usize, fail_after: Option<usize>) -> (BootstrapProviderProxy, ProviderHandles) {
+    let handles = ProviderHandles {
+        produced: Arc::new(AtomicUsize::new(0)),
+        done: Arc::new(AtomicBool::new(false)),
+        cancelled: Arc::new(AtomicBool::new(false)),
+    };
+    let provider = StreamingProvider {
+        n,
+        produced: handles.produced.clone(),
+        done_producing: handles.done.clone(),
+        cancelled: handles.cancelled.clone(),
+        fail_after,
+        source_position: None,
+    };
+    let vtable = build_bootstrap_provider_vtable(Box::new(provider), noop_executor);
+    (BootstrapProviderProxy::new(vtable, None), handles)
+}
+
+fn req() -> BootstrapRequest {
+    BootstrapRequest {
+        query_id: "probe-query".to_string(),
+        node_labels: vec!["Probe".to_string()],
+        relation_labels: vec![],
+        request_id: "probe-request".to_string(),
+    }
+}
+
+fn ctx() -> BootstrapContext {
+    BootstrapContext::new_minimal("probe-server".to_string(), "probe-src".to_string())
+}
+
+/// A consumer that stays idle until the gate opens, then drains everything.
+async fn gated_consumer(
+    mut rx: tokio::sync::mpsc::Receiver<BootstrapEvent>,
+    consumed: Arc<AtomicUsize>,
+    mut gate: tokio::sync::watch::Receiver<bool>,
+) -> Vec<u64> {
+    let mut sequences = Vec::new();
+    while !*gate.borrow() {
+        if gate.changed().await.is_err() {
+            return sequences;
+        }
+    }
+    while let Some(event) = rx.recv().await {
+        sequences.push(event.sequence);
+        consumed.fetch_add(1, Ordering::SeqCst);
+    }
+    sequences
+}
+
+/// Backpressure: with the consumer fully stalled, the provider must stall at
+/// the sum of the channel capacities instead of producing the whole snapshot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stalled_consumer_bounds_in_flight_events() {
+    const N: usize = 20_000;
+    let (proxy, handles) = make_proxy(N, None);
+
+    let (tx, rx) = tokio::sync::mpsc::channel(EVENT_CHANNEL_CAP);
+    let consumed = Arc::new(AtomicUsize::new(0));
+    let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
+    let consumer = tokio::spawn(gated_consumer(rx, consumed.clone(), gate_rx));
+
+    let boot = tokio::spawn(async move { proxy.bootstrap(req(), &ctx(), tx, None).await });
+
+    // Wait for production to plateau (stable over 2 seconds).
+    let mut last = 0usize;
+    let mut stable_since = Instant::now();
+    let start = Instant::now();
+    loop {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let current = handles.produced.load(Ordering::SeqCst);
+        if current != last {
+            last = current;
+            stable_since = Instant::now();
+        }
+        if stable_since.elapsed() > Duration::from_secs(2)
+            || start.elapsed() > Duration::from_secs(60)
+        {
+            break;
+        }
+    }
+
+    let plateau = handles.produced.load(Ordering::SeqCst);
+    assert!(
+        !handles.done.load(Ordering::SeqCst),
+        "provider must be stalled by backpressure, not done (produced {plateau})"
+    );
+    assert!(
+        plateau <= MAX_IN_FLIGHT,
+        "in-flight events must be bounded by channel capacities: {plateau} > {MAX_IN_FLIGHT}"
+    );
+    assert_eq!(consumed.load(Ordering::SeqCst), 0);
+    assert!(!boot.is_finished());
+
+    // Release the consumer: everything drains, nothing is lost.
+    gate_tx.send(true).unwrap();
+    let result = boot.await.unwrap().expect("bootstrap failed");
+    assert_eq!(result.event_count, N);
+    let sequences = consumer.await.unwrap();
+    assert_eq!(sequences.len(), N, "no events lost");
+    assert!(
+        sequences.windows(2).all(|w| w[0] < w[1]),
+        "events arrive in order"
+    );
+    assert!(handles.done.load(Ordering::SeqCst));
+}
+
+/// Liveness: concurrent bootstraps larger than every buffer complete on a
+/// 2-worker runtime because no FFI call ever blocks an async worker.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_bootstraps_complete_on_two_workers() {
+    const N: usize = 5_000;
+    const CONCURRENCY: usize = 4;
+
+    let mut boots = Vec::new();
+    let mut consumers = Vec::new();
+    let mut gates = Vec::new();
+    for _ in 0..CONCURRENCY {
+        let (proxy, _handles) = make_proxy(N, None);
+        let (tx, rx) = tokio::sync::mpsc::channel(EVENT_CHANNEL_CAP);
+        let consumed = Arc::new(AtomicUsize::new(0));
+        let (gate_tx, gate_rx) = tokio::sync::watch::channel(true);
+        gates.push(gate_tx);
+        consumers.push((
+            tokio::spawn(gated_consumer(rx, consumed.clone(), gate_rx)),
+            consumed,
+        ));
+        boots.push(tokio::spawn(async move {
+            proxy.bootstrap(req(), &ctx(), tx, None).await
+        }));
+    }
+
+    let all = async {
+        for boot in boots {
+            let result = boot.await.unwrap().expect("bootstrap failed");
+            assert_eq!(result.event_count, N);
+        }
+        for (consumer, consumed) in consumers {
+            consumer.await.unwrap();
+            assert_eq!(consumed.load(Ordering::SeqCst), N);
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(120), all)
+        .await
+        .expect("concurrent bootstraps deadlocked or stalled");
+}
+
+/// Provider failure surfaces as an error on the host side after the events
+/// sent so far were delivered.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn provider_error_propagates() {
+    const N: usize = 500;
+    let (proxy, _handles) = make_proxy(N, Some(100));
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(EVENT_CHANNEL_CAP);
+    let drain = tokio::spawn(async move {
+        let mut count = 0usize;
+        while rx.recv().await.is_some() {
+            count += 1;
+        }
+        count
+    });
+
+    let err = proxy
+        .bootstrap(req(), &ctx(), tx, None)
+        .await
+        .expect_err("provider failure must propagate");
+    assert!(
+        err.to_string().contains("Bootstrap failed"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        err.to_string()
+            .contains("provider failed deliberately at event 100"),
+        "provider error text must cross the FFI boundary: {err}"
+    );
+    assert_eq!(
+        drain.await.unwrap(),
+        100,
+        "events before the failure arrive"
+    );
+}
+
+/// The source_position handover metadata survives the crossing intact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn source_position_round_trips() {
+    const N: usize = 10;
+    let position = b"lsn:0/16B3748".to_vec();
+    let provider = StreamingProvider {
+        n: N,
+        produced: Arc::new(AtomicUsize::new(0)),
+        done_producing: Arc::new(AtomicBool::new(false)),
+        cancelled: Arc::new(AtomicBool::new(false)),
+        fail_after: None,
+        source_position: Some(position.clone()),
+    };
+    let vtable = build_bootstrap_provider_vtable(Box::new(provider), noop_executor);
+    let proxy = BootstrapProviderProxy::new(vtable, None);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(EVENT_CHANNEL_CAP);
+    let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let result = proxy
+        .bootstrap(req(), &ctx(), tx, None)
+        .await
+        .expect("bootstrap failed");
+    drain.await.unwrap();
+
+    assert_eq!(result.event_count, N);
+    assert_eq!(result.source_position.as_deref(), Some(position.as_slice()));
+}
+
+/// Cancellation: dropping the consuming future mid-stream propagates a channel
+/// close to the provider, which stops producing instead of running to
+/// completion against a dead stream.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropping_bootstrap_future_cancels_provider() {
+    const N: usize = 50_000;
+    let (proxy, handles) = make_proxy(N, None);
+
+    let (tx, rx) = tokio::sync::mpsc::channel(EVENT_CHANNEL_CAP);
+    let consumed = Arc::new(AtomicUsize::new(0));
+    let (gate_tx, gate_rx) = tokio::sync::watch::channel(true);
+    let consumer = tokio::spawn(gated_consumer(rx, consumed.clone(), gate_rx));
+    drop(gate_tx);
+
+    let boot = tokio::spawn(async move { proxy.bootstrap(req(), &ctx(), tx, None).await });
+
+    // Let the stream get going, then abort the bootstrap task mid-flight.
+    let start = Instant::now();
+    while consumed.load(Ordering::SeqCst) < 1000 && start.elapsed() < Duration::from_secs(30) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        consumed.load(Ordering::SeqCst) >= 1000,
+        "stream never started"
+    );
+    boot.abort();
+    let _ = boot.await;
+
+    // The provider must observe the cancellation and bail out.
+    let start = Instant::now();
+    while !handles.cancelled.load(Ordering::SeqCst)
+        && !handles.done.load(Ordering::SeqCst)
+        && start.elapsed() < Duration::from_secs(30)
+    {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        handles.cancelled.load(Ordering::SeqCst),
+        "provider should observe a closed channel after cancellation (produced {}, done {})",
+        handles.produced.load(Ordering::SeqCst),
+        handles.done.load(Ordering::SeqCst)
+    );
+
+    // The consumer's channel closes too; no hang.
+    tokio::time::timeout(Duration::from_secs(30), consumer)
+        .await
+        .expect("consumer hung after cancellation")
+        .unwrap();
+}
+
+/// Layered topology: host wraps a plugin provider proxy back into a vtable for
+/// a source plugin, which consumes it through FfiBootstrapProviderProxy. Both
+/// producer and both consumers run in a chain, and backpressure still bounds
+/// the whole path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn double_hop_chain_stays_bounded_and_lossless() {
+    const N: usize = 8_000;
+    let (inner_proxy, handles) = make_proxy(N, None);
+
+    // Host-side wrap of the (already proxied) provider, as source.rs does when
+    // passing a bootstrap provider into a source plugin.
+    let outer_vtable = build_bootstrap_provider_vtable(Box::new(inner_proxy), noop_executor);
+    let outer_proxy = FfiBootstrapProviderProxy::new(outer_vtable);
+
+    let (tx, rx) = tokio::sync::mpsc::channel(EVENT_CHANNEL_CAP);
+    let consumed = Arc::new(AtomicUsize::new(0));
+    let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
+    let consumer = tokio::spawn(gated_consumer(rx, consumed.clone(), gate_rx));
+
+    let boot = tokio::spawn(async move { outer_proxy.bootstrap(req(), &ctx(), tx, None).await });
+
+    // With the consumer stalled, the provider must plateau even through two
+    // hops (each hop adds one provider channel and one bridge).
+    let mut last = 0usize;
+    let mut stable_since = Instant::now();
+    let start = Instant::now();
+    loop {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let current = handles.produced.load(Ordering::SeqCst);
+        if current != last {
+            last = current;
+            stable_since = Instant::now();
+        }
+        if stable_since.elapsed() > Duration::from_secs(2)
+            || start.elapsed() > Duration::from_secs(60)
+        {
+            break;
+        }
+    }
+    let plateau = handles.produced.load(Ordering::SeqCst);
+    // Each hop adds one provider channel and one bridge; the query channel
+    // appears once at the end of the chain.
+    let two_hop_bound =
+        2 * (BOOTSTRAP_PROVIDER_CAPACITY + BOOTSTRAP_BRIDGE_CAPACITY) + EVENT_CHANNEL_CAP + 20;
+    assert!(
+        !handles.done.load(Ordering::SeqCst),
+        "provider must stall through the double hop (produced {plateau})"
+    );
+    assert!(
+        plateau <= two_hop_bound,
+        "double-hop in-flight events must stay bounded: {plateau} > {two_hop_bound}"
+    );
+
+    gate_tx.send(true).unwrap();
+    let result = boot.await.unwrap().expect("double-hop bootstrap failed");
+    assert_eq!(result.event_count, N);
+    consumer.await.unwrap();
+    assert_eq!(consumed.load(Ordering::SeqCst), N, "no events lost");
+}
+
+/// Error-path cleanup: releasing the receivers of an unconsumed stream must
+/// unblock and cancel the provider instead of leaking it, and the provider
+/// must not have produced past its bounded channel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn releasing_receivers_cancels_provider() {
+    const N: usize = 10_000;
+    // Drive the raw vtable surface directly, the way a consumer that fails
+    // mid-setup would.
+    let handles = ProviderHandles {
+        produced: Arc::new(AtomicUsize::new(0)),
+        done: Arc::new(AtomicBool::new(false)),
+        cancelled: Arc::new(AtomicBool::new(false)),
+    };
+    let provider = StreamingProvider {
+        n: N,
+        produced: handles.produced.clone(),
+        done_producing: handles.done.clone(),
+        cancelled: handles.cancelled.clone(),
+        fail_after: None,
+        source_position: None,
+    };
+    let vtable = build_bootstrap_provider_vtable(Box::new(provider), noop_executor);
+
+    let stream_ptr = (vtable.bootstrap_fn)(
+        vtable.state,
+        FfiStr::from_str("probe-query"),
+        std::ptr::null(),
+        0,
+        std::ptr::null(),
+        0,
+        FfiStr::from_str("probe-request"),
+        FfiStr::from_str("probe-server"),
+        FfiStr::from_str("probe-src"),
+    );
+    assert!(!stream_ptr.is_null());
+    let stream = unsafe { *Box::from_raw(stream_ptr) };
+    let events = unsafe { *Box::from_raw(stream.events) };
+    let result = unsafe { *Box::from_raw(stream.result) };
+
+    // Simulate a consumer that fails before consuming: release both handles.
+    release_bootstrap_receiver(events);
+    release_result_receiver(result);
+
+    // The provider must observe the closed event channel and bail out.
+    let start = Instant::now();
+    while !handles.cancelled.load(Ordering::SeqCst) && start.elapsed() < Duration::from_secs(30) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        handles.cancelled.load(Ordering::SeqCst),
+        "provider must be cancelled after receivers are released (produced {})",
+        handles.produced.load(Ordering::SeqCst)
+    );
+    // It can only have filled its bounded channel before stalling.
+    assert!(
+        handles.produced.load(Ordering::SeqCst) <= BOOTSTRAP_PROVIDER_CAPACITY + 1,
+        "provider must not produce past its bounded channel: {}",
+        handles.produced.load(Ordering::SeqCst)
+    );
+
+    (vtable.drop_fn)(vtable.state);
+}
+
+/// Null label arrays with a non-zero count must be treated as empty instead of
+/// dereferenced, and the stream must still work end to end.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn null_label_arrays_are_treated_as_empty() {
+    const N: usize = 50;
+    let handles = ProviderHandles {
+        produced: Arc::new(AtomicUsize::new(0)),
+        done: Arc::new(AtomicBool::new(false)),
+        cancelled: Arc::new(AtomicBool::new(false)),
+    };
+    let provider = StreamingProvider {
+        n: N,
+        produced: handles.produced.clone(),
+        done_producing: handles.done.clone(),
+        cancelled: handles.cancelled.clone(),
+        fail_after: None,
+        source_position: None,
+    };
+    let vtable = build_bootstrap_provider_vtable(Box::new(provider), noop_executor);
+
+    // Null arrays with NON-ZERO counts: must not be walked.
+    let stream_ptr = (vtable.bootstrap_fn)(
+        vtable.state,
+        FfiStr::from_str("probe-query"),
+        std::ptr::null(),
+        3,
+        std::ptr::null(),
+        2,
+        FfiStr::from_str("probe-request"),
+        FfiStr::from_str("probe-server"),
+        FfiStr::from_str("probe-src"),
+    );
+    assert!(!stream_ptr.is_null());
+    let stream = unsafe { *Box::from_raw(stream_ptr) };
+    let events = unsafe { *Box::from_raw(stream.events) };
+    let result = unsafe { *Box::from_raw(stream.result) };
+
+    let consumer = BootstrapStreamConsumer::new(events);
+    let (result_rx, _guard) = wrap_result_receiver(result);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<BootstrapEvent>(EVENT_CHANNEL_CAP);
+    let drain = tokio::spawn(async move {
+        let mut n = 0usize;
+        while rx.recv().await.is_some() {
+            n += 1;
+        }
+        n
+    });
+    let forwarded = consumer.forward_into(&tx).await;
+    drop(tx);
+    let outcome = result_rx
+        .await
+        .expect("result must arrive")
+        .expect("bootstrap failed");
+
+    assert_eq!(forwarded, N);
+    assert_eq!(outcome.event_count, N);
+    assert_eq!(drain.await.unwrap(), N);
+
+    (vtable.drop_fn)(vtable.state);
+}
+
+/// A provider that panics before producing a result must surface as the
+/// null-result error ("ended without a result"), not a hang or a success.
+struct PanickingProvider;
+
+#[async_trait]
+impl BootstrapProvider for PanickingProvider {
+    async fn bootstrap(
+        &self,
+        _request: BootstrapRequest,
+        _context: &BootstrapContext,
+        _event_tx: BootstrapEventSender,
+        _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
+    ) -> anyhow::Result<BootstrapResult> {
+        panic!("provider panicked before producing a result");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn panicking_provider_yields_ended_without_result_error() {
+    let vtable = build_bootstrap_provider_vtable(Box::new(PanickingProvider), noop_executor);
+    let proxy = BootstrapProviderProxy::new(vtable, None);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<BootstrapEvent>(EVENT_CHANNEL_CAP);
+    let drain = tokio::spawn(async move {
+        let mut n = 0usize;
+        while rx.recv().await.is_some() {
+            n += 1;
+        }
+        n
+    });
+
+    // NOTE: the provider thread's panic message on stderr is expected here.
+    let err = proxy
+        .bootstrap(req(), &ctx(), tx, None)
+        .await
+        .expect_err("panicking provider must surface an error");
+    assert!(
+        err.to_string().contains("ended without a result"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(drain.await.unwrap(), 0, "no events before the panic");
+}

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -18,19 +18,30 @@
 //! the full dynamic loading pipeline: metadata validation, callback wiring,
 //! descriptor factory invocation, and trait method dispatch through FFI vtables.
 //!
-//! **Prerequisites**: Build the cdylib plugins before running these tests:
+//! **Prerequisites**: These tests load plugins from `target/debug/plugins/`,
+//! not `target/debug/`. Build AND copy them in one step with:
 //!
 //! ```sh
 //! cd /path/to/drasi-core
+//! make build-test-plugins
+//! ```
+//!
+//! Or build individually and copy the resulting `.so`/`.dylib`/`.dll` files
+//! into `target/debug/plugins/` yourself:
+//!
+//! ```sh
 //! cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin
 //! cargo build --lib -p drasi-reaction-log --features drasi-reaction-log/dynamic-plugin
+//! cargo build --lib -p drasi-bootstrap-scriptfile --features drasi-bootstrap-scriptfile/dynamic-plugin
 //! ```
 
 use std::path::{Path, PathBuf};
 
 use drasi_host_sdk::callbacks;
 use drasi_host_sdk::loader::{load_plugin_from_path, PluginLoader, PluginLoaderConfig};
-use drasi_plugin_sdk::descriptor::{ReactionPluginDescriptor, SourcePluginDescriptor};
+use drasi_plugin_sdk::descriptor::{
+    BootstrapPluginDescriptor, ReactionPluginDescriptor, SourcePluginDescriptor,
+};
 use serial_test::serial;
 
 /// Locate the drasi-core build output directory.
@@ -3536,4 +3547,164 @@ async fn test_ffi_checkpoint_persist_and_resume_from() {
 
     source2.stop().await.expect("Should stop source2");
     println!("Phase 2 complete: verified position_handle and supports_replay through FFI");
+}
+
+// ============================================================================
+// Bootstrap provider plugin: push-based FFI contract across a real cdylib
+// ============================================================================
+//
+// The bootstrap_provider_ffi_test suite drives the push contract in-process;
+// these tests load the scriptfile bootstrap plugin as a real cdylib so the
+// contract is exercised across an actual dylib boundary (separate allocator,
+// separate tokio), the failure class behind issue #602.
+
+/// Write a JSONL bootstrap script with `node_count` nodes.
+fn write_bootstrap_script(node_count: usize) -> (tempfile::TempDir, PathBuf) {
+    use std::io::Write;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("bootstrap.jsonl");
+    let mut f = std::fs::File::create(&path).expect("create script file");
+    writeln!(
+        f,
+        r#"{{"kind": "Header", "start_time": "2024-01-01T00:00:00Z", "description": "cdylib bootstrap test"}}"#
+    )
+    .expect("write header");
+    for i in 0..node_count {
+        writeln!(
+            f,
+            r#"{{"kind": "Node", "id": "n{i}", "labels": ["Item"], "properties": {{"idx": {i}}}}}"#
+        )
+        .expect("write node");
+    }
+    writeln!(f, r#"{{"kind": "Finish", "description": "done"}}"#).expect("write finish");
+    (dir, path)
+}
+
+/// Load the scriptfile bootstrap plugin and create a provider for `script`.
+async fn load_scriptfile_provider(
+    script: &Path,
+) -> (
+    drasi_host_sdk::loader::LoadedPlugin,
+    Box<dyn drasi_lib::bootstrap::BootstrapProvider>,
+) {
+    let path = require_plugin("drasi-bootstrap-scriptfile");
+    let plugin = load_plugin_from_path(
+        &path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("Failed to load scriptfile bootstrap plugin");
+
+    assert!(
+        !plugin.bootstrap_plugins.is_empty(),
+        "scriptfile plugin should register a bootstrap descriptor"
+    );
+    let descriptor = &plugin.bootstrap_plugins[0];
+    assert_eq!(descriptor.kind(), "scriptfile");
+
+    let config = serde_json::json!({ "filePaths": [script.to_string_lossy()] });
+    let provider = descriptor
+        .create_bootstrap_provider(&config, &serde_json::json!({}))
+        .await
+        .expect("create_bootstrap_provider across cdylib failed");
+    (plugin, provider)
+}
+
+fn bootstrap_request() -> drasi_lib::bootstrap::BootstrapRequest {
+    drasi_lib::bootstrap::BootstrapRequest {
+        query_id: "cdylib-bootstrap-query".to_string(),
+        node_labels: vec![],
+        relation_labels: vec![],
+        request_id: "cdylib-bootstrap-request".to_string(),
+    }
+}
+
+/// Full bootstrap round-trip across the cdylib boundary: every node in the
+/// script arrives as an event and the provider result reports the count.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn test_bootstrap_plugin_streams_across_cdylib() {
+    if !plugin_exists("drasi-bootstrap-scriptfile") {
+        eprintln!("SKIP: drasi-bootstrap-scriptfile not built as cdylib");
+        panic!("SKIP: drasi-bootstrap-scriptfile not built as cdylib");
+    }
+    const N: usize = 2_000;
+    let (_dir, script) = write_bootstrap_script(N);
+    let (_plugin, provider) = load_scriptfile_provider(&script).await;
+
+    let ctx = drasi_lib::bootstrap::BootstrapContext::new_minimal(
+        "itest-server".to_string(),
+        "scriptfile-src".to_string(),
+    );
+    let (tx, mut rx) = tokio::sync::mpsc::channel(100);
+    let drain = tokio::spawn(async move {
+        let mut n = 0usize;
+        while rx.recv().await.is_some() {
+            n += 1;
+        }
+        n
+    });
+
+    let result = provider
+        .bootstrap(bootstrap_request(), &ctx, tx, None)
+        .await
+        .expect("bootstrap across cdylib failed");
+
+    assert_eq!(result.event_count, N, "provider must report all events");
+    assert_eq!(
+        drain.await.unwrap(),
+        N,
+        "all events must cross the boundary"
+    );
+}
+
+/// Backpressure across the cdylib boundary: with a stalled consumer the
+/// bootstrap must stay open (bounded in-flight) instead of running to
+/// completion into unbounded buffers; releasing the consumer drains all
+/// events losslessly.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn test_bootstrap_plugin_backpressure_across_cdylib() {
+    if !plugin_exists("drasi-bootstrap-scriptfile") {
+        eprintln!("SKIP: drasi-bootstrap-scriptfile not built as cdylib");
+        panic!("SKIP: drasi-bootstrap-scriptfile not built as cdylib");
+    }
+    // Must exceed provider channel (100) + consumer bridge (256) + the
+    // query-side channel below (100), so a completed bootstrap would prove
+    // unbounded buffering somewhere in the chain.
+    const N: usize = 5_000;
+    let (_dir, script) = write_bootstrap_script(N);
+    let (_plugin, provider) = load_scriptfile_provider(&script).await;
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(100);
+    let boot = tokio::spawn(async move {
+        let ctx = drasi_lib::bootstrap::BootstrapContext::new_minimal(
+            "itest-server".to_string(),
+            "scriptfile-src".to_string(),
+        );
+        provider
+            .bootstrap(bootstrap_request(), &ctx, tx, None)
+            .await
+    });
+
+    // Consumer stalled: the bootstrap must still be in flight after a pause.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    assert!(
+        !boot.is_finished(),
+        "bootstrap must stall under backpressure across the cdylib boundary"
+    );
+
+    // Release: drain everything and confirm nothing was lost.
+    let mut drained = 0usize;
+    while rx.recv().await.is_some() {
+        drained += 1;
+    }
+    let result = boot
+        .await
+        .unwrap()
+        .expect("bootstrap across cdylib failed after release");
+    assert_eq!(result.event_count, N);
+    assert_eq!(drained, N, "all events must arrive after the stall");
 }

--- a/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
+++ b/components/plugin-sdk/src/ffi/bootstrap_proxy.rs
@@ -17,14 +17,21 @@
 //! Wraps a `BootstrapProviderVtable` (from another cdylib plugin or the host)
 //! into a local `BootstrapProvider` trait implementation. This is how a source
 //! plugin calls a bootstrap provider that lives in a different cdylib.
+//!
+//! The vtable's `bootstrap_fn` returns push-based receivers immediately; this
+//! proxy consumes them via [`BootstrapStreamConsumer`] and
+//! [`wrap_result_receiver`], forwarding events into the caller's bounded
+//! channel. Backpressure propagates through every link (see the
+//! `bootstrap_stream` module docs); nothing blocks an async worker.
 
-use std::ffi::c_void;
 use std::sync::Mutex;
 
-use super::types::{now_us, FfiStr};
-use super::vtables::{
-    BootstrapProviderVtable, FfiBootstrapEvent, FfiBootstrapResult, FfiBootstrapSender,
+use super::bootstrap_stream::{
+    release_bootstrap_receiver, release_result_receiver, wrap_result_receiver,
+    BootstrapStreamConsumer,
 };
+use super::types::FfiStr;
+use super::vtables::BootstrapProviderVtable;
 use drasi_lib::bootstrap::{BootstrapProvider, BootstrapResult};
 
 /// Plugin-side proxy: wraps a `BootstrapProviderVtable` into a local `BootstrapProvider`.
@@ -35,6 +42,15 @@ pub struct FfiBootstrapProviderProxy {
 unsafe impl Send for FfiBootstrapProviderProxy {}
 unsafe impl Sync for FfiBootstrapProviderProxy {}
 
+impl FfiBootstrapProviderProxy {
+    /// Wrap a provider vtable received across the FFI boundary.
+    pub fn new(vtable: BootstrapProviderVtable) -> Self {
+        Self {
+            vtable: Mutex::new(vtable),
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl BootstrapProvider for FfiBootstrapProviderProxy {
     async fn bootstrap(
@@ -42,147 +58,93 @@ impl BootstrapProvider for FfiBootstrapProviderProxy {
         request: drasi_lib::bootstrap::BootstrapRequest,
         context: &drasi_lib::bootstrap::BootstrapContext,
         event_tx: drasi_lib::channels::events::BootstrapEventSender,
-        settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
+        _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
     ) -> anyhow::Result<BootstrapResult> {
-        // Extract vtable fields under the lock, then release immediately
-        let (vtable_state, vtable_bootstrap_fn) = {
-            let vtable = self.vtable.lock().expect("vtable mutex poisoned");
-            (vtable.state, vtable.bootstrap_fn)
-        };
-
-        let query_id = request.query_id.clone();
-        let node_labels: Vec<String> = request.node_labels.clone();
-        let relation_labels: Vec<String> = request.relation_labels.clone();
-        let request_id = request.request_id.clone();
-        let server_id = context.server_id.clone();
-        let source_id = context.source_id.clone();
-
-        // FFI sender callback — wraps tokio sender, called from the bootstrap thread
-        struct SenderState {
-            tx: std::sync::mpsc::Sender<drasi_lib::channels::events::BootstrapEvent>,
-        }
-
-        extern "C" fn send_fn(state: *mut c_void, event: *mut FfiBootstrapEvent) -> i32 {
-            let sender_state = unsafe { &*(state as *const SenderState) };
-            if event.is_null() {
-                return -1;
-            }
-            let ffi_event = unsafe { &*event };
-            // Decode the serialized payload into a plugin-owned BootstrapEvent and
-            // free the producer's buffer via its own deallocator (issue #602: never
-            // reinterpret/drop the other side's repr(Rust) memory). The canonical
-            // consumer also bounds the size and null-guards the drop fn.
-            let decoded = unsafe { crate::ffi::payload::consume_bootstrap_event(ffi_event) };
-            unsafe { drop(Box::from_raw(event)) };
-            let Some(bootstrap_event) = decoded else {
-                return 0;
+        // Start the provider and take ownership of the stream handles inside a
+        // block so no raw pointer is held across an await point.
+        //
+        // Unlike host-sdk's BootstrapProviderProxy, the consumers are built
+        // inline rather than on a dedicated thread: the vtable functions here
+        // are host-compiled, only spawn threads and return, and this caller is
+        // a long-lived plugin runtime worker — so the macOS TLS-destructor-at-
+        // thread-exit hazard that motivates the dedicated thread over there
+        // does not apply in this direction.
+        // The guard keeps the result callback context alive until the result
+        // is read.
+        let (consumer, (result_rx, _result_guard)) = {
+            let (vtable_state, vtable_bootstrap_fn) = {
+                let vtable = self.vtable.lock().expect("vtable mutex poisoned");
+                (vtable.state, vtable.bootstrap_fn)
             };
-            match sender_state.tx.send(bootstrap_event) {
-                Ok(()) => 0,
-                Err(_) => -1,
-            }
-        }
 
-        extern "C" fn drop_sender(state: *mut c_void) {
-            unsafe { drop(Box::from_raw(state as *mut SenderState)) };
-        }
-
-        // Use std::sync::mpsc so the vtable thread can send without async
-        let (std_tx, std_rx) =
-            std::sync::mpsc::channel::<drasi_lib::channels::events::BootstrapEvent>();
-
-        let sender_state = Box::new(SenderState { tx: std_tx });
-        let ffi_sender = Box::new(FfiBootstrapSender {
-            state: Box::into_raw(sender_state) as *mut c_void,
-            send_fn,
-            drop_fn: drop_sender,
-        });
-
-        // Spawn the vtable call on a background thread (breaks out of source's tokio).
-        let vtable_state_usize = vtable_state as usize;
-        let bootstrap_fn = vtable_bootstrap_fn;
-
-        // Channel to carry the FfiBootstrapResult pointer back (as usize for Send)
-        let (result_ptr_tx, result_ptr_rx) = std::sync::mpsc::channel::<usize>();
-
-        std::thread::spawn(move || {
-            let ffi_query_id = FfiStr::from_str(&query_id);
-            let ffi_node_labels: Vec<FfiStr> =
-                node_labels.iter().map(|s| FfiStr::from_str(s)).collect();
-            let ffi_rel_labels: Vec<FfiStr> = relation_labels
+            let node_ffi: Vec<FfiStr> = request
+                .node_labels
                 .iter()
                 .map(|s| FfiStr::from_str(s))
                 .collect();
-            let ffi_request_id = FfiStr::from_str(&request_id);
-            let ffi_server_id = FfiStr::from_str(&server_id);
-            let ffi_source_id = FfiStr::from_str(&source_id);
+            let rel_ffi: Vec<FfiStr> = request
+                .relation_labels
+                .iter()
+                .map(|s| FfiStr::from_str(s))
+                .collect();
 
-            let ffi_sender_ptr = Box::into_raw(ffi_sender);
-            let result_ptr = (bootstrap_fn)(
-                vtable_state_usize as *mut c_void,
-                ffi_query_id,
-                ffi_node_labels.as_ptr(),
-                ffi_node_labels.len(),
-                ffi_rel_labels.as_ptr(),
-                ffi_rel_labels.len(),
-                ffi_request_id,
-                ffi_server_id,
-                ffi_source_id,
-                ffi_sender_ptr,
+            // Non-blocking: spawns the provider and returns handles.
+            let stream_ptr = (vtable_bootstrap_fn)(
+                vtable_state,
+                FfiStr::from_str(&request.query_id),
+                node_ffi.as_ptr(),
+                node_ffi.len(),
+                rel_ffi.as_ptr(),
+                rel_ffi.len(),
+                FfiStr::from_str(&request.request_id),
+                FfiStr::from_str(&context.server_id),
+                FfiStr::from_str(&context.source_id),
             );
-            // Properly drop the FfiBootstrapSender: call drop_fn to free inner state
-            let ffi_sender = unsafe { Box::from_raw(ffi_sender_ptr) };
-            (ffi_sender.drop_fn)(ffi_sender.state);
-            let _ = result_ptr_tx.send(result_ptr as usize);
-        });
 
-        // Forward from std::sync::mpsc → tokio::sync::mpsc on a blocking thread.
-        let count = tokio::task::spawn_blocking(move || {
-            let mut count: usize = 0;
-            while let Ok(record) = std_rx.recv() {
-                if event_tx.blocking_send(record).is_err() {
-                    break;
+            if stream_ptr.is_null() {
+                anyhow::bail!("Bootstrap provider failed to start (null stream)");
+            }
+            let stream = unsafe { *Box::from_raw(stream_ptr) };
+            if stream.events.is_null() || stream.result.is_null() {
+                // Release whichever receiver was populated so neither its
+                // state nor the provider thread blocked on it leaks.
+                if !stream.events.is_null() {
+                    release_bootstrap_receiver(unsafe { *Box::from_raw(stream.events) });
                 }
-                count += 1;
-            }
-            count
-        })
-        .await
-        .expect("forwarding task panicked");
-
-        // Read the FfiBootstrapResult from the vtable thread
-        let ffi_result = result_ptr_rx.recv().ok().and_then(|ptr_usize| {
-            let ptr = ptr_usize as *mut FfiBootstrapResult;
-            if ptr.is_null() {
-                None
-            } else {
-                Some(unsafe { *Box::from_raw(ptr) })
-            }
-        });
-
-        let source_position = if let Some(ref r) = ffi_result {
-            if !r.source_position_ptr.is_null() && r.source_position_len > 0 {
-                let bytes = unsafe {
-                    std::slice::from_raw_parts(r.source_position_ptr, r.source_position_len)
-                };
-                let owned = bytes::Bytes::copy_from_slice(bytes);
-                // Free the source position allocation
-                if let Some(drop_fn) = r.source_position_drop_fn {
-                    (drop_fn)(r.source_position_ptr as *mut u8, r.source_position_len);
+                if !stream.result.is_null() {
+                    release_result_receiver(unsafe { *Box::from_raw(stream.result) });
                 }
-                Some(owned)
-            } else {
-                None
+                anyhow::bail!("Bootstrap provider returned an incomplete stream");
             }
-        } else {
-            return Err(anyhow::anyhow!(
-                "Bootstrap provider returned null result (plugin-side bootstrap failed)"
-            ));
+            let events = unsafe { *Box::from_raw(stream.events) };
+            let result = unsafe { *Box::from_raw(stream.result) };
+
+            (
+                BootstrapStreamConsumer::new(events),
+                wrap_result_receiver(result),
+            )
         };
 
-        Ok(BootstrapResult {
-            event_count: count,
-            source_position,
-        })
+        // Drain every event into the caller's channel, then collect the
+        // provider's result. The consumer returns only after the producer's
+        // end-of-stream sentinel, so all events precede the result.
+        let forwarded = consumer.forward_into(&event_tx).await;
+        let outcome = result_rx
+            .await
+            .map_err(|_| anyhow::anyhow!("Bootstrap result channel dropped without a result"))?;
+        let result = outcome?;
+
+        if result.event_count != forwarded {
+            log::warn!(
+                "Bootstrap event count mismatch: provider reported {} but {forwarded} events \
+                 were delivered",
+                result.event_count
+            );
+        }
+        log::debug!(
+            "FFI bootstrap stream complete: {forwarded} events forwarded, provider reported {}",
+            result.event_count
+        );
+        Ok(result)
     }
 }

--- a/components/plugin-sdk/src/ffi/bootstrap_stream.rs
+++ b/components/plugin-sdk/src/ffi/bootstrap_stream.rs
@@ -1,0 +1,392 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Consumer side of the push-based bootstrap provider stream.
+//!
+//! A `BootstrapProviderVtable::bootstrap_fn` call returns an
+//! [`FfiBootstrapStream`](super::vtables::FfiBootstrapStream): a push-based
+//! event receiver plus a push-based result receiver. This module consumes
+//! both, and is shared by the host proxy (`drasi-host-sdk`) and the
+//! plugin-side proxy that lets a source plugin consume a provider living in
+//! another cdylib.
+//!
+//! Backpressure: events are pushed by the producer's forwarder thread into a
+//! **bounded** std `sync_channel`. When the async consumer falls behind, the
+//! bridge fills, the push callback's blocking `send` stalls the forwarder,
+//! the producer's bounded event channel fills, and the provider's own
+//! `event_tx.send(..).await` pends. No link in the chain is unbounded.
+//!
+//! The cross-boundary channel uses `std::sync::mpsc` (not `tokio::sync::mpsc`)
+//! because the callback runs on the producer's thread, and across cdylibs each
+//! side has its own copy of tokio with incompatible internal state.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use drasi_lib::bootstrap::BootstrapResult;
+use drasi_lib::channels::events::{BootstrapEvent, BootstrapEventSender};
+
+use super::payload::consume_bootstrap_event;
+use super::vtables::{
+    FfiBootstrapEvent, FfiBootstrapReceiver, FfiBootstrapResult, FfiBootstrapResultReceiver,
+};
+
+/// Capacity of the bounded bridge between the producer's push callback and the
+/// async consumer. Mirrors the `sync_channel(256)` used by the CDC
+/// `ChangeReceiverProxy` and the source-plugin `BootstrapReceiverProxy`.
+///
+/// Together with [`BOOTSTRAP_PROVIDER_CAPACITY`] and the query-side channel,
+/// this forms the aggregate in-flight cap per bootstrap stream:
+/// `BOOTSTRAP_PROVIDER_CAPACITY + BOOTSTRAP_BRIDGE_CAPACITY + query channel
+/// capacity` (plus a few events held by the forwarder threads themselves).
+pub const BOOTSTRAP_BRIDGE_CAPACITY: usize = 256;
+
+/// Capacity of the provider-side event channel created by
+/// `build_bootstrap_provider_vtable`. Small by design: it only needs to keep
+/// the forwarder busy, while the bound is what stalls the provider instead of
+/// buffering the snapshot when the consumer falls behind (issue #686). See
+/// [`BOOTSTRAP_BRIDGE_CAPACITY`] for how the aggregate in-flight cap
+/// composes.
+pub const BOOTSTRAP_PROVIDER_CAPACITY: usize = 100;
+
+/// Context handed to the push callback. Holds the bounded bridge sender and a
+/// tokio `Notify` to wake the async consumer.
+struct PushCallbackContext {
+    tx: std::sync::Mutex<Option<std::sync::mpsc::SyncSender<BootstrapEvent>>>,
+    notify: Arc<tokio::sync::Notify>,
+    /// Set once the sentinel has reclaimed the producer's leaked Arc
+    /// reference, so a duplicate sentinel from a buggy producer is a no-op
+    /// instead of a double free. The consumer holds its own Arc reference,
+    /// which keeps this flag readable after the reclaim.
+    reclaimed: AtomicBool,
+}
+
+/// Push callback invoked by the producer's forwarder for each event.
+/// Null event = forwarder-exit sentinel, guaranteed exactly once.
+extern "C" fn bootstrap_push_callback(
+    ctx: *mut std::ffi::c_void,
+    event: *mut FfiBootstrapEvent,
+) -> bool {
+    // Catch panics to prevent unwinding across the extern "C" boundary (UB).
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        bootstrap_push_callback_inner(ctx, event)
+    }))
+    .unwrap_or(false)
+}
+
+fn bootstrap_push_callback_inner(
+    ctx: *mut std::ffi::c_void,
+    event: *mut FfiBootstrapEvent,
+) -> bool {
+    if ctx.is_null() {
+        return false;
+    }
+    let context = unsafe { &*(ctx as *const PushCallbackContext) };
+
+    if event.is_null() {
+        // Forwarder-exit sentinel (the producer guarantees exactly one on
+        // forwarder exit). This is the SOLE point at which the leaked Arc
+        // reference is reclaimed; the `reclaimed` flag makes the reclaim
+        // once-only so a duplicate sentinel from a buggy producer is a no-op
+        // instead of a double free. Tolerate a poisoned lock so the reclaim
+        // below always runs.
+        if let Ok(mut guard) = context.tx.lock() {
+            *guard = None;
+        }
+        context.notify.notify_one();
+        if context
+            .reclaimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            unsafe { Arc::from_raw(ctx as *const PushCallbackContext) };
+        }
+        return false;
+    }
+
+    let ffi_event = unsafe { &*event };
+    // Decode into a consumer-owned BootstrapEvent and free the producer's
+    // buffer via its own deallocator (issue #602: never reinterpret or drop
+    // the other side's repr(Rust) memory).
+    let decoded = unsafe { consume_bootstrap_event(ffi_event) };
+    // Free the producer-allocated #[repr(C)] envelope (POD; no recursive Drop).
+    unsafe { drop(Box::from_raw(event)) };
+
+    let Some(bootstrap_event) = decoded else {
+        // Undecodable payload: skip this event, keep the stream alive.
+        return true;
+    };
+
+    // Forward to the consumer. On failure (receiver gone or poisoned lock)
+    // return false to stop the forwarder, but do NOT reclaim the leaked Arc
+    // here; the guaranteed sentinel does that exactly once. The send blocks
+    // when the bridge is full, which is the backpressure path.
+    let Ok(guard) = context.tx.lock() else {
+        return false;
+    };
+    let Some(tx) = guard.as_ref() else {
+        return false;
+    };
+    let ok = tx.send(bootstrap_event).is_ok();
+    drop(guard);
+    if ok {
+        context.notify.notify_one();
+        true
+    } else {
+        false
+    }
+}
+
+/// Owns the producer-side receiver state and frees it on drop.
+struct FfiReceiverState {
+    drop_fn: extern "C" fn(*mut std::ffi::c_void),
+    state: *mut std::ffi::c_void,
+}
+
+unsafe impl Send for FfiReceiverState {}
+unsafe impl Sync for FfiReceiverState {}
+
+impl Drop for FfiReceiverState {
+    fn drop(&mut self) {
+        // By the time the consumer is dropped the producer state is inert (the
+        // event receiver was moved out by start_push_fn), so this only frees a
+        // box. Guard against a buggy producer panicking in its drop_fn: an
+        // unwind must not escape into our Drop.
+        guarded_producer_drop(self.drop_fn, self.state);
+    }
+}
+
+/// Invoke a producer-supplied `extern "C"` drop function behind a panic
+/// barrier so a buggy producer cannot unwind into consumer code.
+fn guarded_producer_drop(
+    drop_fn: extern "C" fn(*mut std::ffi::c_void),
+    state: *mut std::ffi::c_void,
+) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop_fn(state)));
+}
+
+/// Free a bootstrap event receiver without consuming its stream.
+///
+/// Error-path cleanup for a partially-initialized `FfiBootstrapStream`:
+/// releases the producer-side state via its `drop_fn` (which closes the
+/// provider's event channel, unblocking the provider) so nothing leaks.
+pub fn release_bootstrap_receiver(inner: FfiBootstrapReceiver) {
+    guarded_producer_drop(inner.drop_fn, inner.state);
+}
+
+/// Free a bootstrap result receiver without consuming its result.
+/// Error-path counterpart of [`release_bootstrap_receiver`].
+pub fn release_result_receiver(inner: FfiBootstrapResultReceiver) {
+    guarded_producer_drop(inner.drop_fn, inner.state);
+}
+
+/// Consumes an [`FfiBootstrapReceiver`]: starts the producer's push forwarder
+/// into a bounded bridge and drains it asynchronously.
+pub struct BootstrapStreamConsumer {
+    rx: std::sync::mpsc::Receiver<BootstrapEvent>,
+    notify: Arc<tokio::sync::Notify>,
+    /// Keeps the callback context alive while the producer forwarder runs.
+    _callback_ctx: Arc<PushCallbackContext>,
+    /// Keeps the producer-side receiver state alive until consumption ends.
+    _ffi_state: FfiReceiverState,
+}
+
+unsafe impl Send for BootstrapStreamConsumer {}
+
+impl BootstrapStreamConsumer {
+    /// Take ownership of the receiver and start push-based delivery.
+    pub fn new(inner: FfiBootstrapReceiver) -> Self {
+        let (tx, rx) = std::sync::mpsc::sync_channel(BOOTSTRAP_BRIDGE_CAPACITY);
+        let notify = Arc::new(tokio::sync::Notify::new());
+
+        let callback_ctx = Arc::new(PushCallbackContext {
+            tx: std::sync::Mutex::new(Some(tx)),
+            notify: notify.clone(),
+            reclaimed: AtomicBool::new(false),
+        });
+
+        // Leak one Arc reference for the producer forwarder; reclaimed exactly
+        // once by the sentinel callback.
+        let ctx_ptr = Arc::into_raw(callback_ctx.clone()) as *mut std::ffi::c_void;
+        (inner.start_push_fn)(inner.state, bootstrap_push_callback, ctx_ptr);
+
+        Self {
+            rx,
+            notify,
+            _callback_ctx: callback_ctx,
+            _ffi_state: FfiReceiverState {
+                drop_fn: inner.drop_fn,
+                state: inner.state,
+            },
+        }
+    }
+
+    /// Forward every event into `tx` until the stream ends. Returns the number
+    /// of events forwarded. Dropping the returned future cancels cleanly: the
+    /// bridge receiver drops, the producer's next push fails, and the
+    /// provider's send errors out.
+    pub async fn forward_into(self, tx: &BootstrapEventSender) -> usize {
+        let mut count = 0usize;
+        loop {
+            match self.rx.try_recv() {
+                Ok(event) => {
+                    if tx.send(event).await.is_err() {
+                        return count;
+                    }
+                    count += 1;
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => {
+                    self.notify.notified().await;
+                }
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    return count;
+                }
+            }
+        }
+    }
+}
+
+/// Context for the result callback. Holds the oneshot sender.
+struct ResultCallbackContext {
+    tx: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<anyhow::Result<BootstrapResult>>>>,
+    /// Set once the callback has reclaimed the producer's leaked Arc
+    /// reference, so a duplicate callback from a buggy producer is a no-op
+    /// instead of a double free. The consumer-held [`BootstrapResultGuard`]
+    /// keeps this flag readable after the reclaim.
+    reclaimed: AtomicBool,
+}
+
+/// Keeps the result callback context alive on the consumer side until the
+/// result has been consumed. Hold this until the receiver returned by
+/// [`wrap_result_receiver`] resolves; dropping it earlier is safe but narrows
+/// the window in which a duplicate producer callback is a harmless no-op.
+pub struct BootstrapResultGuard {
+    _ctx: Arc<ResultCallbackContext>,
+}
+
+/// Result callback, invoked exactly once by the producer. Null result means
+/// the provider ended without producing one; negative `event_count` is a
+/// provider failure.
+extern "C" fn bootstrap_result_callback(
+    ctx: *mut std::ffi::c_void,
+    result: *mut FfiBootstrapResult,
+) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if ctx.is_null() {
+            return;
+        }
+        let context = unsafe { &*(ctx as *const ResultCallbackContext) };
+        let tx = match context.tx.lock() {
+            Ok(mut guard) => guard.take(),
+            Err(_) => None,
+        };
+
+        // Decode (and free) the result envelope even when the sender is
+        // already gone, so a duplicate delivery cannot leak the allocation.
+        let outcome: anyhow::Result<BootstrapResult> = if result.is_null() {
+            Err(anyhow::anyhow!("Bootstrap provider ended without a result"))
+        } else {
+            let ffi_result = unsafe { *Box::from_raw(result) };
+            // Extract (and free) the provider error text unconditionally so
+            // the buffer never leaks, whichever branch we take below.
+            let error_text = if !ffi_result.error_ptr.is_null() && ffi_result.error_len > 0 {
+                let bytes = unsafe {
+                    std::slice::from_raw_parts(ffi_result.error_ptr, ffi_result.error_len)
+                };
+                let text = String::from_utf8_lossy(bytes).into_owned();
+                if let Some(drop_fn) = ffi_result.error_drop_fn {
+                    (drop_fn)(ffi_result.error_ptr as *mut u8, ffi_result.error_len);
+                }
+                Some(text)
+            } else {
+                None
+            };
+            if ffi_result.event_count < 0 {
+                Err(match error_text {
+                    Some(msg) => anyhow::anyhow!("Bootstrap failed: {msg}"),
+                    None => {
+                        anyhow::anyhow!("Bootstrap failed with code {}", ffi_result.event_count)
+                    }
+                })
+            } else {
+                let source_position = if !ffi_result.source_position_ptr.is_null()
+                    && ffi_result.source_position_len > 0
+                {
+                    let bytes = unsafe {
+                        std::slice::from_raw_parts(
+                            ffi_result.source_position_ptr,
+                            ffi_result.source_position_len,
+                        )
+                    };
+                    let owned = bytes::Bytes::copy_from_slice(bytes);
+                    if let Some(drop_fn) = ffi_result.source_position_drop_fn {
+                        (drop_fn)(
+                            ffi_result.source_position_ptr as *mut u8,
+                            ffi_result.source_position_len,
+                        );
+                    }
+                    Some(owned)
+                } else {
+                    None
+                };
+                Ok(BootstrapResult {
+                    event_count: ffi_result.event_count as usize,
+                    source_position,
+                })
+            }
+        };
+
+        if let Some(tx) = tx {
+            let _ = tx.send(outcome);
+        }
+
+        // Reclaim the producer's leaked Arc reference exactly once, and do it
+        // last: after this the context may only be kept alive by the
+        // consumer-held guard.
+        if context
+            .reclaimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            unsafe { Arc::from_raw(ctx as *const ResultCallbackContext) };
+        }
+    }));
+}
+
+/// Consume an [`FfiBootstrapResultReceiver`] into a oneshot. The producer
+/// guarantees exactly one callback (a null result if it cannot produce one),
+/// so the returned receiver always resolves; an `Err` from `await` means the
+/// producer state was dropped before delivering anything. Keep the returned
+/// [`BootstrapResultGuard`] alive until the receiver resolves.
+pub fn wrap_result_receiver(
+    inner: FfiBootstrapResultReceiver,
+) -> (
+    tokio::sync::oneshot::Receiver<anyhow::Result<BootstrapResult>>,
+    BootstrapResultGuard,
+) {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let ctx = Arc::new(ResultCallbackContext {
+        tx: std::sync::Mutex::new(Some(tx)),
+        reclaimed: AtomicBool::new(false),
+    });
+    // Leak one Arc reference for the producer; reclaimed exactly once by the
+    // callback. The guard holds a second reference so the context stays alive
+    // on the consumer side.
+    let ctx_ptr = Arc::into_raw(ctx.clone()) as *mut std::ffi::c_void;
+    (inner.start_fn)(inner.state, bootstrap_result_callback, ctx_ptr);
+    // The producer's start_fn moves the pending result out of its state, so
+    // the state can be released immediately (matches the subscribe path).
+    guarded_producer_drop(inner.drop_fn, inner.state);
+    (rx, BootstrapResultGuard { _ctx: ctx })
+}

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -37,7 +37,14 @@ use super::types::FfiStr;
 /// - `0.12.0`: `FfiPluginRegistration` gained a trailing `set_log_level`
 ///   field. The host reports its effective log level and the plugin drops
 ///   more verbose records before formatting or crossing the FFI (#685).
-pub const FFI_SDK_VERSION: &str = "0.12.0";
+/// - `0.13.0`: `BootstrapProviderVtable::bootstrap_fn` returns an
+///   `FfiBootstrapStream` (push-based event and result receivers) immediately
+///   instead of streaming through an `FfiBootstrapSender` in a blocking
+///   run-to-completion call (fixes #686 unbounded buffering and pinned
+///   async workers). `FfiBootstrapResult` also carries optional provider
+///   error text (`error_ptr`/`error_len`/`error_drop_fn`) so failures
+///   surface with their message instead of only a negative code.
+pub const FFI_SDK_VERSION: &str = "0.13.0";
 
 /// The target triple this crate was compiled for.
 pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");

--- a/components/plugin-sdk/src/ffi/mod.rs
+++ b/components/plugin-sdk/src/ffi/mod.rs
@@ -29,6 +29,7 @@
 //! - [`vtable_gen`] — Functions that wrap trait impls into vtables
 
 pub mod bootstrap_proxy;
+pub mod bootstrap_stream;
 pub mod callbacks;
 pub mod identity;
 pub mod identity_proxy;
@@ -69,7 +70,7 @@ pub use vtables::{
     BootstrapPluginVtable, BootstrapProviderVtable, FfiBootstrapContext, FfiBootstrapEvent,
     FfiBootstrapFetchOutboxFn, FfiBootstrapFetchSnapshotFn, FfiBootstrapPushCallbackFn,
     FfiBootstrapReadCheckpointFn, FfiBootstrapReceiver, FfiBootstrapResult,
-    FfiBootstrapResultCallbackFn, FfiBootstrapResultReceiver, FfiBootstrapSender,
+    FfiBootstrapResultCallbackFn, FfiBootstrapResultReceiver, FfiBootstrapStream,
     FfiBootstrapWriteCheckpointFn, FfiChangePushCallbackFn, FfiChangeReceiver, FfiCheckpoint,
     FfiCheckpointResult, FfiOutboxIterator, FfiOutboxIteratorResponse, FfiPluginRegistration,
     FfiQueryResult, FfiResultPushCallbackFn, FfiRuntimeContext, FfiSnapshotIterator,
@@ -79,6 +80,11 @@ pub use vtables::{
 };
 
 pub use bootstrap_proxy::FfiBootstrapProviderProxy;
+pub use bootstrap_stream::{
+    release_bootstrap_receiver, release_result_receiver, wrap_result_receiver,
+    BootstrapResultGuard, BootstrapStreamConsumer, BOOTSTRAP_BRIDGE_CAPACITY,
+    BOOTSTRAP_PROVIDER_CAPACITY,
+};
 pub use identity::{
     credentials_to_ffi, FfiCredentialType, FfiCredentials, FfiCredentialsResult,
     IdentityProviderVtable,

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -102,6 +102,31 @@ extern "C" fn ffi_drop_payload_bytes(ptr: *mut u8, len: usize) {
     }
 }
 
+/// Leak an error message as `(ptr, len, drop_fn)` for `FfiBootstrapResult`,
+/// so provider failure text crosses the boundary instead of only a code.
+fn leak_error_text(msg: String) -> (*const u8, usize, Option<extern "C" fn(*mut u8, usize)>) {
+    if msg.is_empty() {
+        return (std::ptr::null(), 0, None);
+    }
+    let bytes = msg.into_bytes().into_boxed_slice();
+    let len = bytes.len();
+    let ptr = Box::into_raw(bytes) as *const u8;
+    (
+        ptr,
+        len,
+        Some(ffi_drop_error_bytes as extern "C" fn(*mut u8, usize)),
+    )
+}
+
+/// Frees an error buffer produced by [`leak_error_text`].
+extern "C" fn ffi_drop_error_bytes(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() && len > 0 {
+        unsafe {
+            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)));
+        }
+    }
+}
+
 /// Decode a host-sent `*mut FfiQueryResult` into a plugin-owned `QueryResult`.
 ///
 /// Delegates to the canonical [`super::payload::consume_query_result`], which
@@ -2094,13 +2119,246 @@ pub fn build_reaction_vtable_from_boxed(
 // ============================================================================
 
 /// Build a BootstrapProviderVtable from a `Box<dyn BootstrapProvider>`.
-/// Used by the HOST to wrap a bootstrap provider into a vtable for passing to a source plugin.
+/// Used by bootstrap plugins to export a provider, and by the host to wrap a
+/// provider for passing into a source plugin.
+///
+/// `bootstrap_fn` starts the provider and returns an `FfiBootstrapStream`
+/// immediately. Events flow through a bounded channel into the consumer's
+/// bounded bridge, so consumer backpressure reaches the provider; the
+/// completion result is delivered through the result receiver exactly once.
 pub fn build_bootstrap_provider_vtable(
     provider: Box<dyn BootstrapProvider>,
     executor: AsyncExecutorFn,
 ) -> BootstrapProviderVtable {
+    /// The provider is shared with in-flight bootstrap threads so that
+    /// dropping the vtable while a bootstrap is running cannot free the
+    /// provider out from under it.
     struct BootstrapProviderWrapper {
-        inner: Box<dyn BootstrapProvider>,
+        inner: Arc<dyn BootstrapProvider>,
+    }
+
+    use super::bootstrap_stream::BOOTSTRAP_PROVIDER_CAPACITY;
+
+    type ProviderOutcome = Result<drasi_lib::bootstrap::BootstrapResult, String>;
+
+    struct StreamState {
+        rx: std::sync::Mutex<Option<tokio::sync::mpsc::Receiver<BootstrapEvent>>>,
+    }
+
+    struct ResultState {
+        rx: std::sync::Mutex<Option<tokio::sync::oneshot::Receiver<ProviderOutcome>>>,
+    }
+
+    /// Serialize a `BootstrapEvent` into a heap-allocated `FfiBootstrapEvent`.
+    /// Crosses the boundary as MessagePack bytes, never as a reinterpreted
+    /// `repr(Rust)` pointer (issue #602).
+    fn event_to_ffi(record: BootstrapEvent) -> *mut FfiBootstrapEvent {
+        let payload = BootstrapEventPayload::from_event(&record);
+        let timestamp_us = payload.timestamp_us;
+        let sequence = payload.sequence;
+        let (payload_ptr, payload_len) = serialize_ffi_payload(&payload);
+        Box::into_raw(Box::new(FfiBootstrapEvent {
+            payload_ptr,
+            payload_len,
+            payload_drop_fn: Some(ffi_drop_payload_bytes),
+            timestamp_us,
+            sequence,
+        }))
+    }
+
+    extern "C" fn stream_start_push(
+        state: *mut c_void,
+        callback: FfiBootstrapPushCallbackFn,
+        callback_ctx: *mut c_void,
+    ) {
+        ffi_guard((), || {
+            let stream = unsafe { &*(state as *const StreamState) };
+            let rx = stream.rx.lock().ok().and_then(|mut guard| guard.take());
+            let ctx_raw = callback_ctx as usize;
+
+            // The forwarder runs on a dedicated thread: the push callback
+            // blocks when the consumer's bounded bridge is full (that is the
+            // backpressure path), and blocking must never happen on an async
+            // worker.
+            let spawned = std::thread::Builder::new()
+                .name("drasi-bootstrap-forwarder".to_string())
+                .spawn(move || {
+                    // Guarantee exactly one null sentinel on every exit path so
+                    // the consumer can reclaim its callback context (same pattern
+                    // as BootstrapSentinelOnDrop on the subscribe path).
+                    struct SentinelOnDrop {
+                        ctx_raw: usize,
+                        callback: FfiBootstrapPushCallbackFn,
+                    }
+                    impl Drop for SentinelOnDrop {
+                        fn drop(&mut self) {
+                            let cb = self.callback;
+                            let ctx = self.ctx_raw as *mut c_void;
+                            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                cb(ctx, std::ptr::null_mut());
+                            }));
+                        }
+                    }
+                    let _sentinel_guard = SentinelOnDrop { ctx_raw, callback };
+                    let Some(mut rx) = rx else { return };
+                    while let Some(record) = rx.blocking_recv() {
+                        let ffi_event = event_to_ffi(record);
+                        let accepted =
+                            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                callback(ctx_raw as *mut c_void, ffi_event)
+                            }))
+                            .unwrap_or(false);
+                        if !accepted {
+                            break;
+                        }
+                    }
+                });
+            if let Err(e) = spawned {
+                // Spawn failure drops the never-invoked closure, which drops
+                // only its CAPTURES (releasing the event receiver). Body
+                // locals such as SentinelOnDrop are constructed only when the
+                // thread runs the body, so no sentinel fires from that drop:
+                // this inline delivery is the sole firing. The consumer-side
+                // reclaim is once-guarded regardless.
+                log::error!("Failed to spawn bootstrap forwarder thread: {e}");
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    callback(ctx_raw as *mut c_void, std::ptr::null_mut());
+                }));
+            }
+        });
+    }
+
+    extern "C" fn stream_drop(state: *mut c_void) {
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut StreamState)) };
+            }
+        });
+    }
+
+    extern "C" fn result_start(
+        state: *mut c_void,
+        callback: FfiBootstrapResultCallbackFn,
+        ctx: *mut c_void,
+    ) {
+        ffi_guard((), || {
+            let result_state = unsafe { &*(state as *const ResultState) };
+            let rx = result_state
+                .rx
+                .lock()
+                .ok()
+                .and_then(|mut guard| guard.take());
+            let ctx_raw = ctx as usize;
+
+            let spawned =
+                std::thread::Builder::new()
+                    .name("drasi-bootstrap-result".to_string())
+                    .spawn(move || {
+                        // Guarantee exactly one callback on every exit path; a null
+                        // result tells the consumer the provider produced nothing.
+                        struct CallOnce {
+                            ctx_raw: usize,
+                            callback: FfiBootstrapResultCallbackFn,
+                            done: bool,
+                        }
+                        impl CallOnce {
+                            fn fire(&mut self, result: *mut FfiBootstrapResult) {
+                                if !self.done {
+                                    self.done = true;
+                                    let cb = self.callback;
+                                    let ctx = self.ctx_raw as *mut c_void;
+                                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+                                        || {
+                                            cb(ctx, result);
+                                        },
+                                    ));
+                                }
+                            }
+                        }
+                        impl Drop for CallOnce {
+                            fn drop(&mut self) {
+                                self.fire(std::ptr::null_mut());
+                            }
+                        }
+                        let mut call = CallOnce {
+                            ctx_raw,
+                            callback,
+                            done: false,
+                        };
+
+                        let Some(rx) = rx else { return };
+                        let result_ptr = match rx.blocking_recv() {
+                            Ok(Ok(result)) => {
+                                let (
+                                    source_position_ptr,
+                                    source_position_len,
+                                    source_position_drop_fn,
+                                ) = if let Some(ref pos) = result.source_position {
+                                    let pos_vec = pos.to_vec();
+                                    let len = pos_vec.len();
+                                    let leaked = Box::into_raw(pos_vec.into_boxed_slice());
+                                    (
+                                        leaked as *const u8,
+                                        len,
+                                        Some(
+                                            ffi_drop_position_bytes
+                                                as extern "C" fn(*mut u8, usize),
+                                        ),
+                                    )
+                                } else {
+                                    (std::ptr::null(), 0, None)
+                                };
+                                Box::into_raw(Box::new(FfiBootstrapResult {
+                                    event_count: result.event_count as i64,
+                                    source_position_ptr,
+                                    source_position_len,
+                                    source_position_drop_fn,
+                                    error_ptr: std::ptr::null(),
+                                    error_len: 0,
+                                    error_drop_fn: None,
+                                }))
+                            }
+                            Ok(Err(e)) => {
+                                log::error!("Bootstrap provider failed: {e}");
+                                // Carry the error text across the boundary so the
+                                // consumer surfaces the message, not just a code.
+                                let (error_ptr, error_len, error_drop_fn) = leak_error_text(e);
+                                Box::into_raw(Box::new(FfiBootstrapResult {
+                                    event_count: -1,
+                                    source_position_ptr: std::ptr::null(),
+                                    source_position_len: 0,
+                                    source_position_drop_fn: None,
+                                    error_ptr,
+                                    error_len,
+                                    error_drop_fn,
+                                }))
+                            }
+                            // Provider thread exited without sending a result.
+                            Err(_) => std::ptr::null_mut(),
+                        };
+                        call.fire(result_ptr);
+                    });
+            if let Err(e) = spawned {
+                // Spawn failure drops the never-invoked closure, which drops
+                // only its CAPTURES (releasing the oneshot receiver). CallOnce
+                // is a body local, constructed only when the thread runs, so
+                // nothing fires from that drop: this inline delivery is the
+                // sole firing. The consumer-side reclaim is once-guarded
+                // regardless.
+                log::error!("Failed to spawn bootstrap result thread: {e}");
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    callback(ctx_raw as *mut c_void, std::ptr::null_mut());
+                }));
+            }
+        });
+    }
+
+    extern "C" fn result_drop(state: *mut c_void) {
+        ffi_guard((), || {
+            if !state.is_null() {
+                unsafe { drop(Box::from_raw(state as *mut ResultState)) };
+            }
+        });
     }
 
     extern "C" fn bootstrap_fn(
@@ -2113,134 +2371,88 @@ pub fn build_bootstrap_provider_vtable(
         request_id: FfiStr,
         server_id: FfiStr,
         source_id: FfiStr,
-        sender: *mut FfiBootstrapSender,
-    ) -> *mut FfiBootstrapResult {
-        use drasi_lib::bootstrap::{BootstrapContext, BootstrapRequest};
+    ) -> *mut FfiBootstrapStream {
+        ffi_guard(std::ptr::null_mut(), || {
+            use drasi_lib::bootstrap::{BootstrapContext, BootstrapRequest};
 
-        let query_id_str = unsafe { query_id.to_string() };
-        let node_label_strs: Vec<String> = (0..node_labels_count)
-            .map(|i| unsafe { (*node_labels.add(i)).to_string() })
-            .collect();
-        let rel_label_strs: Vec<String> = (0..relation_labels_count)
-            .map(|i| unsafe { (*relation_labels.add(i)).to_string() })
-            .collect();
-        let request_id_str = unsafe { request_id.to_string() };
-        let server_id_str = unsafe { server_id.to_string() };
-        let source_id_str = unsafe { source_id.to_string() };
-
-        let request = BootstrapRequest {
-            query_id: query_id_str,
-            node_labels: node_label_strs,
-            relation_labels: rel_label_strs,
-            request_id: request_id_str,
-        };
-        let context = BootstrapContext::new_minimal(server_id_str, source_id_str.clone());
-
-        let ffi_sender = unsafe { &*sender };
-        let send_fn = ffi_sender.send_fn;
-        let sender_state = ffi_sender.state;
-
-        // Use std::sync::mpsc so we can recv without async context
-        let (std_tx, std_rx) = std::sync::mpsc::channel::<BootstrapEvent>();
-        let (tokio_tx, mut tokio_rx) = tokio::sync::mpsc::channel::<BootstrapEvent>(100);
-
-        // Channel to carry the BootstrapResult back from the provider thread
-        let (result_tx, result_rx) =
-            std::sync::mpsc::channel::<Result<drasi_lib::bootstrap::BootstrapResult, String>>();
-
-        // Run the actual bootstrap provider in a background thread with its own tokio runtime
-        let provider_ptr = SendPtr(state as *const BootstrapProviderWrapper);
-        let _bootstrap_handle = std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("failed to build bootstrap runtime");
-            let inner = unsafe { provider_ptr.as_ref() };
-            rt.block_on(async {
-                let forward_handle = tokio::spawn(async move {
-                    while let Some(record) = tokio_rx.recv().await {
-                        if std_tx.send(record).is_err() {
-                            break;
-                        }
-                    }
-                });
-                let bootstrap_result = inner
-                    .inner
-                    .bootstrap(request, &context, tokio_tx, None)
-                    .await;
-                let _ = forward_handle.await;
-                let _ = result_tx.send(bootstrap_result.map_err(|e| format!("{e:#}")));
-            })
-        });
-
-        // Forward records from std::sync::mpsc to FFI sender
-        let mut count: usize = 0;
-        while let Ok(record) = std_rx.recv() {
-            // Serialize the event payload for cross-cdylib transfer (issue #602):
-            // never hand the host a reinterpreted `repr(Rust)` pointer.
-            let payload = BootstrapEventPayload::from_event(&record);
-            let timestamp_us = payload.timestamp_us;
-            let sequence = payload.sequence;
-            let (payload_ptr, payload_len) = serialize_ffi_payload(&payload);
-            let event = Box::new(FfiBootstrapEvent {
-                payload_ptr,
-                payload_len,
-                payload_drop_fn: Some(ffi_drop_payload_bytes),
-                timestamp_us,
-                sequence,
-            });
-            let event_ptr = Box::into_raw(event);
-            let result = (send_fn)(sender_state, event_ptr);
-            if result != 0 {
-                break;
-            }
-            count += 1;
-        }
-
-        // Collect the BootstrapResult from the provider thread.
-        // If the provider failed, return a null pointer so the host can
-        // detect the error instead of treating it as a successful bootstrap.
-        let provider_result = match result_rx.recv() {
-            Ok(Ok(result)) => Some(result),
-            Ok(Err(e)) => {
-                log::error!("Bootstrap provider failed for source '{source_id_str}': {e}");
-                return std::ptr::null_mut();
-            }
-            Err(_) => {
-                log::error!(
-                    "Bootstrap provider thread exited without sending result for source '{source_id_str}'"
-                );
-                return std::ptr::null_mut();
-            }
-        };
-
-        // Build the FFI result with the source_position handover boundary
-        let (source_position_ptr, source_position_len, source_position_drop_fn) =
-            if let Some(ref br) = provider_result {
-                if let Some(ref pos) = br.source_position {
-                    let pos_vec = pos.to_vec();
-                    let len = pos_vec.len();
-                    let leaked = Box::into_raw(pos_vec.into_boxed_slice());
-                    (
-                        leaked as *const u8,
-                        len,
-                        Some(ffi_drop_position_bytes as extern "C" fn(*mut u8, usize)),
-                    )
-                } else {
-                    (std::ptr::null(), 0, None)
-                }
+            // Defensive: a null array with a non-zero count would be UB to
+            // walk. The host always passes valid arrays; treat null as empty.
+            let node_labels: Vec<String> = if node_labels.is_null() {
+                Vec::new()
             } else {
-                (std::ptr::null(), 0, None)
+                (0..node_labels_count)
+                    .map(|i| unsafe { (*node_labels.add(i)).to_string() })
+                    .collect()
+            };
+            let relation_labels: Vec<String> = if relation_labels.is_null() {
+                Vec::new()
+            } else {
+                (0..relation_labels_count)
+                    .map(|i| unsafe { (*relation_labels.add(i)).to_string() })
+                    .collect()
+            };
+            let request = BootstrapRequest {
+                query_id: unsafe { query_id.to_string() },
+                node_labels,
+                relation_labels,
+                request_id: unsafe { request_id.to_string() },
+            };
+            let server_id_str = unsafe { server_id.to_string() };
+            let source_id_str = unsafe { source_id.to_string() };
+
+            let provider = {
+                let wrapper = unsafe { &*(state as *const BootstrapProviderWrapper) };
+                wrapper.inner.clone()
             };
 
-        let ffi_result = Box::new(FfiBootstrapResult {
-            event_count: count as i64,
-            source_position_ptr,
-            source_position_len,
-            source_position_drop_fn,
-        });
+            let (event_tx, event_rx) =
+                tokio::sync::mpsc::channel::<BootstrapEvent>(BOOTSTRAP_PROVIDER_CAPACITY);
+            let (result_tx, result_rx) = tokio::sync::oneshot::channel::<ProviderOutcome>();
 
-        Box::into_raw(ffi_result)
+            // Run the provider on its own thread + runtime. It produces into
+            // the bounded event channel and reports completion via the oneshot.
+            let spawned = std::thread::Builder::new()
+                .name("drasi-bootstrap-provider".to_string())
+                .spawn(move || {
+                    let rt = match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
+                        Ok(rt) => rt,
+                        Err(e) => {
+                            let _ = result_tx
+                                .send(Err(format!("failed to build bootstrap runtime: {e}")));
+                            return;
+                        }
+                    };
+                    let context = BootstrapContext::new_minimal(server_id_str, source_id_str);
+                    let outcome =
+                        rt.block_on(provider.bootstrap(request, &context, event_tx, None));
+                    let _ = result_tx.send(outcome.map_err(|e| format!("{e:#}")));
+                });
+            if let Err(e) = spawned {
+                // Nothing has crossed the boundary yet; a null stream tells the
+                // caller the bootstrap could not be started.
+                log::error!("Failed to spawn bootstrap provider thread: {e}");
+                return std::ptr::null_mut();
+            }
+
+            let events = Box::into_raw(Box::new(FfiBootstrapReceiver {
+                state: Box::into_raw(Box::new(StreamState {
+                    rx: std::sync::Mutex::new(Some(event_rx)),
+                })) as *mut c_void,
+                start_push_fn: stream_start_push,
+                drop_fn: stream_drop,
+            }));
+            let result = Box::into_raw(Box::new(FfiBootstrapResultReceiver {
+                state: Box::into_raw(Box::new(ResultState {
+                    rx: std::sync::Mutex::new(Some(result_rx)),
+                })) as *mut c_void,
+                start_fn: result_start,
+                drop_fn: result_drop,
+            }));
+            Box::into_raw(Box::new(FfiBootstrapStream { events, result }))
+        })
     }
 
     extern "C" fn ffi_drop_position_bytes(ptr: *mut u8, len: usize) {
@@ -2261,7 +2473,9 @@ pub fn build_bootstrap_provider_vtable(
         });
     }
 
-    let wrapper = Box::new(BootstrapProviderWrapper { inner: provider });
+    let wrapper = Box::new(BootstrapProviderWrapper {
+        inner: Arc::from(provider),
+    });
     BootstrapProviderVtable {
         state: Box::into_raw(wrapper) as *mut c_void,
         executor,
@@ -3129,6 +3343,9 @@ fn wrap_subscription_response(
                                     source_position_ptr,
                                     source_position_len,
                                     source_position_drop_fn,
+                                    error_ptr: std::ptr::null(),
+                                    error_len: 0,
+                                    error_drop_fn: None,
                                 }));
                                 // Defuse sentinel — deliver real result instead.
                                 std::mem::forget(_sentinel);
@@ -3139,11 +3356,16 @@ fn wrap_subscription_response(
                             }
                             Ok(Err(e)) => {
                                 log::error!("Bootstrap result error: {e}");
+                                let (error_ptr, error_len, error_drop_fn) =
+                                    leak_error_text(format!("{e:#}"));
                                 let ffi_result = Box::into_raw(Box::new(FfiBootstrapResult {
                                     event_count: -1,
                                     source_position_ptr: std::ptr::null(),
                                     source_position_len: 0,
                                     source_position_drop_fn: None,
+                                    error_ptr,
+                                    error_len,
+                                    error_drop_fn,
                                 }));
                                 std::mem::forget(_sentinel);
                                 let _ =

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -225,21 +225,30 @@ pub type FfiResultPushCallbackFn =
     extern "C" fn(ctx: *mut c_void, result: *mut c_void) -> *mut c_void;
 
 // ============================================================================
-// Bootstrap sender — callback for sending bootstrap records from provider
+// Bootstrap stream — handles returned by a bootstrap provider vtable
 // ============================================================================
 
-/// FFI-safe callback for sending bootstrap records from a BootstrapProvider.
-/// The host creates this and passes it to the provider.
+/// Handles returned by `BootstrapProviderVtable::bootstrap_fn`.
+///
+/// `bootstrap_fn` starts the provider and returns immediately; events and the
+/// completion result are then delivered through these push-based receivers,
+/// the same pattern used for CDC (`FfiChangeReceiver`) and source-plugin
+/// bootstrap (`FfiSubscriptionResponse`). Backpressure propagates end to end:
+/// the consumer's bounded bridge blocks the push callback, which stalls the
+/// provider's bounded event channel.
+///
+/// Heap-allocated by the callee; the caller takes ownership of the envelope
+/// and both receiver pointers (freed via `Box::from_raw` + each `drop_fn`).
 #[repr(C)]
-pub struct FfiBootstrapSender {
-    pub state: *mut c_void,
-    /// Send a bootstrap record. Returns 0 on success, non-zero if channel closed.
-    pub send_fn: extern "C" fn(state: *mut c_void, event: *mut FfiBootstrapEvent) -> i32,
-    pub drop_fn: extern "C" fn(state: *mut c_void),
+pub struct FfiBootstrapStream {
+    /// Push-based finite stream of bootstrap events (null sentinel = end).
+    pub events: *mut FfiBootstrapReceiver,
+    /// Push-based delivery of the `FfiBootstrapResult` (null = no result).
+    pub result: *mut FfiBootstrapResultReceiver,
 }
 
-unsafe impl Send for FfiBootstrapSender {}
-unsafe impl Sync for FfiBootstrapSender {}
+unsafe impl Send for FfiBootstrapStream {}
+unsafe impl Sync for FfiBootstrapStream {}
 
 /// FFI-safe bootstrap result returned across the plugin boundary.
 ///
@@ -257,6 +266,14 @@ pub struct FfiBootstrapResult {
     /// Drop function for the source position allocation.
     /// Null if `source_position_ptr` is null.
     pub source_position_drop_fn: Option<extern "C" fn(*mut u8, usize)>,
+    /// UTF-8 provider error text (null if none). Only meaningful when
+    /// `event_count < 0`. Callee owns the allocation; caller must free via
+    /// `error_drop_fn`.
+    pub error_ptr: *const u8,
+    /// Length of the error text bytes (0 if ptr is null).
+    pub error_len: usize,
+    /// Drop function for the error text allocation. Null if `error_ptr` is null.
+    pub error_drop_fn: Option<extern "C" fn(*mut u8, usize)>,
 }
 
 unsafe impl Send for FfiBootstrapResult {}
@@ -518,10 +535,11 @@ drasi_ffi_primitives::ffi_vtable! {
     /// FFI-safe vtable for a BootstrapProvider.
     /// The bootstrap plugin creates this; the host wraps it and passes it to the source plugin.
     pub struct BootstrapProviderVtable {
-        /// Perform bootstrap. Sends records via the FfiBootstrapSender.
-        /// Returns a heap-allocated FfiBootstrapResult (caller must free via Box::from_raw),
-        /// or null on catastrophic failure.
-        fn bootstrap_fn(state: *mut, query_id: FfiStr, node_labels: *const FfiStr, node_labels_count: usize, relation_labels: *const FfiStr, relation_labels_count: usize, request_id: FfiStr, server_id: FfiStr, source_id: FfiStr, sender: *mut FfiBootstrapSender) -> *mut FfiBootstrapResult,
+        /// Start a bootstrap and return immediately with push-based handles.
+        /// Returns a heap-allocated FfiBootstrapStream (caller must free via
+        /// Box::from_raw and consume both receivers), or null if the bootstrap
+        /// could not be started.
+        fn bootstrap_fn(state: *mut, query_id: FfiStr, node_labels: *const FfiStr, node_labels_count: usize, relation_labels: *const FfiStr, relation_labels_count: usize, request_id: FfiStr, server_id: FfiStr, source_id: FfiStr) -> *mut FfiBootstrapStream,
     }
 }
 

--- a/lib/src/bootstrap/agents.md
+++ b/lib/src/bootstrap/agents.md
@@ -15,6 +15,7 @@ mediated by the host.
 | `BootstrapRequest` | Deconstructed into individual FFI args (query_id, node_labels, etc.) | Multiple `FfiStr` + `*const FfiStr` arrays |
 | `BootstrapContext` | Deconstructed into individual FFI args (server_id, source_id) | Multiple `FfiStr` args |
 | `BootstrapEvent` | Serialized to MessagePack bytes (`BootstrapEventPayload`) and transferred as a `payload_ptr` + `payload_len` buffer freed via `payload_drop_fn`; never a reinterpreted `repr(Rust)` pointer (issue #602) | `FfiBootstrapEvent` + `payload.rs::consume_bootstrap_event` |
+| `BootstrapResult` | Delivered exactly once through a push-based result receiver (null result = provider ended without one; negative `event_count` = failure, with optional error text) | `FfiBootstrapResult` via `FfiBootstrapResultReceiver` |
 
 ### Cross-plugin bootstrap flow
 
@@ -22,9 +23,16 @@ mediated by the host.
 Source Plugin B calls set_bootstrap_provider(provider)
   → Host wraps host-side BootstrapProvider into BootstrapProviderVtable
   → Plugin B stores vtable, calls vtable.bootstrap_fn() when subscribing
-  → Host receives call, dispatches to Bootstrap Plugin A
-  → Plugin A sends BootstrapEvents via FfiBootstrapSender
-  → Host forwards events back to Plugin B via channel
+  → bootstrap_fn starts the provider on its own thread and returns an
+    FfiBootstrapStream immediately (FfiBootstrapReceiver for events +
+    FfiBootstrapResultReceiver for completion)
+  → Plugin B consumes both via BootstrapStreamConsumer / wrap_result_receiver
+    (plugin-sdk ffi/bootstrap_stream.rs); every link is bounded, so consumer
+    backpressure stalls the provider (issue #686), and cancellation is
+    achieved by dropping the receiver
+  → When the provider is Bootstrap Plugin A, the host-side provider is
+    BootstrapProviderProxy, which consumes Plugin A's FfiBootstrapStream
+    the same way
 ```
 
 ### What to update when changing `BootstrapProvider`
@@ -40,10 +48,12 @@ Source Plugin B calls set_bootstrap_provider(provider)
 
 4. **Host-side proxy** — `components/host-sdk/src/proxies/bootstrap_provider.rs`
    - `BootstrapProviderProxy` — host-side wrapper for plugin-provided bootstrap providers
-   - `build_ffi_bootstrap_sender()` — creates `FfiBootstrapSender` that bridges
-     `std::sync::mpsc` → `tokio::sync::mpsc`
 
-5. **Version bump** — `components/plugin-sdk/src/ffi/metadata.rs` → `FFI_SDK_VERSION`
+5. **Shared stream consumer** — `components/plugin-sdk/src/ffi/bootstrap_stream.rs`
+   - `BootstrapStreamConsumer` / `wrap_result_receiver` — consume the
+     `FfiBootstrapStream` returned by `bootstrap_fn` (shared by both proxies)
+
+6. **Version bump** — `components/plugin-sdk/src/ffi/metadata.rs` → `FFI_SDK_VERSION`
 
 ### What to update when changing `BootstrapRequest` or `BootstrapContext`
 


### PR DESCRIPTION
Closes #686.

Implements the receiver contract from the issue: bootstrap_fn returns FfiBootstrapReceiver plus FfiBootstrapResultReceiver immediately, every link on the path is bounded, and FfiBootstrapSender is gone. One shared consumer module serves both the host proxy and the plugin-side proxy. The provider wrapper is now Arc-shared so dropping the vtable during an in-flight bootstrap cannot free it early. Error paths release partially-initialized streams instead of leaking them, producer drop functions run behind panic barriers, failed thread spawns deliver the stream-end sentinel or result inline, and the host proxy starts its consumers on a dedicated thread, matching the subscribe path.

New integration tests drive the real producer and both consumers in-process: a stalled consumer bounds in-flight events and stalls the provider, concurrent bootstraps complete on a 2-worker runtime, provider errors propagate, source_position round-trips, cancellation stops the provider, and a double-hop chain stays bounded and lossless. The scriptfile bootstrap plugin also builds as a test cdylib now, so streaming and backpressure are verified across a real dylib boundary.

ABI break: BootstrapProviderVtable changed and FFI_SDK_VERSION is now 0.13.0 (0.12.0 was taken by the log-level ABI change in #689), so hosts reject plugins built against the old layout at load time. All existing 0.11.0 and 0.12.0 plugin binaries need a rebuild.


