### PR TITLE
fix(index-rocksdb)!: share memory budgets across query DBs

### DIFF
--- a/components/indexes/rocksdb/Cargo.toml
+++ b/components/indexes/rocksdb/Cargo.toml
@@ -29,7 +29,7 @@ workspace = true
 [dependencies]
 drasi-core.workspace = true
 drasi-query-ast.workspace = true
-rocksdb = { version = "0.21.0", features = ["default", "multi-threaded-cf"] }
+rocksdb = { version = "0.22.0", features = ["default", "multi-threaded-cf"] }
 async-trait = "0.1.68"
 bytes = "1"
 hashers = "1.0.1"

--- a/components/indexes/rocksdb/src/cf_options.rs
+++ b/components/indexes/rocksdb/src/cf_options.rs
@@ -1,0 +1,36 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocksdb::{BlockBasedOptions, Cache, Options};
+
+pub(crate) fn shared_block_based_options(block_cache: &Cache) -> BlockBasedOptions {
+    let mut table_options = BlockBasedOptions::default();
+    table_options.set_block_cache(block_cache);
+    // Otherwise each table reader keeps SST index and filter blocks outside
+    // the shared cache, so their memory grows independently of the budget.
+    table_options.set_cache_index_and_filter_blocks(true);
+    table_options
+}
+
+pub(crate) fn options_with_table(table_options: &BlockBasedOptions) -> Options {
+    let mut options = Options::default();
+    crate::bound_write_buffer_history(&mut options);
+    options.set_block_based_table_factory(table_options);
+    options
+}
+
+pub(crate) fn base_cf_options(block_cache: &Cache) -> Options {
+    let table_options = shared_block_based_options(block_cache);
+    options_with_table(&table_options)
+}

--- a/components/indexes/rocksdb/src/checkpoint.rs
+++ b/components/indexes/rocksdb/src/checkpoint.rs
@@ -33,7 +33,7 @@ use crate::IndexDb;
 use async_trait::async_trait;
 use bytes::Bytes;
 use drasi_core::interface::{CheckpointStore, IndexError, SourceCheckpoint};
-use rocksdb::{ColumnFamilyDescriptor, Options};
+use rocksdb::ColumnFamilyDescriptor;
 use tokio::task;
 
 use crate::RocksDbSessionState;
@@ -47,9 +47,8 @@ const CONFIG_HASH_KEY: &str = "config_hash";
 const RESULT_SEQUENCE_PREFIX: &str = "result_sequence:";
 
 /// Returns the column family descriptor for the stream_state CF.
-pub(crate) fn stream_state_cf_descriptor() -> ColumnFamilyDescriptor {
-    let mut opts = Options::default();
-    crate::bound_write_buffer_history(&mut opts);
+pub(crate) fn stream_state_cf_descriptor(block_cache: &rocksdb::Cache) -> ColumnFamilyDescriptor {
+    let mut opts = crate::cf_options::base_cf_options(block_cache);
     opts.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(16));
     ColumnFamilyDescriptor::new(STREAM_STATE_CF, opts)
 }

--- a/components/indexes/rocksdb/src/descriptor.rs
+++ b/components/indexes/rocksdb/src/descriptor.rs
@@ -26,7 +26,7 @@ use drasi_core::interface::IndexBackendPlugin;
 use drasi_plugin_sdk::prelude::*;
 use utoipa::OpenApi;
 
-use crate::{RocksDbIndexProvider, RocksDbMemoryBudget};
+use crate::RocksDbIndexProvider;
 
 fn default_false() -> ConfigValueBool {
     ConfigValue::Static(false)
@@ -108,12 +108,9 @@ impl RocksDbIndexDescriptor {
 
         let provider = RocksDbIndexProvider::new(path, enable_archive, direct_io);
         match memory_budget_bytes {
-            Some(total_budget_bytes) => {
-                let memory_budget =
-                    RocksDbMemoryBudget::from_total_budget_bytes(total_budget_bytes)
-                        .context("Invalid RocksDB index memory budget")?;
-                Ok(provider.with_memory_budget(memory_budget))
-            }
+            Some(total_budget_bytes) => provider
+                .with_memory_budget_bytes(total_budget_bytes)
+                .context("Invalid RocksDB index memory budget"),
             None => Ok(provider),
         }
     }

--- a/components/indexes/rocksdb/src/descriptor.rs
+++ b/components/indexes/rocksdb/src/descriptor.rs
@@ -26,7 +26,7 @@ use drasi_core::interface::IndexBackendPlugin;
 use drasi_plugin_sdk::prelude::*;
 use utoipa::OpenApi;
 
-use crate::RocksDbIndexProvider;
+use crate::{RocksDbIndexProvider, RocksDbMemoryBudget};
 
 fn default_false() -> ConfigValueBool {
     ConfigValue::Static(false)
@@ -34,7 +34,7 @@ fn default_false() -> ConfigValueBool {
 
 /// Configuration DTO for the RocksDB index backend plugin.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RocksDbIndexConfigDto {
     /// Base directory for RocksDB data files.
     #[schema(value_type = ConfigValueString)]
@@ -49,6 +49,11 @@ pub struct RocksDbIndexConfigDto {
     #[serde(default = "default_false")]
     #[schema(value_type = ConfigValueBool)]
     pub direct_io: ConfigValue<bool>,
+
+    /// Combined capacity for cached blocks and memtable reservations, in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<ConfigValueUsize>)]
+    pub memory_budget_bytes: Option<ConfigValue<usize>>,
 }
 
 #[derive(utoipa::OpenApi)]
@@ -58,6 +63,62 @@ struct RocksDbIndexSchemas;
 /// Descriptor for the RocksDB index backend plugin.
 pub struct RocksDbIndexDescriptor;
 
+impl RocksDbIndexDescriptor {
+    async fn create_provider(
+        &self,
+        config_json: &serde_json::Value,
+    ) -> anyhow::Result<RocksDbIndexProvider> {
+        let dto: RocksDbIndexConfigDto = serde_json::from_value(config_json.clone())
+            .context("Failed to deserialize RocksDB index backend configuration")?;
+
+        let mapper = DtoMapper::new();
+        let path = mapper
+            .resolve_string(&dto.path)
+            .await
+            .context("Failed to resolve RocksDB index 'path'")?;
+        let enable_archive = mapper
+            .resolve_typed(&dto.enable_archive)
+            .await
+            .context("Failed to resolve RocksDB index 'enableArchive'")?;
+        let direct_io = mapper
+            .resolve_typed(&dto.direct_io)
+            .await
+            .context("Failed to resolve RocksDB index 'directIo'")?;
+        let memory_budget_bytes = mapper
+            .resolve_optional(&dto.memory_budget_bytes)
+            .await
+            .context("Failed to resolve RocksDB index 'memoryBudgetBytes'")?;
+
+        if path.trim().is_empty() {
+            anyhow::bail!("RocksDB index 'path' must not be empty");
+        }
+
+        // Relative paths are intentionally supported (resolved against the
+        // process working directory), but parent-directory (`..`) components are
+        // rejected so a configured path cannot escape upward out of its intended
+        // storage root.
+        if std::path::Path::new(&path)
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            anyhow::bail!(
+                "RocksDB index 'path' must not contain parent directory ('..') components, got: {path}"
+            );
+        }
+
+        let provider = RocksDbIndexProvider::new(path, enable_archive, direct_io);
+        match memory_budget_bytes {
+            Some(total_budget_bytes) => {
+                let memory_budget =
+                    RocksDbMemoryBudget::from_total_budget_bytes(total_budget_bytes)
+                        .context("Invalid RocksDB index memory budget")?;
+                Ok(provider.with_memory_budget(memory_budget))
+            }
+            None => Ok(provider),
+        }
+    }
+}
+
 #[async_trait]
 impl IndexBackendPluginDescriptor for RocksDbIndexDescriptor {
     fn kind(&self) -> &str {
@@ -65,7 +126,7 @@ impl IndexBackendPluginDescriptor for RocksDbIndexDescriptor {
     }
 
     fn config_version(&self) -> &str {
-        "1.0.0"
+        "1.1.0"
     }
 
     fn config_schema_json(&self) -> String {
@@ -95,60 +156,45 @@ impl IndexBackendPluginDescriptor for RocksDbIndexDescriptor {
         &self,
         config_json: &serde_json::Value,
     ) -> anyhow::Result<Arc<dyn IndexBackendPlugin>> {
-        let dto: RocksDbIndexConfigDto = serde_json::from_value(config_json.clone())
-            .context("Failed to deserialize RocksDB index backend configuration")?;
-
-        let mapper = DtoMapper::new();
-        let path = mapper
-            .resolve_string(&dto.path)
-            .await
-            .context("Failed to resolve RocksDB index 'path'")?;
-        let enable_archive = mapper
-            .resolve_typed(&dto.enable_archive)
-            .await
-            .context("Failed to resolve RocksDB index 'enableArchive'")?;
-        let direct_io = mapper
-            .resolve_typed(&dto.direct_io)
-            .await
-            .context("Failed to resolve RocksDB index 'directIo'")?;
-
-        if path.trim().is_empty() {
-            anyhow::bail!("RocksDB index 'path' must not be empty");
-        }
-
-        // Relative paths are intentionally supported (resolved against the
-        // process working directory), but parent-directory (`..`) components are
-        // rejected so a configured path cannot escape upward out of its intended
-        // storage root.
-        if std::path::Path::new(&path)
-            .components()
-            .any(|c| matches!(c, std::path::Component::ParentDir))
-        {
-            anyhow::bail!(
-                "RocksDB index 'path' must not contain parent directory ('..') components, got: {path}"
-            );
-        }
-
-        Ok(Arc::new(RocksDbIndexProvider::new(
-            path,
-            enable_archive,
-            direct_io,
-        )))
+        Ok(Arc::new(self.create_provider(config_json).await?))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{DEFAULT_BLOCK_CACHE_CAPACITY_BYTES, DEFAULT_WRITE_BUFFER_BUDGET_BYTES};
+
+    const CUSTOM_MEMORY_BUDGET_BYTES: usize = 64 * 1024 * 1024;
+    const CUSTOM_WRITE_BUFFER_BUDGET_BYTES: usize = 32 * 1024 * 1024;
+
+    fn assert_memory_budget(
+        provider: &RocksDbIndexProvider,
+        block_cache_capacity_bytes: usize,
+        write_buffer_budget_bytes: usize,
+    ) {
+        assert_eq!(
+            provider.memory_budget().block_cache_capacity_bytes(),
+            block_cache_capacity_bytes
+        );
+        assert_eq!(
+            provider
+                .memory_budget()
+                .write_buffer_manager()
+                .get_buffer_size(),
+            write_buffer_budget_bytes
+        );
+    }
 
     #[test]
     fn test_descriptor_metadata() {
         let d = RocksDbIndexDescriptor;
         assert_eq!(d.kind(), "rocksdb");
-        assert_eq!(d.config_version(), "1.0.0");
+        assert_eq!(d.config_version(), "1.1.0");
         assert_eq!(d.config_schema_name(), "index.rocksdb.RocksDbIndexConfig");
         let schema = d.config_schema_json();
         assert!(schema.contains("RocksDbIndexConfigDto"));
+        assert!(schema.contains("memoryBudgetBytes"));
     }
 
     #[test]
@@ -157,35 +203,99 @@ mod tests {
         let dto: RocksDbIndexConfigDto = serde_json::from_value(json).expect("deserialize");
         assert!(matches!(dto.enable_archive, ConfigValue::Static(false)));
         assert!(matches!(dto.direct_io, ConfigValue::Static(false)));
+        assert!(dto.memory_budget_bytes.is_none());
     }
 
     #[tokio::test]
-    async fn test_create_with_static_values() {
+    async fn test_create_uses_default_memory_budget() {
+        let json = serde_json::json!({ "path": "/tmp/drasi-rocks-test" });
+        let provider = RocksDbIndexDescriptor
+            .create_provider(&json)
+            .await
+            .expect("create");
+        assert_memory_budget(
+            &provider,
+            DEFAULT_BLOCK_CACHE_CAPACITY_BYTES,
+            DEFAULT_WRITE_BUFFER_BUDGET_BYTES,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_with_custom_memory_budget() {
         let json = serde_json::json!({
             "path": "/tmp/drasi-rocks-test",
             "enableArchive": true,
-            "directIo": false
+            "directIo": false,
+            "memoryBudgetBytes": CUSTOM_MEMORY_BUDGET_BYTES
         });
         let provider = RocksDbIndexDescriptor
-            .create_index_backend(&json)
+            .create_provider(&json)
             .await
             .expect("create");
         assert!(!provider.is_volatile());
+        assert_memory_budget(
+            &provider,
+            CUSTOM_MEMORY_BUDGET_BYTES,
+            CUSTOM_WRITE_BUFFER_BUDGET_BYTES,
+        );
     }
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn test_create_with_env_var_path() {
+    async fn test_create_with_env_var_values() {
         std::env::set_var("TEST_ROCKSDB_PATH", "/tmp/drasi-rocks-env");
+        std::env::set_var(
+            "TEST_ROCKSDB_MEMORY_BUDGET",
+            CUSTOM_MEMORY_BUDGET_BYTES.to_string(),
+        );
         let json = serde_json::json!({
-            "path": { "kind": "EnvironmentVariable", "name": "TEST_ROCKSDB_PATH" }
+            "path": { "kind": "EnvironmentVariable", "name": "TEST_ROCKSDB_PATH" },
+            "memoryBudgetBytes": {
+                "kind": "EnvironmentVariable",
+                "name": "TEST_ROCKSDB_MEMORY_BUDGET"
+            }
         });
         let provider = RocksDbIndexDescriptor
-            .create_index_backend(&json)
+            .create_provider(&json)
             .await
             .expect("create");
         assert!(!provider.is_volatile());
+        assert_memory_budget(
+            &provider,
+            CUSTOM_MEMORY_BUDGET_BYTES,
+            CUSTOM_WRITE_BUFFER_BUDGET_BYTES,
+        );
         std::env::remove_var("TEST_ROCKSDB_PATH");
+        std::env::remove_var("TEST_ROCKSDB_MEMORY_BUDGET");
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_invalid_memory_budget() {
+        let json = serde_json::json!({
+            "path": "/tmp/drasi-rocks-test",
+            "memoryBudgetBytes": 1
+        });
+        let err = match RocksDbIndexDescriptor.create_provider(&json).await {
+            Ok(_) => panic!("should reject invalid memory budget"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("memory budget"));
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_unknown_fields() {
+        let json = serde_json::json!({
+            "path": "/tmp/drasi-rocks-test",
+            "memoryBudget": CUSTOM_MEMORY_BUDGET_BYTES
+        });
+        let err = match RocksDbIndexDescriptor.create_provider(&json).await {
+            Ok(_) => panic!("should reject unknown fields"),
+            Err(err) => err,
+        };
+        assert!(
+            format!("{err:#}").contains("unknown field"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[tokio::test]
@@ -211,9 +321,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_rejects_parent_dir_traversal() {
         let json = serde_json::json!({ "path": "../../secrets" });
-        let err = match RocksDbIndexDescriptor.create_index_backend(&json).await {
+        let err = match RocksDbIndexDescriptor.create_provider(&json).await {
             Ok(_) => panic!("should reject parent-directory traversal"),
-            Err(e) => e,
+            Err(err) => err,
         };
         assert!(
             err.to_string().contains("parent directory"),

--- a/components/indexes/rocksdb/src/element_index.rs
+++ b/components/indexes/rocksdb/src/element_index.rs
@@ -28,14 +28,14 @@ use drasi_core::{
 };
 use hashers::jenkins::spooky_hash::SpookyHasher;
 use prost::{bytes::BytesMut, Message};
-use rocksdb::{Options, SliceTransform, Transaction};
+use rocksdb::{Cache, Options, SliceTransform, Transaction};
 use tokio::task;
 
 use crate::storage_models::{
     StoredElement, StoredElementContainer, StoredElementMetadata, StoredElementReference,
     StoredRelation, StoredValue, StoredValueMap,
 };
-use crate::RocksDbSessionState;
+use crate::{RocksDbSessionState, RocksIndexOptions};
 
 mod archive_index;
 
@@ -58,21 +58,11 @@ pub struct Context {
     session_state: Arc<RocksDbSessionState>,
 }
 
-#[derive(Clone, Copy)]
-pub struct RocksIndexOptions {
-    pub archive_enabled: bool,
-    pub direct_io: bool,
-}
-
 const ELEMENTS_CF: &str = "elements";
 const SLOT_CF: &str = "slots";
 const INBOUND_CF: &str = "inbound";
 const OUTBOUND_CF: &str = "outbound";
 const PARTIAL_CF: &str = "partial";
-/// Block cache capacity for `elements` and `slots`. Each column family gets
-/// its own cache of this size, not a shared one.
-const ELEMENT_BLOCK_CACHE_BYTES: usize = 32 * 1024 * 1024;
-
 impl RocksDbElementIndex {
     /// Create a new RocksDbElementIndex from a shared database handle.
     ///
@@ -310,7 +300,9 @@ impl ElementIndex for RocksDbElementIndex {
 
     async fn clear(&self) -> Result<(), IndexError> {
         let context = self.context.clone();
+
         let task = task::spawn_blocking(move || {
+            let block_cache = context.options.memory_budget().block_cache();
             if let Err(err) = context.db.drop_cf(ELEMENTS_CF) {
                 return Err(IndexError::other(err));
             }
@@ -329,30 +321,36 @@ impl ElementIndex for RocksDbElementIndex {
 
             if let Err(err) = context
                 .db
-                .create_cf(ELEMENTS_CF, &get_elements_cf_options())
-            {
-                return Err(IndexError::other(err));
-            }
-
-            if let Err(err) = context.db.create_cf(SLOT_CF, &get_elements_cf_options()) {
-                return Err(IndexError::other(err));
-            }
-
-            if let Err(err) = context
-                .db
-                .create_cf(INBOUND_CF, &get_inout_index_cf_options())
+                .create_cf(ELEMENTS_CF, &get_elements_cf_options(block_cache))
             {
                 return Err(IndexError::other(err));
             }
 
             if let Err(err) = context
                 .db
-                .create_cf(OUTBOUND_CF, &get_inout_index_cf_options())
+                .create_cf(SLOT_CF, &get_elements_cf_options(block_cache))
             {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = context.db.create_cf(PARTIAL_CF, &get_partial_cf_options()) {
+            if let Err(err) = context
+                .db
+                .create_cf(INBOUND_CF, &get_inout_index_cf_options(block_cache))
+            {
+                return Err(IndexError::other(err));
+            }
+
+            if let Err(err) = context
+                .db
+                .create_cf(OUTBOUND_CF, &get_inout_index_cf_options(block_cache))
+            {
+                return Err(IndexError::other(err));
+            }
+
+            if let Err(err) = context
+                .db
+                .create_cf(PARTIAL_CF, &get_partial_cf_options(block_cache))
+            {
                 return Err(IndexError::other(err));
             }
 
@@ -373,42 +371,39 @@ impl ElementIndex for RocksDbElementIndex {
     }
 }
 
-pub(crate) fn get_partial_cf_options() -> Options {
-    let mut partial_opts = Options::default();
-    crate::bound_write_buffer_history(&mut partial_opts);
+pub(crate) fn get_partial_cf_options(block_cache: &Cache) -> Options {
+    let mut partial_opts = crate::cf_options::base_cf_options(block_cache);
     partial_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(16));
     partial_opts
 }
 
-pub(crate) fn get_inout_index_cf_options() -> Options {
-    let mut inout_bound_opts = Options::default();
-    crate::bound_write_buffer_history(&mut inout_bound_opts);
+pub(crate) fn get_inout_index_cf_options(block_cache: &Cache) -> Options {
+    let mut inout_bound_opts = crate::cf_options::base_cf_options(block_cache);
     inout_bound_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(18));
     inout_bound_opts
 }
 
-pub(crate) fn get_elements_cf_options() -> Options {
-    let mut elements_opts = crate::point_lookup::point_lookup_cf_options(ELEMENT_BLOCK_CACHE_BYTES);
-    crate::bound_write_buffer_history(&mut elements_opts);
-    elements_opts
+pub(crate) fn get_elements_cf_options(block_cache: &Cache) -> Options {
+    crate::point_lookup::point_lookup_cf_options(block_cache)
 }
 
 /// Collect all column family descriptors needed by the element index.
 pub(crate) fn element_cf_descriptors(
     options: &RocksIndexOptions,
 ) -> Vec<rocksdb::ColumnFamilyDescriptor> {
+    let block_cache = options.memory_budget().block_cache();
     let mut cfs = vec![
-        rocksdb::ColumnFamilyDescriptor::new(ELEMENTS_CF, get_elements_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(SLOT_CF, get_elements_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(INBOUND_CF, get_inout_index_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(OUTBOUND_CF, get_inout_index_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(PARTIAL_CF, get_partial_cf_options()),
+        rocksdb::ColumnFamilyDescriptor::new(ELEMENTS_CF, get_elements_cf_options(block_cache)),
+        rocksdb::ColumnFamilyDescriptor::new(SLOT_CF, get_elements_cf_options(block_cache)),
+        rocksdb::ColumnFamilyDescriptor::new(INBOUND_CF, get_inout_index_cf_options(block_cache)),
+        rocksdb::ColumnFamilyDescriptor::new(OUTBOUND_CF, get_inout_index_cf_options(block_cache)),
+        rocksdb::ColumnFamilyDescriptor::new(PARTIAL_CF, get_partial_cf_options(block_cache)),
     ];
 
-    if options.archive_enabled {
+    if options.archive_enabled() {
         cfs.push(rocksdb::ColumnFamilyDescriptor::new(
             archive_index::ARCHIVE_CF,
-            archive_index::get_archive_cf_options(),
+            archive_index::get_archive_cf_options(block_cache),
         ));
     }
 
@@ -643,7 +638,7 @@ fn set_element_internal(
 
     update_source_joins(context.clone(), txn, &element)?;
 
-    if context.options.archive_enabled {
+    if context.options.archive_enabled() {
         archive_index::insert_archive(
             context.clone(),
             txn,

--- a/components/indexes/rocksdb/src/element_index/archive_index.rs
+++ b/components/indexes/rocksdb/src/element_index/archive_index.rs
@@ -21,7 +21,7 @@ use drasi_core::{
     models::{Element, ElementReference, ElementTimestamp, TimestampBound, TimestampRange},
 };
 use prost::{bytes::Bytes, Message};
-use rocksdb::{Options, SliceTransform, Transaction};
+use rocksdb::{Cache, Options, SliceTransform, Transaction};
 use tokio::task;
 
 use crate::{
@@ -40,7 +40,7 @@ impl ElementArchiveIndex for RocksDbElementIndex {
         element_ref: &ElementReference,
         time: ElementTimestamp,
     ) -> Result<Option<Arc<Element>>, IndexError> {
-        if !self.context.options.archive_enabled {
+        if !self.context.options.archive_enabled() {
             return Err(IndexError::ArchiveNotEnabled);
         }
         let context = self.context.clone();
@@ -95,7 +95,7 @@ impl ElementArchiveIndex for RocksDbElementIndex {
         element_ref: &ElementReference,
         range: TimestampRange<ElementTimestamp>,
     ) -> Result<ElementStream, IndexError> {
-        if !self.context.options.archive_enabled {
+        if !self.context.options.archive_enabled() {
             return Err(IndexError::ArchiveNotEnabled);
         }
         let context = self.context.clone();
@@ -213,6 +213,7 @@ impl ElementArchiveIndex for RocksDbElementIndex {
         let context = self.context.clone();
 
         let task = task::spawn_blocking(move || {
+            let block_cache = context.options.memory_budget().block_cache();
             match context.db.drop_cf(ARCHIVE_CF) {
                 Ok(()) => {}
                 Err(err) => {
@@ -224,7 +225,10 @@ impl ElementArchiveIndex for RocksDbElementIndex {
                     return Err(IndexError::other(err));
                 }
             }
-            if let Err(err) = context.db.create_cf(ARCHIVE_CF, &get_archive_cf_options()) {
+            if let Err(err) = context
+                .db
+                .create_cf(ARCHIVE_CF, &get_archive_cf_options(block_cache))
+            {
                 return Err(IndexError::other(err));
             }
             Ok(())
@@ -253,9 +257,8 @@ pub fn insert_archive(
     }
 }
 
-pub(crate) fn get_archive_cf_options() -> Options {
-    let mut opts = Options::default();
-    crate::bound_write_buffer_history(&mut opts);
+pub(crate) fn get_archive_cf_options(block_cache: &Cache) -> Options {
+    let mut opts = crate::cf_options::base_cf_options(block_cache);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(16));
     opts
 }

--- a/components/indexes/rocksdb/src/future_queue.rs
+++ b/components/indexes/rocksdb/src/future_queue.rs
@@ -25,11 +25,11 @@ use drasi_core::{
 };
 use hashers::jenkins::spooky_hash::SpookyHasher;
 use prost::{bytes::Bytes, Message};
-use rocksdb::{AsColumnFamilyRef, Options, ReadOptions, SliceTransform, Transaction};
+use rocksdb::{AsColumnFamilyRef, Cache, Options, ReadOptions, SliceTransform, Transaction};
 use tokio::task;
 
 use crate::storage_models::{StoredElementReference, StoredFutureElementRef};
-use crate::RocksDbSessionState;
+use crate::{RocksDbSessionState, RocksIndexOptions};
 
 /// RocksDB future queue
 ///
@@ -39,6 +39,7 @@ use crate::RocksDbSessionState;
 pub struct RocksDbFutureQueue {
     db: Arc<IndexDb>,
     session_state: Arc<RocksDbSessionState>,
+    options: RocksIndexOptions,
 }
 
 const QUEUE_CF: &str = "fqueue";
@@ -49,8 +50,16 @@ impl RocksDbFutureQueue {
     ///
     /// The database must already have the required column families created.
     /// Use `open_unified_db()` to open a database with all required CFs.
-    pub fn new(db: Arc<IndexDb>, session_state: Arc<RocksDbSessionState>) -> Self {
-        Self { db, session_state }
+    pub fn new(
+        db: Arc<IndexDb>,
+        session_state: Arc<RocksDbSessionState>,
+        options: RocksIndexOptions,
+    ) -> Self {
+        Self {
+            db,
+            session_state,
+            options,
+        }
     }
 }
 
@@ -255,12 +264,14 @@ impl FutureQueue for RocksDbFutureQueue {
 
     async fn clear(&self) -> Result<(), IndexError> {
         let db = self.db.clone();
+        let options = self.options.clone();
         let task = task::spawn_blocking(move || {
+            let block_cache = options.memory_budget().block_cache();
             if let Err(err) = db.drop_cf(QUEUE_CF) {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = db.create_cf(QUEUE_CF, &get_fqueue_cf_options()) {
+            if let Err(err) = db.create_cf(QUEUE_CF, &get_fqueue_cf_options(block_cache)) {
                 return Err(IndexError::other(err));
             }
 
@@ -268,7 +279,7 @@ impl FutureQueue for RocksDbFutureQueue {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = db.create_cf(INDEX_CF, &get_findex_cf_options()) {
+            if let Err(err) = db.create_cf(INDEX_CF, &get_findex_cf_options(block_cache)) {
                 return Err(IndexError::other(err));
             }
             Ok(())
@@ -341,24 +352,24 @@ fn encode_index_prefix(position_in_query: u32, group_signature: u64) -> [u8; 12]
     buf
 }
 
-pub(crate) fn get_fqueue_cf_options() -> Options {
-    let mut opts = Options::default();
-    crate::bound_write_buffer_history(&mut opts);
+pub(crate) fn get_fqueue_cf_options(block_cache: &Cache) -> Options {
+    let mut opts = crate::cf_options::base_cf_options(block_cache);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
     opts
 }
 
-pub(crate) fn get_findex_cf_options() -> Options {
-    let mut opts = Options::default();
-    crate::bound_write_buffer_history(&mut opts);
+pub(crate) fn get_findex_cf_options(block_cache: &Cache) -> Options {
+    let mut opts = crate::cf_options::base_cf_options(block_cache);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(12));
     opts
 }
 
 /// Collect all column family descriptors needed by the future queue.
-pub(crate) fn future_queue_cf_descriptors() -> Vec<rocksdb::ColumnFamilyDescriptor> {
+pub(crate) fn future_queue_cf_descriptors(
+    block_cache: &Cache,
+) -> Vec<rocksdb::ColumnFamilyDescriptor> {
     vec![
-        rocksdb::ColumnFamilyDescriptor::new(QUEUE_CF, get_fqueue_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(INDEX_CF, get_findex_cf_options()),
+        rocksdb::ColumnFamilyDescriptor::new(QUEUE_CF, get_fqueue_cf_options(block_cache)),
+        rocksdb::ColumnFamilyDescriptor::new(INDEX_CF, get_findex_cf_options(block_cache)),
     ]
 }

--- a/components/indexes/rocksdb/src/lib.rs
+++ b/components/indexes/rocksdb/src/lib.rs
@@ -21,11 +21,13 @@
 //! # Usage
 //!
 //! ```ignore
-//! use drasi_index_rocksdb::RocksDbIndexProvider;
+//! use drasi_index_rocksdb::{RocksDbIndexProvider, RocksDbMemoryBudget};
 //! use drasi_lib::DrasiLib;
 //! use std::sync::Arc;
 //!
-//! let provider = RocksDbIndexProvider::new("/data/drasi", true, false);
+//! let memory = RocksDbMemoryBudget::new(256 << 20, 128 << 20, false)?;
+//! let provider = RocksDbIndexProvider::new("/data/drasi", true, false)
+//!     .with_memory_budget(memory);
 //! let drasi = DrasiLib::builder()
 //!     .with_index_provider("rocksdb", Arc::new(provider))
 //!     .build()?;
@@ -46,12 +48,12 @@ pub type IndexDb = rocksdb::TransactionDB;
 
 /// Flushed-memtable history retained per column family, in bytes.
 ///
-/// Set explicitly on every column family and on the DB-level options: leaving
-/// `max_write_buffer_size_to_maintain` at zero is not neutral, RocksDB
-/// sanitizes it back to a large default (128 MiB per CF observed), and the
-/// retained memtables count against process memory after every flush. A 1 MiB
-/// bound is safe only because pessimistic transactions never validate against
-/// history; do not carry it back to an optimistic DB.
+/// Set explicitly on every column family: leaving
+/// `max_write_buffer_size_to_maintain` at zero is not neutral, RocksDB sanitizes
+/// it back to a large default (128 MiB per CF observed), and the retained
+/// memtables count against process memory after every flush. A 1 MiB bound is
+/// safe only because pessimistic transactions never validate against history;
+/// do not carry it back to an optimistic DB.
 pub(crate) const WRITE_BUFFER_HISTORY_BYTES: usize = 1024 * 1024;
 
 /// Apply the explicit flushed-memtable history bound to a set of options.
@@ -59,12 +61,15 @@ pub(crate) fn bound_write_buffer_history(opts: &mut rocksdb::Options) {
     opts.set_max_write_buffer_size_to_maintain(WRITE_BUFFER_HISTORY_BYTES as i64);
 }
 
+mod cf_options;
 pub mod checkpoint;
 #[cfg(feature = "plugin-descriptor")]
 mod descriptor;
 pub mod element_index;
 pub mod future_queue;
 pub mod live_results;
+mod memory;
+mod options;
 pub mod outbox;
 mod plugin;
 mod point_lookup;
@@ -75,6 +80,11 @@ mod storage_models;
 // Re-export the plugin provider and unified DB opener for easy access
 pub use checkpoint::RocksDbCheckpointStore;
 pub use live_results::RocksDbLiveResultsWriter;
+pub use memory::{
+    RocksDbMemoryBudget, RocksDbMemoryBudgetError, DEFAULT_BLOCK_CACHE_CAPACITY_BYTES,
+    DEFAULT_WRITE_BUFFER_BUDGET_BYTES,
+};
+pub use options::RocksIndexOptions;
 pub use outbox::RocksDbOutboxWriter;
 pub use plugin::open_unified_db;
 pub use plugin::RocksDbIndexProvider;

--- a/components/indexes/rocksdb/src/lib.rs
+++ b/components/indexes/rocksdb/src/lib.rs
@@ -21,13 +21,12 @@
 //! # Usage
 //!
 //! ```ignore
-//! use drasi_index_rocksdb::{RocksDbIndexProvider, RocksDbMemoryBudget};
+//! use drasi_index_rocksdb::RocksDbIndexProvider;
 //! use drasi_lib::DrasiLib;
 //! use std::sync::Arc;
 //!
-//! let memory = RocksDbMemoryBudget::new(256 << 20, 128 << 20, false)?;
 //! let provider = RocksDbIndexProvider::new("/data/drasi", true, false)
-//!     .with_memory_budget(memory);
+//!     .with_memory_budget_bytes(512 << 20)?;
 //! let drasi = DrasiLib::builder()
 //!     .with_index_provider("rocksdb", Arc::new(provider))
 //!     .build()?;

--- a/components/indexes/rocksdb/src/live_results.rs
+++ b/components/indexes/rocksdb/src/live_results.rs
@@ -25,16 +25,15 @@ use std::sync::Arc;
 use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::interface::{IndexError, LiveResultsWriter, RowMutation};
-use rocksdb::{ColumnFamilyDescriptor, IteratorMode, Options, WriteBatchWithTransaction};
+use rocksdb::{ColumnFamilyDescriptor, IteratorMode, WriteBatchWithTransaction};
 use tokio::task;
 
 /// Column family name for live results data.
 pub(crate) const LIVE_RESULTS_CF: &str = "live_results";
 
 /// Returns the column family descriptor for the live_results CF.
-pub(crate) fn live_results_cf_descriptor() -> ColumnFamilyDescriptor {
-    let mut opts = Options::default();
-    crate::bound_write_buffer_history(&mut opts);
+pub(crate) fn live_results_cf_descriptor(block_cache: &rocksdb::Cache) -> ColumnFamilyDescriptor {
+    let opts = crate::cf_options::base_cf_options(block_cache);
     ColumnFamilyDescriptor::new(LIVE_RESULTS_CF, opts)
 }
 

--- a/components/indexes/rocksdb/src/memory.rs
+++ b/components/indexes/rocksdb/src/memory.rs
@@ -1,0 +1,214 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::sync::Arc;
+
+use rocksdb::{Cache, WriteBufferManager};
+
+/// Default combined cache capacity for unconfigured embedders.
+pub const DEFAULT_BLOCK_CACHE_CAPACITY_BYTES: usize = 256 * 1024 * 1024;
+
+/// Default provider-wide memtable budget.
+pub const DEFAULT_WRITE_BUFFER_BUDGET_BYTES: usize = 128 * 1024 * 1024;
+
+const WRITE_BUFFER_BUDGET_DIVISOR: usize = 2;
+
+/// Invalid shared RocksDB memory budget configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RocksDbMemoryBudgetError {
+    ZeroBlockCacheCapacity,
+    ZeroWriteBufferBudget,
+    WriteBufferExceedsCache {
+        block_cache_capacity_bytes: usize,
+        write_buffer_budget_bytes: usize,
+    },
+}
+
+impl fmt::Display for RocksDbMemoryBudgetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ZeroBlockCacheCapacity => write!(f, "block cache capacity must be greater than 0"),
+            Self::ZeroWriteBufferBudget => write!(f, "write buffer budget must be greater than 0"),
+            Self::WriteBufferExceedsCache {
+                block_cache_capacity_bytes,
+                write_buffer_budget_bytes,
+            } => write!(
+                f,
+                "write buffer budget ({write_buffer_budget_bytes} bytes) must not exceed block cache capacity ({block_cache_capacity_bytes} bytes)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RocksDbMemoryBudgetError {}
+
+struct RocksDbMemoryBudgetInner {
+    block_cache: Cache,
+    block_cache_capacity_bytes: usize,
+    write_buffer_manager: WriteBufferManager,
+}
+
+/// Shared block-cache and memtable resources for RocksDB query databases.
+///
+/// Clone this value into multiple providers to extend the sharing scope beyond
+/// one provider. The write-buffer manager is charged to the same cache, so its
+/// memtable reservations compete with data, index, and filter blocks under one
+/// cache capacity. Sustained write pressure therefore reduces block-cache
+/// headroom rather than exceeding the combined bound.
+#[derive(Clone)]
+pub struct RocksDbMemoryBudget {
+    inner: Arc<RocksDbMemoryBudgetInner>,
+}
+
+impl RocksDbMemoryBudget {
+    /// Create a budget from one combined capacity using the default policy.
+    ///
+    /// Half of the capacity is available to memtables. Memtable reservations
+    /// are charged to the same cache, so the two capacities are not additive.
+    pub fn from_total_budget_bytes(
+        total_budget_bytes: usize,
+    ) -> Result<Self, RocksDbMemoryBudgetError> {
+        Self::new(
+            total_budget_bytes,
+            total_budget_bytes / WRITE_BUFFER_BUDGET_DIVISOR,
+            false,
+        )
+    }
+
+    /// Create a coherent cache and write-buffer budget.
+    pub fn new(
+        block_cache_capacity_bytes: usize,
+        write_buffer_budget_bytes: usize,
+        allow_stall: bool,
+    ) -> Result<Self, RocksDbMemoryBudgetError> {
+        if block_cache_capacity_bytes == 0 {
+            return Err(RocksDbMemoryBudgetError::ZeroBlockCacheCapacity);
+        }
+        if write_buffer_budget_bytes == 0 {
+            return Err(RocksDbMemoryBudgetError::ZeroWriteBufferBudget);
+        }
+        if write_buffer_budget_bytes > block_cache_capacity_bytes {
+            return Err(RocksDbMemoryBudgetError::WriteBufferExceedsCache {
+                block_cache_capacity_bytes,
+                write_buffer_budget_bytes,
+            });
+        }
+
+        Ok(Self::from_sizes(
+            block_cache_capacity_bytes,
+            write_buffer_budget_bytes,
+            allow_stall,
+        ))
+    }
+
+    /// Shared block cache used by every query database and column family.
+    pub fn block_cache(&self) -> &Cache {
+        &self.inner.block_cache
+    }
+
+    /// Capacity configured when the shared block cache was created.
+    pub fn block_cache_capacity_bytes(&self) -> usize {
+        self.inner.block_cache_capacity_bytes
+    }
+
+    /// Shared manager charged with every query database's memtable allocations.
+    pub fn write_buffer_manager(&self) -> &WriteBufferManager {
+        &self.inner.write_buffer_manager
+    }
+
+    fn from_sizes(
+        block_cache_capacity_bytes: usize,
+        write_buffer_budget_bytes: usize,
+        allow_stall: bool,
+    ) -> Self {
+        let block_cache = Cache::new_lru_cache(block_cache_capacity_bytes);
+        let write_buffer_manager = WriteBufferManager::new_write_buffer_manager_with_cache(
+            write_buffer_budget_bytes,
+            allow_stall,
+            block_cache.clone(),
+        );
+        Self {
+            inner: Arc::new(RocksDbMemoryBudgetInner {
+                block_cache,
+                block_cache_capacity_bytes,
+                write_buffer_manager,
+            }),
+        }
+    }
+}
+
+impl Default for RocksDbMemoryBudget {
+    fn default() -> Self {
+        Self::from_sizes(
+            DEFAULT_BLOCK_CACHE_CAPACITY_BYTES,
+            DEFAULT_WRITE_BUFFER_BUDGET_BYTES,
+            false,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_budget_has_expected_write_limit() {
+        let budget = RocksDbMemoryBudget::default();
+        assert_eq!(
+            budget.block_cache_capacity_bytes(),
+            DEFAULT_BLOCK_CACHE_CAPACITY_BYTES
+        );
+        assert_eq!(
+            budget.write_buffer_manager().get_buffer_size(),
+            DEFAULT_WRITE_BUFFER_BUDGET_BYTES
+        );
+        assert!(budget.write_buffer_manager().enabled());
+    }
+
+    #[test]
+    fn total_budget_derives_cache_and_write_limits() {
+        let budget = RocksDbMemoryBudget::from_total_budget_bytes(64 * 1024 * 1024)
+            .expect("valid total budget");
+        assert_eq!(budget.block_cache_capacity_bytes(), 64 * 1024 * 1024);
+        assert_eq!(
+            budget.write_buffer_manager().get_buffer_size(),
+            32 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_sizes() {
+        assert!(matches!(
+            RocksDbMemoryBudget::from_total_budget_bytes(0),
+            Err(RocksDbMemoryBudgetError::ZeroBlockCacheCapacity)
+        ));
+        assert!(matches!(
+            RocksDbMemoryBudget::from_total_budget_bytes(1),
+            Err(RocksDbMemoryBudgetError::ZeroWriteBufferBudget)
+        ));
+        assert!(matches!(
+            RocksDbMemoryBudget::new(0, 1, false),
+            Err(RocksDbMemoryBudgetError::ZeroBlockCacheCapacity)
+        ));
+        assert!(matches!(
+            RocksDbMemoryBudget::new(1, 0, false),
+            Err(RocksDbMemoryBudgetError::ZeroWriteBufferBudget)
+        ));
+        assert!(matches!(
+            RocksDbMemoryBudget::new(1, 2, false),
+            Err(RocksDbMemoryBudgetError::WriteBufferExceedsCache { .. })
+        ));
+    }
+}

--- a/components/indexes/rocksdb/src/options.rs
+++ b/components/indexes/rocksdb/src/options.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::RocksDbMemoryBudget;
+
+#[derive(Clone)]
+pub struct RocksIndexOptions {
+    archive_enabled: bool,
+    direct_io: bool,
+    memory_budget: RocksDbMemoryBudget,
+}
+
+impl RocksIndexOptions {
+    /// Create options with the memory resources used to open and maintain the index.
+    pub fn new(archive_enabled: bool, direct_io: bool, memory_budget: RocksDbMemoryBudget) -> Self {
+        Self {
+            archive_enabled,
+            direct_io,
+            memory_budget,
+        }
+    }
+
+    /// Whether historical element versions are retained.
+    pub fn archive_enabled(&self) -> bool {
+        self.archive_enabled
+    }
+
+    /// Whether RocksDB uses direct I/O.
+    pub fn direct_io(&self) -> bool {
+        self.direct_io
+    }
+
+    /// Memory resources shared by the query databases opened with these options.
+    pub fn memory_budget(&self) -> &RocksDbMemoryBudget {
+        &self.memory_budget
+    }
+}

--- a/components/indexes/rocksdb/src/outbox.rs
+++ b/components/indexes/rocksdb/src/outbox.rs
@@ -25,16 +25,15 @@ use std::sync::Arc;
 use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::interface::{IndexError, OutboxWriter};
-use rocksdb::{ColumnFamilyDescriptor, IteratorMode, Options};
+use rocksdb::{ColumnFamilyDescriptor, IteratorMode};
 use tokio::task;
 
 /// Column family name for outbox data.
 pub(crate) const OUTBOX_CF: &str = "outbox";
 
 /// Returns the column family descriptor for the outbox CF.
-pub(crate) fn outbox_cf_descriptor() -> ColumnFamilyDescriptor {
-    let mut opts = Options::default();
-    crate::bound_write_buffer_history(&mut opts);
+pub(crate) fn outbox_cf_descriptor(block_cache: &rocksdb::Cache) -> ColumnFamilyDescriptor {
+    let opts = crate::cf_options::base_cf_options(block_cache);
     ColumnFamilyDescriptor::new(OUTBOX_CF, opts)
 }
 

--- a/components/indexes/rocksdb/src/plugin.rs
+++ b/components/indexes/rocksdb/src/plugin.rs
@@ -20,13 +20,12 @@
 //! # Example
 //!
 //! ```ignore
-//! use drasi_index_rocksdb::{RocksDbIndexProvider, RocksDbMemoryBudget};
+//! use drasi_index_rocksdb::RocksDbIndexProvider;
 //! use drasi_lib::DrasiLib;
 //! use std::sync::Arc;
 //!
-//! let memory = RocksDbMemoryBudget::new(256 << 20, 128 << 20, false)?;
 //! let provider = RocksDbIndexProvider::new("/data/drasi", true, false)
-//!     .with_memory_budget(memory);
+//!     .with_memory_budget_bytes(512 << 20)?;
 //! let drasi = DrasiLib::builder()
 //!     .with_index_provider("rocksdb", Arc::new(provider))
 //!     .build()?;
@@ -44,7 +43,10 @@ use crate::future_queue::{self, RocksDbFutureQueue};
 use crate::live_results::{self, RocksDbLiveResultsWriter};
 use crate::outbox::{self, RocksDbOutboxWriter};
 use crate::result_index::{self, RocksDbResultIndex};
-use crate::{RocksDbMemoryBudget, RocksDbSessionControl, RocksDbSessionState, RocksIndexOptions};
+use crate::{
+    RocksDbMemoryBudget, RocksDbMemoryBudgetError, RocksDbSessionControl, RocksDbSessionState,
+    RocksIndexOptions,
+};
 
 /// Open a unified RocksDB database with all column families needed for a query.
 ///
@@ -167,7 +169,23 @@ impl RocksDbIndexProvider {
         }
     }
 
-    /// Replace the provider-wide default memory budget.
+    /// Set the provider-wide combined memory budget using the standard policy.
+    ///
+    /// Half of the capacity is available to memtables. Memtable reservations
+    /// are charged to the same cache, so the two capacities are not additive.
+    pub fn with_memory_budget_bytes(
+        mut self,
+        total_budget_bytes: usize,
+    ) -> Result<Self, RocksDbMemoryBudgetError> {
+        self.memory_budget = RocksDbMemoryBudget::from_total_budget_bytes(total_budget_bytes)?;
+        Ok(self)
+    }
+
+    /// Inject provider-wide memory resources using a custom policy.
+    ///
+    /// This expert API supports custom cache/write-buffer splits, stall
+    /// behavior, and sharing one budget across multiple providers. Prefer
+    /// [`Self::with_memory_budget_bytes`] for standard configuration.
     pub fn with_memory_budget(mut self, memory_budget: RocksDbMemoryBudget) -> Self {
         self.memory_budget = memory_budget;
         self
@@ -282,18 +300,49 @@ mod tests {
     }
 
     #[test]
-    fn test_rocksdb_index_provider_custom_memory_budget() {
-        let budget = RocksDbMemoryBudget::new(32 * 1024 * 1024, 16 * 1024 * 1024, false)
-            .expect("valid budget");
-        let provider =
-            RocksDbIndexProvider::new("/data/drasi", false, false).with_memory_budget(budget);
+    fn test_rocksdb_index_provider_total_memory_budget() {
+        let provider = RocksDbIndexProvider::new("/data/drasi", false, false)
+            .with_memory_budget_bytes(64 * 1024 * 1024)
+            .expect("valid total budget");
 
+        assert_eq!(
+            provider.memory_budget().block_cache_capacity_bytes(),
+            64 * 1024 * 1024
+        );
         assert_eq!(
             provider
                 .memory_budget()
                 .write_buffer_manager()
                 .get_buffer_size(),
-            16 * 1024 * 1024
+            32 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn test_rocksdb_index_provider_rejects_invalid_total_memory_budget() {
+        assert!(matches!(
+            RocksDbIndexProvider::new("/data/drasi", false, false).with_memory_budget_bytes(1),
+            Err(RocksDbMemoryBudgetError::ZeroWriteBufferBudget)
+        ));
+    }
+
+    #[test]
+    fn test_rocksdb_index_provider_custom_memory_budget() {
+        let budget = RocksDbMemoryBudget::new(32 * 1024 * 1024, 8 * 1024 * 1024, false)
+            .expect("valid budget");
+        let provider =
+            RocksDbIndexProvider::new("/data/drasi", false, false).with_memory_budget(budget);
+
+        assert_eq!(
+            provider.memory_budget().block_cache_capacity_bytes(),
+            32 * 1024 * 1024
+        );
+        assert_eq!(
+            provider
+                .memory_budget()
+                .write_buffer_manager()
+                .get_buffer_size(),
+            8 * 1024 * 1024
         );
     }
 

--- a/components/indexes/rocksdb/src/plugin.rs
+++ b/components/indexes/rocksdb/src/plugin.rs
@@ -20,11 +20,13 @@
 //! # Example
 //!
 //! ```ignore
-//! use drasi_index_rocksdb::RocksDbIndexProvider;
+//! use drasi_index_rocksdb::{RocksDbIndexProvider, RocksDbMemoryBudget};
 //! use drasi_lib::DrasiLib;
 //! use std::sync::Arc;
 //!
-//! let provider = RocksDbIndexProvider::new("/data/drasi", true, false);
+//! let memory = RocksDbMemoryBudget::new(256 << 20, 128 << 20, false)?;
+//! let provider = RocksDbIndexProvider::new("/data/drasi", true, false)
+//!     .with_memory_budget(memory);
 //! let drasi = DrasiLib::builder()
 //!     .with_index_provider("rocksdb", Arc::new(provider))
 //!     .build()?;
@@ -33,17 +35,16 @@
 use crate::IndexDb;
 use async_trait::async_trait;
 use drasi_core::interface::{CreatedIndexes, IndexBackendPlugin, IndexError, IndexSet};
-use rocksdb::Options;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::checkpoint::{self, RocksDbCheckpointStore};
-use crate::element_index::{self, RocksDbElementIndex, RocksIndexOptions};
+use crate::element_index::{self, RocksDbElementIndex};
 use crate::future_queue::{self, RocksDbFutureQueue};
 use crate::live_results::{self, RocksDbLiveResultsWriter};
 use crate::outbox::{self, RocksDbOutboxWriter};
 use crate::result_index::{self, RocksDbResultIndex};
-use crate::{RocksDbSessionControl, RocksDbSessionState};
+use crate::{RocksDbMemoryBudget, RocksDbSessionControl, RocksDbSessionState, RocksIndexOptions};
 
 /// Open a unified RocksDB database with all column families needed for a query.
 ///
@@ -54,7 +55,7 @@ use crate::{RocksDbSessionControl, RocksDbSessionState};
 ///
 /// * `path` - Base directory for RocksDB data files
 /// * `query_id` - Unique identifier for the query
-/// * `options` - RocksDB index options (archive, direct I/O)
+/// * `options` - RocksDB index options and shared memory budget
 ///
 /// # Directory Structure
 ///
@@ -80,13 +81,13 @@ pub fn open_unified_db(
         )));
     }
 
-    let mut db_opts = Options::default();
+    let block_cache = options.memory_budget().block_cache();
+    let mut db_opts = rocksdb::Options::default();
     db_opts.create_if_missing(true);
     db_opts.create_missing_column_families(true);
-    db_opts.set_db_write_buffer_size(128 * 1024 * 1024);
-    crate::bound_write_buffer_history(&mut db_opts);
-    db_opts.set_use_direct_reads(options.direct_io);
-    db_opts.set_use_direct_io_for_flush_and_compaction(options.direct_io);
+    db_opts.set_write_buffer_manager(options.memory_budget().write_buffer_manager());
+    db_opts.set_use_direct_reads(options.direct_io());
+    db_opts.set_use_direct_io_for_flush_and_compaction(options.direct_io());
 
     let db_path = PathBuf::from(path).join(query_id);
     let db_path = match db_path.to_str() {
@@ -95,17 +96,16 @@ pub fn open_unified_db(
     };
 
     let mut cfs = element_index::element_cf_descriptors(options);
-    cfs.extend(result_index::result_cf_descriptors());
-    cfs.extend(future_queue::future_queue_cf_descriptors());
-    cfs.push(checkpoint::stream_state_cf_descriptor());
-    cfs.push(outbox::outbox_cf_descriptor());
-    cfs.push(live_results::live_results_cf_descriptor());
+    cfs.extend(result_index::result_cf_descriptors(block_cache));
+    cfs.extend(future_queue::future_queue_cf_descriptors(block_cache));
+    cfs.push(checkpoint::stream_state_cf_descriptor(block_cache));
+    cfs.push(outbox::outbox_cf_descriptor(block_cache));
+    cfs.push(live_results::live_results_cf_descriptor(block_cache));
 
     // The default CF is not covered by db_opts: rust-rocksdb opens it with
     // fresh Options unless a descriptor is supplied, and an unset retention
     // bound is sanitized to 128 MiB (caught by retention_bound_tests).
-    let mut default_cf_opts = Options::default();
-    crate::bound_write_buffer_history(&mut default_cf_opts);
+    let default_cf_opts = crate::cf_options::base_cf_options(block_cache);
     cfs.push(rocksdb::ColumnFamilyDescriptor::new(
         rocksdb::DEFAULT_COLUMN_FAMILY_NAME,
         default_cf_opts,
@@ -128,6 +128,7 @@ pub fn open_unified_db(
 /// - `path`: Base directory for RocksDB data files
 /// - `enable_archive`: Enable archive index for `past()` function support
 /// - `direct_io`: Use direct I/O for better performance on SSDs
+/// - `memory_budget`: Shared block cache and write-buffer manager
 ///
 /// # Directory Structure
 ///
@@ -140,6 +141,7 @@ pub struct RocksDbIndexProvider {
     path: PathBuf,
     enable_archive: bool,
     direct_io: bool,
+    memory_budget: RocksDbMemoryBudget,
 }
 
 impl RocksDbIndexProvider {
@@ -161,7 +163,19 @@ impl RocksDbIndexProvider {
             path: path.into(),
             enable_archive,
             direct_io,
+            memory_budget: RocksDbMemoryBudget::default(),
         }
+    }
+
+    /// Replace the provider-wide default memory budget.
+    pub fn with_memory_budget(mut self, memory_budget: RocksDbMemoryBudget) -> Self {
+        self.memory_budget = memory_budget;
+        self
+    }
+
+    /// Shared memory resources used by this provider's query databases.
+    pub fn memory_budget(&self) -> &RocksDbMemoryBudget {
+        &self.memory_budget
     }
 
     /// Get the configured path.
@@ -184,10 +198,11 @@ impl RocksDbIndexProvider {
 impl IndexBackendPlugin for RocksDbIndexProvider {
     async fn create_indexes(&self, query_id: &str) -> Result<CreatedIndexes, IndexError> {
         let path = self.path.to_string_lossy().to_string();
-        let options = RocksIndexOptions {
-            archive_enabled: self.enable_archive,
-            direct_io: self.direct_io,
-        };
+        let options = RocksIndexOptions::new(
+            self.enable_archive,
+            self.direct_io,
+            self.memory_budget.clone(),
+        );
 
         let db = open_unified_db(&path, query_id, &options).map_err(|e| {
             log::error!(
@@ -201,11 +216,19 @@ impl IndexBackendPlugin for RocksDbIndexProvider {
 
         let element_index = Arc::new(RocksDbElementIndex::new(
             db.clone(),
-            options,
+            options.clone(),
             session_state.clone(),
         ));
-        let result_index = Arc::new(RocksDbResultIndex::new(db.clone(), session_state.clone()));
-        let future_queue = Arc::new(RocksDbFutureQueue::new(db.clone(), session_state.clone()));
+        let result_index = Arc::new(RocksDbResultIndex::new(
+            db.clone(),
+            session_state.clone(),
+            options.clone(),
+        ));
+        let future_queue = Arc::new(RocksDbFutureQueue::new(
+            db.clone(),
+            session_state.clone(),
+            options,
+        ));
         let checkpoint_store = Arc::new(RocksDbCheckpointStore::new(db.clone(), session_state));
         let outbox_writer = Arc::new(RocksDbOutboxWriter::new(db.clone()));
         let live_results_writer = Arc::new(RocksDbLiveResultsWriter::new(db));
@@ -240,6 +263,13 @@ mod tests {
         assert_eq!(provider.path(), &PathBuf::from("/data/drasi"));
         assert!(provider.is_archive_enabled());
         assert!(!provider.is_direct_io_enabled());
+        assert_eq!(
+            provider
+                .memory_budget()
+                .write_buffer_manager()
+                .get_buffer_size(),
+            crate::DEFAULT_WRITE_BUFFER_BUDGET_BYTES
+        );
     }
 
     #[test]
@@ -249,6 +279,22 @@ mod tests {
         assert_eq!(provider.path(), &PathBuf::from("/var/lib/drasi"));
         assert!(!provider.is_archive_enabled());
         assert!(provider.is_direct_io_enabled());
+    }
+
+    #[test]
+    fn test_rocksdb_index_provider_custom_memory_budget() {
+        let budget = RocksDbMemoryBudget::new(32 * 1024 * 1024, 16 * 1024 * 1024, false)
+            .expect("valid budget");
+        let provider =
+            RocksDbIndexProvider::new("/data/drasi", false, false).with_memory_budget(budget);
+
+        assert_eq!(
+            provider
+                .memory_budget()
+                .write_buffer_manager()
+                .get_buffer_size(),
+            16 * 1024 * 1024
+        );
     }
 
     #[test]
@@ -297,10 +343,7 @@ mod tests {
     #[test]
     fn test_open_unified_db() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let options = RocksIndexOptions {
-            archive_enabled: true,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
 
         let path = temp_dir.path().to_string_lossy().to_string();
         let result = open_unified_db(&path, "test_query", &options);
@@ -310,10 +353,7 @@ mod tests {
     #[test]
     fn test_open_unified_db_rejects_unsafe_query_id() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let options = RocksIndexOptions {
-            archive_enabled: true,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
         let path = temp_dir.path().to_string_lossy().to_string();
 
         for bad in ["", ".", "..", "a/b", "../escape", "a\\b", "with\0nul"] {

--- a/components/indexes/rocksdb/src/point_lookup.rs
+++ b/components/indexes/rocksdb/src/point_lookup.rs
@@ -28,15 +28,15 @@
 //! injected through it (see #634).
 //!
 //! The settings below mirror `ColumnFamilyOptions::OptimizeForPointLookup`
-//! in RocksDB 8.1.1 (`options/options.cc:609`), which is the version pinned
-//! by `librocksdb-sys 0.11.0+8.1.1`:
+//! in RocksDB 8.10.0 (`options/options.cc:629`), which is the version pinned
+//! by `librocksdb-sys 0.16.0+8.10.0`:
 //!
 //! | `OptimizeForPointLookup(mb)` | Here |
 //! |---|---|
 //! | `data_block_index_type = kDataBlockBinaryAndHash` | [`DataBlockIndexType::BinaryAndHash`] |
 //! | `data_block_hash_table_util_ratio = 0.75` | [`DATA_BLOCK_HASH_RATIO`] |
 //! | `filter_policy = NewBloomFilterPolicy(10)` | [`BLOOM_BITS_PER_KEY`] |
-//! | `block_cache = NewLRUCache(mb * 1024 * 1024)` | `block_cache_bytes` argument |
+//! | `block_cache = NewLRUCache(mb * 1024 * 1024)` | injected shared cache |
 //! | `memtable_prefix_bloom_size_ratio = 0.02` | [`MEMTABLE_BLOOM_RATIO`] |
 //! | `memtable_whole_key_filtering = true` | set unconditionally |
 //!
@@ -53,7 +53,7 @@
 //! wrapper's name omits the parameters), and the block cache is not
 //! serialized at all.
 
-use rocksdb::{BlockBasedOptions, Cache, DataBlockIndexType, Options};
+use rocksdb::{Cache, DataBlockIndexType, Options};
 
 /// Bits per key for the SST bloom filter, matching `NewBloomFilterPolicy(10)`.
 const BLOOM_BITS_PER_KEY: f64 = 10.0;
@@ -66,29 +66,16 @@ const MEMTABLE_BLOOM_RATIO: f64 = 0.02;
 const DATA_BLOCK_HASH_RATIO: f64 = 0.75;
 
 /// Options for a column family read only by exact key.
-///
-/// `block_cache_bytes` is in **bytes**, unlike the megabytes taken by the
-/// `optimize_for_point_lookup` preset this replaces.
-///
-/// Each call constructs its own [`Cache`], so two column families built from
-/// this function get independent caches of the given size, matching the
-/// per-call cache the preset created. #634 replaces this with one shared
-/// handle passed in; until then, hoisting a single `Cache` into a shared
-/// value here would quietly halve the capacity available to `elements` and
-/// `slots`, and nothing in the OPTIONS file would show it.
-pub(crate) fn point_lookup_cf_options(block_cache_bytes: usize) -> Options {
-    let mut opts = Options::default();
-
-    let mut table_opts = BlockBasedOptions::default();
+pub(crate) fn point_lookup_cf_options(block_cache: &Cache) -> Options {
+    let mut table_opts = crate::cf_options::shared_block_based_options(block_cache);
     table_opts.set_data_block_index_type(DataBlockIndexType::BinaryAndHash);
     table_opts.set_data_block_hash_ratio(DATA_BLOCK_HASH_RATIO);
-    // `false` selects the full-filter builder. On RocksDB 8.1.1 the flag is
+    // `false` selects the full-filter builder. On RocksDB 8.10.0 the flag is
     // ignored (`NewBloomFilterPolicy`'s second parameter is named
     // `IGNORED_use_block_based_builder`), but the block-based builder is the
     // one that would be wrong if it were ever honoured again.
     table_opts.set_bloom_filter(BLOOM_BITS_PER_KEY, false);
-    table_opts.set_block_cache(&Cache::new_lru_cache(block_cache_bytes));
-    opts.set_block_based_table_factory(&table_opts);
+    let mut opts = crate::cf_options::options_with_table(&table_opts);
 
     opts.set_memtable_prefix_bloom_ratio(MEMTABLE_BLOOM_RATIO);
     opts.set_memtable_whole_key_filtering(true);

--- a/components/indexes/rocksdb/src/result_index.rs
+++ b/components/indexes/rocksdb/src/result_index.rs
@@ -32,11 +32,11 @@ use prost::{
     bytes::{Bytes, BytesMut},
     Message,
 };
-use rocksdb::{Direction, IteratorMode, MergeOperands, Options, SliceTransform};
+use rocksdb::{Cache, Direction, IteratorMode, MergeOperands, Options, SliceTransform};
 use tokio::task;
 
 use crate::storage_models::{StoredValueAccumulator, StoredValueAccumulatorContainer};
-use crate::RocksDbSessionState;
+use crate::{RocksDbSessionState, RocksIndexOptions};
 
 /// RocksDB accumulator index store
 ///
@@ -46,25 +46,28 @@ use crate::RocksDbSessionState;
 pub struct RocksDbResultIndex {
     db: Arc<IndexDb>,
     session_state: Arc<RocksDbSessionState>,
+    options: RocksIndexOptions,
 }
 
 const VALUES_CF: &str = "values";
 const SETS_CF: &str = "sorted-sets";
 const METADATA_CF: &str = "metadata";
-/// Block cache capacity for `values` (aggregation accumulators).
-const VALUES_BLOCK_CACHE_BYTES: usize = 32 * 1024 * 1024;
-
-/// Block cache capacity for `metadata`, which holds a single result-sequence
-/// record and needs no more than one block.
-const METADATA_BLOCK_CACHE_BYTES: usize = 1024 * 1024;
 
 impl RocksDbResultIndex {
     /// Create a new RocksDbResultIndex from a shared database handle.
     ///
     /// The database must already have the required column families created.
     /// Use `open_unified_db()` to open a database with all required CFs.
-    pub fn new(db: Arc<IndexDb>, session_state: Arc<RocksDbSessionState>) -> Self {
-        RocksDbResultIndex { db, session_state }
+    pub fn new(
+        db: Arc<IndexDb>,
+        session_state: Arc<RocksDbSessionState>,
+        options: RocksIndexOptions,
+    ) -> Self {
+        RocksDbResultIndex {
+            db,
+            session_state,
+            options,
+        }
     }
 }
 
@@ -144,12 +147,14 @@ impl AccumulatorIndex for RocksDbResultIndex {
 
     async fn clear(&self) -> Result<(), IndexError> {
         let db = self.db.clone();
+        let options = self.options.clone();
         let task = task::spawn_blocking(move || {
+            let block_cache = options.memory_budget().block_cache();
             if let Err(err) = db.drop_cf(VALUES_CF) {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = db.create_cf(VALUES_CF, &get_value_cf_options()) {
+            if let Err(err) = db.create_cf(VALUES_CF, &get_value_cf_options(block_cache)) {
                 return Err(IndexError::other(err));
             }
 
@@ -157,7 +162,7 @@ impl AccumulatorIndex for RocksDbResultIndex {
                 return Err(IndexError::other(err));
             }
 
-            if let Err(err) = db.create_cf(SETS_CF, &get_lss_cf_options()) {
+            if let Err(err) = db.create_cf(SETS_CF, &get_lss_cf_options(block_cache)) {
                 return Err(IndexError::other(err));
             }
             Ok(())
@@ -368,34 +373,28 @@ impl ResultSequenceCounter for RocksDbResultIndex {
     }
 }
 
-pub(crate) fn get_lss_cf_options() -> Options {
-    let mut lss_opts = Options::default();
-    crate::bound_write_buffer_history(&mut lss_opts);
+pub(crate) fn get_lss_cf_options(block_cache: &Cache) -> Options {
+    let mut lss_opts = crate::cf_options::base_cf_options(block_cache);
     lss_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
     lss_opts.set_merge_operator_associative("increment", increment_merge);
     lss_opts.set_compaction_filter("remove0", compact);
     lss_opts
 }
 
-pub(crate) fn get_value_cf_options() -> Options {
-    let mut values_opts = crate::point_lookup::point_lookup_cf_options(VALUES_BLOCK_CACHE_BYTES);
-    crate::bound_write_buffer_history(&mut values_opts);
-    values_opts
+pub(crate) fn get_value_cf_options(block_cache: &Cache) -> Options {
+    crate::point_lookup::point_lookup_cf_options(block_cache)
 }
 
-pub(crate) fn get_metadata_cf_options() -> Options {
-    let mut metadata_opts =
-        crate::point_lookup::point_lookup_cf_options(METADATA_BLOCK_CACHE_BYTES);
-    crate::bound_write_buffer_history(&mut metadata_opts);
-    metadata_opts
+pub(crate) fn get_metadata_cf_options(block_cache: &Cache) -> Options {
+    crate::point_lookup::point_lookup_cf_options(block_cache)
 }
 
 /// Collect all column family descriptors needed by the result index.
-pub(crate) fn result_cf_descriptors() -> Vec<rocksdb::ColumnFamilyDescriptor> {
+pub(crate) fn result_cf_descriptors(block_cache: &Cache) -> Vec<rocksdb::ColumnFamilyDescriptor> {
     vec![
-        rocksdb::ColumnFamilyDescriptor::new(VALUES_CF, get_value_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(SETS_CF, get_lss_cf_options()),
-        rocksdb::ColumnFamilyDescriptor::new(METADATA_CF, get_metadata_cf_options()),
+        rocksdb::ColumnFamilyDescriptor::new(VALUES_CF, get_value_cf_options(block_cache)),
+        rocksdb::ColumnFamilyDescriptor::new(SETS_CF, get_lss_cf_options(block_cache)),
+        rocksdb::ColumnFamilyDescriptor::new(METADATA_CF, get_metadata_cf_options(block_cache)),
     ]
 }
 

--- a/components/indexes/rocksdb/src/session_state.rs
+++ b/components/indexes/rocksdb/src/session_state.rs
@@ -304,15 +304,12 @@ impl std::error::Error for SessionStateError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::element_index::RocksIndexOptions;
     use crate::open_unified_db;
+    use crate::RocksIndexOptions;
 
     fn setup_test_db() -> (tempfile::TempDir, Arc<IndexDb>) {
         let dir = tempfile::TempDir::new().expect("failed to create temp dir");
-        let options = RocksIndexOptions {
-            archive_enabled: false,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(false, false, crate::RocksDbMemoryBudget::default());
         let db = open_unified_db(dir.path().to_str().expect("path"), "test", &options)
             .expect("failed to open db");
         (dir, db)

--- a/components/indexes/rocksdb/tests/outbox_live_results_tests.rs
+++ b/components/indexes/rocksdb/tests/outbox_live_results_tests.rs
@@ -23,17 +23,14 @@ use std::sync::Arc;
 
 use drasi_core::interface::{LiveResultsWriter, OutboxWriter, RowMutation};
 use drasi_index_rocksdb::{
-    element_index::RocksIndexOptions, open_unified_db, RocksDbLiveResultsWriter,
-    RocksDbOutboxWriter,
+    open_unified_db, RocksDbLiveResultsWriter, RocksDbMemoryBudget, RocksDbOutboxWriter,
+    RocksIndexOptions,
 };
 use tempfile::TempDir;
 
 /// Helper: open a RocksDB database at the given path with a test query ID.
 fn open_db(path: &str, query_id: &str) -> Arc<drasi_index_rocksdb::IndexDb> {
-    let options = RocksIndexOptions {
-        archive_enabled: false,
-        direct_io: false,
-    };
+    let options = RocksIndexOptions::new(false, false, RocksDbMemoryBudget::default());
     open_unified_db(path, query_id, &options).expect("Failed to open RocksDB")
 }
 

--- a/components/indexes/rocksdb/tests/point_lookup_options_tests.rs
+++ b/components/indexes/rocksdb/tests/point_lookup_options_tests.rs
@@ -33,8 +33,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use drasi_index_rocksdb::element_index::RocksIndexOptions;
-use drasi_index_rocksdb::open_unified_db;
+use drasi_index_rocksdb::{open_unified_db, RocksDbMemoryBudget, RocksIndexOptions};
 
 /// Column families read only by exact key, which must carry the full
 /// point-lookup policy.
@@ -44,6 +43,24 @@ const POINT_LOOKUP_CFS: &[&str] = &["elements", "slots", "values", "metadata"];
 /// negative control: without them a test that asserted the policy everywhere,
 /// or nowhere, would still pass.
 const SCAN_CFS: &[&str] = &["inbound", "partial", "sorted-sets"];
+
+const ALL_CFS: &[&str] = &[
+    "default",
+    "elements",
+    "slots",
+    "inbound",
+    "outbound",
+    "partial",
+    "archive",
+    "values",
+    "sorted-sets",
+    "metadata",
+    "fqueue",
+    "findex",
+    "stream_state",
+    "outbox",
+    "live_results",
+];
 
 /// `section -> key -> value` from the newest OPTIONS-* file of the DB at
 /// `db_dir`. Sections are kept verbatim, e.g. `[CFOptions "elements"]` and
@@ -90,10 +107,7 @@ fn value<'a>(
 }
 
 fn open_and_parse(dir: &tempfile::TempDir, name: &str) -> HashMap<String, HashMap<String, String>> {
-    let options = RocksIndexOptions {
-        archive_enabled: true,
-        direct_io: false,
-    };
+    let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
     let db = open_unified_db(dir.path().to_str().expect("utf-8 path"), name, &options)
         .expect("open unified db");
     let sections = parse_options_file(&dir.path().join(name));
@@ -200,6 +214,25 @@ fn scan_cfs_do_not_carry_the_point_lookup_policy() {
             ),
             "nullptr",
             "CF '{cf}' unexpectedly has an SST bloom filter"
+        );
+    }
+}
+
+#[test]
+fn every_cf_charges_index_and_filter_blocks_to_the_shared_cache() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sections = open_and_parse(&dir, "metadata-cache-test");
+
+    for cf in ALL_CFS {
+        assert_eq!(
+            value(
+                &sections,
+                "TableOptions/BlockBasedTable",
+                cf,
+                "cache_index_and_filter_blocks"
+            ),
+            "true",
+            "CF '{cf}' leaves index/filter blocks outside the shared cache"
         );
     }
 }

--- a/components/indexes/rocksdb/tests/retention_bound_tests.rs
+++ b/components/indexes/rocksdb/tests/retention_bound_tests.rs
@@ -22,16 +22,12 @@
 //! both a reintroduced zero and a column family the bound was never applied
 //! to.
 
-use drasi_index_rocksdb::element_index::RocksIndexOptions;
-use drasi_index_rocksdb::open_unified_db;
+use drasi_index_rocksdb::{open_unified_db, RocksDbMemoryBudget, RocksIndexOptions};
 
 #[test]
 fn effective_retention_is_the_explicit_bound_on_every_cf() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let options = RocksIndexOptions {
-        archive_enabled: true,
-        direct_io: false,
-    };
+    let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
     let db =
         open_unified_db(dir.path().to_str().unwrap(), "retention-test", &options).expect("open db");
 

--- a/components/indexes/rocksdb/tests/scenario_tests.rs
+++ b/components/indexes/rocksdb/tests/scenario_tests.rs
@@ -24,11 +24,9 @@ use shared_tests::QueryTestConfig;
 use uuid::Uuid;
 
 use drasi_index_rocksdb::{
-    element_index::{RocksDbElementIndex, RocksIndexOptions},
-    future_queue::RocksDbFutureQueue,
-    open_unified_db,
-    result_index::RocksDbResultIndex,
-    RocksDbSessionControl, RocksDbSessionState,
+    element_index::RocksDbElementIndex, future_queue::RocksDbFutureQueue, open_unified_db,
+    result_index::RocksDbResultIndex, RocksDbMemoryBudget, RocksDbSessionControl,
+    RocksDbSessionState, RocksIndexOptions,
 };
 
 struct RocksDbQueryConfig {
@@ -55,14 +53,14 @@ impl RocksDbQueryConfig {
         RocksDbFutureQueue,
         Arc<dyn drasi_core::interface::SessionControl>,
     ) {
-        let options = RocksIndexOptions {
-            archive_enabled: true,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
         let db = open_unified_db(&self.url, query_id, &options).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
-        (RocksDbFutureQueue::new(db, session_state), session_control)
+        (
+            RocksDbFutureQueue::new(db, session_state, options),
+            session_control,
+        )
     }
 }
 
@@ -80,17 +78,15 @@ impl QueryTestConfig for RocksDbQueryConfig {
         log::info!("using in RocksDb indexes");
         let query_id = format!("test-{}", Uuid::new_v4());
 
-        let options = RocksIndexOptions {
-            archive_enabled: true,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
 
         let db = open_unified_db(&self.url, &query_id, &options).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
 
-        let element_index = RocksDbElementIndex::new(db.clone(), options, session_state.clone());
-        let ari = RocksDbResultIndex::new(db.clone(), session_state.clone());
-        let fqi = RocksDbFutureQueue::new(db, session_state.clone());
+        let element_index =
+            RocksDbElementIndex::new(db.clone(), options.clone(), session_state.clone());
+        let ari = RocksDbResultIndex::new(db.clone(), session_state.clone(), options.clone());
+        let fqi = RocksDbFutureQueue::new(db, session_state.clone(), options);
         let session_control = Arc::new(RocksDbSessionControl::new(session_state));
 
         element_index.clear().await.unwrap();
@@ -411,11 +407,9 @@ mod session {
         models::{Element, ElementMetadata, ElementPropertyMap, ElementReference},
     };
     use drasi_index_rocksdb::{
-        element_index::{RocksDbElementIndex, RocksIndexOptions},
-        future_queue::RocksDbFutureQueue,
-        open_unified_db,
-        result_index::RocksDbResultIndex,
-        RocksDbSessionControl, RocksDbSessionState,
+        element_index::RocksDbElementIndex, future_queue::RocksDbFutureQueue, open_unified_db,
+        result_index::RocksDbResultIndex, RocksDbMemoryBudget, RocksDbSessionControl,
+        RocksDbSessionState, RocksIndexOptions,
     };
     use serial_test::serial;
     use uuid::Uuid;
@@ -426,15 +420,14 @@ mod session {
     async fn session_rollback_discards_writes() {
         let url = format!("test-data/{}", Uuid::new_v4());
         let query_id = format!("test-{}", Uuid::new_v4());
-        let options = RocksIndexOptions {
-            archive_enabled: true,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
         let db = open_unified_db(&url, &query_id, &options).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
-        let element_index = RocksDbElementIndex::new(db.clone(), options, session_state.clone());
-        let result_index = RocksDbResultIndex::new(db.clone(), session_state.clone());
-        let future_queue = RocksDbFutureQueue::new(db, session_state.clone());
+        let element_index =
+            RocksDbElementIndex::new(db.clone(), options.clone(), session_state.clone());
+        let result_index =
+            RocksDbResultIndex::new(db.clone(), session_state.clone(), options.clone());
+        let future_queue = RocksDbFutureQueue::new(db, session_state.clone(), options);
         let session_control = RocksDbSessionControl::new(session_state);
 
         element_index.clear().await.unwrap();
@@ -498,15 +491,14 @@ mod session {
     async fn session_commit_persists_writes() {
         let url = format!("test-data/{}", Uuid::new_v4());
         let query_id = format!("test-{}", Uuid::new_v4());
-        let options = RocksIndexOptions {
-            archive_enabled: true,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
         let db = open_unified_db(&url, &query_id, &options).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
-        let element_index = RocksDbElementIndex::new(db.clone(), options, session_state.clone());
-        let result_index = RocksDbResultIndex::new(db.clone(), session_state.clone());
-        let future_queue = RocksDbFutureQueue::new(db, session_state.clone());
+        let element_index =
+            RocksDbElementIndex::new(db.clone(), options.clone(), session_state.clone());
+        let result_index =
+            RocksDbResultIndex::new(db.clone(), session_state.clone(), options.clone());
+        let future_queue = RocksDbFutureQueue::new(db, session_state.clone(), options);
         let session_control = RocksDbSessionControl::new(session_state);
 
         element_index.clear().await.unwrap();
@@ -622,10 +614,7 @@ mod checkpoint_tests {
     async fn sequence_counter() {
         let config = RocksDbQueryConfig::new();
         let query_id = format!("test-{}", Uuid::new_v4());
-        let options = RocksIndexOptions {
-            archive_enabled: false,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(false, false, RocksDbMemoryBudget::default());
         let db = open_unified_db(&config.url, &query_id, &options).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
@@ -640,10 +629,7 @@ mod checkpoint_tests {
     async fn checkpoint_round_trip() {
         let config = RocksDbQueryConfig::new();
         let query_id = format!("test-{}", Uuid::new_v4());
-        let options = RocksIndexOptions {
-            archive_enabled: false,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(false, false, RocksDbMemoryBudget::default());
         let db = open_unified_db(&config.url, &query_id, &options).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
@@ -658,14 +644,11 @@ mod checkpoint_tests {
     async fn result_sequence_counter() {
         let config = RocksDbQueryConfig::new();
         let query_id = format!("test-{}", Uuid::new_v4());
-        let options = RocksIndexOptions {
-            archive_enabled: false,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(false, false, RocksDbMemoryBudget::default());
         let db = open_unified_db(&config.url, &query_id, &options).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
-        let subject = RocksDbResultIndex::new(db, session_state);
+        let subject = RocksDbResultIndex::new(db, session_state, options);
 
         session_control.begin().await.unwrap();
         shared_tests::sequence_counter::result_sequence_counter(&subject).await;
@@ -682,10 +665,7 @@ mod checkpoint_tests {
 
         let config = RocksDbQueryConfig::new();
         let query_id = format!("test-{}", Uuid::new_v4());
-        let options = RocksIndexOptions {
-            archive_enabled: false,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(false, false, RocksDbMemoryBudget::default());
         let db = open_unified_db(&config.url, &query_id, &options).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));
@@ -757,10 +737,7 @@ mod checkpoint_tests {
 
         let config = RocksDbQueryConfig::new();
         let query_id = format!("test-{}", Uuid::new_v4());
-        let options = RocksIndexOptions {
-            archive_enabled: false,
-            direct_io: false,
-        };
+        let options = RocksIndexOptions::new(false, false, RocksDbMemoryBudget::default());
         let db = open_unified_db(&config.url, &query_id, &options).unwrap();
         let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
         let session_control = Arc::new(RocksDbSessionControl::new(session_state.clone()));

--- a/components/indexes/rocksdb/tests/shared_memory_budget.rs
+++ b/components/indexes/rocksdb/tests/shared_memory_budget.rs
@@ -1,0 +1,316 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use drasi_core::interface::{AccumulatorIndex, ElementArchiveIndex, ElementIndex, FutureQueue};
+use drasi_index_rocksdb::{
+    element_index::RocksDbElementIndex, future_queue::RocksDbFutureQueue, open_unified_db,
+    result_index::RocksDbResultIndex, RocksDbMemoryBudget, RocksDbSessionState, RocksIndexOptions,
+};
+use rocksdb::{Options, DB};
+
+const NON_DEFAULT_CFS: &[&str] = &[
+    "elements",
+    "slots",
+    "inbound",
+    "outbound",
+    "partial",
+    "archive",
+    "values",
+    "sorted-sets",
+    "metadata",
+    "fqueue",
+    "findex",
+    "stream_state",
+    "outbox",
+    "live_results",
+];
+
+const RECREATED_CFS: &[&str] = &[
+    "elements",
+    "slots",
+    "inbound",
+    "outbound",
+    "partial",
+    "archive",
+    "values",
+    "sorted-sets",
+    "fqueue",
+    "findex",
+];
+
+fn parse_options_file(db_dir: &std::path::Path) -> HashMap<String, HashMap<String, String>> {
+    let options_file = std::fs::read_dir(db_dir)
+        .expect("read db dir")
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("OPTIONS-"))
+        .max_by_key(|entry| entry.file_name().to_string_lossy().to_string())
+        .expect("OPTIONS file present");
+    let text = std::fs::read_to_string(options_file.path()).expect("read OPTIONS");
+
+    let mut sections: HashMap<String, HashMap<String, String>> = HashMap::new();
+    let mut current = String::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            current = line.to_string();
+        } else if let Some((key, value)) = line.split_once('=') {
+            if !current.is_empty() {
+                sections
+                    .entry(current.clone())
+                    .or_default()
+                    .insert(key.trim().to_string(), value.trim().to_string());
+            }
+        }
+    }
+    sections
+}
+
+fn option_value<'a>(
+    sections: &'a HashMap<String, HashMap<String, String>>,
+    section_prefix: &str,
+    cf: &str,
+    key: &str,
+) -> &'a str {
+    sections
+        .get(&format!("[{section_prefix} \"{cf}\"]"))
+        .unwrap_or_else(|| panic!("no [{section_prefix} \"{cf}\"] section in OPTIONS"))
+        .get(key)
+        .unwrap_or_else(|| panic!("no {key} for CF '{cf}'"))
+        .as_str()
+}
+
+#[test]
+fn shared_budget_tracks_multiple_query_databases() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let budget =
+        RocksDbMemoryBudget::new(64 * 1024 * 1024, 32 * 1024 * 1024, false).expect("budget");
+    let options = RocksIndexOptions::new(true, false, budget.clone());
+
+    let first = open_unified_db(dir.path().to_str().expect("utf-8 path"), "first", &options)
+        .expect("open first database");
+    let first_cf = first.cf_handle("elements").expect("elements CF");
+    let cache_before_first = budget.block_cache().get_usage();
+    for index in 0..2000_u32 {
+        first
+            .put_cf(&first_cf, format!("first-{index}"), vec![1_u8; 4096])
+            .expect("write first database");
+    }
+    let first_usage = budget.write_buffer_manager().get_usage();
+    assert!(first_usage > 0);
+    assert!(budget.block_cache().get_usage() > cache_before_first);
+
+    let second = open_unified_db(dir.path().to_str().expect("utf-8 path"), "second", &options)
+        .expect("open second database");
+    let second_cf = second.cf_handle("elements").expect("elements CF");
+    let cache_before_second = budget.block_cache().get_usage();
+    for index in 0..2000_u32 {
+        second
+            .put_cf(&second_cf, format!("second-{index}"), vec![2_u8; 4096])
+            .expect("write second database");
+    }
+    assert!(budget.write_buffer_manager().get_usage() > first_usage);
+    assert!(budget.block_cache().get_usage() > cache_before_second);
+}
+
+#[test]
+fn memtable_writes_charge_the_shared_cache() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let budget =
+        RocksDbMemoryBudget::new(64 * 1024 * 1024, 32 * 1024 * 1024, false).expect("budget");
+    let options = RocksIndexOptions::new(false, false, budget.clone());
+    let db = open_unified_db(
+        dir.path().to_str().expect("utf-8 path"),
+        "memtable-charge",
+        &options,
+    )
+    .expect("open database");
+    let cf = db.cf_handle("elements").expect("elements CF");
+    let usage_before = budget.block_cache().get_usage();
+
+    for index in 0..2000_u32 {
+        db.put_cf(&cf, format!("key-{index}"), vec![7_u8; 4096])
+            .expect("write memtable");
+    }
+
+    assert!(budget.block_cache().get_usage() > usage_before);
+}
+
+#[test]
+fn all_column_families_use_the_shared_cache() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let budget =
+        RocksDbMemoryBudget::new(64 * 1024 * 1024, 32 * 1024 * 1024, false).expect("budget");
+    let cache = budget.block_cache().clone();
+    let options = RocksIndexOptions::new(true, false, budget);
+    let query_id = "cache-test";
+    let query_path = dir.path().join(query_id);
+
+    let schema_db = open_unified_db(dir.path().to_str().expect("utf-8 path"), query_id, &options)
+        .expect("open database");
+    drop(schema_db);
+
+    let seed_db =
+        DB::open_cf(&Options::default(), &query_path, NON_DEFAULT_CFS).expect("open seed database");
+    for (index, cf_name) in std::iter::once(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+        .chain(NON_DEFAULT_CFS.iter().copied())
+        .enumerate()
+    {
+        let cf = seed_db.cf_handle(cf_name).expect("seed CF");
+        let key = format!("key-{index}");
+        let value: Vec<u8> = (0..32 * 1024)
+            .map(|offset| ((offset * 31 + index * 17) % 251) as u8)
+            .collect();
+        seed_db.put_cf(&cf, key.as_bytes(), value).expect("seed CF");
+        seed_db.flush_cf(&cf).expect("flush seed CF");
+    }
+    drop(seed_db);
+
+    let db = open_unified_db(dir.path().to_str().expect("utf-8 path"), query_id, &options)
+        .expect("reopen database");
+    for (index, cf_name) in std::iter::once(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+        .chain(NON_DEFAULT_CFS.iter().copied())
+        .enumerate()
+    {
+        let cf = db.cf_handle(cf_name).expect("reopened CF");
+        let key = format!("key-{index}");
+        let usage_before = cache.get_usage();
+        assert!(db
+            .get_cf(&cf, key.as_bytes())
+            .expect("read shared-cache CF")
+            .is_some());
+        assert!(
+            cache.get_usage() > usage_before,
+            "CF '{cf_name}' did not populate the shared cache"
+        );
+    }
+}
+
+#[tokio::test]
+async fn clear_paths_preserve_column_family_options() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let budget =
+        RocksDbMemoryBudget::new(64 * 1024 * 1024, 4 * 1024 * 1024, false).expect("budget");
+    let mut cache = budget.block_cache().clone();
+    let options = RocksIndexOptions::new(true, false, budget.clone());
+    let query_id = "clear-test";
+    let db = open_unified_db(dir.path().to_str().expect("utf-8 path"), query_id, &options)
+        .expect("open database");
+    let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
+
+    let element_index =
+        RocksDbElementIndex::new(db.clone(), options.clone(), session_state.clone());
+    let result_index = RocksDbResultIndex::new(db.clone(), session_state.clone(), options.clone());
+    let future_queue = RocksDbFutureQueue::new(db.clone(), session_state, options.clone());
+
+    ElementIndex::clear(&element_index)
+        .await
+        .expect("clear element index");
+    ElementArchiveIndex::clear(&element_index)
+        .await
+        .expect("clear archive index");
+    AccumulatorIndex::clear(&result_index)
+        .await
+        .expect("clear result index");
+    FutureQueue::clear(&future_queue)
+        .await
+        .expect("clear future queue");
+
+    let write_usage_before = budget.write_buffer_manager().get_usage();
+    for (cf_index, cf_name) in RECREATED_CFS.iter().copied().enumerate() {
+        let cf = db.cf_handle(cf_name).expect("recreated CF");
+        for entry in 0..2000_u32 {
+            let key = format!("{cf_name}-{entry}");
+            let value: Vec<u8> = (0..4096)
+                .map(|offset| ((offset * 31 + cf_index * 17 + entry as usize) % 251) as u8)
+                .collect();
+            db.put_cf(&cf, key.as_bytes(), &value)
+                .expect("write recreated CF");
+        }
+    }
+    assert!(budget.write_buffer_manager().get_usage() > write_usage_before);
+
+    drop(element_index);
+    drop(result_index);
+    drop(future_queue);
+    drop(db);
+
+    let query_path = dir.path().join(query_id);
+    let flush_db = DB::open_cf(&Options::default(), &query_path, NON_DEFAULT_CFS)
+        .expect("open flush database");
+    for cf_name in
+        std::iter::once(rocksdb::DEFAULT_COLUMN_FAMILY_NAME).chain(NON_DEFAULT_CFS.iter().copied())
+    {
+        let cf = flush_db.cf_handle(cf_name).expect("flush CF");
+        flush_db.flush_cf(&cf).expect("flush CF");
+    }
+    drop(flush_db);
+
+    let db = open_unified_db(dir.path().to_str().expect("utf-8 path"), query_id, &options)
+        .expect("reopen database");
+
+    let sections = parse_options_file(&query_path);
+    for cf_name in RECREATED_CFS {
+        assert_eq!(
+            option_value(
+                &sections,
+                "CFOptions",
+                cf_name,
+                "max_write_buffer_size_to_maintain"
+            ),
+            "1048576",
+            "CF '{cf_name}' lost the write-buffer history bound"
+        );
+        assert_eq!(
+            option_value(
+                &sections,
+                "TableOptions/BlockBasedTable",
+                cf_name,
+                "cache_index_and_filter_blocks"
+            ),
+            "true",
+            "CF '{cf_name}' leaves index/filter blocks outside the shared cache"
+        );
+    }
+    for cf_name in ["elements", "slots", "values"] {
+        assert_eq!(
+            option_value(
+                &sections,
+                "CFOptions",
+                cf_name,
+                "memtable_whole_key_filtering"
+            ),
+            "true",
+            "CF '{cf_name}' lost the point-lookup policy"
+        );
+    }
+
+    for cf_name in RECREATED_CFS {
+        let cf = db.cf_handle(cf_name).expect("recreated CF");
+        let key = format!("{cf_name}-0");
+        cache.set_capacity(0);
+        cache.set_capacity(64 * 1024 * 1024);
+        let usage_before = cache.get_usage();
+        assert!(db
+            .get_cf(&cf, key.as_bytes())
+            .expect("read recreated CF")
+            .is_some());
+        assert!(
+            cache.get_usage() > usage_before,
+            "CF '{cf_name}' did not populate the shared cache"
+        );
+    }
+}

--- a/query-perf/src/main.rs
+++ b/query-perf/src/main.rs
@@ -28,10 +28,8 @@ use drasi_index_garnet::{
     GarnetSessionState,
 };
 use drasi_index_rocksdb::{
-    element_index::{RocksDbElementIndex, RocksIndexOptions},
-    open_unified_db,
-    result_index::RocksDbResultIndex,
-    RocksDbSessionControl, RocksDbSessionState,
+    element_index::RocksDbElementIndex, open_unified_db, result_index::RocksDbResultIndex,
+    RocksDbMemoryBudget, RocksDbSessionControl, RocksDbSessionState, RocksIndexOptions,
 };
 use drasi_query_cypher::CypherParser;
 
@@ -117,23 +115,20 @@ async fn main() {
 
         // Open shared RocksDB if either index type needs it (avoids LOCK conflict
         // from opening the same unified DB path twice)
-        let (rocks_db, rocks_session_state) = if test_run_config.element_index_type
+        let (rocks_db, rocks_session_state, rocks_options) = if test_run_config.element_index_type
             == IndexType::RocksDB
             || test_run_config.result_index_type == IndexType::RocksDB
         {
-            let options = RocksIndexOptions {
-                archive_enabled: false,
-                direct_io: false,
-            };
+            let options = RocksIndexOptions::new(false, false, RocksDbMemoryBudget::default());
             let path = match env::var("ROCKS_PATH") {
                 Ok(p) => p,
                 Err(_) => "test-data".to_string(),
             };
             let db = open_unified_db(&path, &query_id, &options).unwrap();
             let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
-            (Some(db), Some(session_state))
+            (Some(db), Some(session_state), Some(options))
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         // Configure the correct element index
@@ -147,14 +142,10 @@ async fn main() {
                 builder.with_element_index(Arc::new(element_index))
             }
             IndexType::RocksDB => {
-                let options = RocksIndexOptions {
-                    archive_enabled: false,
-                    direct_io: false,
-                };
-
                 let db = rocks_db.clone().unwrap();
                 let session_state = rocks_session_state.clone().unwrap();
-                let element_index = RocksDbElementIndex::new(db, options, session_state);
+                let options = rocks_options.clone().unwrap();
+                let element_index = RocksDbElementIndex::new(db, options.clone(), session_state);
                 element_index.clear().await.unwrap();
 
                 builder.with_element_index(Arc::new(element_index))
@@ -174,7 +165,8 @@ async fn main() {
             IndexType::RocksDB => {
                 let db = rocks_db.unwrap();
                 let session_state = rocks_session_state.clone().unwrap();
-                let ari = RocksDbResultIndex::new(db, session_state);
+                let options = rocks_options.unwrap();
+                let ari = RocksDbResultIndex::new(db, session_state, options);
                 ari.clear().await.unwrap();
 
                 builder.with_result_index(Arc::new(ari))


### PR DESCRIPTION
Closes #634.

- Share one block cache and write buffer manager across a provider's query databases.
- Charge memtables to the shared cache instead of using per-DB limits.
- Preserve the shared cache across every column family and reset path.
- Add a programmatic API for caller-owned memory budgets.
- Upgrade rust-rocksdb to 0.22.

**Breaking API changes**

- `RocksIndexOptions` is re-exported from the crate root, uses private fields/getters, and requires an explicit `RocksDbMemoryBudget`.
- `RocksIndexOptions` is `Clone` rather than `Copy`.
- The public `rocksdb` dependency is upgraded to 0.22.