### PR TITLE
Return a clear error for temporal reads when archive is disabled (#699)

### DIFF
--- a/components/indexes/garnet/src/element_index/archive_index.rs
+++ b/components/indexes/garnet/src/element_index/archive_index.rs
@@ -40,6 +40,9 @@ impl ElementArchiveIndex for GarnetElementIndex {
         element_ref: &ElementReference,
         time: ElementTimestamp,
     ) -> Result<Option<Arc<Element>>, IndexError> {
+        if !self.archive_enabled {
+            return Err(IndexError::ArchiveNotEnabled);
+        }
         let key = self.key_formatter.get_archive_key(element_ref);
 
         // Check buffer first (cheap: mutex + hashmap lookup) to decide
@@ -133,6 +136,9 @@ impl ElementArchiveIndex for GarnetElementIndex {
         element_ref: &ElementReference,
         range: TimestampRange<ElementTimestamp>,
     ) -> Result<ElementStream, IndexError> {
+        if !self.archive_enabled {
+            return Err(IndexError::ArchiveNotEnabled);
+        }
         let mut con = self.connection.clone();
         let key = self.key_formatter.get_archive_key(element_ref);
 

--- a/components/indexes/garnet/tests/archive_disabled.rs
+++ b/components/indexes/garnet/tests/archive_disabled.rs
@@ -1,0 +1,99 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Temporal reads on an index created with enable_archive = false must return
+//! IndexError::ArchiveNotEnabled instead of silently returning nothing (issue #699).
+
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use drasi_core::interface::{ElementArchiveIndex, IndexError, SessionControl};
+use drasi_core::models::{ElementReference, TimestampBound, TimestampRange};
+use drasi_index_garnet::{
+    element_index::GarnetElementIndex, GarnetSessionControl, GarnetSessionState,
+};
+use shared_tests::redis_helpers::{setup_redis, RedisGuard};
+use tokio::sync::OnceCell;
+
+static SHARED_REDIS: OnceCell<RedisGuard> = OnceCell::const_new();
+
+async fn shared_redis() -> &'static RedisGuard {
+    SHARED_REDIS
+        .get_or_init(|| async { setup_redis().await })
+        .await
+}
+
+async fn build_index(query_id: &str, archive_enabled: bool) -> GarnetElementIndex {
+    let redis = shared_redis().await;
+    let client = redis::Client::open(redis.url()).unwrap();
+    let connection = client.get_multiplexed_async_connection().await.unwrap();
+    let session_state = Arc::new(GarnetSessionState::new(connection.clone()));
+    GarnetElementIndex::new(query_id, connection, archive_enabled, session_state)
+}
+
+#[tokio::test]
+async fn get_element_as_at_archive_disabled() {
+    let index = build_index("archive-disabled-as-at", false).await;
+    let result = index
+        .get_element_as_at(&ElementReference::new("source1", "node1"), 1000)
+        .await;
+    assert!(matches!(result, Err(IndexError::ArchiveNotEnabled)));
+}
+
+#[tokio::test]
+async fn get_element_versions_archive_disabled() {
+    let index = build_index("archive-disabled-versions", false).await;
+    for from in [
+        TimestampBound::Included(0),
+        TimestampBound::StartFromPrevious(0),
+    ] {
+        let result = index
+            .get_element_versions(
+                &ElementReference::new("source1", "node1"),
+                TimestampRange { from, to: 2000 },
+            )
+            .await;
+        assert!(matches!(result, Err(IndexError::ArchiveNotEnabled)));
+    }
+}
+
+#[tokio::test]
+async fn archive_reads_with_archive_enabled() {
+    let redis = shared_redis().await;
+    let client = redis::Client::open(redis.url()).unwrap();
+    let connection = client.get_multiplexed_async_connection().await.unwrap();
+    let session_state = Arc::new(GarnetSessionState::new(connection.clone()));
+    let session_control = GarnetSessionControl::new(session_state.clone());
+    let index = GarnetElementIndex::new("archive-enabled", connection, true, session_state);
+
+    // Reads require an active session.
+    session_control.begin().await.unwrap();
+
+    let as_at = index
+        .get_element_as_at(&ElementReference::new("source1", "node1"), 1000)
+        .await;
+    assert!(matches!(as_at, Ok(None)));
+
+    let versions = index
+        .get_element_versions(
+            &ElementReference::new("source1", "node1"),
+            TimestampRange {
+                from: TimestampBound::Included(0),
+                to: 2000,
+            },
+        )
+        .await;
+    assert!(versions.is_ok());
+}

--- a/components/indexes/rocksdb/src/element_index/archive_index.rs
+++ b/components/indexes/rocksdb/src/element_index/archive_index.rs
@@ -40,16 +40,19 @@ impl ElementArchiveIndex for RocksDbElementIndex {
         element_ref: &ElementReference,
         time: ElementTimestamp,
     ) -> Result<Option<Arc<Element>>, IndexError> {
+        if !self.context.options.archive_enabled {
+            return Err(IndexError::ArchiveNotEnabled);
+        }
         let context = self.context.clone();
         let element_key = super::hash_element_ref(element_ref);
         let mut key = element_key.to_vec();
         key.extend_from_slice(&time.to_be_bytes());
 
         let task = task::spawn_blocking(move || {
-            let archive_cf = context
-                .db
-                .cf_handle(ARCHIVE_CF)
-                .expect("Archive CF not found");
+            let archive_cf = match context.db.cf_handle(ARCHIVE_CF) {
+                Some(cf) => cf,
+                None => return Err(IndexError::ArchiveNotEnabled),
+            };
             context.session_state.with_txn(|txn| {
                 let mut iter = txn
                     .iterator_cf(
@@ -92,6 +95,9 @@ impl ElementArchiveIndex for RocksDbElementIndex {
         element_ref: &ElementReference,
         range: TimestampRange<ElementTimestamp>,
     ) -> Result<ElementStream, IndexError> {
+        if !self.context.options.archive_enabled {
+            return Err(IndexError::ArchiveNotEnabled);
+        }
         let context = self.context.clone();
         let element_key = super::hash_element_ref(element_ref);
 
@@ -101,10 +107,10 @@ impl ElementArchiveIndex for RocksDbElementIndex {
             TimestampBound::StartFromPrevious(from) => {
                 let context = context.clone();
                 let task = task::spawn_blocking(move || {
-                    let archive_cf = context
-                        .db
-                        .cf_handle(ARCHIVE_CF)
-                        .expect("Archive CF not found");
+                    let archive_cf = match context.db.cf_handle(ARCHIVE_CF) {
+                        Some(cf) => cf,
+                        None => return Err(IndexError::ArchiveNotEnabled),
+                    };
                     let mut start_key = element_key.clone().to_vec();
                     start_key.extend_from_slice(&from.to_be_bytes());
                     context.session_state.with_txn(|txn| {
@@ -147,10 +153,10 @@ impl ElementArchiveIndex for RocksDbElementIndex {
 
         let task = task::spawn_blocking(move || {
             start_key.extend_from_slice(&from_timestamp.to_be_bytes());
-            let archive_cf = context
-                .db
-                .cf_handle(ARCHIVE_CF)
-                .expect("Archive CF not found");
+            let archive_cf = match context.db.cf_handle(ARCHIVE_CF) {
+                Some(cf) => cf,
+                None => return Err(IndexError::ArchiveNotEnabled),
+            };
             context.session_state.with_txn(|txn| {
                 let mut results: Vec<Result<Arc<Element>, IndexError>> = Vec::new();
                 for item in txn.iterator_cf(

--- a/components/indexes/rocksdb/tests/archive_disabled.rs
+++ b/components/indexes/rocksdb/tests/archive_disabled.rs
@@ -1,0 +1,98 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Temporal reads on an index opened with enable_archive = false must return
+//! IndexError::ArchiveNotEnabled instead of panicking (issue #699).
+
+#![allow(clippy::unwrap_used)]
+
+use drasi_core::interface::{ElementArchiveIndex, IndexBackendPlugin, IndexError};
+use drasi_core::models::{ElementReference, TimestampBound, TimestampRange};
+use drasi_index_rocksdb::RocksDbIndexProvider;
+
+#[tokio::test]
+async fn get_element_as_at_archive_disabled() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let provider = RocksDbIndexProvider::new(temp_dir.path(), false, false);
+    let created = provider.create_indexes("archive-disabled").await.unwrap();
+
+    let result = created
+        .set
+        .archive_index
+        .get_element_as_at(&ElementReference::new("source1", "node1"), 1000)
+        .await;
+    assert!(matches!(result, Err(IndexError::ArchiveNotEnabled)));
+}
+
+#[tokio::test]
+async fn get_element_versions_archive_disabled() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let provider = RocksDbIndexProvider::new(temp_dir.path(), false, false);
+    let created = provider.create_indexes("archive-disabled").await.unwrap();
+
+    for from in [
+        TimestampBound::Included(0),
+        TimestampBound::StartFromPrevious(0),
+    ] {
+        let result = created
+            .set
+            .archive_index
+            .get_element_versions(
+                &ElementReference::new("source1", "node1"),
+                TimestampRange { from, to: 2000 },
+            )
+            .await;
+        assert!(matches!(result, Err(IndexError::ArchiveNotEnabled)));
+    }
+}
+
+#[tokio::test]
+async fn clear_archive_disabled_is_ok() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let provider = RocksDbIndexProvider::new(temp_dir.path(), false, false);
+    let created = provider.create_indexes("archive-disabled").await.unwrap();
+
+    let result = created.set.archive_index.clone().clear().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn archive_reads_with_archive_enabled() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
+    let created = provider.create_indexes("archive-enabled").await.unwrap();
+
+    // Reads require an active session.
+    created.set.session_control.begin().await.unwrap();
+
+    let as_at = created
+        .set
+        .archive_index
+        .get_element_as_at(&ElementReference::new("source1", "node1"), 1000)
+        .await;
+    assert!(matches!(as_at, Ok(None)));
+
+    let versions = created
+        .set
+        .archive_index
+        .get_element_versions(
+            &ElementReference::new("source1", "node1"),
+            TimestampRange {
+                from: TimestampBound::Included(0),
+                to: 2000,
+            },
+        )
+        .await;
+    assert!(versions.is_ok());
+}

--- a/core/src/in_memory_index/in_memory_element_index.rs
+++ b/core/src/in_memory_index/in_memory_element_index.rs
@@ -594,7 +594,7 @@ impl ElementArchiveIndex for InMemoryElementIndex {
         time: ElementTimestamp,
     ) -> Result<Option<Arc<Element>>, IndexError> {
         if !self.archive_enabled {
-            return Err(IndexError::NotSupported);
+            return Err(IndexError::ArchiveNotEnabled);
         }
 
         let guard = self.element_archive.read().await;
@@ -613,7 +613,7 @@ impl ElementArchiveIndex for InMemoryElementIndex {
         range: TimestampRange<ElementTimestamp>,
     ) -> Result<ElementStream, IndexError> {
         if !self.archive_enabled {
-            return Err(IndexError::NotSupported);
+            return Err(IndexError::ArchiveNotEnabled);
         }
 
         let from = range.from;
@@ -1226,5 +1226,62 @@ mod tests {
             .expect("outer entry for the still-populated value must remain");
         assert!(remaining.get(join_key).unwrap().contains(&ref_b));
         assert_eq!(guard.len(), 1, "only the emptied value should be pruned");
+    }
+
+    #[tokio::test]
+    async fn test_get_element_as_at_archive_disabled() {
+        let index = InMemoryElementIndex::new();
+        let result = index
+            .get_element_as_at(&ElementReference::new("source1", "node1"), 0)
+            .await;
+        assert!(matches!(result, Err(IndexError::ArchiveNotEnabled)));
+    }
+
+    #[tokio::test]
+    async fn test_get_element_versions_archive_disabled() {
+        let index = InMemoryElementIndex::new();
+        let result = index
+            .get_element_versions(
+                &ElementReference::new("source1", "node1"),
+                TimestampRange {
+                    from: TimestampBound::Included(0),
+                    to: 100,
+                },
+            )
+            .await;
+        assert!(matches!(result, Err(IndexError::ArchiveNotEnabled)));
+    }
+
+    #[tokio::test]
+    async fn test_clear_archive_disabled_returns_not_supported() {
+        let index = InMemoryElementIndex::new();
+        let result = ElementArchiveIndex::clear(&index).await;
+        assert!(matches!(result, Err(IndexError::NotSupported)));
+    }
+
+    #[tokio::test]
+    async fn test_archive_reads_with_archive_enabled() {
+        let mut index = InMemoryElementIndex::new();
+        index.enable_archive();
+
+        let element = create_test_node("source1", "node1", "Person");
+        index.set_element(&element, &vec![0]).await.unwrap();
+
+        let as_at = index
+            .get_element_as_at(&ElementReference::new("source1", "node1"), 10)
+            .await
+            .unwrap();
+        assert!(as_at.is_some());
+
+        let versions = index
+            .get_element_versions(
+                &ElementReference::new("source1", "node1"),
+                TimestampRange {
+                    from: TimestampBound::Included(0),
+                    to: 100,
+                },
+            )
+            .await;
+        assert!(versions.is_ok());
     }
 }

--- a/core/src/interface/mod.rs
+++ b/core/src/interface/mod.rs
@@ -66,6 +66,8 @@ use crate::evaluation::EvaluationError;
 pub enum IndexError {
     IOError,
     NotSupported,
+    /// A temporal read was attempted on an index whose archive is not enabled.
+    ArchiveNotEnabled,
     CorruptedData,
     ConnectionFailed(Box<dyn std::error::Error + Send + Sync>),
     UnknownStore(String),
@@ -77,6 +79,7 @@ impl PartialEq for IndexError {
         match (self, other) {
             (IndexError::IOError, IndexError::IOError) => true,
             (IndexError::NotSupported, IndexError::NotSupported) => true,
+            (IndexError::ArchiveNotEnabled, IndexError::ArchiveNotEnabled) => true,
             (IndexError::CorruptedData, IndexError::CorruptedData) => true,
             (IndexError::ConnectionFailed(a), IndexError::ConnectionFailed(b)) => {
                 a.to_string() == b.to_string()
@@ -95,7 +98,13 @@ impl PartialEq for IndexError {
 
 impl Display for IndexError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        format!("{self:?}").fmt(f)
+        match self {
+            IndexError::ArchiveNotEnabled => write!(
+                f,
+                "archive index not enabled for this query; set enable_archive to use past()"
+            ),
+            _ => format!("{self:?}").fmt(f),
+        }
     }
 }
 


### PR DESCRIPTION
# Description

Temporal reads (drasi.getVersionByTimestamp, drasi.getVersionsByTimeRange) on an index without archive enabled behaved differently per backend: RocksDB panicked on the missing archive column family and surfaced an opaque JoinError, Garnet silently returned nothing, and the in-memory index returned NotSupported.

All backends now return a new IndexError::ArchiveNotEnabled from get_element_as_at and get_element_versions when archive is off. Its message says what to do: "archive index not enabled for this query; set enable_archive to use past()". The RocksDB read paths no longer contain a panic.

clear() is unchanged (Ok for RocksDB, NotSupported for in-memory), since drasi-lib's clear_persistent_indexes treats only those as success and anything else would fail query reset for archive-disabled queries.

Tests: one per backend per read method asserting the error, plus enabled baselines asserting no behavior change. Garnet tests use the existing Redis testcontainer helper.

## Type of change

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).

Fixes: #699
