### PR TITLE
refactor(index-rocksdb): unroll optimize_for_point_lookup into explicit options

### DIFF
--- a/components/indexes/rocksdb/src/element_index.rs
+++ b/components/indexes/rocksdb/src/element_index.rs
@@ -69,7 +69,9 @@ const SLOT_CF: &str = "slots";
 const INBOUND_CF: &str = "inbound";
 const OUTBOUND_CF: &str = "outbound";
 const PARTIAL_CF: &str = "partial";
-const ELEMENT_BLOCK_CACHE_SIZE: u64 = 32;
+/// Block cache capacity for `elements` and `slots`. Each column family gets
+/// its own cache of this size, not a shared one.
+const ELEMENT_BLOCK_CACHE_BYTES: usize = 32 * 1024 * 1024;
 
 impl RocksDbElementIndex {
     /// Create a new RocksDbElementIndex from a shared database handle.
@@ -386,9 +388,8 @@ pub(crate) fn get_inout_index_cf_options() -> Options {
 }
 
 pub(crate) fn get_elements_cf_options() -> Options {
-    let mut elements_opts = Options::default();
+    let mut elements_opts = crate::point_lookup::point_lookup_cf_options(ELEMENT_BLOCK_CACHE_BYTES);
     crate::bound_write_buffer_history(&mut elements_opts);
-    elements_opts.optimize_for_point_lookup(ELEMENT_BLOCK_CACHE_SIZE);
     elements_opts
 }
 

--- a/components/indexes/rocksdb/src/lib.rs
+++ b/components/indexes/rocksdb/src/lib.rs
@@ -67,6 +67,7 @@ pub mod future_queue;
 pub mod live_results;
 pub mod outbox;
 mod plugin;
+mod point_lookup;
 pub mod result_index;
 mod session_state;
 mod storage_models;

--- a/components/indexes/rocksdb/src/point_lookup.rs
+++ b/components/indexes/rocksdb/src/point_lookup.rs
@@ -1,0 +1,96 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Column-family options for point-lookup access.
+//!
+//! Four column families are read only by exact key: `elements` and `slots`
+//! (16-byte element-reference hashes) and `values` and `metadata` (`u64` set
+//! ids). None of them has a prefix extractor, and none is ever scanned.
+//!
+//! They previously took their options from RocksDB's
+//! `Options::optimize_for_point_lookup` convenience preset. The preset is
+//! unrolled here so every setting it bundles is explicit and reviewable, and
+//! so the block cache is a handle this crate constructs rather than one the
+//! preset builds internally from a size argument. The preset's signature
+//! accepts only a size, which is what prevents a shared cache from being
+//! injected through it (see #634).
+//!
+//! The settings below mirror `ColumnFamilyOptions::OptimizeForPointLookup`
+//! in RocksDB 8.1.1 (`options/options.cc:609`), which is the version pinned
+//! by `librocksdb-sys 0.11.0+8.1.1`:
+//!
+//! | `OptimizeForPointLookup(mb)` | Here |
+//! |---|---|
+//! | `data_block_index_type = kDataBlockBinaryAndHash` | [`DataBlockIndexType::BinaryAndHash`] |
+//! | `data_block_hash_table_util_ratio = 0.75` | [`DATA_BLOCK_HASH_RATIO`] |
+//! | `filter_policy = NewBloomFilterPolicy(10)` | [`BLOOM_BITS_PER_KEY`] |
+//! | `block_cache = NewLRUCache(mb * 1024 * 1024)` | `block_cache_bytes` argument |
+//! | `memtable_prefix_bloom_size_ratio = 0.02` | [`MEMTABLE_BLOOM_RATIO`] |
+//! | `memtable_whole_key_filtering = true` | set unconditionally |
+//!
+//! The preset also replaces the whole table factory rather than merging into
+//! it, so unrolling it is only equivalence-preserving as long as these column
+//! families set no other block-based table options. They set none today; a
+//! future one must be added to [`point_lookup_cf_options`] rather than layered
+//! on at the call site, or it will be silently dropped.
+//!
+//! Two of these values are not recoverable from the OPTIONS file RocksDB
+//! writes at open, so `point_lookup_options_tests` cannot pin them and they
+//! are held by this module instead: the bloom policy serializes as
+//! `bloomfilter` without its bits-per-key (the C API wraps the policy and the
+//! wrapper's name omits the parameters), and the block cache is not
+//! serialized at all.
+
+use rocksdb::{BlockBasedOptions, Cache, DataBlockIndexType, Options};
+
+/// Bits per key for the SST bloom filter, matching `NewBloomFilterPolicy(10)`.
+const BLOOM_BITS_PER_KEY: f64 = 10.0;
+
+/// Memtable bloom filter size, as a fraction of `write_buffer_size`. Allocated
+/// eagerly when the memtable is constructed, so it is a fixed per-CF floor.
+const MEMTABLE_BLOOM_RATIO: f64 = 0.02;
+
+/// Target utilization of the hash table appended to each data block.
+const DATA_BLOCK_HASH_RATIO: f64 = 0.75;
+
+/// Options for a column family read only by exact key.
+///
+/// `block_cache_bytes` is in **bytes**, unlike the megabytes taken by the
+/// `optimize_for_point_lookup` preset this replaces.
+///
+/// Each call constructs its own [`Cache`], so two column families built from
+/// this function get independent caches of the given size, matching the
+/// per-call cache the preset created. #634 replaces this with one shared
+/// handle passed in; until then, hoisting a single `Cache` into a shared
+/// value here would quietly halve the capacity available to `elements` and
+/// `slots`, and nothing in the OPTIONS file would show it.
+pub(crate) fn point_lookup_cf_options(block_cache_bytes: usize) -> Options {
+    let mut opts = Options::default();
+
+    let mut table_opts = BlockBasedOptions::default();
+    table_opts.set_data_block_index_type(DataBlockIndexType::BinaryAndHash);
+    table_opts.set_data_block_hash_ratio(DATA_BLOCK_HASH_RATIO);
+    // `false` selects the full-filter builder. On RocksDB 8.1.1 the flag is
+    // ignored (`NewBloomFilterPolicy`'s second parameter is named
+    // `IGNORED_use_block_based_builder`), but the block-based builder is the
+    // one that would be wrong if it were ever honoured again.
+    table_opts.set_bloom_filter(BLOOM_BITS_PER_KEY, false);
+    table_opts.set_block_cache(&Cache::new_lru_cache(block_cache_bytes));
+    opts.set_block_based_table_factory(&table_opts);
+
+    opts.set_memtable_prefix_bloom_ratio(MEMTABLE_BLOOM_RATIO);
+    opts.set_memtable_whole_key_filtering(true);
+
+    opts
+}

--- a/components/indexes/rocksdb/src/result_index.rs
+++ b/components/indexes/rocksdb/src/result_index.rs
@@ -51,7 +51,12 @@ pub struct RocksDbResultIndex {
 const VALUES_CF: &str = "values";
 const SETS_CF: &str = "sorted-sets";
 const METADATA_CF: &str = "metadata";
-const VALUES_BLOCK_CACHE_SIZE: u64 = 32;
+/// Block cache capacity for `values` (aggregation accumulators).
+const VALUES_BLOCK_CACHE_BYTES: usize = 32 * 1024 * 1024;
+
+/// Block cache capacity for `metadata`, which holds a single result-sequence
+/// record and needs no more than one block.
+const METADATA_BLOCK_CACHE_BYTES: usize = 1024 * 1024;
 
 impl RocksDbResultIndex {
     /// Create a new RocksDbResultIndex from a shared database handle.
@@ -373,17 +378,16 @@ pub(crate) fn get_lss_cf_options() -> Options {
 }
 
 pub(crate) fn get_value_cf_options() -> Options {
-    let mut values_opts = Options::default();
+    let mut values_opts = crate::point_lookup::point_lookup_cf_options(VALUES_BLOCK_CACHE_BYTES);
     crate::bound_write_buffer_history(&mut values_opts);
-    values_opts.optimize_for_point_lookup(VALUES_BLOCK_CACHE_SIZE);
     values_opts
 }
 
 pub(crate) fn get_metadata_cf_options() -> Options {
-    let mut values_opts = Options::default();
-    crate::bound_write_buffer_history(&mut values_opts);
-    values_opts.optimize_for_point_lookup(1);
-    values_opts
+    let mut metadata_opts =
+        crate::point_lookup::point_lookup_cf_options(METADATA_BLOCK_CACHE_BYTES);
+    crate::bound_write_buffer_history(&mut metadata_opts);
+    metadata_opts
 }
 
 /// Collect all column family descriptors needed by the result index.

--- a/components/indexes/rocksdb/tests/point_lookup_options_tests.rs
+++ b/components/indexes/rocksdb/tests/point_lookup_options_tests.rs
@@ -1,0 +1,234 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression tests for the point-lookup column family options.
+//!
+//! `src/point_lookup.rs` unrolls RocksDB's `optimize_for_point_lookup` preset
+//! into explicit settings. Dropping one of them changes no functional
+//! behavior and fails no functional test; the cost is a silent point-read
+//! regression. These tests read the effective (post-sanitization) values back
+//! from the OPTIONS file RocksDB writes at open, so a dropped setting fails
+//! here instead.
+//!
+//! Two of the unrolled settings cannot be checked this way and are held by
+//! review against the upstream preset instead:
+//!
+//! - The bloom policy serializes as `bloomfilter` with no bits-per-key. The
+//!   preset, which calls `NewBloomFilterPolicy(10)` directly, serializes as
+//!   `bloomfilter:10:false`; going through the C API wraps the policy and the
+//!   wrapper's name omits the parameters. Presence is still asserted, which
+//!   catches the filter being dropped entirely.
+//! - The block cache is not written to the OPTIONS file at all, in any form.
+
+use std::collections::{BTreeSet, HashMap};
+
+use drasi_index_rocksdb::element_index::RocksIndexOptions;
+use drasi_index_rocksdb::open_unified_db;
+
+/// Column families read only by exact key, which must carry the full
+/// point-lookup policy.
+const POINT_LOOKUP_CFS: &[&str] = &["elements", "slots", "values", "metadata"];
+
+/// Representative scan-oriented column families, which must not. These are the
+/// negative control: without them a test that asserted the policy everywhere,
+/// or nowhere, would still pass.
+const SCAN_CFS: &[&str] = &["inbound", "partial", "sorted-sets"];
+
+/// `section -> key -> value` from the newest OPTIONS-* file of the DB at
+/// `db_dir`. Sections are kept verbatim, e.g. `[CFOptions "elements"]` and
+/// `[TableOptions/BlockBasedTable "elements"]`.
+fn parse_options_file(db_dir: &std::path::Path) -> HashMap<String, HashMap<String, String>> {
+    let options_file = std::fs::read_dir(db_dir)
+        .expect("read db dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().starts_with("OPTIONS-"))
+        .max_by_key(|e| e.file_name().to_string_lossy().to_string())
+        .expect("OPTIONS file present");
+    let text = std::fs::read_to_string(options_file.path()).expect("read OPTIONS");
+
+    let mut sections: HashMap<String, HashMap<String, String>> = HashMap::new();
+    let mut current = String::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            current = line.to_string();
+        } else if let Some((key, value)) = line.split_once('=') {
+            if !current.is_empty() {
+                sections
+                    .entry(current.clone())
+                    .or_default()
+                    .insert(key.trim().to_string(), value.trim().to_string());
+            }
+        }
+    }
+    sections
+}
+
+fn value<'a>(
+    sections: &'a HashMap<String, HashMap<String, String>>,
+    section_prefix: &str,
+    cf: &str,
+    key: &str,
+) -> &'a str {
+    sections
+        .get(&format!("[{section_prefix} \"{cf}\"]"))
+        .unwrap_or_else(|| panic!("no [{section_prefix} \"{cf}\"] section in OPTIONS"))
+        .get(key)
+        .unwrap_or_else(|| panic!("no {key} for CF '{cf}'"))
+        .as_str()
+}
+
+fn open_and_parse(dir: &tempfile::TempDir, name: &str) -> HashMap<String, HashMap<String, String>> {
+    let options = RocksIndexOptions {
+        archive_enabled: true,
+        direct_io: false,
+    };
+    let db = open_unified_db(dir.path().to_str().expect("utf-8 path"), name, &options)
+        .expect("open unified db");
+    let sections = parse_options_file(&dir.path().join(name));
+    drop(db);
+    sections
+}
+
+#[test]
+fn point_lookup_cfs_carry_every_unrolled_setting() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sections = open_and_parse(&dir, "point-lookup-test");
+
+    for cf in POINT_LOOKUP_CFS {
+        // Memtable whole-key bloom, sized at 2% of write_buffer_size and
+        // allocated when the memtable is constructed.
+        assert_eq!(
+            value(
+                &sections,
+                "CFOptions",
+                cf,
+                "memtable_prefix_bloom_size_ratio"
+            ),
+            "0.020000",
+            "CF '{cf}' lost the memtable bloom ratio"
+        );
+        assert_eq!(
+            value(&sections, "CFOptions", cf, "memtable_whole_key_filtering"),
+            "true",
+            "CF '{cf}' lost memtable whole-key filtering"
+        );
+        // Hash index appended to each data block.
+        assert_eq!(
+            value(
+                &sections,
+                "TableOptions/BlockBasedTable",
+                cf,
+                "data_block_index_type"
+            ),
+            "kDataBlockBinaryAndHash",
+            "CF '{cf}' lost the in-block hash index"
+        );
+        assert_eq!(
+            value(
+                &sections,
+                "TableOptions/BlockBasedTable",
+                cf,
+                "data_block_hash_table_util_ratio"
+            ),
+            "0.750000",
+            "CF '{cf}' has an unexpected data block hash ratio"
+        );
+        // Presence only: the serialized name carries no bits-per-key. See the
+        // module comment.
+        assert_eq!(
+            value(
+                &sections,
+                "TableOptions/BlockBasedTable",
+                cf,
+                "filter_policy"
+            ),
+            "bloomfilter",
+            "CF '{cf}' lost the SST bloom filter"
+        );
+    }
+}
+
+#[test]
+fn scan_cfs_do_not_carry_the_point_lookup_policy() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sections = open_and_parse(&dir, "scan-control-test");
+
+    for cf in SCAN_CFS {
+        assert_eq!(
+            value(
+                &sections,
+                "CFOptions",
+                cf,
+                "memtable_prefix_bloom_size_ratio"
+            ),
+            "0.000000",
+            "CF '{cf}' unexpectedly has a memtable bloom"
+        );
+        assert_eq!(
+            value(&sections, "CFOptions", cf, "memtable_whole_key_filtering"),
+            "false",
+            "CF '{cf}' unexpectedly has memtable whole-key filtering"
+        );
+        assert_eq!(
+            value(
+                &sections,
+                "TableOptions/BlockBasedTable",
+                cf,
+                "data_block_index_type"
+            ),
+            "kDataBlockBinarySearch",
+            "CF '{cf}' unexpectedly has the in-block hash index"
+        );
+        assert_eq!(
+            value(
+                &sections,
+                "TableOptions/BlockBasedTable",
+                cf,
+                "filter_policy"
+            ),
+            "nullptr",
+            "CF '{cf}' unexpectedly has an SST bloom filter"
+        );
+    }
+}
+
+/// Pins the membership of the policy, not just its contents: exactly the four
+/// point-lookup column families carry it. Catches the policy being applied to
+/// a new CF, or a CF being added to `POINT_LOOKUP_CFS` without the options
+/// actually reaching it.
+#[test]
+fn exactly_the_point_lookup_cfs_carry_the_policy() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sections = open_and_parse(&dir, "membership-test");
+
+    let mut with_policy = BTreeSet::new();
+    for (section, keys) in &sections {
+        let Some(rest) = section.strip_prefix("[CFOptions \"") else {
+            continue;
+        };
+        let Some(cf) = rest.strip_suffix("\"]") else {
+            continue;
+        };
+        if keys.get("memtable_whole_key_filtering").map(String::as_str) == Some("true") {
+            with_policy.insert(cf.to_string());
+        }
+    }
+
+    let expected: BTreeSet<String> = POINT_LOOKUP_CFS.iter().map(|s| s.to_string()).collect();
+    assert_eq!(
+        with_policy, expected,
+        "the set of CFs carrying the point-lookup policy changed"
+    );
+}


### PR DESCRIPTION
Closes #709.

The four point-lookup column families (`elements`, `slots`, `values`, `metadata`) took their options from RocksDB's `optimize_for_point_lookup` convenience preset. The preset builds its block cache internally and its signature accepts only a size, so a shared cache cannot be injected through it. This unrolls the preset into explicit settings in a new `src/point_lookup.rs`, leaving the cache as a handle the crate constructs. No functional change.

### Equivalence

`ColumnFamilyOptions::OptimizeForPointLookup` in RocksDB 8.1.1 (`options/options.cc:609`, the version pinned by `librocksdb-sys 0.11.0+8.1.1`) sets six things. All six are preserved:

| Preset | This PR |
|---|---|
| `data_block_index_type = kDataBlockBinaryAndHash` | `set_data_block_index_type(BinaryAndHash)` |
| `data_block_hash_table_util_ratio = 0.75` | `set_data_block_hash_ratio(0.75)` |
| `filter_policy = NewBloomFilterPolicy(10)` | `set_bloom_filter(10.0, false)` |
| `block_cache = NewLRUCache(mb * 1024 * 1024)` | `set_block_cache(&Cache::new_lru_cache(bytes))` |
| `memtable_prefix_bloom_size_ratio = 0.02` | `set_memtable_prefix_bloom_ratio(0.02)` |
| `memtable_whole_key_filtering = true` | `set_memtable_whole_key_filtering(true)` |

The preset also *replaces* the table factory rather than merging into it. These four CFs set no other block-based table options, so nothing is lost; the module comment records that a future one has to go through `point_lookup_cf_options` rather than being layered on at the call site.

Cache sizes are unchanged: 32 MiB each for `elements`, `slots` and `values`, 1 MiB for `metadata`. The `metadata` size was a bare `optimize_for_point_lookup(1)`; it is now a named constant.

### Two unit traps, closed

- The preset takes **megabytes**, `Cache::new_lru_cache` takes **bytes**. The constants are now `usize` byte counts with explicit `* 1024 * 1024`, and the parameter is documented as bytes, so the old `32` cannot be passed through by mistake.
- `get_elements_cf_options()` is called twice, once for `elements` and once for `slots`, and each call previously got its own 32 MiB cache. `point_lookup_cf_options` constructs a fresh `Cache` per call to preserve that. Hoisting a single shared `Cache` here would quietly halve the capacity available to those two CFs and nothing in the OPTIONS file would show it, so the invariant is written down next to the code.

### Tests

New `tests/point_lookup_options_tests.rs` reads the effective values back from the OPTIONS file RocksDB writes at open:

- `point_lookup_cfs_carry_every_unrolled_setting` asserts the memtable bloom ratio, whole-key filtering, the in-block hash index, the hash ratio, and the presence of the bloom filter, on all four CFs.
- `scan_cfs_do_not_carry_the_point_lookup_policy` is the negative control on `inbound`, `partial` and `sorted-sets`. Without it, a test that applied the policy everywhere or nowhere would still pass.
- `exactly_the_point_lookup_cfs_carry_the_policy` pins membership, so the policy cannot silently spread to another CF or fail to reach one.

Two of the six settings cannot be checked this way, and the module comment says so rather than leaving it implied:

- **Bloom bits-per-key.** The preset calls `NewBloomFilterPolicy(10)` directly and serializes as `filter_policy=bloomfilter:10:false`. Going through the C API wraps the policy, and the wrapper's name omits the parameters, so after the unroll it serializes as `filter_policy=bloomfilter`. Behavior is identical (`rocksdb_filterpolicy_create_bloom_format` delegates `GetBuilderWithContext` to `NewBloomFilterPolicy(10)`); only the recorded name differs. The test asserts presence, which still catches the filter being dropped entirely.
- **Block cache.** Not written to the OPTIONS file in any form. Only `no_block_cache=false` appears. This matters for #634, which should not assume OPTIONS-file assertions can guard the shared-cache swap.

`data_block_hash_table_util_ratio = 0.75` is also RocksDB's default, so that one assertion passes whether or not the code sets it. It is kept as documentation of intent, not as a guard.

### Verification

- `cargo test -p drasi-index-rocksdb` green: 24 unit, 14 outbox/live-results, 3 new point-lookup, 1 retention bound, 44 scenario. `cargo clippy --all-targets --all-features` clean.
- The new tests were mutation-checked rather than assumed to work. Deleting `set_memtable_whole_key_filtering(true)` fails two of them (`CF 'elements' lost memtable whole-key filtering`, and the membership set collapses to empty); deleting `set_bloom_filter(...)` fails one (`CF 'elements' lost the SST bloom filter`, `nullptr` vs `bloomfilter`). Both mutations leave every functional test passing, which is the failure mode this PR exists to close.
- The equivalence and the two OPTIONS-file gaps were established empirically before writing the change, by opening a database with the preset and a hand-unroll side by side and diffing the resulting OPTIONS file. Every `[CFOptions]` key was identical; the only delta anywhere was the `filter_policy` name described above.

### Follow-up

#634 now only has to replace the per-CF `Cache::new_lru_cache(...)` in `point_lookup_cf_options` with an injected shared handle, and do the same for the non-point-lookup CFs. It will need its own verification for that swap, since the OPTIONS file cannot see it.
