### PR TITLE
Bridge state store durability over plugin FFI

### DIFF
--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           echo "=== Building cdylib test plugins ==="
           cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin
+          cargo build --lib -p drasi-source-github-workgraph --features drasi-source-github-workgraph/dynamic-plugin
           cargo build --lib -p drasi-reaction-log --features drasi-reaction-log/dynamic-plugin
           cargo build --lib -p drasi-reaction-sse --features drasi-reaction-sse/dynamic-plugin
           cargo build --lib -p drasi-reaction-snapshot-test
@@ -87,7 +88,7 @@ jobs:
           mkdir -p target/debug/plugins
           PREFIX="${{ matrix.lib_prefix }}"
           EXT="${{ matrix.lib_ext }}"
-          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test drasi_bootstrap_scriptfile; do
+          for name in drasi_source_mock drasi_source_github_workgraph drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test drasi_bootstrap_scriptfile; do
             SRC="target/debug/${PREFIX}${name}.${EXT}"
             if [ -f "$SRC" ]; then
               cp "$SRC" target/debug/plugins/
@@ -103,7 +104,7 @@ jobs:
           PREFIX="${{ matrix.lib_prefix }}"
           EXT="${{ matrix.lib_ext }}"
           MISSING=0
-          for name in drasi_source_mock drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test drasi_bootstrap_scriptfile; do
+          for name in drasi_source_mock drasi_source_github_workgraph drasi_reaction_log drasi_reaction_sse drasi_reaction_snapshot_test drasi_identity_test drasi_bootstrap_scriptfile; do
             FILE="target/debug/plugins/${PREFIX}${name}.${EXT}"
             if [ ! -f "$FILE" ]; then
               echo "ERROR: Expected plugin not found: $FILE"
@@ -115,7 +116,7 @@ jobs:
             ls -la target/debug/plugins/ || true
             exit 1
           fi
-          echo "All 6 test plugins verified."
+          echo "All 7 test plugins verified."
 
       - name: Run host-sdk FFI integration tests
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ PLUGIN_OUT_DIR := target/debug/plugins
 build-test-plugins:
 	@echo "=== Building cdylib test plugins ==="
 	cargo build --lib -p drasi-source-mock --features drasi-source-mock/dynamic-plugin
+	cargo build --lib -p drasi-source-github-workgraph --features drasi-source-github-workgraph/dynamic-plugin
 	cargo build --lib -p drasi-reaction-log --features drasi-reaction-log/dynamic-plugin
 	cargo build --lib -p drasi-reaction-sse --features drasi-reaction-sse/dynamic-plugin
 	cargo build --lib -p drasi-reaction-snapshot-test
@@ -56,12 +57,14 @@ build-test-plugins:
 	@echo "=== Copying plugins to $(PLUGIN_OUT_DIR) ==="
 	@for ext in dylib so dll; do \
 		for f in target/debug/libdrasi_source_mock.$$ext \
+		         target/debug/libdrasi_source_github_workgraph.$$ext \
 		         target/debug/libdrasi_reaction_log.$$ext \
 		         target/debug/libdrasi_reaction_sse.$$ext \
 		         target/debug/libdrasi_reaction_snapshot_test.$$ext \
 		         target/debug/libdrasi_identity_test.$$ext \
 		         target/debug/libdrasi_bootstrap_scriptfile.$$ext \
 		         target/debug/drasi_source_mock.$$ext \
+		         target/debug/drasi_source_github_workgraph.$$ext \
 		         target/debug/drasi_reaction_log.$$ext \
 		         target/debug/drasi_reaction_sse.$$ext \
 		         target/debug/drasi_reaction_snapshot_test.$$ext \

--- a/components/host-sdk/Cargo.toml
+++ b/components/host-sdk/Cargo.toml
@@ -62,4 +62,6 @@ tokio-util = { version = "0.7", features = ["io"] }
 serial_test = "3"
 im = "15"
 tokio-stream = "0.1"
+drasi-state-store-redb = { path = "../state_stores/redb" }
+drasi-wal-redb = { path = "../wals/redb" }
 async-stream = "0.3"

--- a/components/host-sdk/src/state_store_bridge.rs
+++ b/components/host-sdk/src/state_store_bridge.rs
@@ -298,3 +298,93 @@ extern "C" fn ss_drop(state: *mut c_void) {
         unsafe { drop(Box::from_raw(state as *mut Arc<dyn StateStoreProvider>)) };
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use drasi_lib::{MemoryStateStoreProvider, StateStoreProvider};
+    use drasi_plugin_sdk::ffi::FfiStateStoreProxy;
+    use drasi_state_store_redb::RedbStateStoreProvider;
+
+    fn release(vtable: StateStoreVtable) {
+        (vtable.drop_fn)(vtable.state);
+    }
+
+    #[test]
+    fn durable_redb_reports_true_through_host_vtable_and_plugin_proxy() {
+        let temp_dir = tempfile::tempdir().expect("temp directory");
+        let provider = Arc::new(
+            RedbStateStoreProvider::new(temp_dir.path().join("state.redb"))
+                .expect("redb state store"),
+        );
+        let vtable = StateStoreVtableBuilder::build(provider);
+        {
+            let proxy = unsafe { FfiStateStoreProxy::from_raw(&vtable) };
+            assert!(proxy.is_durable());
+        }
+
+        release(vtable);
+    }
+
+    #[test]
+    fn in_memory_store_reports_false_through_host_vtable_and_plugin_proxy() {
+        let provider = Arc::new(MemoryStateStoreProvider::new());
+        let vtable = StateStoreVtableBuilder::build(provider);
+        {
+            let proxy = unsafe { FfiStateStoreProxy::from_raw(&vtable) };
+            assert!(!proxy.is_durable());
+        }
+
+        release(vtable);
+    }
+
+    #[test]
+    fn missing_durability_callback_fails_closed() {
+        let temp_dir = tempfile::tempdir().expect("temp directory");
+        let provider = Arc::new(
+            RedbStateStoreProvider::new(temp_dir.path().join("state.redb"))
+                .expect("redb state store"),
+        );
+        let mut vtable = StateStoreVtableBuilder::build(provider);
+        vtable.is_durable_fn = None;
+        {
+            let proxy = unsafe { FfiStateStoreProxy::from_raw(&vtable) };
+            assert!(!proxy.is_durable());
+        }
+
+        release(vtable);
+    }
+
+    #[test]
+    fn invalid_null_state_fails_closed() {
+        let temp_dir = tempfile::tempdir().expect("temp directory");
+        let provider = Arc::new(
+            RedbStateStoreProvider::new(temp_dir.path().join("state.redb"))
+                .expect("redb state store"),
+        );
+        let mut vtable = StateStoreVtableBuilder::build(provider);
+        let provider_state = vtable.state;
+        vtable.state = std::ptr::null_mut();
+        {
+            let proxy = unsafe { FfiStateStoreProxy::from_raw(&vtable) };
+            assert!(!proxy.is_durable());
+        }
+
+        vtable.state = provider_state;
+        release(vtable);
+    }
+
+    #[test]
+    fn durability_callback_is_versioned_and_trailing() {
+        assert_eq!(drasi_plugin_sdk::ffi::metadata::FFI_SDK_VERSION, "0.14.0");
+
+        let callback_offset = std::mem::offset_of!(StateStoreVtable, is_durable_fn);
+        let callback_size =
+            std::mem::size_of::<Option<extern "C" fn(state: *mut c_void) -> bool>>();
+
+        assert_eq!(
+            callback_offset + callback_size,
+            std::mem::size_of::<StateStoreVtable>()
+        );
+    }
+}

--- a/components/host-sdk/src/state_store_bridge.rs
+++ b/components/host-sdk/src/state_store_bridge.rs
@@ -64,6 +64,7 @@ impl StateStoreVtableBuilder {
             key_count_fn: ss_key_count,
             sync_fn: ss_sync,
             drop_fn: ss_drop,
+            is_durable_fn: Some(ss_is_durable),
         }
     }
 }
@@ -279,6 +280,15 @@ extern "C" fn ss_sync(state: *mut c_void) -> FfiResult {
             Some(Err(e)) => FfiResult::err(e.to_string()),
             None => FfiResult::err("failed to build runtime".to_string()),
         }
+    })
+}
+
+extern "C" fn ss_is_durable(state: *mut c_void) -> bool {
+    ffi_guard(false, || {
+        if state.is_null() {
+            return false;
+        }
+        provider_ref(state).is_durable()
     })
 }
 

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -2264,6 +2264,119 @@ async fn test_reaction_identity_provider_cross_cdylib_clone_stress() {
 }
 
 // ============================================================================
+// State store durability bridge E2E test
+// ============================================================================
+
+extern "C" fn resolve_github_workgraph_test_secret(
+    _ctx: *const std::ffi::c_void,
+    _config_value_json: drasi_plugin_sdk::ffi::FfiStr,
+) -> drasi_plugin_sdk::ffi::FfiGetSecretResult {
+    drasi_plugin_sdk::ffi::FfiGetSecretResult::ok("test-webhook-secret".to_string())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn test_github_workgraph_source_state_store_durability_cross_cdylib() {
+    let path = require_plugin("drasi-source-github-workgraph");
+    let plugin = load_plugin_from_path(
+        &path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .unwrap_or_else(|error| panic!("failed to load GitHub WorkGraph source: {error:#}"));
+    plugin.inject_config_resolver(std::ptr::null_mut(), resolve_github_workgraph_test_secret);
+    let descriptor = plugin
+        .source_plugins
+        .first()
+        .expect("GitHub WorkGraph source descriptor");
+    let config = serde_json::json!({
+        "organization": "drasi-project",
+        "webhook": {
+            "host": "127.0.0.1",
+            "port": 0,
+            "path": "/webhook",
+            "secret": {
+                "kind": "Secret",
+                "name": "github-webhook-secret"
+            },
+            "bodyLimitBytes": 1024
+        },
+        "durability": {
+            "enabled": true,
+            "maxEvents": 10000,
+            "capacityPolicy": "RejectIncoming"
+        }
+    });
+
+    let durable_source = descriptor
+        .create_source("github-workgraph-durable", &config, false)
+        .await
+        .expect("create durable GitHub WorkGraph source");
+    let durable_temp = tempfile::tempdir().expect("durable temp directory");
+    let durable_store: std::sync::Arc<dyn drasi_lib::StateStoreProvider> = std::sync::Arc::new(
+        drasi_state_store_redb::RedbStateStoreProvider::new(durable_temp.path().join("state.redb"))
+            .expect("redb state store"),
+    );
+    let durable_wal: std::sync::Arc<dyn drasi_lib::WalProvider> = std::sync::Arc::new(
+        drasi_wal_redb::RedbWalProvider::new(durable_temp.path().join("wal")),
+    );
+    let (durable_update_tx, _durable_update_rx) =
+        tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(16);
+    let mut durable_context = drasi_lib::SourceRuntimeContext::new(
+        "durability-bridge-test",
+        "github-workgraph-durable",
+        Some(durable_store),
+        durable_update_tx,
+        None,
+    );
+    durable_context.wal_provider = Some(durable_wal);
+    durable_source.initialize(durable_context).await;
+    durable_source
+        .start()
+        .await
+        .unwrap_or_else(|error| panic!("GitHub WorkGraph rejected bridged redb: {error:#}"));
+    durable_source
+        .stop()
+        .await
+        .expect("stop durable GitHub WorkGraph source");
+
+    let memory_source = descriptor
+        .create_source("github-workgraph-memory", &config, false)
+        .await
+        .expect("create in-memory GitHub WorkGraph source");
+    let memory_temp = tempfile::tempdir().expect("memory temp directory");
+    let memory_store: std::sync::Arc<dyn drasi_lib::StateStoreProvider> =
+        std::sync::Arc::new(drasi_lib::MemoryStateStoreProvider::new());
+    let memory_wal: std::sync::Arc<dyn drasi_lib::WalProvider> = std::sync::Arc::new(
+        drasi_wal_redb::RedbWalProvider::new(memory_temp.path().join("wal")),
+    );
+    let (memory_update_tx, _memory_update_rx) =
+        tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(16);
+    let mut memory_context = drasi_lib::SourceRuntimeContext::new(
+        "durability-bridge-test",
+        "github-workgraph-memory",
+        Some(memory_store),
+        memory_update_tx,
+        None,
+    );
+    memory_context.wal_provider = Some(memory_wal);
+    memory_source.initialize(memory_context).await;
+    let error = memory_source
+        .start()
+        .await
+        .expect_err("in-memory state store must be rejected");
+    assert!(
+        error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("requires a durable state store"),
+        "unexpected GitHub WorkGraph startup error: {error:#}"
+    );
+}
+
+// ============================================================================
 // Reaction enqueue_query_result E2E Tests
 // ============================================================================
 

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -44,7 +44,10 @@ use super::types::FfiStr;
 ///   async workers). `FfiBootstrapResult` also carries optional provider
 ///   error text (`error_ptr`/`error_len`/`error_drop_fn`) so failures
 ///   surface with their message instead of only a negative code.
-pub const FFI_SDK_VERSION: &str = "0.13.0";
+/// - `0.14.0`: `StateStoreVtable` appends `is_durable_fn` so dynamic plugins
+///   can distinguish persistent host stores from in-memory providers. The
+///   nullable callback fails closed when the capability is unavailable.
+pub const FFI_SDK_VERSION: &str = "0.14.0";
 
 /// The target triple this crate was compiled for.
 pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");

--- a/components/plugin-sdk/src/ffi/state_store_proxy.rs
+++ b/components/plugin-sdk/src/ffi/state_store_proxy.rs
@@ -34,6 +34,18 @@ pub struct FfiStateStoreProxy {
 unsafe impl Send for FfiStateStoreProxy {}
 unsafe impl Sync for FfiStateStoreProxy {}
 
+impl FfiStateStoreProxy {
+    /// Wrap a host-provided state-store vtable.
+    ///
+    /// # Safety
+    ///
+    /// `vtable` must be non-null, point to a fully initialized vtable, and remain
+    /// valid with its backing state for the lifetime of this proxy.
+    pub unsafe fn from_raw(vtable: *const StateStoreVtable) -> Self {
+        Self { vtable }
+    }
+}
+
 #[async_trait::async_trait]
 impl StateStoreProvider for FfiStateStoreProxy {
     async fn get(&self, store_id: &str, key: &str) -> StateStoreResult<Option<Vec<u8>>> {

--- a/components/plugin-sdk/src/ffi/state_store_proxy.rs
+++ b/components/plugin-sdk/src/ffi/state_store_proxy.rs
@@ -173,4 +173,17 @@ impl StateStoreProvider for FfiStateStoreProxy {
                 .map_err(drasi_lib::StateStoreError::Other)
         }
     }
+
+    fn is_durable(&self) -> bool {
+        let Some(vtable) = (unsafe { self.vtable.as_ref() }) else {
+            return false;
+        };
+        if vtable.state.is_null() {
+            return false;
+        }
+
+        vtable
+            .is_durable_fn
+            .is_some_and(|is_durable_fn| is_durable_fn(vtable.state))
+    }
 }

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -2898,8 +2898,8 @@ fn build_source_runtime_context(
     let state_store: Option<Arc<dyn StateStoreProvider>> = if ffi_ctx.state_store.is_null() {
         None
     } else {
-        Some(Arc::new(FfiStateStoreProxy {
-            vtable: ffi_ctx.state_store,
+        Some(Arc::new(unsafe {
+            FfiStateStoreProxy::from_raw(ffi_ctx.state_store)
         }))
     };
     let identity_provider: Option<Arc<dyn drasi_lib::identity::IdentityProvider>> =
@@ -2944,8 +2944,8 @@ fn build_reaction_runtime_context(
     let state_store: Option<Arc<dyn StateStoreProvider>> = if ffi_ctx.state_store.is_null() {
         None
     } else {
-        Some(Arc::new(FfiStateStoreProxy {
-            vtable: ffi_ctx.state_store,
+        Some(Arc::new(unsafe {
+            FfiStateStoreProxy::from_raw(ffi_ctx.state_store)
         }))
     };
     let identity_provider: Option<Arc<dyn drasi_lib::identity::IdentityProvider>> =

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -669,7 +669,7 @@ pub struct StateStoreVtable {
     pub drop_fn: extern "C" fn(state: *mut c_void),
     /// Whether the host provider persists state durably across restarts.
     ///
-    /// A missing callback is treated as non-durable.
+    /// Appended in SDK 0.14.0. A missing callback is treated as non-durable.
     pub is_durable_fn: Option<extern "C" fn(state: *mut c_void) -> bool>,
 }
 

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -667,6 +667,10 @@ pub struct StateStoreVtable {
     pub sync_fn: extern "C" fn(state: *mut c_void) -> FfiResult,
     // Cleanup
     pub drop_fn: extern "C" fn(state: *mut c_void),
+    /// Whether the host provider persists state durably across restarts.
+    ///
+    /// A missing callback is treated as non-durable.
+    pub is_durable_fn: Option<extern "C" fn(state: *mut c_void) -> bool>,
 }
 
 unsafe impl Send for StateStoreVtable {}


### PR DESCRIPTION
## Summary

- append `is_durable_fn` to `StateStoreVtable` and bridge `StateStoreProvider::is_durable()` through the host/plugin boundary
- bump `FFI_SDK_VERSION` from `0.13.0` to `0.14.0`, as required for a pre-1.0 `#[repr(C)]` layout change
- fail closed for missing callbacks or invalid state
- add bridge unit coverage and a real GitHub WorkGraph source cdylib startup test using durable Redb state/WAL, with in-memory state rejection

This PR is stacked on #740 at exact base head `d9f3fd782312dbd80fa40cacaf23459fa70d837c`. It does not import the unrelated CAS ABI or other #739 behavior.

## Validation

- `cargo fmt -- --check`
- `cargo test -p drasi-plugin-sdk --lib` (59 passed)
- `cargo test -p drasi-host-sdk --lib` (101 passed)
- `cargo test -p drasi-host-sdk state_store_bridge::tests --lib` (5 passed)
- `cargo build --lib -p drasi-source-github-workgraph --features drasi-source-github-workgraph/dynamic-plugin`
- `cargo test -p drasi-host-sdk --test integration_test test_github_workgraph_source_state_store_durability_cross_cdylib -- --test-threads=1 --nocapture` (1 passed)
- `cargo check -p drasi-host-sdk`