### PR TITLE
feat: add GitHub WorkGraph bootstrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "components/bootstrappers/neo4j",
   "components/neo4j-common",
   "components/bootstrappers/kafka",
+  "components/bootstrappers/github-workgraph",
 
   # Source Plugins
   "components/sources/postgres",
@@ -207,6 +208,7 @@ drasi-source-open511 = { version = "0.1.1", path = "components/sources/open511" 
 drasi-bootstrap-open511 = { version = "0.1.0", path = "components/bootstrappers/open511" }
 drasi-source-neo4j = { version = "0.1.4", path = "components/sources/neo4j" }
 drasi-source-github-workgraph = { version = "0.1.0", path = "components/sources/github-workgraph" }
+drasi-bootstrap-github-workgraph = { version = "0.1.0", path = "components/bootstrappers/github-workgraph" }
 drasi-bootstrap-neo4j = { version = "0.1.4", path = "components/bootstrappers/neo4j" }
 drasi-neo4j-common = { version = "0.1.4", path = "components/neo4j-common" }
 drasi-bootstrap-sqlite = { version = "0.1.9", path = "components/bootstrappers/sqlite" }

--- a/components/bootstrappers/github-workgraph/Cargo.toml
+++ b/components/bootstrappers/github-workgraph/Cargo.toml
@@ -1,0 +1,53 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-bootstrap-github-workgraph"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors = ["Drasi Project"]
+description = "GitHub WorkGraph bootstrap plugin for Drasi (read-only GraphQL snapshot of open Issues/PRs)"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi", "plugin", "bootstrap", "github"]
+categories = ["development-tools"]
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+drasi-lib.workspace = true
+drasi-core.workspace = true
+drasi-plugin-sdk = { workspace = true }
+drasi-source-github-workgraph = { workspace = true }
+utoipa = { workspace = true }
+anyhow = "1.0"
+async-trait = "0.1"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1.0", features = ["macros", "rt", "sync", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
+wiremock = "0.6"
+
+[features]
+# default = []
+dynamic-plugin = []

--- a/components/bootstrappers/github-workgraph/Makefile
+++ b/components/bootstrappers/github-workgraph/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build:
+	cargo build -p drasi-bootstrap-github-workgraph
+
+lint:
+	cargo clippy -p drasi-bootstrap-github-workgraph --all-targets --all-features -- -D warnings
+
+test:
+	cargo test -p drasi-bootstrap-github-workgraph
+
+integration-test:
+	cargo test -p drasi-bootstrap-github-workgraph -- --ignored --nocapture

--- a/components/bootstrappers/github-workgraph/README.md
+++ b/components/bootstrappers/github-workgraph/README.md
@@ -1,0 +1,130 @@
+# GitHub WorkGraph Bootstrap Provider
+
+`drasi-bootstrap-github-workgraph` is a [Drasi bootstrap provider](../README.md)
+that snapshots one GitHub organization's currently-open Issues and Pull
+Requests — plus their conversation comments and PR reviews — as the initial
+state for a query subscribed to the
+[`drasi-source-github-workgraph`](../../sources/github-workgraph/README.md)
+source.
+
+## Reuse, not duplication
+
+This crate owns **all** GitHub API access; the streaming source itself makes
+zero GitHub API calls (it only receives webhook deliveries). To keep that
+separation without duplicating any WorkGraph domain logic, this crate:
+
+1. Fetches data over the GitHub GraphQL v4 API, aliasing fields so the JSON
+   shape matches GitHub's REST/webhook resource representation.
+2. Performs a small amount of purely syntactic reshaping (flattening
+   `defaultBranchRef`/`repositoryTopics` connections, nesting
+   `head`/`base` ref+sha pairs, lowercasing a few enum fields) — no
+   WorkGraph node/relation/status semantics are touched here.
+3. Wraps each entity in a synthetic webhook-delivery envelope (e.g.
+   `{"action": "opened", "organization": ..., "repository": ..., "issue": ...}`)
+   and hands it to
+   `drasi_source_github_workgraph::mapping::Converter::convert(...)` — the
+   **exact same converter** the streaming source uses for live webhook
+   deliveries.
+
+Every node label, relation ID/direction, status-label derivation rule, and
+`WorkGraphAssignment`/`WorkGraphResult`/`WorkGraphError` comment-parsing rule
+therefore comes from the source crate, unchanged. This crate never
+re-implements any of that.
+
+## Scope (prototype)
+
+- One configured GitHub organization; every repository the token can see.
+- Only currently **open** Issues and Pull Requests (no closed history).
+- Issue/PR conversation comments and submitted or dismissed PR reviews.
+- **Excluded**: GitHub Projects and Project Items, inline diff/review
+  comments, closed-item history, reactions, and workflow-run execution
+  state. None of these map to a WorkGraph node/relation the source
+  understands.
+
+## Configuration
+
+| Field             | Type                 | Description                                                                 |
+| ----------------- | -------------------- | ---------------------------------------------------------------------------- |
+| `token`           | `ConfigValue<string>`| A **read-only** GitHub token. Use a `Secret` reference in production.       |
+| `apiBaseUrl`      | `ConfigValue<string>`| GraphQL endpoint. Default `https://api.github.com/graphql`; override for GHE.|
+| `maxConcurrency`  | `ConfigValue<usize>` | Bound on concurrently in-flight GraphQL requests and concurrent repository tasks. Default `4`. |
+
+### Example
+
+```yaml
+bootstrap_provider:
+  type: github-workgraph
+  token:
+    kind: Secret
+    name: github-readonly-token
+  maxConcurrency: 4
+```
+
+The organization is read from the parent `github-workgraph` Source
+configuration, ensuring bootstrap and webhook streaming cannot target different
+organizations.
+
+### Authentication
+
+The token must be **read-only**: a fine-grained personal access token scoped
+to `Issues: Read`, `Pull requests: Read`, and `Metadata: Read` on the target
+organization is sufficient, or an equivalent read-only GitHub App
+installation token. This bootstrapper never requests or uses any write
+scope, and never mutates GitHub state.
+
+## `source_position` is always `None`
+
+> **This bootstrapper never sets `source_position`.**
+
+The GitHub WorkGraph source is driven entirely by webhook deliveries. Unlike
+a database WAL LSN or a Kafka partition offset, a missed webhook delivery
+cannot be re-requested from GitHub by position — there is no durable,
+replayable cursor to snapshot against. Because of this, every
+`BootstrapResult` this provider returns carries `source_position: None`, and
+the framework cannot seed a bootstrap-to-streaming replay checkpoint for this
+source. This is a fundamental limitation of GitHub's webhook delivery model,
+not an oversight.
+
+## Bounded concurrency
+
+Two independent bounds, both derived from `max_concurrency`:
+
+- A `tokio::sync::Semaphore`-gated `JoinSet` limits how many repositories are
+  processed concurrently.
+- The GraphQL client itself holds a semaphore bounding the number of
+  concurrently in-flight HTTP requests, regardless of how many repository
+  tasks are running.
+
+Within one repository, issues, pull requests, and their comments/reviews are
+fetched sequentially — cross-repository parallelism plus the client's
+request-level semaphore already provide genuine bounded concurrency without
+the added complexity of per-repository fan-out.
+
+## Known prototype limitations
+
+- GitHub does not provide a transaction spanning the GraphQL requests used to
+  enumerate the organization. The bootstrapper fails rather than returning a
+  known partial snapshot when a request or repository task fails, but upstream
+  state can still change between successfully fetched pages.
+- Issue/PR labels, comments, reviews, repositories, issues, and pull requests
+  are cursor-paginated in full. Assignees and repository topics fit within
+  GitHub's resource limits and are fetched inline.
+- Enum casing (`state`, `state_reason`, `visibility`, review `state`) is
+  lowercased to match the REST/webhook convention `Converter` expects; this
+  covers every enum value currently used by `mapping.rs`.
+
+## Testing
+
+```bash
+make build   # cargo build
+make test    # cargo test (wiremock-backed, no network access required)
+make lint    # cargo clippy --all-targets --all-features -- -D warnings
+```
+
+The test suite in `src/tests.rs` runs a fake GitHub GraphQL API via
+[`wiremock`](https://docs.rs/wiremock) and verifies: multi-page cursor
+pagination, `BootstrapRequest` node/relation label filtering, exact
+`event_count`, `source_position` always being `None`, and that a
+WorkGraph Assignment comment is reconstructed into a `WorkGraphAssignment`
+node purely through the shared `Converter`/`workgraph::classify` — proving
+this crate does not duplicate that parsing logic.

--- a/components/bootstrappers/github-workgraph/README.md
+++ b/components/bootstrappers/github-workgraph/README.md
@@ -51,18 +51,53 @@ re-implements any of that.
 
 ### Example
 
+Configure the bootstrapper as a top-level provider and reference it by ID from
+the Source:
+
 ```yaml
-bootstrap_provider:
-  type: github-workgraph
-  token:
-    kind: Secret
-    name: github-readonly-token
-  maxConcurrency: 4
+stateStore:
+  kind: redb
+  path: ./data/github-workgraph-state.redb
+
+bootstrapProviders:
+  - id: github-workgraph-bootstrap
+    kind: github-workgraph
+    token:
+      kind: Secret
+      name: github-workgraph-api-token
+    apiBaseUrl: https://api.github.com/graphql
+    maxConcurrency: 4
+
+sources:
+  - id: github-workgraph
+    kind: github-workgraph
+    organization: drasi-project
+    webhook:
+      host: 0.0.0.0
+      port: 8080
+      path: /webhook
+      secret:
+        kind: Secret
+        name: github-workgraph-webhook-secret
+      bodyLimitBytes: 26214400
+    durability:
+      enabled: true
+      maxEvents: 10000
+      capacityPolicy: RejectIncoming
+    bootstrapProvider: github-workgraph-bootstrap
 ```
 
 The organization is read from the parent `github-workgraph` Source
 configuration, ensuring bootstrap and webhook streaming cannot target different
-organizations.
+organizations. Do not use an inline `bootstrapProvider` mapping for this pair:
+drasi-server applies same-kind inheritance to inline providers, which would copy
+Source-only fields such as `organization`, `webhook`, and `durability` into this
+bootstrapper's strict configuration. A top-level `bootstrapProviders` entry and
+string reference keep the two configurations separate while still passing the
+parent Source configuration to the bootstrap descriptor.
+
+The durable `stateStore` is required by the streaming Source, not by this
+bootstrapper.
 
 ### Authentication
 
@@ -87,7 +122,7 @@ not an oversight.
 
 ## Bounded concurrency
 
-Two independent bounds, both derived from `max_concurrency`:
+Two independent bounds, both derived from `maxConcurrency`:
 
 - A `tokio::sync::Semaphore`-gated `JoinSet` limits how many repositories are
   processed concurrently.

--- a/components/bootstrappers/github-workgraph/src/client.rs
+++ b/components/bootstrappers/github-workgraph/src/client.rs
@@ -1,0 +1,749 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A minimal GitHub GraphQL v4 client: one query surface with correct cursor
+//! pagination and a bounded number of concurrently in-flight requests.
+//!
+//! Every query below aliases its fields to the exact REST/webhook JSON shape
+//! that `drasi_source_github_workgraph::mapping::Converter` already knows how
+//! to parse (see that crate's `*_PROPS` pointer tables). A handful of GraphQL
+//! shapes cannot be aliased into that shape directly (connections that must
+//! become flat arrays, enums that must become lowercase strings, and
+//! `head`/`base` sub-objects) — the `reshape_*` functions below perform that
+//! purely-syntactic, GitHub-API-shape-only transformation. No WorkGraph domain
+//! rule (label, relation ID, status derivation, Assignment/Result parsing) is
+//! reimplemented anywhere in this crate; all of that stays in `Converter`.
+
+use anyhow::{anyhow, bail, Context, Result};
+use log::warn;
+use reqwest::Client;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+use tokio::time::sleep;
+
+use crate::config::DEFAULT_PAGE_SIZE;
+
+const MAX_ATTEMPTS: u32 = 4;
+const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+const ORG_QUERY: &str = r#"
+query($org: String!) {
+  organization(login: $org) {
+    node_id: id
+    id: databaseId
+    login
+    url
+    avatar_url: avatarUrl
+    description
+  }
+}
+"#;
+
+const REPOS_QUERY: &str = r#"
+query($org: String!, $cursor: String, $pageSize: Int!) {
+  organization(login: $org) {
+    repositories(first: $pageSize, after: $cursor, orderBy: {field: NAME, direction: ASC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        node_id: id
+        id: databaseId
+        name
+        full_name: nameWithOwner
+        owner { login }
+        description
+        html_url: url
+        private: isPrivate
+        archived: isArchived
+        fork: isFork
+        visibility
+        created_at: createdAt
+        updated_at: updatedAt
+        defaultBranchRef { name }
+        repositoryTopics(first: 50) { nodes { topic { name } } }
+      }
+    }
+  }
+}
+"#;
+
+const ISSUES_QUERY: &str = r#"
+query($owner: String!, $name: String!, $cursor: String, $pageSize: Int!) {
+  repository(owner: $owner, name: $name) {
+    issues(first: $pageSize, after: $cursor, states: [OPEN]) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        node_id: id
+        id: databaseId
+        number
+        title
+        body
+        state
+        state_reason: stateReason
+        locked
+        created_at: createdAt
+        updated_at: updatedAt
+        closed_at: closedAt
+        html_url: url
+        author_association: authorAssociation
+        user: author { login type: __typename ... on Node { node_id: id } ... on Bot { id: databaseId } ... on Mannequin { id: databaseId } ... on Organization { id: databaseId } ... on User { id: databaseId } }
+        assignees(first: 50) { nodes { login } }
+        labels(first: $pageSize) {
+          pageInfo { hasNextPage endCursor }
+          nodes { name }
+        }
+        comments { totalCount }
+      }
+    }
+  }
+}
+"#;
+
+const PULL_REQUESTS_QUERY: &str = r#"
+query($owner: String!, $name: String!, $cursor: String, $pageSize: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: $pageSize, after: $cursor, states: [OPEN]) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        node_id: id
+        id: databaseId
+        number
+        title
+        body
+        state
+        locked
+        created_at: createdAt
+        updated_at: updatedAt
+        closed_at: closedAt
+        html_url: url
+        author_association: authorAssociation
+        user: author { login type: __typename ... on Node { node_id: id } ... on Bot { id: databaseId } ... on Mannequin { id: databaseId } ... on Organization { id: databaseId } ... on User { id: databaseId } }
+        assignees(first: 50) { nodes { login } }
+        labels(first: $pageSize) {
+          pageInfo { hasNextPage endCursor }
+          nodes { name }
+        }
+        draft: isDraft
+        merged
+        merged_at: mergedAt
+        head_ref_name: headRefName
+        head_sha: headRefOid
+        base_ref_name: baseRefName
+        base_sha: baseRefOid
+        comments { totalCount }
+        reviews(states: [COMMENTED, APPROVED, CHANGES_REQUESTED, DISMISSED]) { totalCount }
+      }
+    }
+  }
+}
+"#;
+
+const ITEM_LABELS_QUERY: &str = r#"
+query($id: ID!, $cursor: String, $pageSize: Int!) {
+  node(id: $id) {
+    ... on Issue {
+      labels(first: $pageSize, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { name }
+      }
+    }
+    ... on PullRequest {
+      labels(first: $pageSize, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { name }
+      }
+    }
+  }
+}
+"#;
+
+const ISSUE_COMMENTS_QUERY: &str = r#"
+query($id: ID!, $cursor: String, $pageSize: Int!) {
+  node(id: $id) {
+    ... on Issue {
+      comments(first: $pageSize, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          node_id: id
+          id: databaseId
+          body
+          created_at: createdAt
+          updated_at: updatedAt
+          html_url: url
+          author_association: authorAssociation
+          user: author { login type: __typename ... on Node { node_id: id } ... on Bot { id: databaseId } ... on Mannequin { id: databaseId } ... on Organization { id: databaseId } ... on User { id: databaseId } }
+        }
+      }
+    }
+  }
+}
+"#;
+
+const PR_COMMENTS_QUERY: &str = r#"
+query($id: ID!, $cursor: String, $pageSize: Int!) {
+  node(id: $id) {
+    ... on PullRequest {
+      comments(first: $pageSize, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          node_id: id
+          id: databaseId
+          body
+          created_at: createdAt
+          updated_at: updatedAt
+          html_url: url
+          author_association: authorAssociation
+          user: author { login type: __typename ... on Node { node_id: id } ... on Bot { id: databaseId } ... on Mannequin { id: databaseId } ... on Organization { id: databaseId } ... on User { id: databaseId } }
+        }
+      }
+    }
+  }
+}
+"#;
+
+const PR_REVIEWS_QUERY: &str = r#"
+query($id: ID!, $cursor: String, $pageSize: Int!) {
+  node(id: $id) {
+    ... on PullRequest {
+      reviews(
+        first: $pageSize
+        after: $cursor
+        states: [COMMENTED, APPROVED, CHANGES_REQUESTED, DISMISSED]
+      ) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          node_id: id
+          id: databaseId
+          state
+          body
+          submitted_at: submittedAt
+          commit { oid }
+          html_url: url
+          author_association: authorAssociation
+          user: author { login type: __typename ... on Node { node_id: id } ... on Bot { id: databaseId } ... on Mannequin { id: databaseId } ... on Organization { id: databaseId } ... on User { id: databaseId } }
+        }
+      }
+    }
+  }
+}
+"#;
+
+/// A minimal, read-only GitHub GraphQL v4 client.
+///
+/// Holds a semaphore that bounds the number of GraphQL requests in flight at
+/// once, regardless of how many logical tasks (repositories, issues, PRs) are
+/// concurrently trying to fetch data.
+///
+/// Cheaply `Clone`: `reqwest::Client` is internally `Arc`-backed and the
+/// concurrency semaphore is `Arc`-wrapped, so clones share both the
+/// connection pool and the concurrency bound.
+#[derive(Clone)]
+pub struct GitHubGraphQLClient {
+    http: Client,
+    api_url: String,
+    semaphore: Arc<Semaphore>,
+}
+
+impl GitHubGraphQLClient {
+    pub fn new(token: &str, api_base_url: &str, max_concurrency: usize) -> Result<Self> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            reqwest::header::HeaderValue::from_str(&format!("bearer {token}"))
+                .context("invalid GitHub token header value")?,
+        );
+        headers.insert(
+            reqwest::header::USER_AGENT,
+            reqwest::header::HeaderValue::from_static("drasi-bootstrap-github-workgraph"),
+        );
+        let http = Client::builder()
+            .default_headers(headers)
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("failed to build GitHub GraphQL HTTP client")?;
+        Ok(Self {
+            http,
+            api_url: api_base_url.to_string(),
+            semaphore: Arc::new(Semaphore::new(max_concurrency.max(1))),
+        })
+    }
+
+    /// Execute one GraphQL request, retrying on transport errors, GitHub rate
+    /// limiting (429/403 secondary limit), and 5xx responses.
+    async fn execute(&self, query: &str, variables: Value) -> Result<Value> {
+        let _permit = self
+            .semaphore
+            .acquire()
+            .await
+            .map_err(|_| anyhow!("GraphQL client semaphore closed"))?;
+        let body = json!({ "query": query, "variables": variables });
+        let mut delay = INITIAL_RETRY_DELAY;
+        for attempt in 1..=MAX_ATTEMPTS {
+            let response = match self.http.post(&self.api_url).json(&body).send().await {
+                Ok(response) => response,
+                Err(err) if attempt < MAX_ATTEMPTS => {
+                    warn!("GitHub GraphQL request failed ({err}); retrying in {delay:?}");
+                    sleep(delay).await;
+                    delay *= 2;
+                    continue;
+                }
+                Err(err) => return Err(err).context("GitHub GraphQL request failed"),
+            };
+            let status = response.status();
+            if status.as_u16() == 429 || status.is_server_error() {
+                if attempt >= MAX_ATTEMPTS {
+                    bail!("GitHub GraphQL API error after retries: {status}");
+                }
+                warn!("GitHub GraphQL API rate limited/server error ({status}); retrying");
+                sleep(delay).await;
+                delay *= 2;
+                continue;
+            }
+            if !status.is_success() {
+                let text = response.text().await.unwrap_or_default();
+                bail!("GitHub GraphQL API request failed: {status}: {text}");
+            }
+            let payload: Value = response
+                .json()
+                .await
+                .context("failed to decode GitHub GraphQL response as JSON")?;
+            if let Some(errors) = payload.get("errors").and_then(Value::as_array) {
+                if !errors.is_empty() {
+                    bail!("GitHub GraphQL API returned errors: {errors:?}");
+                }
+            }
+            return payload
+                .get("data")
+                .cloned()
+                .ok_or_else(|| anyhow!("GitHub GraphQL response missing 'data'"));
+        }
+        unreachable!("loop always returns or bails");
+    }
+
+    /// Fetch every page of a `nodes`/`pageInfo` connection located at `path`
+    /// within the response, calling `build_vars` with the current cursor.
+    /// `initial_cursor` is `None` for a full connection and set when continuing
+    /// after a connection page already embedded in a parent query.
+    async fn fetch_connection<F>(
+        &self,
+        query: &str,
+        path: &[&str],
+        initial_cursor: Option<String>,
+        mut build_vars: F,
+    ) -> Result<Vec<Value>>
+    where
+        F: FnMut(Option<&str>) -> Value,
+    {
+        let mut cursor = initial_cursor;
+        let mut all = Vec::new();
+        let path_display = path.join(".");
+        loop {
+            let data = self.execute(query, build_vars(cursor.as_deref())).await?;
+            let mut connection = &data;
+            for key in path {
+                connection = connection
+                    .get(key)
+                    .filter(|value| !value.is_null())
+                    .ok_or_else(|| {
+                        anyhow!("GitHub GraphQL response missing connection '{path_display}'")
+                    })?;
+            }
+            let nodes = connection
+                .get("nodes")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    anyhow!("GitHub GraphQL connection '{path_display}' missing 'nodes'")
+                })?;
+            all.extend(nodes.iter().cloned());
+            let page_info = connection.get("pageInfo").ok_or_else(|| {
+                anyhow!("GitHub GraphQL connection '{path_display}' missing 'pageInfo'")
+            })?;
+            let has_next = page_info
+                .get("hasNextPage")
+                .and_then(Value::as_bool)
+                .ok_or_else(|| {
+                    anyhow!("GitHub GraphQL connection '{path_display}' has invalid 'hasNextPage'")
+                })?;
+            if !has_next {
+                break;
+            }
+            let next_cursor = page_info
+                .get("endCursor")
+                .and_then(Value::as_str)
+                .filter(|cursor| !cursor.is_empty())
+                .ok_or_else(|| {
+                    anyhow!(
+                        "GitHub GraphQL connection '{path_display}' has another page but no cursor"
+                    )
+                })?;
+            if cursor.as_deref() == Some(next_cursor) {
+                bail!("GitHub GraphQL connection '{path_display}' returned a non-advancing cursor");
+            }
+            cursor = Some(next_cursor.to_string());
+        }
+        Ok(all)
+    }
+
+    pub async fn fetch_organization(&self, org: &str) -> Result<Value> {
+        let data = self.execute(ORG_QUERY, json!({ "org": org })).await?;
+        data.get("organization")
+            .filter(|v| !v.is_null())
+            .cloned()
+            .ok_or_else(|| anyhow!("GitHub organization '{org}' not found or inaccessible"))
+    }
+
+    pub async fn fetch_repositories(&self, org: &str) -> Result<Vec<Value>> {
+        let org = org.to_string();
+        let nodes = self
+            .fetch_connection(
+                REPOS_QUERY,
+                &["organization", "repositories"],
+                None,
+                move |cursor| {
+                    json!({ "org": org, "cursor": cursor, "pageSize": DEFAULT_PAGE_SIZE })
+                },
+            )
+            .await?;
+        Ok(nodes.into_iter().map(reshape_repository).collect())
+    }
+
+    pub async fn fetch_issues(&self, owner: &str, name: &str) -> Result<Vec<Value>> {
+        let (owner, name) = (owner.to_string(), name.to_string());
+        let nodes = self
+            .fetch_connection(
+                ISSUES_QUERY,
+                &["repository", "issues"],
+                None,
+                move |cursor| {
+                    json!({ "owner": owner, "name": name, "cursor": cursor, "pageSize": DEFAULT_PAGE_SIZE })
+                },
+            )
+            .await?;
+        let mut items = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            items.push(reshape_work_item(self.complete_item_labels(node).await?));
+        }
+        Ok(items)
+    }
+
+    pub async fn fetch_pull_requests(&self, owner: &str, name: &str) -> Result<Vec<Value>> {
+        let (owner, name) = (owner.to_string(), name.to_string());
+        let nodes = self
+            .fetch_connection(
+                PULL_REQUESTS_QUERY,
+                &["repository", "pullRequests"],
+                None,
+                move |cursor| {
+                    json!({ "owner": owner, "name": name, "cursor": cursor, "pageSize": DEFAULT_PAGE_SIZE })
+                },
+            )
+            .await?;
+        let mut items = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            let node = self.complete_item_labels(node).await?;
+            items.push(reshape_pull_request(reshape_work_item(node)));
+        }
+        Ok(items)
+    }
+
+    pub async fn fetch_issue_comments(&self, node_id: &str) -> Result<Vec<Value>> {
+        let id = node_id.to_string();
+        let nodes = self
+            .fetch_connection(
+                ISSUE_COMMENTS_QUERY,
+                &["node", "comments"],
+                None,
+                move |cursor| json!({ "id": id, "cursor": cursor, "pageSize": DEFAULT_PAGE_SIZE }),
+            )
+            .await?;
+        Ok(nodes.into_iter().map(reshape_comment).collect())
+    }
+
+    pub async fn fetch_pr_comments(&self, node_id: &str) -> Result<Vec<Value>> {
+        let id = node_id.to_string();
+        let nodes = self
+            .fetch_connection(
+                PR_COMMENTS_QUERY,
+                &["node", "comments"],
+                None,
+                move |cursor| json!({ "id": id, "cursor": cursor, "pageSize": DEFAULT_PAGE_SIZE }),
+            )
+            .await?;
+        Ok(nodes.into_iter().map(reshape_comment).collect())
+    }
+
+    pub async fn fetch_pr_reviews(&self, node_id: &str) -> Result<Vec<Value>> {
+        let id = node_id.to_string();
+        let nodes = self
+            .fetch_connection(
+                PR_REVIEWS_QUERY,
+                &["node", "reviews"],
+                None,
+                move |cursor| json!({ "id": id, "cursor": cursor, "pageSize": DEFAULT_PAGE_SIZE }),
+            )
+            .await?;
+        Ok(nodes.into_iter().map(reshape_review).collect())
+    }
+
+    async fn complete_item_labels(&self, mut node: Value) -> Result<Value> {
+        let page_info = node
+            .pointer("/labels/pageInfo")
+            .ok_or_else(|| anyhow!("GitHub work item labels missing 'pageInfo'"))?;
+        let has_next = page_info
+            .get("hasNextPage")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| anyhow!("GitHub work item labels have invalid 'hasNextPage'"))?;
+        if !has_next {
+            return Ok(node);
+        }
+
+        let cursor = page_info
+            .get("endCursor")
+            .and_then(Value::as_str)
+            .filter(|cursor| !cursor.is_empty())
+            .ok_or_else(|| anyhow!("GitHub work item labels have another page but no cursor"))?
+            .to_string();
+        let id = node
+            .get("node_id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("GitHub work item missing 'node_id'"))?
+            .to_string();
+        let additional = self
+            .fetch_connection(
+                ITEM_LABELS_QUERY,
+                &["node", "labels"],
+                Some(cursor),
+                move |cursor| json!({ "id": id, "cursor": cursor, "pageSize": DEFAULT_PAGE_SIZE }),
+            )
+            .await?;
+        node.pointer_mut("/labels/nodes")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| anyhow!("GitHub work item labels missing 'nodes'"))?
+            .extend(additional);
+        Ok(node)
+    }
+}
+
+fn lower_str(value: &mut Value, key: &str) {
+    if let Some(s) = value.get(key).and_then(Value::as_str) {
+        let lowered = s.to_lowercase();
+        value[key] = Value::String(lowered);
+    }
+}
+
+/// Flatten `defaultBranchRef { name }` and `repositoryTopics.nodes[].topic.name`
+/// into the flat `default_branch`/`topics` shape the REST/webhook payload
+/// (and therefore `Converter`) uses, and lowercase the `visibility` enum.
+fn reshape_repository(mut node: Value) -> Value {
+    let default_branch = node
+        .get("defaultBranchRef")
+        .and_then(|r| r.get("name"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    if let Value::Object(map) = &mut node {
+        map.remove("defaultBranchRef");
+        map.insert(
+            "default_branch".to_string(),
+            default_branch.map(Value::String).unwrap_or(Value::Null),
+        );
+        let topics: Vec<Value> = map
+            .remove("repositoryTopics")
+            .and_then(|v| v.get("nodes").cloned())
+            .and_then(|v| v.as_array().cloned())
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|n| n.pointer("/topic/name").cloned())
+            .collect();
+        map.insert("topics".to_string(), Value::Array(topics));
+    }
+    lower_str(&mut node, "visibility");
+    node
+}
+
+/// Common reshaping for both Issues and PRs: lowercase `state`/`state_reason`,
+/// flatten `comments.totalCount` into a private `_comment_count` marker used
+/// only for deciding whether a follow-up comments fetch is worthwhile, and
+/// unwrap the `assignees`/`labels` connections' `nodes` array into a flat
+/// array of `{login}`/`{name}` objects — the exact REST/webhook shape
+/// `mapping::names()` expects (it calls `.get(field)` on each element, so the
+/// elements must stay objects, not be reduced to bare strings).
+fn reshape_work_item(mut node: Value) -> Value {
+    lower_str(&mut node, "state");
+    lower_str(&mut node, "state_reason");
+    if let Value::Object(map) = &mut node {
+        if let Some(count) = map
+            .remove("comments")
+            .and_then(|v| v.get("totalCount").cloned())
+        {
+            map.insert("_comment_count".to_string(), count);
+        }
+        if let Some(assignees) = map.remove("assignees") {
+            let nodes = assignees
+                .get("nodes")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            map.insert("assignees".to_string(), Value::Array(nodes));
+        }
+        if let Some(labels) = map.remove("labels") {
+            let nodes = labels
+                .get("nodes")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            map.insert("labels".to_string(), Value::Array(nodes));
+        }
+    }
+    node
+}
+
+/// PR-only reshaping: flatten `reviews.totalCount` into `_review_count`, and
+/// `head_ref_name`/`head_sha`/`base_ref_name`/`base_sha` into the nested
+/// `head: {ref, sha}` / `base: {ref, sha}` shape `Converter` expects.
+fn reshape_pull_request(mut node: Value) -> Value {
+    if let Value::Object(map) = &mut node {
+        if let Some(count) = map
+            .remove("reviews")
+            .and_then(|v| v.get("totalCount").cloned())
+        {
+            map.insert("_review_count".to_string(), count);
+        }
+        let head_ref = map.remove("head_ref_name").unwrap_or(Value::Null);
+        let head_sha = map.remove("head_sha").unwrap_or(Value::Null);
+        let base_ref = map.remove("base_ref_name").unwrap_or(Value::Null);
+        let base_sha = map.remove("base_sha").unwrap_or(Value::Null);
+        map.insert(
+            "head".to_string(),
+            json!({ "ref": head_ref, "sha": head_sha }),
+        );
+        map.insert(
+            "base".to_string(),
+            json!({ "ref": base_ref, "sha": base_sha }),
+        );
+    }
+    node
+}
+
+fn reshape_comment(node: Value) -> Value {
+    node
+}
+
+/// Flatten `commit { oid }` into the flat `commit_id` string REST/webhook
+/// payloads use, and lowercase the review `state` enum.
+fn reshape_review(mut node: Value) -> Value {
+    lower_str(&mut node, "state");
+    if let Value::Object(map) = &mut node {
+        let commit_id = map
+            .remove("commit")
+            .and_then(|c| c.get("oid").cloned())
+            .unwrap_or(Value::Null);
+        map.insert("commit_id".to_string(), commit_id);
+    }
+    node
+}
+
+/// Read back the `_comment_count`/`_review_count` markers `reshape_work_item`/
+/// `reshape_pull_request` attach, defaulting to 0 (treated as "fetch anyway"
+/// callers should not rely on a missing marker meaning zero).
+pub fn item_comment_count(item: &Value) -> u64 {
+    item.get("_comment_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+}
+
+pub fn pr_review_count(item: &Value) -> u64 {
+    item.get("_review_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reshape_repository_flattens_topics_and_default_branch() {
+        let raw = json!({
+            "node_id": "R_1",
+            "visibility": "PUBLIC",
+            "defaultBranchRef": { "name": "main" },
+            "repositoryTopics": { "nodes": [
+                { "topic": { "name": "graphs" } },
+                { "topic": { "name": "streaming" } }
+            ]}
+        });
+        let shaped = reshape_repository(raw);
+        assert_eq!(shaped["default_branch"], json!("main"));
+        assert_eq!(shaped["topics"], json!(["graphs", "streaming"]));
+        assert_eq!(shaped["visibility"], json!("public"));
+        assert!(shaped.get("defaultBranchRef").is_none());
+        assert!(shaped.get("repositoryTopics").is_none());
+    }
+
+    #[test]
+    fn reshape_repository_handles_empty_repo() {
+        let raw = json!({ "node_id": "R_1", "defaultBranchRef": null, "repositoryTopics": null });
+        let shaped = reshape_repository(raw);
+        assert_eq!(shaped["default_branch"], Value::Null);
+        assert_eq!(shaped["topics"], json!([]));
+    }
+
+    #[test]
+    fn reshape_work_item_lowercases_state_and_flattens_lists() {
+        let raw = json!({
+            "state": "OPEN",
+            "state_reason": "NOT_PLANNED",
+            "comments": { "totalCount": 3 },
+            "assignees": { "nodes": [{ "login": "ada" }, { "login": "grace" }] },
+            "labels": { "nodes": [{ "name": "status: needs-review" }] }
+        });
+        let shaped = reshape_work_item(raw);
+        assert_eq!(shaped["state"], json!("open"));
+        assert_eq!(shaped["state_reason"], json!("not_planned"));
+        assert_eq!(shaped["_comment_count"], json!(3));
+        assert_eq!(
+            shaped["assignees"],
+            json!([{ "login": "ada" }, { "login": "grace" }])
+        );
+        assert_eq!(
+            shaped["labels"],
+            json!([{ "name": "status: needs-review" }])
+        );
+        assert_eq!(item_comment_count(&shaped), 3);
+    }
+
+    #[test]
+    fn reshape_pull_request_nests_head_and_base() {
+        let raw = json!({
+            "head_ref_name": "feature",
+            "head_sha": "abc123",
+            "base_ref_name": "main",
+            "base_sha": "def456",
+            "reviews": { "totalCount": 2 }
+        });
+        let shaped = reshape_pull_request(raw);
+        assert_eq!(shaped["head"], json!({ "ref": "feature", "sha": "abc123" }));
+        assert_eq!(shaped["base"], json!({ "ref": "main", "sha": "def456" }));
+        assert_eq!(pr_review_count(&shaped), 2);
+    }
+
+    #[test]
+    fn reshape_review_flattens_commit_and_lowercases_state() {
+        let raw = json!({ "state": "CHANGES_REQUESTED", "commit": { "oid": "sha1" } });
+        let shaped = reshape_review(raw);
+        assert_eq!(shaped["state"], json!("changes_requested"));
+        assert_eq!(shaped["commit_id"], json!("sha1"));
+    }
+}

--- a/components/bootstrappers/github-workgraph/src/config.rs
+++ b/components/bootstrappers/github-workgraph/src/config.rs
@@ -1,0 +1,118 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+/// Default GitHub GraphQL API endpoint (github.com; override for GHE).
+pub const DEFAULT_API_BASE_URL: &str = "https://api.github.com/graphql";
+/// Default number of GraphQL requests allowed in flight at once.
+pub const DEFAULT_MAX_CONCURRENCY: usize = 4;
+/// Page size used for every paginated GraphQL connection.
+pub const DEFAULT_PAGE_SIZE: u32 = 100;
+
+/// Configuration for [`crate::GitHubWorkGraphBootstrapProvider`].
+///
+/// This bootstrapper owns all GitHub API access; the streaming
+/// `drasi-source-github-workgraph` source is payload-only and never calls the
+/// GitHub API. The `token` MUST be a read-only credential (a fine-grained PAT
+/// with only `Issues: Read`, `Pull requests: Read`, and `Metadata: Read`
+/// suffices) — this bootstrapper never writes to GitHub.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubWorkGraphBootstrapConfig {
+    /// The single GitHub organization login to enumerate.
+    pub organization: String,
+    /// A read-only GitHub token (PAT or GitHub App installation token).
+    pub token: String,
+    /// GraphQL API endpoint. Override for GitHub Enterprise Server.
+    pub api_base_url: String,
+    /// Upper bound on concurrently in-flight GraphQL requests, and on the
+    /// number of repositories processed concurrently.
+    pub max_concurrency: usize,
+}
+
+impl Default for GitHubWorkGraphBootstrapConfig {
+    fn default() -> Self {
+        Self {
+            organization: String::new(),
+            token: String::new(),
+            api_base_url: DEFAULT_API_BASE_URL.to_string(),
+            max_concurrency: DEFAULT_MAX_CONCURRENCY,
+        }
+    }
+}
+
+impl GitHubWorkGraphBootstrapConfig {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.organization.trim().is_empty(),
+            "organization cannot be empty"
+        );
+        anyhow::ensure!(
+            !self.organization.contains('/') && self.organization.trim() == self.organization,
+            "organization must be one GitHub organization login"
+        );
+        anyhow::ensure!(!self.token.trim().is_empty(), "token cannot be empty");
+        anyhow::ensure!(
+            !self.api_base_url.trim().is_empty(),
+            "api_base_url cannot be empty"
+        );
+        anyhow::ensure!(self.max_concurrency > 0, "max_concurrency must be > 0");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_sane_values() {
+        let config = GitHubWorkGraphBootstrapConfig::default();
+        assert_eq!(config.api_base_url, DEFAULT_API_BASE_URL);
+        assert_eq!(config.max_concurrency, DEFAULT_MAX_CONCURRENCY);
+        assert!(config.validate().is_err(), "empty org/token must fail");
+    }
+
+    #[test]
+    fn rejects_multi_segment_organization() {
+        let config = GitHubWorkGraphBootstrapConfig {
+            organization: "acme/eng".to_string(),
+            token: "t".to_string(),
+            ..GitHubWorkGraphBootstrapConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_zero_max_concurrency() {
+        let config = GitHubWorkGraphBootstrapConfig {
+            organization: "acme".to_string(),
+            token: "t".to_string(),
+            max_concurrency: 0,
+            ..GitHubWorkGraphBootstrapConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn accepts_valid_config() {
+        let config = GitHubWorkGraphBootstrapConfig {
+            organization: "acme".to_string(),
+            token: "t".to_string(),
+            ..GitHubWorkGraphBootstrapConfig::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+}

--- a/components/bootstrappers/github-workgraph/src/descriptor.rs
+++ b/components/bootstrappers/github-workgraph/src/descriptor.rs
@@ -1,0 +1,145 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! GitHub WorkGraph bootstrap plugin descriptor and configuration DTO.
+
+use drasi_lib::bootstrap::BootstrapProvider;
+use drasi_plugin_sdk::prelude::*;
+use drasi_source_github_workgraph::descriptor::GitHubWorkGraphSourceConfigDto;
+use utoipa::OpenApi;
+
+use crate::GitHubWorkGraphBootstrapProvider;
+
+// ── DTO types ────────────────────────────────────────────────────────────────
+
+fn default_api_base_url() -> ConfigValue<String> {
+    ConfigValue::Static(crate::config::DEFAULT_API_BASE_URL.to_string())
+}
+
+fn default_max_concurrency() -> ConfigValue<usize> {
+    ConfigValue::Static(crate::config::DEFAULT_MAX_CONCURRENCY)
+}
+
+/// GitHub WorkGraph bootstrap configuration DTO.
+///
+/// The organization comes from the parent `github-workgraph` Source
+/// configuration so bootstrap and streaming always target the same graph.
+/// `token` **must** be a read-only credential (a fine-grained PAT scoped to
+/// `Issues: Read`, `Pull requests: Read`, `Metadata: Read` on the target
+/// organization, or an equivalent read-only GitHub App installation token).
+/// This bootstrapper never writes to GitHub.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[schema(as = bootstrap::github_workgraph::GitHubWorkGraphBootstrapConfig)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GitHubWorkGraphBootstrapConfigDto {
+    /// A read-only GitHub token (PAT or GitHub App installation token).
+    /// Use a `Secret` reference in production; never inline a live token.
+    #[schema(value_type = ConfigValueString)]
+    pub token: ConfigValue<String>,
+    /// GraphQL API endpoint. Override for GitHub Enterprise Server, e.g.
+    /// `https://github.example.com/api/graphql`.
+    #[serde(default = "default_api_base_url")]
+    #[schema(value_type = ConfigValueString)]
+    pub api_base_url: ConfigValue<String>,
+    /// Upper bound on concurrently in-flight GraphQL requests, and on the
+    /// number of repositories processed concurrently.
+    #[serde(default = "default_max_concurrency")]
+    #[schema(value_type = ConfigValueUsize)]
+    pub max_concurrency: ConfigValue<usize>,
+}
+
+// ── Descriptor ───────────────────────────────────────────────────────────────
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(GitHubWorkGraphBootstrapConfigDto)))]
+struct GitHubWorkGraphBootstrapSchemas;
+
+/// Plugin descriptor for the GitHub WorkGraph bootstrap provider.
+pub struct GitHubWorkGraphBootstrapDescriptor;
+
+#[async_trait]
+impl BootstrapPluginDescriptor for GitHubWorkGraphBootstrapDescriptor {
+    fn kind(&self) -> &str {
+        "github-workgraph"
+    }
+
+    fn config_version(&self) -> &str {
+        "1.0.0"
+    }
+
+    fn config_schema_name(&self) -> &str {
+        "bootstrap.github_workgraph.GitHubWorkGraphBootstrapConfig"
+    }
+
+    fn config_schema_json(&self) -> String {
+        let api = GitHubWorkGraphBootstrapSchemas::openapi();
+        match api
+            .components
+            .as_ref()
+            .and_then(|components| serde_json::to_string(&components.schemas).ok())
+        {
+            Some(schema) => schema,
+            None => {
+                log::warn!(
+                    "GitHub WorkGraph bootstrap schema generation failed; returning empty schema"
+                );
+                "{}".to_string()
+            }
+        }
+    }
+
+    async fn create_bootstrap_provider(
+        &self,
+        config_json: &serde_json::Value,
+        source_config_json: &serde_json::Value,
+    ) -> anyhow::Result<Box<dyn BootstrapProvider>> {
+        let dto: GitHubWorkGraphBootstrapConfigDto = serde_json::from_value(config_json.clone())?;
+        let source_dto: GitHubWorkGraphSourceConfigDto =
+            serde_json::from_value(source_config_json.clone())?;
+        let mapper = DtoMapper::new();
+
+        let provider = GitHubWorkGraphBootstrapProvider::builder()
+            .with_organization(mapper.resolve_string(&source_dto.organization).await?)
+            .with_token(mapper.resolve_string(&dto.token).await?)
+            .with_api_base_url(mapper.resolve_string(&dto.api_base_url).await?)
+            .with_max_concurrency(mapper.resolve_typed(&dto.max_concurrency).await?)
+            .build()?;
+        Ok(Box::new(provider))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn descriptor_reads_organization_from_source_config() {
+        let descriptor = GitHubWorkGraphBootstrapDescriptor;
+        let provider = descriptor
+            .create_bootstrap_provider(
+                &json!({ "token": "read-only-token" }),
+                &json!({
+                    "organization": "acme",
+                    "webhook": { "secret": "webhook-secret" }
+                }),
+            )
+            .await;
+
+        assert!(provider.is_ok());
+        let schema = descriptor.config_schema_json();
+        assert!(schema.contains("\"token\""));
+        assert!(!schema.contains("\"organization\""));
+    }
+}

--- a/components/bootstrappers/github-workgraph/src/lib.rs
+++ b/components/bootstrappers/github-workgraph/src/lib.rs
@@ -1,0 +1,510 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! GitHub WorkGraph bootstrap provider.
+//!
+//! Enumerates every repository in one configured GitHub organization over the
+//! GitHub GraphQL v4 API, and snapshots each repository's currently-open
+//! Issues and Pull Requests, their conversation comments, and PR reviews.
+//!
+//! # Reuse, not duplication
+//!
+//! This crate never re-implements any WorkGraph domain rule. Every node
+//! label, relation ID/direction, status-label derivation, and
+//! `WorkGraphAssignment`/`WorkGraphResult`/`WorkGraphError` parsing rule comes
+//! from [`drasi_source_github_workgraph::mapping::Converter`] — the exact
+//! same converter the streaming `drasi-source-github-workgraph` source uses
+//! for live webhook deliveries. This crate's only job is to fetch GitHub data
+//! over GraphQL and reshape it into the same JSON envelope shape a GitHub
+//! webhook delivery would have (see [`client`] module docs), then hand that
+//! envelope to `Converter` unchanged.
+//!
+//! # Scope (prototype)
+//!
+//! - One configured organization; all repositories the token can see.
+//! - Only currently-**open** Issues and Pull Requests (no closed history).
+//! - Issue/PR conversation comments and PR reviews only.
+//! - Excluded: Projects, Project Items, inline diff comments, closed-item
+//!   history, reactions, and workflow-run execution state.
+//!
+//! # `source_position` is always `None`
+//!
+//! The GitHub WorkGraph source is driven entirely by webhook deliveries,
+//! which have no durable, replayable position analogous to a database WAL
+//! LSN or a Kafka offset — a webhook delivery, once missed, cannot be
+//! re-requested from GitHub by position. Because of this, [`BootstrapResult`]
+//! from this provider always carries `source_position: None`; there is no
+//! snapshot boundary for the framework to seed a replay checkpoint from.
+
+mod client;
+mod config;
+pub mod descriptor;
+#[cfg(test)]
+mod tests;
+
+pub use config::GitHubWorkGraphBootstrapConfig;
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use chrono::Utc;
+use client::GitHubGraphQLClient;
+use drasi_core::models::SourceChange;
+use drasi_lib::bootstrap::{
+    BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
+};
+use drasi_lib::channels::{BootstrapEvent, BootstrapEventSender};
+use drasi_source_github_workgraph::mapping::{Converter, NODE_LABELS, RELATION_LABELS};
+use log::{info, warn};
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+pub struct GitHubWorkGraphBootstrapProvider {
+    config: GitHubWorkGraphBootstrapConfig,
+}
+
+impl GitHubWorkGraphBootstrapProvider {
+    pub fn builder() -> GitHubWorkGraphBootstrapProviderBuilder {
+        GitHubWorkGraphBootstrapProviderBuilder::new()
+    }
+}
+
+#[derive(Default)]
+pub struct GitHubWorkGraphBootstrapProviderBuilder {
+    config: GitHubWorkGraphBootstrapConfig,
+}
+
+impl GitHubWorkGraphBootstrapProviderBuilder {
+    pub fn new() -> Self {
+        Self {
+            config: GitHubWorkGraphBootstrapConfig::default(),
+        }
+    }
+
+    pub fn with_organization(mut self, organization: impl Into<String>) -> Self {
+        self.config.organization = organization.into();
+        self
+    }
+
+    pub fn with_token(mut self, token: impl Into<String>) -> Self {
+        self.config.token = token.into();
+        self
+    }
+
+    pub fn with_api_base_url(mut self, api_base_url: impl Into<String>) -> Self {
+        self.config.api_base_url = api_base_url.into();
+        self
+    }
+
+    pub fn with_max_concurrency(mut self, max_concurrency: usize) -> Self {
+        self.config.max_concurrency = max_concurrency;
+        self
+    }
+
+    pub fn build(self) -> Result<GitHubWorkGraphBootstrapProvider> {
+        self.config.validate()?;
+        Ok(GitHubWorkGraphBootstrapProvider {
+            config: self.config,
+        })
+    }
+}
+
+#[async_trait]
+impl BootstrapProvider for GitHubWorkGraphBootstrapProvider {
+    async fn bootstrap(
+        &self,
+        request: BootstrapRequest,
+        context: &BootstrapContext,
+        event_tx: BootstrapEventSender,
+        _settings: Option<&drasi_lib::config::SourceSubscriptionSettings>,
+    ) -> Result<BootstrapResult> {
+        info!(
+            "[{}] GitHub WorkGraph bootstrap started for org '{}', query {}",
+            context.source_id, self.config.organization, request.query_id
+        );
+
+        let client = GitHubGraphQLClient::new(
+            &self.config.token,
+            &self.config.api_base_url,
+            self.config.max_concurrency,
+        )?;
+
+        let org_value = client.fetch_organization(&self.config.organization).await?;
+        let repos = client.fetch_repositories(&self.config.organization).await?;
+        info!(
+            "[{}] GitHub WorkGraph bootstrap: {} repositories in '{}'",
+            context.source_id,
+            repos.len(),
+            self.config.organization
+        );
+
+        // Fan out one task per repository, bounded to `max_concurrency`
+        // concurrently-running repository tasks. The GraphQL client itself
+        // additionally bounds the number of concurrently in-flight HTTP
+        // requests to the same limit, so total request concurrency stays
+        // bounded even though each repository task issues several requests
+        // in sequence (issues, PRs, then per-item comments/reviews).
+        let semaphore = Arc::new(Semaphore::new(self.config.max_concurrency.max(1)));
+        let mut join_set = JoinSet::new();
+        for repo in repos {
+            let client = client.clone();
+            let organization = self.config.organization.clone();
+            let source_id = context.source_id.clone();
+            let org_value = org_value.clone();
+            let semaphore = semaphore.clone();
+            join_set.spawn(async move {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| anyhow!("bootstrap concurrency semaphore closed"))?;
+                process_repository(&client, &organization, &source_id, &org_value, repo).await
+            });
+        }
+
+        let mut all_changes: Vec<SourceChange> = Vec::new();
+        let mut repo_errors = Vec::new();
+        while let Some(joined) = join_set.join_next().await {
+            match joined {
+                Ok(Ok(changes)) => all_changes.extend(changes),
+                Ok(Err(err)) => {
+                    repo_errors.push(format!("{err:#}"));
+                    warn!(
+                        "[{}] GitHub WorkGraph bootstrap: repository task failed: {err:#}",
+                        context.source_id
+                    );
+                }
+                Err(join_err) => {
+                    repo_errors.push(join_err.to_string());
+                    warn!(
+                        "[{}] GitHub WorkGraph bootstrap: repository task panicked: {join_err}",
+                        context.source_id
+                    );
+                }
+            }
+        }
+        if let Some(first_error) = repo_errors.first() {
+            return Err(anyhow!(
+                "GitHub WorkGraph bootstrap failed for {} repository task(s); first error: \
+                 {first_error}",
+                repo_errors.len()
+            ));
+        }
+
+        // Filtering, dedup, and event sending happen sequentially here (after
+        // all concurrent fetches have completed) so `event_count` and the
+        // dedup/"first occurrence becomes Insert" logic below stay simple and
+        // deterministic without needing a shared, lock-protected `HashSet`
+        // across tasks.
+        let mut sent_ids: HashSet<String> = HashSet::new();
+        let mut event_count = 0usize;
+        for change in all_changes {
+            event_count += send_if_requested(
+                change,
+                &request,
+                &context.source_id,
+                &event_tx,
+                context,
+                &mut sent_ids,
+            )
+            .await?;
+        }
+
+        info!(
+            "[{}] GitHub WorkGraph bootstrap complete for query {}: {event_count} event(s) sent",
+            context.source_id, request.query_id
+        );
+
+        Ok(BootstrapResult {
+            event_count,
+            // Webhooks have no replay boundary to snapshot against (see the
+            // module-level docs); this is always `None`.
+            source_position: None,
+        })
+    }
+}
+
+/// Fetch and convert one repository's data into `SourceChange`s, entirely via
+/// [`Converter`] (this function only assembles the synthetic webhook-shaped
+/// JSON envelopes `Converter` expects; it never inspects or derives any
+/// WorkGraph node/relation/status semantics itself).
+async fn process_repository(
+    client: &GitHubGraphQLClient,
+    organization: &str,
+    source_id: &str,
+    org_value: &Value,
+    repo_value: Value,
+) -> Result<Vec<SourceChange>> {
+    let owner = repo_value
+        .pointer("/owner/login")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("repository missing owner.login"))?
+        .to_string();
+    let name = repo_value
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("repository missing name"))?
+        .to_string();
+
+    let mut changes = Vec::new();
+
+    changes.extend(convert(
+        source_id,
+        organization,
+        "repository",
+        "created",
+        json!({ "organization": org_value, "repository": repo_value }),
+    )?);
+
+    let issues = client
+        .fetch_issues(&owner, &name)
+        .await
+        .with_context(|| format!("failed to fetch issues for {owner}/{name}"))?;
+    for issue in issues {
+        let issue_node_id = required_node_id(&issue)?;
+        changes.extend(convert(
+            source_id,
+            organization,
+            "issues",
+            "opened",
+            json!({
+                "organization": org_value,
+                "repository": repo_value,
+                "issue": issue,
+            }),
+        )?);
+
+        if client::item_comment_count(&issue) > 0 {
+            let comments = client
+                .fetch_issue_comments(&issue_node_id)
+                .await
+                .with_context(|| {
+                    format!("failed to fetch comments for issue {owner}/{name}#{issue_node_id}")
+                })?;
+            for comment in comments {
+                changes.extend(convert(
+                    source_id,
+                    organization,
+                    "issue_comment",
+                    "created",
+                    json!({
+                        "organization": org_value,
+                        "repository": repo_value,
+                        "issue": { "node_id": issue_node_id },
+                        "comment": comment,
+                    }),
+                )?);
+            }
+        }
+    }
+
+    let pull_requests = client
+        .fetch_pull_requests(&owner, &name)
+        .await
+        .with_context(|| format!("failed to fetch pull requests for {owner}/{name}"))?;
+    for pr in pull_requests {
+        let pr_node_id = required_node_id(&pr)?;
+        changes.extend(convert(
+            source_id,
+            organization,
+            "pull_request",
+            "opened",
+            json!({
+                "organization": org_value,
+                "repository": repo_value,
+                "pull_request": pr,
+            }),
+        )?);
+
+        if client::item_comment_count(&pr) > 0 {
+            let comments = client
+                .fetch_pr_comments(&pr_node_id)
+                .await
+                .with_context(|| {
+                    format!("failed to fetch comments for pull request {owner}/{name}#{pr_node_id}")
+                })?;
+            for comment in comments {
+                changes.extend(convert(
+                    source_id,
+                    organization,
+                    "issue_comment",
+                    "created",
+                    json!({
+                        "organization": org_value,
+                        "repository": repo_value,
+                        // `pull_request` present (even empty) is exactly the
+                        // discriminator `mapping::comment_event` checks via
+                        // `issue.get("pull_request").is_some()`.
+                        "issue": { "node_id": pr_node_id, "pull_request": {} },
+                        "comment": comment,
+                    }),
+                )?);
+            }
+        }
+
+        if client::pr_review_count(&pr) > 0 {
+            let reviews = client
+                .fetch_pr_reviews(&pr_node_id)
+                .await
+                .with_context(|| {
+                    format!("failed to fetch reviews for pull request {owner}/{name}#{pr_node_id}")
+                })?;
+            for review in reviews {
+                changes.extend(convert(
+                    source_id,
+                    organization,
+                    "pull_request_review",
+                    "submitted",
+                    json!({
+                        "organization": org_value,
+                        "repository": repo_value,
+                        "pull_request": { "node_id": pr_node_id },
+                        "review": review,
+                    }),
+                )?);
+            }
+        }
+    }
+
+    Ok(changes)
+}
+
+fn required_node_id(value: &Value) -> Result<String> {
+    value
+        .get("node_id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("GitHub entity missing 'node_id'"))
+}
+
+/// Build one synthetic webhook-envelope `action` field and hand the payload
+/// to the shared `Converter`. Each call gets a fresh `effective_from`
+/// timestamp (matching the streaming source's own per-delivery convention in
+/// `drasi-source-github-workgraph`'s webhook ingress).
+fn convert(
+    source_id: &str,
+    organization: &str,
+    event_type: &str,
+    action: &str,
+    mut payload: Value,
+) -> Result<Vec<SourceChange>> {
+    if let Value::Object(map) = &mut payload {
+        map.insert("action".to_string(), json!(action));
+    }
+    let effective_from = Utc::now().timestamp_millis().max(0) as u64;
+    let converter = Converter::new(source_id, organization, effective_from);
+    match converter.convert(event_type, &payload) {
+        Ok(Some(changes)) => Ok(changes),
+        Ok(None) => Ok(Vec::new()),
+        Err(err) => Err(anyhow!(
+            "GitHub WorkGraph mapping failed for '{event_type}'/'{action}': {err:?}"
+        )),
+    }
+}
+
+/// Normalize streaming changes into snapshot state. Existing elements become
+/// inserts, while defensive deletes emitted by the shared converter (for
+/// example, clearing a prior status error on an opened issue) do not represent
+/// current graph state and must not be sent during bootstrap.
+fn into_snapshot_insert(change: SourceChange) -> Option<SourceChange> {
+    match change {
+        SourceChange::Insert { element } | SourceChange::Update { element } => {
+            Some(SourceChange::Insert { element })
+        }
+        SourceChange::Delete { .. } | SourceChange::Future { .. } => None,
+    }
+}
+
+fn source_change_label(change: &SourceChange) -> Option<Arc<str>> {
+    match change {
+        SourceChange::Insert { element } | SourceChange::Update { element } => {
+            element.get_metadata().labels.first().cloned()
+        }
+        SourceChange::Delete { metadata } => metadata.labels.first().cloned(),
+        SourceChange::Future { .. } => None,
+    }
+}
+
+/// Mirrors the `query_requests_any` convention used across other bootstrap
+/// providers in this workspace (e.g. `cloudflare-radar`): when the request
+/// carries no labels at all it means "send everything"; otherwise a change is
+/// sent only if its own label is explicitly present in the matching
+/// (node vs. relation) requested-labels list.
+fn label_requested(request: &BootstrapRequest, label: &str, is_node: bool) -> bool {
+    if request.node_labels.is_empty() && request.relation_labels.is_empty() {
+        return true;
+    }
+    if is_node {
+        request.node_labels.iter().any(|l| l == label)
+    } else {
+        request.relation_labels.iter().any(|l| l == label)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_if_requested(
+    change: SourceChange,
+    request: &BootstrapRequest,
+    source_id: &str,
+    event_tx: &BootstrapEventSender,
+    context: &BootstrapContext,
+    sent_ids: &mut HashSet<String>,
+) -> Result<usize> {
+    let Some(change) = into_snapshot_insert(change) else {
+        return Ok(0);
+    };
+    let Some(label) = source_change_label(&change) else {
+        return Ok(0);
+    };
+    let is_node = NODE_LABELS.contains(&label.as_ref());
+    let is_relation = RELATION_LABELS.contains(&label.as_ref());
+    if !is_node && !is_relation {
+        // Converter only ever emits the WorkGraph labels above; this branch
+        // should be unreachable, but skip defensively rather than send an
+        // unrecognized element type.
+        return Ok(0);
+    }
+    if !label_requested(request, label.as_ref(), is_node) {
+        return Ok(0);
+    }
+    let key = format!("{source_id}:{}", change.get_reference().element_id);
+    if !sent_ids.insert(key) {
+        return Ok(0);
+    }
+    let sequence = context.next_sequence();
+    let event = BootstrapEvent {
+        source_id: source_id.to_string(),
+        change,
+        timestamp: Utc::now(),
+        sequence,
+    };
+    event_tx
+        .send(event)
+        .await
+        .map_err(|err| anyhow!(err.to_string()))?;
+    Ok(1)
+}
+
+/// Dynamic plugin entry point.
+#[cfg(feature = "dynamic-plugin")]
+drasi_plugin_sdk::export_plugin!(
+    plugin_id = "github-workgraph-bootstrap",
+    core_version = env!("CARGO_PKG_VERSION"),
+    lib_version = env!("CARGO_PKG_VERSION"),
+    plugin_version = env!("CARGO_PKG_VERSION"),
+    source_descriptors = [],
+    reaction_descriptors = [],
+    bootstrap_descriptors = [descriptor::GitHubWorkGraphBootstrapDescriptor],
+);

--- a/components/bootstrappers/github-workgraph/src/tests.rs
+++ b/components/bootstrappers/github-workgraph/src/tests.rs
@@ -1,0 +1,598 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Wiremock-backed tests exercising the bootstrap provider end-to-end against
+//! a fake GitHub GraphQL API. These prove:
+//! - GraphQL cursor pagination is followed correctly.
+//! - `BootstrapRequest` node/relation label filtering is honored.
+//! - `event_count` is exact and `source_position` is always `None`.
+//! - WorkGraph `Assignment`/comment/review reconstruction flows entirely
+//!   through the shared `drasi_source_github_workgraph::mapping::Converter`
+//!   (proving this crate does not duplicate any WorkGraph domain rule).
+
+use crate::GitHubWorkGraphBootstrapProvider;
+use drasi_core::models::{Element, ElementValue, SourceChange};
+use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
+use drasi_lib::channels::BootstrapEvent;
+use drasi_source_github_workgraph::mapping::{NODE_ISSUE, NODE_ORGANIZATION};
+use drasi_source_github_workgraph::workgraph::{assignment_element_id, comment_error_element_id};
+use serde_json::{json, Value};
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const ORG_NODE_ID: &str = "O_org1";
+const REPO_NODE_ID: &str = "R_repo1";
+const ISSUE_NODE_ID: &str = "I_issue1";
+const PR_NODE_ID: &str = "PR_pr1";
+const RESULT_COMMENT_NODE_ID: &str = "IC_result";
+const INVALID_COMMENT_NODE_ID: &str = "IC_invalid";
+const ORDINARY_COMMENT_NODE_ID: &str = "IC_ordinary";
+
+const ASSIGNMENT_COMMENT_BODY: &str = "WorkGraphAssignment/v1\n\
+Please validate this issue.\n\
+```json\n\
+{\"assignmentId\":\"assign-1\",\"agentProfile\":\"triage-bot\",\"priority\":1,\"taskType\":\"issue-validation\",\"task\":{\"validationProfile\":\"default\",\"criteria\":[\"title-present\"]}}\n\
+```";
+
+const RESULT_COMMENT_BODY: &str = "WorkGraphResult/v1\n\
+Validation complete.\n\
+```json\n\
+{\"assignmentId\":\"assign-1\",\"taskType\":\"issue-validation\",\"outcome\":\"succeeded\",\"summary\":\"Passed.\",\"result\":{\"criteria\":[{\"criterion\":\"title-present\",\"passed\":true,\"evidence\":\"Title is present.\"}]}}\n\
+```";
+
+fn org_fixture() -> Value {
+    json!({
+        "node_id": ORG_NODE_ID,
+        "id": 1001,
+        "login": "acme",
+        "url": "https://github.com/acme",
+        "avatar_url": "https://avatars.example/acme.png",
+        "description": "Acme org",
+    })
+}
+
+fn repo_fixture() -> Value {
+    json!({
+        "node_id": REPO_NODE_ID,
+        "id": 2001,
+        "name": "widgets",
+        "full_name": "acme/widgets",
+        "owner": { "login": "acme" },
+        "description": "Widgets repo",
+        "html_url": "https://github.com/acme/widgets",
+        "private": false,
+        "archived": false,
+        "fork": false,
+        "visibility": "PUBLIC",
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+        "defaultBranchRef": { "name": "main" },
+        "repositoryTopics": { "nodes": [] },
+    })
+}
+
+fn issue_fixture() -> Value {
+    json!({
+        "node_id": ISSUE_NODE_ID,
+        "id": 3001,
+        "number": 42,
+        "title": "Bug report",
+        "body": "Something broke",
+        "state": "OPEN",
+        "state_reason": null,
+        "locked": false,
+        "created_at": "2024-01-03T00:00:00Z",
+        "updated_at": "2024-01-03T01:00:00Z",
+        "closed_at": null,
+        "html_url": "https://github.com/acme/widgets/issues/42",
+        "author_association": "MEMBER",
+        "user": { "login": "ada", "node_id": "U_ada", "id": 5001, "type": "User" },
+        "assignees": { "nodes": [{ "login": "ada" }] },
+        "labels": {
+            "pageInfo": { "hasNextPage": true, "endCursor": "LABEL_PAGE_2" },
+            "nodes": [{ "name": "bug" }]
+        },
+        "comments": { "totalCount": 4 },
+    })
+}
+
+fn result_comment_fixture() -> Value {
+    let mut comment = assignment_comment_fixture();
+    comment["node_id"] = json!(RESULT_COMMENT_NODE_ID);
+    comment["id"] = json!(6002);
+    comment["body"] = json!(RESULT_COMMENT_BODY);
+    comment
+}
+
+fn invalid_comment_fixture() -> Value {
+    let mut comment = assignment_comment_fixture();
+    comment["node_id"] = json!(INVALID_COMMENT_NODE_ID);
+    comment["id"] = json!(6003);
+    comment["body"] = json!("WorkGraphResult/v1\nInvalid payload.\n```json\nnot-json\n```");
+    comment
+}
+
+fn ordinary_comment_fixture() -> Value {
+    let mut comment = assignment_comment_fixture();
+    comment["node_id"] = json!(ORDINARY_COMMENT_NODE_ID);
+    comment["id"] = json!(6004);
+    comment["body"] = json!(" WorkGraphResult/v1\nLeading whitespace makes this ordinary.");
+    comment
+}
+
+fn assignment_comment_fixture() -> Value {
+    json!({
+        "node_id": "IC_c1",
+        "id": 6001,
+        "body": ASSIGNMENT_COMMENT_BODY,
+        "created_at": "2024-01-03T02:00:00Z",
+        "updated_at": "2024-01-03T02:00:00Z",
+        "html_url": "https://github.com/acme/widgets/issues/42#issuecomment-6001",
+        "author_association": "MEMBER",
+        "user": { "login": "triage-bot", "node_id": "U_bot", "type": "Bot" },
+    })
+}
+
+fn pr_fixture() -> Value {
+    json!({
+        "node_id": PR_NODE_ID,
+        "id": 7001,
+        "number": 7,
+        "title": "Add feature",
+        "body": "This adds a feature",
+        "state": "OPEN",
+        "locked": false,
+        "created_at": "2024-01-04T00:00:00Z",
+        "updated_at": "2024-01-04T01:00:00Z",
+        "closed_at": null,
+        "html_url": "https://github.com/acme/widgets/pull/7",
+        "author_association": "MEMBER",
+        "user": { "login": "grace", "node_id": "U_grace", "id": 5003, "type": "User" },
+        "assignees": { "nodes": [] },
+        "labels": {
+            "pageInfo": { "hasNextPage": false, "endCursor": null },
+            "nodes": []
+        },
+        "draft": false,
+        "merged": false,
+        "merged_at": null,
+        "head_ref_name": "feature-branch",
+        "head_sha": "abcdef1",
+        "base_ref_name": "main",
+        "base_sha": "1234567",
+        "comments": { "totalCount": 0 },
+        "reviews": { "totalCount": 1 },
+    })
+}
+
+fn review_fixture() -> Value {
+    json!({
+        "node_id": "PRR_r1",
+        "id": 8001,
+        "state": "APPROVED",
+        "body": "Looks good",
+        "submitted_at": "2024-01-04T02:00:00Z",
+        "commit": { "oid": "abcdef1" },
+        "html_url": "https://github.com/acme/widgets/pull/7#pullrequestreview-8001",
+        "author_association": "MEMBER",
+        "user": { "login": "bob", "node_id": "U_bob", "id": 5004, "type": "User" },
+    })
+}
+
+fn connection(nodes: Vec<Value>, has_next: bool, end_cursor: Option<&str>) -> Value {
+    json!({
+        "pageInfo": { "hasNextPage": has_next, "endCursor": end_cursor },
+        "nodes": nodes,
+    })
+}
+
+async fn mount_query(
+    server: &MockServer,
+    must_contain: &[&str],
+    data: Value,
+    expect_calls: Option<u64>,
+) {
+    let mut mock = Mock::given(method("POST")).and(path("/graphql"));
+    for needle in must_contain {
+        mock = mock.and(body_string_contains(needle.to_string()));
+    }
+    let mock = mock.respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": data })));
+    let mock = match expect_calls {
+        Some(n) => mock.expect(n),
+        None => mock,
+    };
+    mock.mount(server).await;
+}
+
+/// Mounts one full single-repo/single-issue/single-PR/single-review fixture
+/// set (the scenario used by most tests below).
+async fn mount_full_fixture(server: &MockServer) {
+    mount_query(
+        server,
+        &["avatar_url: avatarUrl"],
+        json!({ "organization": org_fixture() }),
+        None,
+    )
+    .await;
+    mount_query(
+        server,
+        &["repositories(first"],
+        json!({ "organization": { "repositories": connection(vec![repo_fixture()], false, None) } }),
+        None,
+    )
+    .await;
+    mount_query(
+        server,
+        &["issues(first"],
+        json!({ "repository": { "issues": connection(vec![issue_fixture()], false, None) } }),
+        None,
+    )
+    .await;
+    mount_query(
+        server,
+        &["pullRequests(first"],
+        json!({ "repository": { "pullRequests": connection(vec![pr_fixture()], false, None) } }),
+        None,
+    )
+    .await;
+    mount_query(
+        server,
+        &["labels(first: $pageSize", "\"cursor\":\"LABEL_PAGE_2\""],
+        json!({ "node": { "labels": connection(
+            vec![json!({ "name": "status:in-progress" })],
+            false,
+            None,
+        ) } }),
+        Some(1),
+    )
+    .await;
+    mount_query(
+        server,
+        &["... on Issue {", "comments(first"],
+        json!({ "node": { "comments": connection(vec![
+            assignment_comment_fixture(),
+            result_comment_fixture(),
+            invalid_comment_fixture(),
+            ordinary_comment_fixture(),
+        ], false, None) } }),
+        None,
+    )
+    .await;
+    mount_query(
+        server,
+        &[
+            "... on PullRequest {",
+            "reviews(",
+            "states: [COMMENTED, APPROVED, CHANGES_REQUESTED, DISMISSED]",
+        ],
+        json!({ "node": { "reviews": connection(vec![review_fixture()], false, None) } }),
+        None,
+    )
+    .await;
+}
+
+fn provider_for(server: &MockServer) -> GitHubWorkGraphBootstrapProvider {
+    GitHubWorkGraphBootstrapProvider::builder()
+        .with_organization("acme")
+        .with_token("read-only-test-token")
+        .with_api_base_url(format!("{}/graphql", server.uri()))
+        .with_max_concurrency(2)
+        .build()
+        .expect("valid config")
+}
+
+fn all_labels_request() -> BootstrapRequest {
+    BootstrapRequest {
+        query_id: "q1".to_string(),
+        node_labels: Vec::new(),
+        relation_labels: Vec::new(),
+        request_id: "r1".to_string(),
+    }
+}
+
+async fn run_bootstrap(
+    provider: &GitHubWorkGraphBootstrapProvider,
+    request: BootstrapRequest,
+) -> (drasi_lib::bootstrap::BootstrapResult, Vec<BootstrapEvent>) {
+    let context = BootstrapContext::new_minimal("test-server".to_string(), "gh-src".to_string());
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1024);
+    let result = provider
+        .bootstrap(request, &context, tx, None)
+        .await
+        .expect("bootstrap should succeed");
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    (result, events)
+}
+
+fn label_of(event: &BootstrapEvent) -> String {
+    match &event.change {
+        SourceChange::Insert { element } | SourceChange::Update { element } => element
+            .get_metadata()
+            .labels
+            .first()
+            .map(|l| l.to_string())
+            .unwrap_or_default(),
+        SourceChange::Delete { metadata } => metadata
+            .labels
+            .first()
+            .map(|l| l.to_string())
+            .unwrap_or_default(),
+        SourceChange::Future { .. } => String::new(),
+    }
+}
+
+#[tokio::test]
+async fn bootstraps_full_repository_via_shared_converter() {
+    let server = MockServer::start().await;
+    mount_full_fixture(&server).await;
+    let provider = provider_for(&server);
+
+    let (result, events) = run_bootstrap(&provider, all_labels_request()).await;
+
+    assert_eq!(
+        result.source_position, None,
+        "webhooks have no replay boundary"
+    );
+    assert_eq!(result.event_count, events.len());
+    assert_eq!(result.event_count, 18, "unexpected event set: {events:#?}");
+    assert!(
+        events
+            .iter()
+            .all(|event| matches!(event.change, SourceChange::Insert { .. })),
+        "bootstrap state must contain inserts only"
+    );
+
+    let org_events: Vec<_> = events
+        .iter()
+        .filter(|e| label_of(e) == NODE_ORGANIZATION)
+        .collect();
+    assert_eq!(org_events.len(), 1, "organization node must be deduped");
+    assert!(
+        matches!(org_events[0].change, SourceChange::Insert { .. }),
+        "bootstrap snapshot must always Insert, even though Converter emits \
+         the organization node as Update on every repository conversion"
+    );
+
+    let issue_event = events
+        .iter()
+        .find(|e| label_of(e) == NODE_ISSUE)
+        .expect("issue node present");
+    let SourceChange::Insert { element } = &issue_event.change else {
+        panic!("issue must be an Insert");
+    };
+    assert_eq!(
+        element.get_property("statusLabel"),
+        &drasi_core::models::ElementValue::from(&json!("status:in-progress")),
+        "status label must be derived by the shared mapping::derive_status, not reimplemented"
+    );
+
+    let assignment_id = assignment_element_id(ORG_NODE_ID, "assign-1");
+    let assignment_event = events
+        .iter()
+        .find(|e| e.change.get_reference().element_id.as_ref() == assignment_id)
+        .expect("WorkGraphAssignment node reconstructed via the shared workgraph parser");
+    assert_eq!(label_of(assignment_event), "WorkGraphAssignment");
+
+    let result_event = events
+        .iter()
+        .find(|event| event.change.get_reference().element_id.as_ref() == RESULT_COMMENT_NODE_ID)
+        .expect("WorkGraphResult node reconstructed via the shared workgraph parser");
+    assert_eq!(label_of(result_event), "WorkGraphResult");
+
+    let result_for = events
+        .iter()
+        .find(|event| label_of(event) == "RESULT_FOR")
+        .expect("RESULT_FOR relation reconstructed by the shared converter");
+    let SourceChange::Insert {
+        element: Element::Relation {
+            in_node, out_node, ..
+        },
+    } = &result_for.change
+    else {
+        panic!("RESULT_FOR must be an inserted relation");
+    };
+    assert_eq!(in_node.element_id.as_ref(), RESULT_COMMENT_NODE_ID);
+    assert_eq!(out_node.element_id.as_ref(), assignment_id);
+
+    let error_id = comment_error_element_id(INVALID_COMMENT_NODE_ID);
+    let error_event = events
+        .iter()
+        .find(|event| event.change.get_reference().element_id.as_ref() == error_id)
+        .expect("recognized malformed WorkGraph comment becomes WorkGraphError");
+    assert_eq!(label_of(error_event), "WorkGraphError");
+    let SourceChange::Insert { element } = &error_event.change else {
+        panic!("WorkGraphError must be inserted");
+    };
+    assert_eq!(
+        element.get_property("errorCode"),
+        &ElementValue::from(&json!("invalid-json"))
+    );
+
+    let ordinary_event = events
+        .iter()
+        .find(|event| event.change.get_reference().element_id.as_ref() == ORDINARY_COMMENT_NODE_ID)
+        .expect("lookalike marker remains an ordinary comment");
+    assert_eq!(label_of(ordinary_event), "GitHubIssueComment");
+
+    let relation_labels: Vec<String> = events
+        .iter()
+        .filter(|e| {
+            let l = label_of(e);
+            drasi_source_github_workgraph::mapping::RELATION_LABELS.contains(&l.as_str())
+        })
+        .map(label_of)
+        .collect();
+    assert!(relation_labels.contains(&"IN_ORGANIZATION".to_string()));
+    assert!(relation_labels.contains(&"IN_REPOSITORY".to_string()));
+    assert!(relation_labels.contains(&"COMMENT_ON".to_string()));
+    assert!(relation_labels.contains(&"REVIEW_OF".to_string()));
+    assert!(relation_labels.contains(&"RESULT_FOR".to_string()));
+}
+
+#[tokio::test]
+async fn filters_events_by_requested_node_labels() {
+    let server = MockServer::start().await;
+    mount_full_fixture(&server).await;
+    let provider = provider_for(&server);
+
+    let request = BootstrapRequest {
+        query_id: "q2".to_string(),
+        node_labels: vec![NODE_ISSUE.to_string()],
+        relation_labels: Vec::new(),
+        request_id: "r2".to_string(),
+    };
+    let (result, events) = run_bootstrap(&provider, request).await;
+
+    assert_eq!(
+        result.event_count, 1,
+        "only the requested node label should be sent"
+    );
+    assert_eq!(label_of(&events[0]), NODE_ISSUE);
+}
+
+#[tokio::test]
+async fn filters_events_by_requested_relation_labels() {
+    let server = MockServer::start().await;
+    mount_full_fixture(&server).await;
+    let provider = provider_for(&server);
+
+    let request = BootstrapRequest {
+        query_id: "q3".to_string(),
+        node_labels: Vec::new(),
+        relation_labels: vec!["REVIEW_OF".to_string()],
+        request_id: "r3".to_string(),
+    };
+    let (result, events) = run_bootstrap(&provider, request).await;
+
+    assert_eq!(result.event_count, 1);
+    assert_eq!(label_of(&events[0]), "REVIEW_OF");
+}
+
+#[tokio::test]
+async fn paginates_repositories_across_multiple_pages() {
+    let server = MockServer::start().await;
+    mount_query(
+        &server,
+        &["avatar_url: avatarUrl"],
+        json!({ "organization": org_fixture() }),
+        None,
+    )
+    .await;
+
+    let mut repo_page_2 = repo_fixture();
+    repo_page_2["node_id"] = json!("R_repo2");
+    repo_page_2["name"] = json!("gadgets");
+    repo_page_2["full_name"] = json!("acme/gadgets");
+
+    // Page 1: cursor is null, has a next page.
+    mount_query(
+        &server,
+        &["repositories(first", "\"cursor\":null"],
+        json!({ "organization": { "repositories": connection(vec![repo_fixture()], true, Some("PAGE2")) } }),
+        Some(1),
+    )
+    .await;
+    // Page 2: cursor is "PAGE2", no more pages.
+    mount_query(
+        &server,
+        &["repositories(first", "\"cursor\":\"PAGE2\""],
+        json!({ "organization": { "repositories": connection(vec![repo_page_2], false, None) } }),
+        Some(1),
+    )
+    .await;
+
+    // Both repositories have no issues/PRs, to keep this test focused on
+    // repository-connection pagination.
+    mount_query(
+        &server,
+        &["issues(first"],
+        json!({ "repository": { "issues": connection(vec![], false, None) } }),
+        None,
+    )
+    .await;
+    mount_query(
+        &server,
+        &["pullRequests(first"],
+        json!({ "repository": { "pullRequests": connection(vec![], false, None) } }),
+        None,
+    )
+    .await;
+
+    let provider = provider_for(&server);
+    let (result, events) = run_bootstrap(&provider, all_labels_request()).await;
+
+    // org(1) + 2x(repo + IN_ORGANIZATION) == 5
+    assert_eq!(
+        result.event_count, 5,
+        "both pages of repositories must be processed: {events:#?}"
+    );
+    let repo_ids: std::collections::HashSet<String> = events
+        .iter()
+        .filter(|e| label_of(e) == "GitHubRepository")
+        .map(|e| e.change.get_reference().element_id.to_string())
+        .collect();
+    assert_eq!(repo_ids.len(), 2);
+    assert!(repo_ids.contains(REPO_NODE_ID));
+    assert!(repo_ids.contains("R_repo2"));
+}
+
+#[tokio::test]
+async fn fails_without_emitting_a_partial_repository_snapshot() {
+    let server = MockServer::start().await;
+    mount_query(
+        &server,
+        &["avatar_url: avatarUrl"],
+        json!({ "organization": org_fixture() }),
+        None,
+    )
+    .await;
+    mount_query(
+        &server,
+        &["repositories(first"],
+        json!({ "organization": { "repositories": connection(vec![repo_fixture()], false, None) } }),
+        None,
+    )
+    .await;
+    mount_query(
+        &server,
+        &["issues(first"],
+        json!({ "repository": { "issues": connection(vec![], false, None) } }),
+        None,
+    )
+    .await;
+    mount_query(
+        &server,
+        &["pullRequests(first"],
+        json!({ "repository": null }),
+        None,
+    )
+    .await;
+
+    let provider = provider_for(&server);
+    let context = BootstrapContext::new_minimal("test-server".to_string(), "gh-src".to_string());
+    let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+    let error = provider
+        .bootstrap(all_labels_request(), &context, tx, None)
+        .await
+        .expect_err("a missing repository connection must fail bootstrap");
+
+    assert!(error.to_string().contains("repository task"));
+    assert!(
+        rx.try_recv().is_err(),
+        "no events may be sent from a partial snapshot"
+    );
+}


### PR DESCRIPTION
# Description

Adds the smallest matching bootstrap provider for the payload-only GitHub WorkGraph Source. The provider uses read-only GitHub GraphQL queries to enumerate one Source-configured organization and bootstrap its accessible repositories, open Issues, open Pull Requests, conversation comments, and submitted/dismissed PR reviews.

All graph semantics are reused from `drasi-source-github-workgraph::mapping::Converter`: labels, properties, global node IDs, relation IDs/directions, status derivation, typed Assignment/Result parsing, `RESULT_FOR`, and narrow `WorkGraphError` behavior. The Source crate is unchanged.

The bootstrapper cursor-paginates repositories, issues, pull requests, status-sensitive labels, comments, and reviews with bounded concurrency; honors node/relation label filters; emits insert-only snapshot events with exact `event_count`; and fails before emission rather than returning a known partial repository snapshot.

`source_position` is intentionally always `None`: GitHub webhooks provide no replayable boundary, and GitHub GraphQL provides no cross-request snapshot transaction. This limitation is documented in the component README.

**Stack:** depends on #737 and targets `agentofreality-implement-github-source` at `dd9c1f9fc19762ece438e53dbe5c0dc601d7fe99`.

**Validation:**
- `cargo test -p drasi-bootstrap-github-workgraph` (15 passed)
- `cargo clippy -p drasi-bootstrap-github-workgraph --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo build --lib -p drasi-bootstrap-github-workgraph --features dynamic-plugin`
- GitHub GraphQL list/detail query shapes validated against the live schema

## Type of change

- This pull request adds or changes features of Drasi and has an approved issue (issue link required).

Fixes: N/A — stacked prototype follow-up to #737.