### PR TITLE
Fix durable reaction delivery after restart

### DIFF
--- a/components/host-sdk/Cargo.toml
+++ b/components/host-sdk/Cargo.toml
@@ -64,3 +64,4 @@ im = "15"
 tokio-stream = "0.1"
 drasi-state-store-redb = { path = "../state_stores/redb" }
 async-stream = "0.3"
+bincode = "1.3"

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -2781,6 +2781,133 @@ async fn test_e2e_cdylib_source_query_reaction() {
     core.stop().await.expect("Should stop DrasiLib");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn test_cdylib_reaction_receives_results_above_legacy_redb_checkpoint() {
+    use drasi_lib::{ReactionCheckpoint, StateStoreProvider};
+
+    if !plugin_exists("drasi-source-mock") || !plugin_exists("drasi-reaction-sse") {
+        eprintln!(
+            "SKIPPING: cdylib plugins not found (need drasi-source-mock and drasi-reaction-sse)"
+        );
+        return;
+    }
+
+    let mock_plugin = load_plugin_from_path(
+        &require_plugin("drasi-source-mock"),
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("load mock-source cdylib");
+    let sse_plugin = load_plugin_from_path(
+        &require_plugin("drasi-reaction-sse"),
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("load SSE-reaction cdylib");
+
+    let source = mock_plugin.source_plugins[0]
+        .create_source(
+            "restart-source",
+            &serde_json::json!({
+                "dataType": { "type": "counter" },
+                "intervalMs": 100
+            }),
+            true,
+        )
+        .await
+        .expect("create mock source");
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve SSE port");
+    let port = listener.local_addr().expect("SSE address").port();
+    drop(listener);
+    let reaction = sse_plugin.reaction_plugins[0]
+        .create_reaction(
+            "restart-reaction",
+            vec!["restart-query".to_string()],
+            &serde_json::json!({
+                "host": "127.0.0.1",
+                "port": port,
+                "sse_path": "/events"
+            }),
+            true,
+        )
+        .await
+        .expect("create SSE reaction");
+
+    let query = drasi_lib::Query::cypher("restart-query")
+        .query("MATCH (n:Counter) RETURN n.value AS Value")
+        .from_source("restart-source")
+        .with_outbox_capacity(100)
+        .build();
+    let checkpoint = ReactionCheckpoint {
+        sequence: 50,
+        config_hash: drasi_lib::queries::compute_config_hash(&query),
+    };
+    let temp_dir = tempfile::tempdir().expect("redb temp directory");
+    let store: std::sync::Arc<dyn StateStoreProvider> = std::sync::Arc::new(
+        drasi_state_store_redb::RedbStateStoreProvider::new(
+            temp_dir.path().join("legacy-state.redb"),
+        )
+        .expect("create redb state store"),
+    );
+    store
+        .set(
+            "restart-reaction",
+            "checkpoint:restart-query",
+            bincode::serialize(&checkpoint).expect("serialize checkpoint"),
+        )
+        .await
+        .expect("seed legacy reaction checkpoint");
+
+    let core = drasi_lib::DrasiLib::builder()
+        .with_id("cdylib-restart-baseline")
+        .with_state_store_provider(store.clone())
+        .with_source(source)
+        .with_query(query)
+        .with_reaction(reaction)
+        .build()
+        .await
+        .expect("build DrasiLib");
+    core.start().await.expect("start DrasiLib");
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    let events = collect_sse_events(
+        &format!("http://127.0.0.1:{port}/events"),
+        1,
+        std::time::Duration::from_secs(3),
+    )
+    .await;
+    assert_eq!(
+        events.len(),
+        1,
+        "dynamic reaction did not receive a result above its legacy checkpoint"
+    );
+    let event: serde_json::Value =
+        serde_json::from_str(&events[0]).expect("SSE event should be JSON");
+    assert_eq!(event["queryId"], "restart-query");
+    let sequence_bytes = store
+        .get("__drasi_query_output_sequences", "restart-query")
+        .await
+        .expect("read query sequence")
+        .expect("query sequence should be durable");
+    let sequence = u64::from_le_bytes(
+        sequence_bytes
+            .try_into()
+            .expect("query sequence should contain eight bytes"),
+    );
+    assert!(
+        sequence > 50,
+        "dynamic reaction received a result while query sequence remained at {sequence}"
+    );
+
+    core.shutdown().await.expect("shutdown DrasiLib");
+}
+
 /// E2E test exercising fan-out patterns: multiple queries from one source
 /// and multiple reactions subscribed to one query.
 ///

--- a/lib-integration-tests/Cargo.toml
+++ b/lib-integration-tests/Cargo.toml
@@ -14,6 +14,7 @@ drasi-core.workspace = true
 drasi-source-postgres.workspace = true
 drasi-source-application.workspace = true
 drasi-reaction-application.workspace = true
+drasi-state-store-redb = { path = "../components/state_stores/redb" }
 
 tokio = { version = "1.6", features = ["full"] }
 testcontainers = "0.27"
@@ -23,5 +24,7 @@ async-trait = "0.1"
 chrono = "0.4"
 serde_json = "1.0"
 anyhow = "1.0"
+bincode = "1.3"
 tracing = "0.1"
 serial_test = "3"
+tempfile = "3.8"

--- a/lib-integration-tests/tests/restart_sequence_redb.rs
+++ b/lib-integration-tests/tests/restart_sequence_redb.rs
@@ -1,0 +1,319 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use drasi_lib::channels::{ComponentStatus, QueryResult};
+use drasi_lib::reactions::{
+    ManagerCheckpointOwnership, ReactionBase, ReactionBaseParams, ReactionCheckpoint,
+};
+use drasi_lib::{DrasiLib, Query, Reaction, ReactionRuntimeContext, StateStoreProvider};
+use drasi_source_application::{
+    ApplicationSource, ApplicationSourceConfig, ApplicationSourceHandle, PropertyMapBuilder,
+};
+use drasi_state_store_redb::RedbStateStoreProvider;
+use tokio::sync::mpsc;
+
+const SOURCE_ID: &str = "restart-source";
+const QUERY_ID: &str = "q1";
+const REACTION_ID: &str = "durable-recorder";
+const OUTPUT_SEQUENCE_STORE_ID: &str = "__drasi_query_output_sequences";
+
+struct DurableRecordingReaction {
+    base: Arc<ReactionBase>,
+    delivered: mpsc::UnboundedSender<QueryResult>,
+}
+
+impl DurableRecordingReaction {
+    fn new() -> (Self, mpsc::UnboundedReceiver<QueryResult>) {
+        let (delivered, receiver) = mpsc::unbounded_channel();
+        let base = ReactionBase::new(ReactionBaseParams::new(
+            REACTION_ID,
+            vec![QUERY_ID.to_string()],
+        ));
+        (
+            Self {
+                base: Arc::new(base),
+                delivered,
+            },
+            receiver,
+        )
+    }
+}
+
+#[async_trait]
+impl Reaction for DurableRecordingReaction {
+    fn id(&self) -> &str {
+        self.base.get_id()
+    }
+
+    fn type_name(&self) -> &str {
+        "durable-recording"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+
+    fn query_ids(&self) -> Vec<String> {
+        self.base.get_queries().to_vec()
+    }
+
+    fn auto_start(&self) -> bool {
+        true
+    }
+
+    async fn initialize(&self, context: ReactionRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.base
+            .set_status(ComponentStatus::Running, Some("Started".to_string()))
+            .await;
+        let mut shutdown = self.base.create_shutdown_channel().await;
+        let base = self.base.clone();
+        let delivered = self.delivered.clone();
+        let task = tokio::spawn(async move {
+            loop {
+                let event = tokio::select! {
+                    biased;
+                    _ = &mut shutdown => break,
+                    event = base.priority_queue.dequeue() => event,
+                };
+                let existing = base
+                    .read_checkpoint(&event.query_id)
+                    .await
+                    .expect("read durable reaction checkpoint");
+                if existing
+                    .as_ref()
+                    .is_some_and(|checkpoint| event.sequence <= checkpoint.sequence)
+                {
+                    continue;
+                }
+
+                delivered
+                    .send(event.as_ref().clone())
+                    .expect("record delivered result");
+                base.write_checkpoint(
+                    &event.query_id,
+                    &ReactionCheckpoint {
+                        sequence: event.sequence,
+                        config_hash: existing.map_or(0, |checkpoint| checkpoint.config_hash),
+                    },
+                )
+                .await
+                .expect("persist acknowledged reaction checkpoint");
+            }
+        });
+        self.base.set_processing_task(task).await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base.stop_common().await
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+        self.base.enqueue_query_result(result).await
+    }
+
+    fn is_durable(&self) -> bool {
+        true
+    }
+
+    fn checkpoint_ownership(&self) -> ManagerCheckpointOwnership {
+        ManagerCheckpointOwnership::Reaction
+    }
+}
+
+fn query(cypher: &str) -> drasi_lib::QueryConfig {
+    Query::cypher(QUERY_ID)
+        .query(cypher)
+        .from_source(SOURCE_ID)
+        .with_outbox_capacity(32)
+        .auto_start(true)
+        .build()
+}
+
+async fn build_run(
+    store: Arc<dyn StateStoreProvider>,
+    cypher: &str,
+) -> Result<(
+    DrasiLib,
+    ApplicationSourceHandle,
+    mpsc::UnboundedReceiver<QueryResult>,
+)> {
+    let (source, source_handle) = ApplicationSource::new(
+        SOURCE_ID,
+        ApplicationSourceConfig {
+            properties: HashMap::new(),
+            durability: None,
+        },
+    )?;
+    let (reaction, delivered) = DurableRecordingReaction::new();
+    let core = DrasiLib::builder()
+        .with_id("restart-sequence-redb")
+        .with_source(source)
+        .with_query(query(cypher))
+        .with_reaction(reaction)
+        .with_state_store_provider(store.clone())
+        .build()
+        .await?;
+    Ok((core, source_handle, delivered))
+}
+
+async fn insert_person(source: &ApplicationSourceHandle, id: &str, name: &str) -> Result<()> {
+    source
+        .send_node_insert(
+            id,
+            vec!["Person"],
+            PropertyMapBuilder::new().with_string("name", name).build(),
+        )
+        .await
+}
+
+async fn receive(delivered: &mut mpsc::UnboundedReceiver<QueryResult>) -> Result<QueryResult> {
+    tokio::time::timeout(Duration::from_secs(5), delivered.recv())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("recording reaction closed"))
+}
+
+async fn wait_for_checkpoint(
+    store: &dyn StateStoreProvider,
+    sequence: u64,
+) -> Result<ReactionCheckpoint> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Some(bytes) = store
+                .get(REACTION_ID, &format!("checkpoint:{QUERY_ID}"))
+                .await
+                .expect("read redb checkpoint")
+            {
+                let checkpoint: ReactionCheckpoint =
+                    bincode::deserialize(&bytes).expect("decode reaction checkpoint");
+                if checkpoint.sequence >= sequence {
+                    return checkpoint;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .map_err(Into::into)
+}
+
+async fn wait_until_stopped(core: &DrasiLib) -> Result<()> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if core
+                .list_reactions()
+                .await
+                .expect("list reactions")
+                .iter()
+                .any(|(id, status)| id == REACTION_ID && *status == ComponentStatus::Stopped)
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn durable_redb_restart_rebases_legacy_checkpoint_and_delivers_once() -> Result<()> {
+    let directory = tempfile::tempdir()?;
+    let db_path = directory.path().join("reaction-state.redb");
+    let store: Arc<dyn StateStoreProvider> = Arc::new(RedbStateStoreProvider::new(&db_path)?);
+    let cypher = "MATCH (p:Person) RETURN p.name AS name";
+
+    // Run 1 advances a real reaction-owned checkpoint. Remove only the new
+    // query clock to leave the exact legacy shape written before this fix.
+    {
+        let (core, source, mut delivered) = build_run(store.clone(), cypher).await?;
+        core.start().await?;
+        for (id, name) in [("p1", "Alice"), ("p2", "Bob"), ("p3", "Charlie")] {
+            insert_person(&source, id, name).await?;
+            receive(&mut delivered).await?;
+        }
+        let checkpoint = wait_for_checkpoint(store.as_ref(), 3).await?;
+        assert_eq!(checkpoint.sequence, 3);
+        assert_ne!(checkpoint.config_hash, 0);
+        store.delete(OUTPUT_SEQUENCE_STORE_ID, QUERY_ID).await?;
+        core.shutdown().await?;
+    }
+
+    // A new DrasiLib reconstructs QueryOutputState at raw sequence zero. The
+    // legacy reaction checkpoint seeds the shared query clock, so the first
+    // genuinely new result is 4 rather than being discarded as raw sequence 1.
+    {
+        let (core, source, mut delivered) = build_run(store.clone(), cypher).await?;
+        core.start().await?;
+        insert_person(&source, "p4", "Diana").await?;
+        let result = receive(&mut delivered).await?;
+        assert_eq!(result.sequence, 4);
+        wait_for_checkpoint(store.as_ref(), 4).await?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            delivered.try_recv().is_err(),
+            "the run-2 diff must be delivered exactly once"
+        );
+
+        // Restarting the reaction in the same process replays its outbox
+        // position, but the acknowledged sequence remains suppressed.
+        core.stop_reaction(REACTION_ID).await?;
+        wait_until_stopped(&core).await?;
+        core.start_reaction(REACTION_ID).await?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            delivered.try_recv().is_err(),
+            "acknowledged outbox replay must remain suppressed"
+        );
+
+        insert_person(&source, "p5", "Eve").await?;
+        let next = receive(&mut delivered).await?;
+        assert_eq!(next.sequence, 5);
+        wait_for_checkpoint(store.as_ref(), 5).await?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(delivered.try_recv().is_err());
+        core.shutdown().await?;
+    }
+
+    // The sequence migration is independent of config validation: Strict still
+    // rejects a changed query, and no stale result is delivered as a side effect.
+    {
+        let changed = "MATCH (p:Person) WHERE p.name IS NOT NULL RETURN p.name AS name";
+        let (core, _source, mut delivered) = build_run(store.clone(), changed).await?;
+        let error = core
+            .start()
+            .await
+            .expect_err("Strict recovery must reject a config-hash mismatch");
+        assert!(error.to_string().contains("Strict recovery policy"));
+        assert!(delivered.try_recv().is_err());
+        assert_eq!(wait_for_checkpoint(store.as_ref(), 5).await?.sequence, 5);
+        let _ = core.shutdown().await;
+    }
+
+    Ok(())
+}

--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -607,6 +607,9 @@ impl DrasiLibBuilder {
         core.source_manager
             .inject_state_store(state_store.clone())
             .await;
+        core.query_manager
+            .inject_state_store(state_store.clone())
+            .await;
         core.reaction_manager.inject_state_store(state_store).await;
 
         // Inject WAL provider into SourceManager (if configured)

--- a/lib/src/lib_core.rs
+++ b/lib/src/lib_core.rs
@@ -418,6 +418,9 @@ impl DrasiLib {
         self.source_manager
             .inject_state_store(state_store.clone())
             .await;
+        self.query_manager
+            .inject_state_store(state_store.clone())
+            .await;
         self.reaction_manager.inject_state_store(state_store).await;
 
         // Inject IdentityProvider into SourceManager and ReactionManager (if configured)

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::{Notify, RwLock};
 
@@ -54,7 +55,74 @@ use crate::queries::QueryBase;
 use crate::sources::FutureQueueSource;
 use crate::sources::Source;
 use crate::sources::SourceManager;
+use crate::state_store::{StateStoreCompareAndSwapResult, StateStoreError, StateStoreProvider};
 use tracing::Instrument;
+
+const QUERY_OUTPUT_SEQUENCE_STORE_ID: &str = "__drasi_query_output_sequences";
+
+async fn read_durable_output_sequence(
+    store: &dyn StateStoreProvider,
+    query_id: &str,
+) -> Result<Option<u64>> {
+    let Some(bytes) = store.get(QUERY_OUTPUT_SEQUENCE_STORE_ID, query_id).await? else {
+        return Ok(None);
+    };
+    let encoded: [u8; 8] = bytes.try_into().map_err(|bytes: Vec<u8>| {
+        anyhow::anyhow!(
+            "Invalid durable output sequence for query '{query_id}': expected 8 bytes, got {}",
+            bytes.len()
+        )
+    })?;
+    Ok(Some(u64::from_le_bytes(encoded)))
+}
+
+async fn write_durable_output_sequence(
+    store: &dyn StateStoreProvider,
+    query_id: &str,
+    sequence: u64,
+) -> Result<()> {
+    let new_value = sequence.to_le_bytes();
+    for _ in 0..8 {
+        let existing = store.get(QUERY_OUTPUT_SEQUENCE_STORE_ID, query_id).await?;
+        if let Some(bytes) = existing.as_ref() {
+            let encoded: [u8; 8] = bytes.as_slice().try_into().map_err(|_| {
+                anyhow::anyhow!(
+                    "Invalid durable output sequence for query '{query_id}': expected 8 bytes, got {}",
+                    bytes.len()
+                )
+            })?;
+            if u64::from_le_bytes(encoded) >= sequence {
+                return Ok(());
+            }
+        }
+
+        match store
+            .compare_and_swap(
+                QUERY_OUTPUT_SEQUENCE_STORE_ID,
+                query_id,
+                existing.as_deref(),
+                new_value.to_vec(),
+            )
+            .await
+        {
+            Ok(StateStoreCompareAndSwapResult::Swapped) => return Ok(()),
+            Ok(StateStoreCompareAndSwapResult::Mismatch) => continue,
+            Err(StateStoreError::Unsupported(_)) => {
+                // Legacy providers are serialized by the query output-state
+                // lock within one runtime, so a direct durable write retains
+                // the pre-CAS behavior for them.
+                store
+                    .set(QUERY_OUTPUT_SEQUENCE_STORE_ID, query_id, new_value.to_vec())
+                    .await?;
+                return Ok(());
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Err(anyhow::anyhow!(
+        "Failed to persist durable output sequence for query '{query_id}' after repeated CAS retries"
+    ))
+}
 
 /// Default query configuration
 struct DefaultQueryConfig;
@@ -236,6 +304,21 @@ pub trait Query: Send + Sync {
     /// `fetch_snapshot`.
     async fn fetch_outbox(&self, after_sequence: u64) -> Result<OutboxResponse, FetchError>;
 
+    /// Ensure result sequences remain comparable with durable reaction
+    /// checkpoints from an earlier process.
+    ///
+    /// Query implementations without a process-local sequence source may keep
+    /// the default no-op implementation.
+    async fn ensure_output_sequence_at_least(&self, _minimum: u64) -> Result<()> {
+        Ok(())
+    }
+
+    /// Restore any query-owned durable sequence baseline before merging
+    /// reaction checkpoints.
+    async fn restore_output_sequence_baseline(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// Get the query's output metrics (outbox health, sequence rate, snapshot tracking).
     ///
     /// Returns `None` for query implementations that don't support metrics.
@@ -280,6 +363,7 @@ async fn dispatch_query_results(
     outbox_writer: &Option<Arc<dyn OutboxWriter>>,
     live_results_writer: &Option<Arc<dyn LiveResultsWriter>>,
     checkpoint_store: &Option<Arc<dyn CheckpointStore>>,
+    output_sequence_store: &Option<Arc<dyn StateStoreProvider>>,
     outbox_capacity: usize,
     profiling: crate::profiling::ProfilingMetadata,
     output_metrics: &Arc<QueryOutputMetrics>,
@@ -375,6 +459,25 @@ async fn dispatch_query_results(
         );
 
         let result = state.advance_sequence_and_push(query_result);
+
+        // Persist the sequence clock before publishing the result. Reaction
+        // checkpoints live in this same durable store, so a new process must
+        // never restart result numbering below an acknowledged checkpoint.
+        // Keep the output-state lock across this write so legacy rebasing and
+        // concurrent result production cannot reorder sequence persistence.
+        if let Some(store) = output_sequence_store {
+            if let Err(e) =
+                write_durable_output_sequence(store.as_ref(), query_id, result.sequence).await
+            {
+                // Continue delivery to preserve availability. If a durable
+                // reaction acknowledges this result, its checkpoint is read as
+                // a fallback floor before the next query start.
+                warn!(
+                    "Query '{query_id}' failed to persist durable output sequence {}: {e}",
+                    result.sequence
+                );
+            }
+        }
 
         // Update query output metrics
         let duration_ns = u64::try_from(tx_start.elapsed().as_nanos()).unwrap_or(u64::MAX);
@@ -550,6 +653,13 @@ pub struct DrasiQuery {
     future_queue_source: Arc<RwLock<Option<Arc<FutureQueueSource>>>>,
     // Persisted checkpoint_store across stop/start cycles for checkpoint recovery
     checkpoint_store: Arc<RwLock<Option<Arc<dyn CheckpointStore>>>>,
+    // Shared state store used to make the query-result sequence clock durable,
+    // even when the query's index backend itself is in-memory.
+    output_sequence_store: Option<Arc<dyn StateStoreProvider>>,
+    // True only when this process restored or established a restart baseline.
+    // A sequence written by an early result in a legacy run does not set this:
+    // the manager must still rebase that result above legacy reaction checkpoints.
+    output_sequence_has_restart_baseline: AtomicBool,
     // Persistent outbox writer for reaction replay (from index backend)
     outbox_writer: Arc<RwLock<Option<Arc<dyn OutboxWriter>>>>,
     // Persistent live results writer for snapshot recovery (from index backend)
@@ -572,6 +682,7 @@ impl DrasiQuery {
         index_factory: Arc<crate::indexes::IndexFactory>,
         middleware_registry: Arc<MiddlewareTypeRegistry>,
         default_recovery_policy: Option<crate::recovery::RecoveryPolicy>,
+        output_sequence_store: Option<Arc<dyn StateStoreProvider>>,
     ) -> Result<Self> {
         // Create priority queue with configured capacity (fallback to 10000 if not set)
         let priority_capacity = config.priority_queue_capacity.unwrap_or(10000);
@@ -603,6 +714,8 @@ impl DrasiQuery {
             middleware_registry,
             future_queue_source: Arc::new(RwLock::new(None)),
             checkpoint_store: Arc::new(RwLock::new(None)),
+            output_sequence_store,
+            output_sequence_has_restart_baseline: AtomicBool::new(false),
             outbox_writer: Arc::new(RwLock::new(None)),
             live_results_writer: Arc::new(RwLock::new(None)),
             bootstrap_timeout,
@@ -622,6 +735,59 @@ impl DrasiQuery {
 
     pub async fn get_current_results(&self) -> Vec<serde_json::Value> {
         self.output_state.read().await.get_results_as_vec()
+    }
+
+    async fn restore_output_sequence(&self) -> Result<()> {
+        let Some(store) = self.output_sequence_store.as_ref() else {
+            return Ok(());
+        };
+        let Some(sequence) =
+            read_durable_output_sequence(store.as_ref(), &self.base.config.id).await?
+        else {
+            self.output_sequence_has_restart_baseline
+                .store(false, Ordering::Release);
+            return Ok(());
+        };
+
+        let mut state = self.output_state.write().await;
+        let delta = sequence.saturating_sub(state.as_of_sequence());
+        state
+            .rebase_sequence(delta)
+            .map_err(|e| anyhow::anyhow!("Failed to restore query output sequence: {e}"))?;
+        self.output_sequence_has_restart_baseline
+            .store(true, Ordering::Release);
+        Ok(())
+    }
+
+    async fn establish_output_sequence_floor(&self, minimum: u64) -> Result<()> {
+        let Some(store) = self.output_sequence_store.as_ref() else {
+            return Ok(());
+        };
+
+        let mut state = self.output_state.write().await;
+        let has_baseline = self
+            .output_sequence_has_restart_baseline
+            .load(Ordering::Acquire);
+        let delta = if has_baseline {
+            minimum.saturating_sub(state.as_of_sequence())
+        } else {
+            // No sequence key existed when this process started. This is legacy
+            // state: retained results belong to the new process-local epoch and
+            // must all be shifted above the old reaction checkpoint watermark.
+            minimum
+        };
+        let sequence = state
+            .as_of_sequence()
+            .checked_add(delta)
+            .ok_or_else(|| anyhow::anyhow!("Query output sequence overflow"))?;
+
+        write_durable_output_sequence(store.as_ref(), &self.base.config.id, sequence).await?;
+        state
+            .rebase_sequence(delta)
+            .map_err(|e| anyhow::anyhow!("Failed to establish query output sequence: {e}"))?;
+        self.output_sequence_has_restart_baseline
+            .store(true, Ordering::Release);
+        Ok(())
     }
 
     /// Wait until the query has finished bootstrapping (status is no longer `Starting`).
@@ -747,6 +913,7 @@ impl Query for DrasiQuery {
     async fn start(&self) -> Result<()> {
         log_component_start("Query", &self.base.config.id);
 
+        self.restore_output_sequence().await?;
         self.bootstrap_state.write().await.clear();
 
         // Set Starting on the local status handle. The manager has already validated
@@ -1112,6 +1279,19 @@ impl Query for DrasiQuery {
             // Only read checkpoints if the config hash matched — otherwise we
             // cleared them above and a full bootstrap will run.
             if config_matches {
+                if let Some(sequence) = checkpoint_store
+                    .read_result_sequence(&self.base.config.id)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Query '{}' failed to read its persisted result sequence",
+                            self.base.config.id
+                        )
+                    })?
+                {
+                    self.establish_output_sequence_floor(sequence).await?;
+                }
+
                 match checkpoint_store.read_all_checkpoints().await {
                     Ok(checkpoints) => {
                         for settings in &mut subscription_settings {
@@ -2081,6 +2261,7 @@ impl Query for DrasiQuery {
         let position_handles_for_processor = position_handles;
         let outbox_writer_for_processor = self.outbox_writer.read().await.clone();
         let live_results_writer_for_processor = self.live_results_writer.read().await.clone();
+        let output_sequence_store_for_processor = self.output_sequence_store.clone();
         let outbox_capacity_for_processor = self.output_state.read().await.outbox_capacity();
         let output_metrics_for_processor = self.output_metrics.clone();
         let source_ids_for_processor: Vec<String> = self
@@ -2231,6 +2412,7 @@ impl Query for DrasiQuery {
                                                         &outbox_writer_for_processor,
                                                         &live_results_writer_for_processor,
                                                         &checkpoint_store_for_dispatch,
+                                                        &output_sequence_store_for_processor,
                                                         outbox_capacity_for_processor,
                                                         profiling,
                                                         &output_metrics_for_processor,
@@ -2303,6 +2485,7 @@ impl Query for DrasiQuery {
                                                     &outbox_writer_for_processor,
                                                     &live_results_writer_for_processor,
                                                     &checkpoint_store_for_dispatch,
+                                                    &output_sequence_store_for_processor,
                                                     outbox_capacity_for_processor,
                                                     profiling,
                                                     &output_metrics_for_processor,
@@ -2540,6 +2723,14 @@ impl Query for DrasiQuery {
         })
     }
 
+    async fn ensure_output_sequence_at_least(&self, minimum: u64) -> Result<()> {
+        self.establish_output_sequence_floor(minimum).await
+    }
+
+    async fn restore_output_sequence_baseline(&self) -> Result<()> {
+        self.restore_output_sequence().await
+    }
+
     fn output_metrics(&self) -> Option<Arc<QueryOutputMetrics>> {
         Some(self.output_metrics.clone())
     }
@@ -2581,6 +2772,8 @@ pub struct QueryManager {
     /// Managers send transitional states (Starting, Stopping, Reconfiguring) here;
     /// the loop applies them to the graph and records events automatically.
     update_tx: ComponentUpdateSender,
+    /// Shared state store used for restart-stable query output sequences.
+    state_store: Arc<RwLock<Option<Arc<dyn StateStoreProvider>>>>,
     /// Global default recovery policy. Per-query overrides this; if neither is set,
     /// defaults to `Strict`.
     default_recovery_policy: Option<crate::recovery::RecoveryPolicy>,
@@ -2608,9 +2801,58 @@ impl QueryManager {
             log_registry,
             graph,
             update_tx,
+            state_store: Arc::new(RwLock::new(None)),
             default_recovery_policy,
             label_cache: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Inject the shared state store before queries are provisioned.
+    pub async fn inject_state_store(&self, state_store: Arc<dyn StateStoreProvider>) {
+        *self.state_store.write().await = Some(state_store);
+    }
+
+    async fn prepare_output_sequence(&self, query_id: &str, query: &Arc<dyn Query>) -> Result<()> {
+        query.restore_output_sequence_baseline().await?;
+
+        let Some(store) = self.state_store.read().await.clone() else {
+            return Ok(());
+        };
+        let config_hash = crate::queries::compute_config_hash(query.get_config());
+        let reaction_ids = {
+            let graph = self.graph.read().await;
+            graph
+                .get_dependents(query_id)
+                .into_iter()
+                .filter(|node| node.kind == ComponentKind::Reaction)
+                .map(|node| node.id.clone())
+                .collect::<Vec<_>>()
+        };
+
+        let mut sequence_floor = 0;
+        for reaction_id in reaction_ids {
+            if let Some(checkpoint) = crate::reactions::checkpoint::read_checkpoint(
+                store.as_ref(),
+                &reaction_id,
+                query_id,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to read restart checkpoint for reaction '{reaction_id}', query '{query_id}'"
+                )
+            })?
+            {
+                if checkpoint.config_hash == config_hash {
+                    sequence_floor = sequence_floor.max(checkpoint.sequence);
+                }
+            }
+        }
+
+        query
+            .ensure_output_sequence_at_least(sequence_floor)
+            .await
+            .with_context(|| format!("Failed to prepare result sequence for query '{query_id}'"))
     }
 
     /// Register and provision a new query from the given configuration.
@@ -2679,6 +2921,7 @@ impl QueryManager {
             self.index_factory.clone(),
             self.middleware_registry.clone(),
             self.default_recovery_policy,
+            self.state_store.read().await.clone(),
         )?;
 
         // Wire status handle to graph via context (same pattern as Source/Reaction)
@@ -2723,6 +2966,7 @@ impl QueryManager {
                     anyhow::Error::new(crate::managers::ComponentNotFoundError::new("query", &id))
                 })?;
 
+        self.prepare_output_sequence(&id, &query).await?;
         crate::managers::lifecycle_helpers::start_component(&self.graph, &id, "query", &query).await
     }
 
@@ -2862,6 +3106,15 @@ impl QueryManager {
             || async {},
         )
         .await?;
+
+        if let Some(store) = self.state_store.read().await.as_ref() {
+            store
+                .delete(QUERY_OUTPUT_SEQUENCE_STORE_ID, &id)
+                .await
+                .with_context(|| {
+                    format!("Failed to clear durable output sequence for removed query '{id}'")
+                })?;
+        }
 
         // After teardown: clear persistent indexes + checkpoints so a future
         // query with the same ID starts fresh. Only needed for persistent backends.
@@ -3016,6 +3269,8 @@ impl QueryManager {
             "query",
             |q| q.get_config().auto_start,
             |id, query| async move {
+                self.prepare_output_sequence(&id, &query).await?;
+
                 // Validate and apply Starting transition atomically through the graph
                 {
                     let mut graph = self.graph.write().await;

--- a/lib/src/queries/output_state.rs
+++ b/lib/src/queries/output_state.rs
@@ -89,6 +89,38 @@ impl QueryOutputState {
         }
     }
 
+    /// Move the output sequence and every retained outbox entry forward by
+    /// `delta`.
+    ///
+    /// This is used when restoring the durable sequence clock before reactions
+    /// compare their persisted checkpoints with results produced by a newly
+    /// constructed query.
+    pub fn rebase_sequence(&mut self, delta: u64) -> Result<(), &'static str> {
+        if delta == 0 {
+            return Ok(());
+        }
+
+        let rebased_sequence = self
+            .as_of_sequence
+            .checked_add(delta)
+            .ok_or("query output sequence overflow")?;
+
+        let mut rebased_outbox = VecDeque::with_capacity(self.outbox.len());
+        for result in &self.outbox {
+            let sequence = result
+                .sequence
+                .checked_add(delta)
+                .ok_or("query outbox sequence overflow")?;
+            let mut rebased = result.as_ref().clone();
+            rebased.sequence = sequence;
+            rebased_outbox.push_back(Arc::new(rebased));
+        }
+
+        self.as_of_sequence = rebased_sequence;
+        self.outbox = rebased_outbox;
+        Ok(())
+    }
+
     /// Apply a set of result diffs to the live result set using O(1) HashMap operations.
     ///
     /// This does NOT increment the sequence or push to the outbox — that is done
@@ -630,6 +662,32 @@ mod tests {
         let arc = state.advance_sequence_and_push(result);
         assert_eq!(arc.sequence, 2);
         assert_eq!(state.outbox.len(), 2);
+    }
+
+    #[test]
+    fn rebase_sequence_preserves_retained_outbox_order() {
+        let mut state = QueryOutputState::new(3);
+        for _ in 0..2 {
+            state.advance_sequence_and_push(make_query_result("q1", vec![]));
+        }
+
+        state.rebase_sequence(7).unwrap();
+
+        assert_eq!(state.as_of_sequence(), 9);
+        let entries = state.fetch_outbox_after(7).unwrap();
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.sequence)
+                .collect::<Vec<_>>(),
+            vec![8, 9]
+        );
+        assert_eq!(
+            state
+                .advance_sequence_and_push(make_query_result("q1", vec![]))
+                .sequence,
+            10
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Description

Persist the query-result sequence clock in the configured state store and restore it before queries start. Legacy redb state is migrated from the highest matching reaction checkpoint, so process-local numbering cannot fall behind acknowledged progress after restart. The fix is shared by all reaction kinds and keeps strict/config-hash recovery semantics intact.

Adds real-redb clean-restart coverage, acknowledged replay/no-duplicate and config-mismatch checks, plus a dynamic cross-cdylib regression.

SDK FFI ABI remains 0.15; existing dynamic plugins only require a host/Core rebuild.

## Type of change

- This pull request fixes a bug in Drasi.

## Validation

- `cargo test -p lib-integration-tests --test restart_sequence_redb`
- `cargo test -p drasi-lib --test reaction_recovery_e2e`
- `cargo test -p drasi-lib queries::checkpoint_tests`
- `cargo test -p drasi-host-sdk --test integration_test state_store_durability_cross_cdylib`
- `cargo test -p drasi-host-sdk --test integration_test test_cdylib_reaction_receives_results_above_legacy_redb_checkpoint`
- `cargo clippy -p drasi-lib -p lib-integration-tests -p drasi-host-sdk --tests -- -D warnings`
- `cargo fmt --all -- --check`

Fixes: N/A