### PR TITLE
Parse canonical WorkGraph comment envelopes

### DIFF
--- a/components/bootstrappers/github-workgraph/README.md
+++ b/components/bootstrappers/github-workgraph/README.md
@@ -35,7 +35,8 @@ LF-only spacing, typed two-space JSON, and single final LF as live webhooks.
 
 ## Scope (prototype)
 
-- One configured GitHub organization; every repository the token can see.
+- One configured GitHub organization; all repositories the token can see by
+  default, or only the Source's normalized `repositories` allowlist.
 - Only currently **open** Issues and Pull Requests (no closed history).
 - Issue/PR conversation comments and submitted or dismissed PR reviews.
 - **Excluded**: GitHub Projects and Project Items, inline diff/review
@@ -74,6 +75,8 @@ sources:
   - id: github-workgraph
     kind: github-workgraph
     organization: drasi-project
+    repositories:
+      - drasi-workgraph-demo
     webhook:
       host: 0.0.0.0
       port: 8080
@@ -89,9 +92,15 @@ sources:
     bootstrapProvider: github-workgraph-bootstrap
 ```
 
-The organization is read from the parent `github-workgraph` Source
-configuration, ensuring bootstrap and webhook streaming cannot target different
-organizations. Do not use an inline `bootstrapProvider` mapping for this pair:
+The organization and optional `repositories` allowlist are read from the parent
+`github-workgraph` Source configuration, ensuring bootstrap and webhook
+streaming cannot target different repository scopes. Omitted or empty means all
+repositories. Bare names and same-organization `owner/name` values are accepted,
+then normalized to sorted, deduplicated lowercase bare names. Bootstrap
+enumerates the organization once and filters that repository list before any
+per-repository Issue, PR, comment, or review request; it needs no repository
+cache and makes no extra filtering API calls. Do not use an inline
+`bootstrapProvider` mapping for this pair:
 drasi-server applies same-kind inheritance to inline providers, which would copy
 Source-only fields such as `organization`, `webhook`, and `durability` into this
 bootstrapper's strict configuration. A top-level `bootstrapProviders` entry and

--- a/components/bootstrappers/github-workgraph/README.md
+++ b/components/bootstrappers/github-workgraph/README.md
@@ -37,12 +37,18 @@ Issue and Pull Request label selections alias each GraphQL label `id` to
 `labelDetails: [{name, nodeId}]` property as live webhooks while retaining
 `labels`, `status`, and `statusLabel`. Missing or malformed label node IDs fail
 bootstrap rather than emit a partial identity list.
+The synthetic comment and review envelopes passed to the shared converter mark
+their parents open because those parents came from the `states: [OPEN]`
+connections. A response that nevertheless contains a closed work item fails
+shared conversion instead of entering the snapshot.
 
 ## Scope (prototype)
 
 - One configured GitHub organization; all repositories the token can see by
   default, or only the Source's normalized `repositories` allowlist.
 - Only currently **open** Issues and Pull Requests (no closed history).
+  Both top-level GraphQL connections use `states: [OPEN]`; every cursor page
+  reuses that same filtered query.
 - Issue/PR conversation comments and submitted or dismissed PR reviews.
 - **Excluded**: GitHub Projects and Project Items, inline diff/review
   comments, closed-item history, reactions, and workflow-run execution

--- a/components/bootstrappers/github-workgraph/README.md
+++ b/components/bootstrappers/github-workgraph/README.md
@@ -29,7 +29,9 @@ separation without duplicating any WorkGraph domain logic, this crate:
 Every node label, relation ID/direction, status-label derivation rule, and
 `WorkGraphAssignment`/`WorkGraphResult`/`WorkGraphError` comment-parsing rule
 therefore comes from the source crate, unchanged. This crate never
-re-implements any of that.
+re-implements any of that. In particular, bootstrap comments use the same
+literal closed `<details>` wrapper, exact Assignment/Result summary labels,
+LF-only spacing, typed two-space JSON, and single final LF as live webhooks.
 
 ## Scope (prototype)
 
@@ -160,6 +162,7 @@ The test suite in `src/tests.rs` runs a fake GitHub GraphQL API via
 [`wiremock`](https://docs.rs/wiremock) and verifies: multi-page cursor
 pagination, `BootstrapRequest` node/relation label filtering, exact
 `event_count`, `source_position` always being `None`, and that a
-WorkGraph Assignment comment is reconstructed into a `WorkGraphAssignment`
-node purely through the shared `Converter`/`workgraph::classify` — proving
-this crate does not duplicate that parsing logic.
+canonical WorkGraph Assignment and Result comments are reconstructed into their
+typed nodes purely through the shared `Converter`/`workgraph::classify`, while
+a malformed canonical wrapper becomes `WorkGraphError` — proving this crate
+does not duplicate that parsing logic.

--- a/components/bootstrappers/github-workgraph/README.md
+++ b/components/bootstrappers/github-workgraph/README.md
@@ -32,6 +32,11 @@ therefore comes from the source crate, unchanged. This crate never
 re-implements any of that. In particular, bootstrap comments use the same
 literal closed `<details>` wrapper, exact Assignment/Result summary labels,
 LF-only spacing, typed two-space JSON, and single final LF as live webhooks.
+Issue and Pull Request label selections alias each GraphQL label `id` to
+`node_id`; the shared converter therefore emits the same ordered
+`labelDetails: [{name, nodeId}]` property as live webhooks while retaining
+`labels`, `status`, and `statusLabel`. Missing or malformed label node IDs fail
+bootstrap rather than emit a partial identity list.
 
 ## Scope (prototype)
 
@@ -153,8 +158,9 @@ the added complexity of per-repository fan-out.
   known partial snapshot when a request or repository task fails, but upstream
   state can still change between successfully fetched pages.
 - Issue/PR labels, comments, reviews, repositories, issues, and pull requests
-  are cursor-paginated in full. Assignees and repository topics fit within
-  GitHub's resource limits and are fetched inline.
+  are cursor-paginated in full. Label pages fetch both name and GraphQL node ID,
+  without a label cache or any additional webhook-side API call. Assignees and
+  repository topics fit within GitHub's resource limits and are fetched inline.
 - Enum casing (`state`, `state_reason`, `visibility`, review `state`) is
   lowercased to match the REST/webhook convention `Converter` expects; this
   covers every enum value currently used by `mapping.rs`.

--- a/components/bootstrappers/github-workgraph/src/client.rs
+++ b/components/bootstrappers/github-workgraph/src/client.rs
@@ -102,7 +102,7 @@ query($owner: String!, $name: String!, $cursor: String, $pageSize: Int!) {
         assignees(first: 50) { nodes { login } }
         labels(first: $pageSize) {
           pageInfo { hasNextPage endCursor }
-          nodes { name }
+          nodes { name node_id: id }
         }
         comments { totalCount }
       }
@@ -133,7 +133,7 @@ query($owner: String!, $name: String!, $cursor: String, $pageSize: Int!) {
         assignees(first: 50) { nodes { login } }
         labels(first: $pageSize) {
           pageInfo { hasNextPage endCursor }
-          nodes { name }
+          nodes { name node_id: id }
         }
         draft: isDraft
         merged
@@ -156,13 +156,13 @@ query($id: ID!, $cursor: String, $pageSize: Int!) {
     ... on Issue {
       labels(first: $pageSize, after: $cursor) {
         pageInfo { hasNextPage endCursor }
-        nodes { name }
+        nodes { name node_id: id }
       }
     }
     ... on PullRequest {
       labels(first: $pageSize, after: $cursor) {
         pageInfo { hasNextPage endCursor }
-        nodes { name }
+        nodes { name node_id: id }
       }
     }
   }

--- a/components/bootstrappers/github-workgraph/src/config.rs
+++ b/components/bootstrappers/github-workgraph/src/config.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use drasi_source_github_workgraph::config::RepositoryFilter;
 use serde::{Deserialize, Serialize};
 
 /// Default GitHub GraphQL API endpoint (github.com; override for GHE).
@@ -33,6 +34,9 @@ pub const DEFAULT_PAGE_SIZE: u32 = 100;
 pub struct GitHubWorkGraphBootstrapConfig {
     /// The single GitHub organization login to enumerate.
     pub organization: String,
+    /// Canonical lowercase repository names to include. Empty means all.
+    #[serde(default)]
+    pub repositories: Vec<String>,
     /// A read-only GitHub token (PAT or GitHub App installation token).
     pub token: String,
     /// GraphQL API endpoint. Override for GitHub Enterprise Server.
@@ -46,6 +50,7 @@ impl Default for GitHubWorkGraphBootstrapConfig {
     fn default() -> Self {
         Self {
             organization: String::new(),
+            repositories: Vec::new(),
             token: String::new(),
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             max_concurrency: DEFAULT_MAX_CONCURRENCY,
@@ -69,7 +74,15 @@ impl GitHubWorkGraphBootstrapConfig {
             "api_base_url cannot be empty"
         );
         anyhow::ensure!(self.max_concurrency > 0, "max_concurrency must be > 0");
+        RepositoryFilter::new(&self.organization, &self.repositories)?;
         Ok(())
+    }
+
+    pub fn normalized(mut self) -> anyhow::Result<Self> {
+        self.validate()?;
+        self.repositories =
+            RepositoryFilter::new(&self.organization, &self.repositories)?.canonical_names();
+        Ok(self)
     }
 }
 
@@ -114,5 +127,35 @@ mod tests {
             ..GitHubWorkGraphBootstrapConfig::default()
         };
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn normalizes_repository_filter() {
+        let config = GitHubWorkGraphBootstrapConfig {
+            organization: "acme".to_string(),
+            repositories: vec![
+                "Widgets".to_string(),
+                "acme/widgets".to_string(),
+                "gadgets".to_string(),
+            ],
+            token: "t".to_string(),
+            ..GitHubWorkGraphBootstrapConfig::default()
+        }
+        .normalized()
+        .unwrap();
+
+        assert_eq!(config.repositories, vec!["gadgets", "widgets"]);
+    }
+
+    #[test]
+    fn rejects_foreign_repository_owner() {
+        let config = GitHubWorkGraphBootstrapConfig {
+            organization: "acme".to_string(),
+            repositories: vec!["other/widgets".to_string()],
+            token: "t".to_string(),
+            ..GitHubWorkGraphBootstrapConfig::default()
+        };
+
+        assert!(config.validate().is_err());
     }
 }

--- a/components/bootstrappers/github-workgraph/src/descriptor.rs
+++ b/components/bootstrappers/github-workgraph/src/descriptor.rs
@@ -33,8 +33,9 @@ fn default_max_concurrency() -> ConfigValue<usize> {
 
 /// GitHub WorkGraph bootstrap configuration DTO.
 ///
-/// The organization comes from the parent `github-workgraph` Source
-/// configuration so bootstrap and streaming always target the same graph.
+/// The organization and repository allowlist come from the parent
+/// `github-workgraph` Source configuration so bootstrap and streaming always
+/// target the same graph.
 /// `token` **must** be a read-only credential (a fine-grained PAT scoped to
 /// `Issues: Read`, `Pull requests: Read`, `Metadata: Read` on the target
 /// organization, or an equivalent read-only GitHub App installation token).
@@ -108,9 +109,11 @@ impl BootstrapPluginDescriptor for GitHubWorkGraphBootstrapDescriptor {
         let source_dto: GitHubWorkGraphSourceConfigDto =
             serde_json::from_value(source_config_json.clone())?;
         let mapper = DtoMapper::new();
+        let repositories = mapper.resolve_string_vec(&source_dto.repositories).await?;
 
         let provider = GitHubWorkGraphBootstrapProvider::builder()
             .with_organization(mapper.resolve_string(&source_dto.organization).await?)
+            .with_repositories(repositories)
             .with_token(mapper.resolve_string(&dto.token).await?)
             .with_api_base_url(mapper.resolve_string(&dto.api_base_url).await?)
             .with_max_concurrency(mapper.resolve_typed(&dto.max_concurrency).await?)
@@ -125,13 +128,14 @@ mod tests {
     use serde_json::json;
 
     #[tokio::test]
-    async fn descriptor_reads_organization_from_source_config() {
+    async fn descriptor_reads_scope_from_source_config() {
         let descriptor = GitHubWorkGraphBootstrapDescriptor;
         let provider = descriptor
             .create_bootstrap_provider(
                 &json!({ "token": "read-only-token" }),
                 &json!({
                     "organization": "acme",
+                    "repositories": ["widgets", "acme/widgets"],
                     "webhook": { "secret": "webhook-secret" }
                 }),
             )
@@ -141,5 +145,18 @@ mod tests {
         let schema = descriptor.config_schema_json();
         assert!(schema.contains("\"token\""));
         assert!(!schema.contains("\"organization\""));
+        assert!(!schema.contains("\"repositories\""));
+
+        let foreign = descriptor
+            .create_bootstrap_provider(
+                &json!({ "token": "read-only-token" }),
+                &json!({
+                    "organization": "acme",
+                    "repositories": ["other/widgets"],
+                    "webhook": { "secret": "webhook-secret" }
+                }),
+            )
+            .await;
+        assert!(foreign.is_err());
     }
 }

--- a/components/bootstrappers/github-workgraph/src/lib.rs
+++ b/components/bootstrappers/github-workgraph/src/lib.rs
@@ -323,7 +323,7 @@ async fn process_repository(
                     json!({
                         "organization": org_value,
                         "repository": repo_value,
-                        "issue": { "node_id": issue_node_id },
+                        "issue": { "node_id": issue_node_id, "state": "open" },
                         "comment": comment,
                     }),
                 )?);
@@ -368,7 +368,11 @@ async fn process_repository(
                         // `pull_request` present (even empty) is exactly the
                         // discriminator `mapping::comment_event` checks via
                         // `issue.get("pull_request").is_some()`.
-                        "issue": { "node_id": pr_node_id, "pull_request": {} },
+                        "issue": {
+                            "node_id": pr_node_id,
+                            "state": "open",
+                            "pull_request": {}
+                        },
                         "comment": comment,
                     }),
                 )?);
@@ -391,7 +395,7 @@ async fn process_repository(
                     json!({
                         "organization": org_value,
                         "repository": repo_value,
-                        "pull_request": { "node_id": pr_node_id },
+                        "pull_request": { "node_id": pr_node_id, "state": "open" },
                         "review": review,
                     }),
                 )?);

--- a/components/bootstrappers/github-workgraph/src/lib.rs
+++ b/components/bootstrappers/github-workgraph/src/lib.rs
@@ -14,9 +14,10 @@
 
 //! GitHub WorkGraph bootstrap provider.
 //!
-//! Enumerates every repository in one configured GitHub organization over the
-//! GitHub GraphQL v4 API, and snapshots each repository's currently-open
-//! Issues and Pull Requests, their conversation comments, and PR reviews.
+//! Enumerates repositories in one configured GitHub organization over the
+//! GitHub GraphQL v4 API, applies the Source's optional repository allowlist,
+//! and snapshots each selected repository's currently-open Issues and Pull
+//! Requests, their conversation comments, and PR reviews.
 //!
 //! # Reuse, not duplication
 //!
@@ -32,7 +33,8 @@
 //!
 //! # Scope (prototype)
 //!
-//! - One configured organization; all repositories the token can see.
+//! - One configured organization; all repositories the token can see by
+//!   default, or the Source's normalized repository allowlist.
 //! - Only currently-**open** Issues and Pull Requests (no closed history).
 //! - Issue/PR conversation comments and PR reviews only.
 //! - Excluded: Projects, Project Items, inline diff comments, closed-item
@@ -64,6 +66,7 @@ use drasi_lib::bootstrap::{
     BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
 };
 use drasi_lib::channels::{BootstrapEvent, BootstrapEventSender};
+use drasi_source_github_workgraph::config::RepositoryFilter;
 use drasi_source_github_workgraph::mapping::{Converter, NODE_LABELS, RELATION_LABELS};
 use log::{info, warn};
 use serde_json::{json, Value};
@@ -74,6 +77,7 @@ use tokio::task::JoinSet;
 
 pub struct GitHubWorkGraphBootstrapProvider {
     config: GitHubWorkGraphBootstrapConfig,
+    repository_filter: RepositoryFilter,
 }
 
 impl GitHubWorkGraphBootstrapProvider {
@@ -104,6 +108,11 @@ impl GitHubWorkGraphBootstrapProviderBuilder {
         self
     }
 
+    pub fn with_repositories(mut self, repositories: Vec<String>) -> Self {
+        self.config.repositories = repositories;
+        self
+    }
+
     pub fn with_api_base_url(mut self, api_base_url: impl Into<String>) -> Self {
         self.config.api_base_url = api_base_url.into();
         self
@@ -115,9 +124,11 @@ impl GitHubWorkGraphBootstrapProviderBuilder {
     }
 
     pub fn build(self) -> Result<GitHubWorkGraphBootstrapProvider> {
-        self.config.validate()?;
+        let config = self.config.normalized()?;
+        let repository_filter = RepositoryFilter::new(&config.organization, &config.repositories)?;
         Ok(GitHubWorkGraphBootstrapProvider {
-            config: self.config,
+            config,
+            repository_filter,
         })
     }
 }
@@ -144,10 +155,20 @@ impl BootstrapProvider for GitHubWorkGraphBootstrapProvider {
 
         let org_value = client.fetch_organization(&self.config.organization).await?;
         let repos = client.fetch_repositories(&self.config.organization).await?;
+        let mut selected_repos = Vec::new();
+        for repo in repos {
+            if self
+                .repository_filter
+                .includes_repository(&repo)
+                .context("GitHub repository cannot be matched against repositories filter")?
+            {
+                selected_repos.push(repo);
+            }
+        }
         info!(
-            "[{}] GitHub WorkGraph bootstrap: {} repositories in '{}'",
+            "[{}] GitHub WorkGraph bootstrap: {} selected repositories in '{}'",
             context.source_id,
-            repos.len(),
+            selected_repos.len(),
             self.config.organization
         );
 
@@ -159,7 +180,7 @@ impl BootstrapProvider for GitHubWorkGraphBootstrapProvider {
         // in sequence (issues, PRs, then per-item comments/reviews).
         let semaphore = Arc::new(Semaphore::new(self.config.max_concurrency.max(1)));
         let mut join_set = JoinSet::new();
-        for repo in repos {
+        for repo in selected_repos {
             let client = client.clone();
             let organization = self.config.organization.clone();
             let source_id = context.source_id.clone();

--- a/components/bootstrappers/github-workgraph/src/tests.rs
+++ b/components/bootstrappers/github-workgraph/src/tests.rs
@@ -39,17 +39,62 @@ const RESULT_COMMENT_NODE_ID: &str = "IC_result";
 const INVALID_COMMENT_NODE_ID: &str = "IC_invalid";
 const ORDINARY_COMMENT_NODE_ID: &str = "IC_ordinary";
 
-const ASSIGNMENT_COMMENT_BODY: &str = "WorkGraphAssignment/v1\n\
-Please validate this issue.\n\
-```json\n\
-{\"assignmentId\":\"assign-1\",\"agentProfile\":\"triage-bot\",\"priority\":1,\"taskType\":\"issue-validation\",\"task\":{\"validationProfile\":\"default\",\"criteria\":[\"title-present\"]}}\n\
-```";
+const ASSIGNMENT_COMMENT_BODY: &str = r#"<details>
+<summary>WorkGraph Assignment</summary>
 
-const RESULT_COMMENT_BODY: &str = "WorkGraphResult/v1\n\
-Validation complete.\n\
-```json\n\
-{\"assignmentId\":\"assign-1\",\"taskType\":\"issue-validation\",\"outcome\":\"succeeded\",\"summary\":\"Passed.\",\"result\":{\"criteria\":[{\"criterion\":\"title-present\",\"passed\":true,\"evidence\":\"Title is present.\"}]}}\n\
-```";
+WorkGraphAssignment/v1
+
+Validate the synthetic fixture Issue.
+
+```json
+{
+  "assignmentId": "fixture-701-validation",
+  "agentProfile": "issue-validator",
+  "priority": 10,
+  "taskType": "issue-validation",
+  "task": {
+    "validationProfile": "default",
+    "criteria": [
+      "The Issue has a non-empty title",
+      "The Issue body is present"
+    ]
+  }
+}
+```
+</details>
+"#;
+
+const RESULT_COMMENT_BODY: &str = r#"<details>
+<summary>WorkGraph Result</summary>
+
+WorkGraphResult/v1
+
+Evaluated both requested validation criteria.
+
+```json
+{
+  "assignmentId": "assignment-validation-001",
+  "taskType": "issue-validation",
+  "outcome": "succeeded",
+  "summary": "Evaluated both requested validation criteria.",
+  "result": {
+    "criteria": [
+      {
+        "criterion": "The issue defines acceptance criteria",
+        "passed": true,
+        "evidence": "The body contains an acceptance checklist."
+      },
+      {
+        "criterion": "The issue identifies an owner",
+        "passed": false,
+        "evidence": "The title and body do not identify an owner."
+      }
+    ]
+  }
+}
+```
+</details>
+"#;
 
 fn org_fixture() -> Value {
     json!({
@@ -119,7 +164,20 @@ fn invalid_comment_fixture() -> Value {
     let mut comment = assignment_comment_fixture();
     comment["node_id"] = json!(INVALID_COMMENT_NODE_ID);
     comment["id"] = json!(6003);
-    comment["body"] = json!("WorkGraphResult/v1\nInvalid payload.\n```json\nnot-json\n```");
+    comment["body"] = json!(
+        r#"<details>
+<summary>WorkGraph Result</summary>
+
+WorkGraphResult/v1
+
+Invalid payload.
+
+```json
+not-json
+```
+</details>
+"#
+    );
     comment
 }
 
@@ -380,7 +438,7 @@ async fn bootstraps_full_repository_via_shared_converter() {
         "status label must be derived by the shared mapping::derive_status, not reimplemented"
     );
 
-    let assignment_id = assignment_element_id(ORG_NODE_ID, "assign-1");
+    let assignment_id = assignment_element_id(ORG_NODE_ID, "fixture-701-validation");
     let assignment_event = events
         .iter()
         .find(|e| e.change.get_reference().element_id.as_ref() == assignment_id)
@@ -406,7 +464,10 @@ async fn bootstraps_full_repository_via_shared_converter() {
         panic!("RESULT_FOR must be an inserted relation");
     };
     assert_eq!(in_node.element_id.as_ref(), RESULT_COMMENT_NODE_ID);
-    assert_eq!(out_node.element_id.as_ref(), assignment_id);
+    assert_eq!(
+        out_node.element_id.as_ref(),
+        assignment_element_id(ORG_NODE_ID, "assignment-validation-001")
+    );
 
     let error_id = comment_error_element_id(INVALID_COMMENT_NODE_ID);
     let error_event = events

--- a/components/bootstrappers/github-workgraph/src/tests.rs
+++ b/components/bootstrappers/github-workgraph/src/tests.rs
@@ -25,7 +25,7 @@ use crate::GitHubWorkGraphBootstrapProvider;
 use drasi_core::models::{Element, ElementValue, SourceChange};
 use drasi_lib::bootstrap::{BootstrapContext, BootstrapProvider, BootstrapRequest};
 use drasi_lib::channels::BootstrapEvent;
-use drasi_source_github_workgraph::mapping::{NODE_ISSUE, NODE_ORGANIZATION};
+use drasi_source_github_workgraph::mapping::{NODE_ISSUE, NODE_ORGANIZATION, NODE_PULL_REQUEST};
 use drasi_source_github_workgraph::workgraph::{assignment_element_id, comment_error_element_id};
 use serde_json::{json, Value};
 use wiremock::matchers::{body_string_contains, method, path};
@@ -142,7 +142,7 @@ fn issue_fixture() -> Value {
         "assignees": { "nodes": [{ "login": "ada" }] },
         "labels": {
             "pageInfo": { "hasNextPage": true, "endCursor": "LABEL_PAGE_2" },
-            "nodes": [{ "name": "bug" }]
+            "nodes": [{ "name": "bug", "node_id": "L_bug" }]
         },
         "comments": { "totalCount": 4 },
     })
@@ -216,7 +216,7 @@ fn pr_fixture() -> Value {
         "assignees": { "nodes": [] },
         "labels": {
             "pageInfo": { "hasNextPage": false, "endCursor": null },
-            "nodes": []
+            "nodes": [{ "name": "enhancement", "node_id": "L_enhancement" }]
         },
         "draft": false,
         "merged": false,
@@ -288,23 +288,27 @@ async fn mount_full_fixture(server: &MockServer) {
     .await;
     mount_query(
         server,
-        &["issues(first"],
+        &["issues(first", "nodes { name node_id: id }"],
         json!({ "repository": { "issues": connection(vec![issue_fixture()], false, None) } }),
         None,
     )
     .await;
     mount_query(
         server,
-        &["pullRequests(first"],
+        &["pullRequests(first", "nodes { name node_id: id }"],
         json!({ "repository": { "pullRequests": connection(vec![pr_fixture()], false, None) } }),
         None,
     )
     .await;
     mount_query(
         server,
-        &["labels(first: $pageSize", "\"cursor\":\"LABEL_PAGE_2\""],
+        &[
+            "labels(first: $pageSize",
+            "nodes { name node_id: id }",
+            "\"cursor\":\"LABEL_PAGE_2\"",
+        ],
         json!({ "node": { "labels": connection(
-            vec![json!({ "name": "status:in-progress" })],
+            vec![json!({ "name": "status:in-progress", "node_id": "L_status_in_progress" })],
             false,
             None,
         ) } }),
@@ -490,6 +494,27 @@ async fn bootstraps_full_repository_via_shared_converter() {
         &drasi_core::models::ElementValue::from(&json!("status:in-progress")),
         "status label must be derived by the shared mapping::derive_status, not reimplemented"
     );
+    assert_eq!(
+        element.get_property("labelDetails"),
+        &ElementValue::from(&json!([
+            {"name":"bug","nodeId":"L_bug"},
+            {"name":"status:in-progress","nodeId":"L_status_in_progress"}
+        ])),
+        "bootstrap must expose the same ordered label name/node-ID pairs as live mapping"
+    );
+    let pr_event = events
+        .iter()
+        .find(|event| label_of(event) == NODE_PULL_REQUEST)
+        .expect("pull request node present");
+    let SourceChange::Insert { element } = &pr_event.change else {
+        panic!("pull request must be an Insert");
+    };
+    assert_eq!(
+        element.get_property("labelDetails"),
+        &ElementValue::from(&json!([
+            {"name":"enhancement","nodeId":"L_enhancement"}
+        ]))
+    );
 
     let assignment_id = assignment_element_id(ORG_NODE_ID, "fixture-701-validation");
     let assignment_event = events
@@ -662,6 +687,56 @@ async fn paginates_repositories_across_multiple_pages() {
     assert_eq!(repo_ids.len(), 2);
     assert!(repo_ids.contains(REPO_NODE_ID));
     assert!(repo_ids.contains("R_repo2"));
+}
+
+#[tokio::test]
+async fn bootstrap_rejects_labels_without_graphql_node_ids() {
+    let server = MockServer::start().await;
+    mount_query(
+        &server,
+        &["avatar_url: avatarUrl"],
+        json!({ "organization": org_fixture() }),
+        Some(1),
+    )
+    .await;
+    mount_query(
+        &server,
+        &["repositories(first"],
+        json!({ "organization": { "repositories": connection(vec![repo_fixture()], false, None) } }),
+        Some(1),
+    )
+    .await;
+    let mut issue = issue_fixture();
+    issue["labels"]["pageInfo"] = json!({ "hasNextPage": false, "endCursor": null });
+    issue["labels"]["nodes"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("node_id");
+    issue["comments"]["totalCount"] = json!(0);
+    mount_query(
+        &server,
+        &["issues(first", "nodes { name node_id: id }"],
+        json!({ "repository": { "issues": connection(vec![issue], false, None) } }),
+        Some(1),
+    )
+    .await;
+
+    let provider = provider_for(&server);
+    let context = BootstrapContext::new_minimal("test-server".to_string(), "gh-src".to_string());
+    let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+    let error = provider
+        .bootstrap(all_labels_request(), &context, tx, None)
+        .await
+        .expect_err("a label without a GraphQL node ID must fail bootstrap");
+
+    assert!(
+        format!("{error:#}").contains("'labels[0].node_id' must be nonempty text"),
+        "unexpected bootstrap error: {error:#}"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "invalid label identity must not emit a partial snapshot"
+    );
 }
 
 #[tokio::test]

--- a/components/bootstrappers/github-workgraph/src/tests.rs
+++ b/components/bootstrappers/github-workgraph/src/tests.rs
@@ -53,11 +53,7 @@ Validate the synthetic fixture Issue.
   "priority": 10,
   "taskType": "issue-validation",
   "task": {
-    "validationProfile": "default",
-    "criteria": [
-      "The Issue has a non-empty title",
-      "The Issue body is present"
-    ]
+    "validationProfile": "new-issue-default"
   }
 }
 ```

--- a/components/bootstrappers/github-workgraph/src/tests.rs
+++ b/components/bootstrappers/github-workgraph/src/tests.rs
@@ -288,14 +288,22 @@ async fn mount_full_fixture(server: &MockServer) {
     .await;
     mount_query(
         server,
-        &["issues(first", "nodes { name node_id: id }"],
+        &[
+            "issues(first",
+            "states: [OPEN]",
+            "nodes { name node_id: id }",
+        ],
         json!({ "repository": { "issues": connection(vec![issue_fixture()], false, None) } }),
         None,
     )
     .await;
     mount_query(
         server,
-        &["pullRequests(first", "nodes { name node_id: id }"],
+        &[
+            "pullRequests(first",
+            "states: [OPEN]",
+            "nodes { name node_id: id }",
+        ],
         json!({ "repository": { "pullRequests": connection(vec![pr_fixture()], false, None) } }),
         None,
     )
@@ -690,6 +698,75 @@ async fn paginates_repositories_across_multiple_pages() {
 }
 
 #[tokio::test]
+async fn open_state_filter_is_reused_for_every_issue_and_pr_page() {
+    let server = MockServer::start().await;
+    mount_query(
+        &server,
+        &["avatar_url: avatarUrl"],
+        json!({ "organization": org_fixture() }),
+        Some(1),
+    )
+    .await;
+    mount_query(
+        &server,
+        &["repositories(first"],
+        json!({ "organization": { "repositories": connection(vec![repo_fixture()], false, None) } }),
+        Some(1),
+    )
+    .await;
+
+    mount_query(
+        &server,
+        &["issues(first", "states: [OPEN]", "\"cursor\":null"],
+        json!({ "repository": {
+            "issues": connection(vec![], true, Some("ISSUE_PAGE_2"))
+        } }),
+        Some(1),
+    )
+    .await;
+    mount_query(
+        &server,
+        &[
+            "issues(first",
+            "states: [OPEN]",
+            "\"cursor\":\"ISSUE_PAGE_2\"",
+        ],
+        json!({ "repository": {
+            "issues": connection(vec![], false, None)
+        } }),
+        Some(1),
+    )
+    .await;
+    mount_query(
+        &server,
+        &["pullRequests(first", "states: [OPEN]", "\"cursor\":null"],
+        json!({ "repository": {
+            "pullRequests": connection(vec![], true, Some("PR_PAGE_2"))
+        } }),
+        Some(1),
+    )
+    .await;
+    mount_query(
+        &server,
+        &[
+            "pullRequests(first",
+            "states: [OPEN]",
+            "\"cursor\":\"PR_PAGE_2\"",
+        ],
+        json!({ "repository": {
+            "pullRequests": connection(vec![], false, None)
+        } }),
+        Some(1),
+    )
+    .await;
+
+    let provider = provider_for(&server);
+    let (result, events) = run_bootstrap(&provider, all_labels_request()).await;
+    assert_eq!(result.event_count, 3);
+    assert_eq!(result.event_count, events.len());
+}
+
+#[tokio::test]
 async fn bootstrap_rejects_labels_without_graphql_node_ids() {
     let server = MockServer::start().await;
     mount_query(
@@ -736,6 +813,53 @@ async fn bootstrap_rejects_labels_without_graphql_node_ids() {
     assert!(
         rx.try_recv().is_err(),
         "invalid label identity must not emit a partial snapshot"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_rejects_closed_item_returned_by_open_filter() {
+    let server = MockServer::start().await;
+    mount_query(
+        &server,
+        &["avatar_url: avatarUrl"],
+        json!({ "organization": org_fixture() }),
+        Some(1),
+    )
+    .await;
+    mount_query(
+        &server,
+        &["repositories(first"],
+        json!({ "organization": { "repositories": connection(vec![repo_fixture()], false, None) } }),
+        Some(1),
+    )
+    .await;
+    let mut issue = issue_fixture();
+    issue["state"] = json!("CLOSED");
+    issue["labels"]["pageInfo"] = json!({ "hasNextPage": false, "endCursor": null });
+    issue["comments"]["totalCount"] = json!(0);
+    mount_query(
+        &server,
+        &["issues(first", "states: [OPEN]"],
+        json!({ "repository": { "issues": connection(vec![issue], false, None) } }),
+        Some(1),
+    )
+    .await;
+
+    let provider = provider_for(&server);
+    let context = BootstrapContext::new_minimal("test-server".to_string(), "gh-src".to_string());
+    let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+    let error = provider
+        .bootstrap(all_labels_request(), &context, tx, None)
+        .await
+        .expect_err("a closed item from an OPEN-filtered query must fail bootstrap");
+
+    assert!(
+        format!("{error:#}").contains("'issue.state' must be 'open' for action 'opened'"),
+        "unexpected bootstrap error: {error:#}"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "a violated OPEN invariant must not emit a partial snapshot"
     );
 }
 

--- a/components/bootstrappers/github-workgraph/src/tests.rs
+++ b/components/bootstrappers/github-workgraph/src/tests.rs
@@ -337,13 +337,70 @@ async fn mount_full_fixture(server: &MockServer) {
 }
 
 fn provider_for(server: &MockServer) -> GitHubWorkGraphBootstrapProvider {
+    provider_for_repositories(server, Vec::new())
+}
+
+fn provider_for_repositories(
+    server: &MockServer,
+    repositories: Vec<String>,
+) -> GitHubWorkGraphBootstrapProvider {
     GitHubWorkGraphBootstrapProvider::builder()
         .with_organization("acme")
+        .with_repositories(repositories)
         .with_token("read-only-test-token")
         .with_api_base_url(format!("{}/graphql", server.uri()))
         .with_max_concurrency(2)
         .build()
         .expect("valid config")
+}
+
+#[tokio::test]
+async fn empty_repository_filter_preserves_all_repository_bootstrap() {
+    let server = MockServer::start().await;
+    mount_full_fixture(&server).await;
+    let provider = provider_for_repositories(&server, Vec::new());
+
+    let (result, events) = run_bootstrap(&provider, all_labels_request()).await;
+
+    assert_eq!(result.event_count, 18);
+    assert_eq!(result.event_count, events.len());
+}
+
+#[tokio::test]
+async fn repository_filter_matches_streaming_scope_before_child_fetches() {
+    let included_server = MockServer::start().await;
+    mount_full_fixture(&included_server).await;
+    let provider = provider_for_repositories(
+        &included_server,
+        vec![
+            "ACME/Widgets".to_string(),
+            "widgets".to_string(),
+            "WIDGETS".to_string(),
+        ],
+    );
+    let (included, events) = run_bootstrap(&provider, all_labels_request()).await;
+    assert_eq!(included.event_count, 18);
+    assert_eq!(included.event_count, events.len());
+
+    let excluded_server = MockServer::start().await;
+    mount_query(
+        &excluded_server,
+        &["avatar_url: avatarUrl"],
+        json!({ "organization": org_fixture() }),
+        Some(1),
+    )
+    .await;
+    mount_query(
+        &excluded_server,
+        &["repositories(first"],
+        json!({ "organization": { "repositories": connection(vec![repo_fixture()], false, None) } }),
+        Some(1),
+    )
+    .await;
+    let provider = provider_for_repositories(&excluded_server, vec!["gadgets".to_string()]);
+    let (excluded, events) = run_bootstrap(&provider, all_labels_request()).await;
+    assert_eq!(excluded.event_count, 0);
+    assert!(events.is_empty());
 }
 
 fn all_labels_request() -> BootstrapRequest {

--- a/components/sources/github-workgraph/Cargo.toml
+++ b/components/sources/github-workgraph/Cargo.toml
@@ -49,6 +49,7 @@ subtle = "2"
 tokio = { version = "1.0", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
+drasi-query-cypher.workspace = true
 drasi-state-store-redb = { path = "../../state_stores/redb" }
 drasi-wal-redb = { path = "../../wals/redb" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }

--- a/components/sources/github-workgraph/README.md
+++ b/components/sources/github-workgraph/README.md
@@ -95,11 +95,7 @@ Validate the synthetic fixture Issue.
   "priority": 10,
   "taskType": "issue-validation",
   "task": {
-    "validationProfile": "default",
-    "criteria": [
-      "The Issue has a non-empty title",
-      "The Issue body is present"
-    ]
+    "validationProfile": "new-issue-default"
   }
 }
 ```
@@ -124,11 +120,17 @@ the marker supplies the version.
 | Type | Strict required JSON |
 |---|---|
 | Assignment | non-empty `assignmentId`, non-empty `agentProfile`, integer `priority >= 0`, `taskType`, typed `task` |
-| validation task | `validationProfile`, non-empty `criteria` array of non-empty strings |
+| validation task | one non-empty `validationProfile`; criteria resolve from `.github/workgraph/profiles/issue-validation/<validationProfile>.md` |
 | risk task | `riskProfile`, non-empty `dimensions` array of non-empty strings |
 | Result | non-empty `assignmentId`, `taskType`, `outcome` (`succeeded`, `failed`, `blocked`), non-empty `summary`, typed `result` |
 | validation result | non-empty `criteria` array of `{criterion, passed, evidence}` |
 | risk result | non-empty `dimensions` array of `{dimension, score: 0..=100, rationale}` |
+
+An issue-validation Assignment carries only the profile name. Core does not
+resolve repository profile files; the agent/reporter reads
+`.github/workgraph/profiles/issue-validation/<validationProfile>.md`. A legacy
+`task.criteria` field is rejected as unknown. Result criterion entries are
+unchanged.
 
 `taskType` is `issue-validation` or `issue-risk-profile`. There is no
 `assignedBy` or `resultId`. A Result's immutable comment ID is its identity;

--- a/components/sources/github-workgraph/README.md
+++ b/components/sources/github-workgraph/README.md
@@ -114,8 +114,8 @@ payload, including field order. CRLF, literal `\n` separators, compact JSON,
 additional or mismatched fences, wrapper attributes, missing or extra blank
 lines, prose outside the wrapper, and missing or extra final LFs are invalid.
 The Result human summary and typed `summary` field must not contain
-`WorkGraphResult/v1`, even as a substring. Every object rejects unknown fields;
-the marker supplies the version.
+`WorkGraphResult/v1`, even as a substring, and they must byte-equal each other.
+Every object rejects unknown fields; the marker supplies the version.
 
 | Type | Strict required JSON |
 |---|---|

--- a/components/sources/github-workgraph/README.md
+++ b/components/sources/github-workgraph/README.md
@@ -117,7 +117,9 @@ The fenced object must equal the canonical two-space serialization of the typed
 payload, including field order. CRLF, literal `\n` separators, compact JSON,
 additional or mismatched fences, wrapper attributes, missing or extra blank
 lines, prose outside the wrapper, and missing or extra final LFs are invalid.
-Every object rejects unknown fields; the marker supplies the version.
+The Result human summary and typed `summary` field must not contain
+`WorkGraphResult/v1`, even as a substring. Every object rejects unknown fields;
+the marker supplies the version.
 
 | Type | Strict required JSON |
 |---|---|

--- a/components/sources/github-workgraph/README.md
+++ b/components/sources/github-workgraph/README.md
@@ -12,6 +12,8 @@ id: github-workgraph
 kind: github-workgraph
 autoStart: true
 organization: drasi-project
+repositories:
+  - drasi-workgraph-demo
 webhook:
   host: 0.0.0.0
   port: 8080
@@ -26,14 +28,23 @@ durability:
   capacityPolicy: RejectIncoming
 ```
 
-`organization` is one login; there is no repository, Project, token, or API
-scope. The secret is a `SecretReference`, the path is static, durability uses
+`organization` is one login. `repositories` is optional: omitted or empty means
+all repositories in that organization. Each entry is either a bare repository
+name (`drasi-workgraph-demo`) or a full `owner/name`; a full owner must match
+`organization` case-insensitively. Names are case-insensitive, limited to 100
+ASCII letters, digits, `.`, `-`, or `_`, and normalized to sorted, deduplicated
+lowercase bare names. Malformed entries and foreign owners are rejected. The
+secret is a `SecretReference`, the path is static, durability uses
 `RejectIncoming`, and unknown or obsolete fields are rejected.
 
 Create one organization webhook using `application/json` and the same secret for
 `repository`, `issues`, `issue_comment`, `pull_request`, and
 `pull_request_review`. Other families, including inline comments and Projects,
-are ignored.
+are ignored. Filtering is stateless: each supported delivery carries its
+repository metadata, so an excluded repository returns `204` before any WAL or
+delivery-dedupe write. Transfers and repository renames use the old/new
+repository metadata in that delivery to emit only the in-scope side. The Source
+does not call GitHub or maintain a repository cache.
 
 ## Graph contract
 

--- a/components/sources/github-workgraph/README.md
+++ b/components/sources/github-workgraph/README.md
@@ -55,7 +55,7 @@ remain null. GitHub IDs are global payload `node_id` values.
 |---|---|---|
 | `GitHubOrganization` | `organization.node_id` | `nodeId`, `databaseId`, `login`, `url`, `avatarUrl`, `description` |
 | `GitHubRepository` | `repository.node_id` | identity/name/owner, URL, privacy/archive/fork/visibility, default branch, topics, timestamps |
-| `GitHubIssue` | `issue.node_id` | identity/number/title/body/bodyDigest/state/stateReason/lock/timestamps, author, URL, repository, assignees, labels, status |
+| `GitHubIssue` | `issue.node_id` | identity/number/title/body/bodyDigest/state/stateReason/lock/timestamps, author, URL, repository, assignees, labels, labelDetails, status/statusLabel |
 | `GitHubPullRequest` | `pull_request.node_id` | Issue fields except `stateReason`, plus draft/merge and head/base ref/SHA |
 | `GitHubIssueComment`, `GitHubPullRequestComment` | `comment.node_id` | identity/body/timestamps/isEdited, author, URL, repository |
 | `GitHubPullRequestReview` | `review.node_id` | identity/state/body/submittedAt/commitId, author, URL, repository |
@@ -68,6 +68,39 @@ remain null. GitHub IDs are global payload `node_id` values.
 `encode` leaves ASCII alphanumerics and `-._~` literal and encodes every other
 UTF-8 byte as uppercase `%HH`. Reviews use `submittedAt`; no timestamp is
 fabricated.
+
+`labels` remains the ordered list of label names. `labelDetails` is the same
+ordered list with generic paired GitHub identity:
+
+```json
+[
+  {
+    "name": "bug",
+    "nodeId": "LA_kwDO..."
+  }
+]
+```
+
+The list-of-map value is directly consumable by Drasi Cypher. To preserve every
+current non-status label and prepend the configured `status:awaitingValidation`
+GraphQL node ID, use:
+
+```cypher
+coll.insert(
+  [label IN issue.labelDetails
+   WHERE NOT (label.name STARTS WITH 'status:')
+   | label.nodeId],
+  0,
+  $awaitingValidationLabelId
+)
+```
+
+`coll.insert` is used because the supported dialect does not concatenate lists
+with `+`. Webhook Issue/PR label objects already carry both fields, so this adds
+no API call or cache. A present `labels` array is rejected as a payload-shape
+error unless every entry has a nonempty string `name` and `node_id`; omitting the
+whole field on a partial update still leaves all label-derived properties
+unchanged.
 
 | Relation and direction | Stable ID |
 |---|---|
@@ -159,7 +192,7 @@ The exact case-sensitive `status:` prefix derives Issue/PR workflow status:
 zero matches sets `status`/`statusLabel` null and deletes any prior error; one
 sets suffix/full label and deletes the error; multiple set both null and upsert
 a deterministic error plus `ERROR_ON`. A missing `labels` array changes none of
-those fields.
+`labels`, `labelDetails`, `status`, or `statusLabel`.
 
 Ingress verifies raw-body `X-Hub-Signature-256`, validates and converts, then
 serially appends every `SourceChange` to the existing WAL before storing the

--- a/components/sources/github-workgraph/README.md
+++ b/components/sources/github-workgraph/README.md
@@ -44,7 +44,11 @@ are ignored. Filtering is stateless: each supported delivery carries its
 repository metadata, so an excluded repository returns `204` before any WAL or
 delivery-dedupe write. Transfers and repository renames use the old/new
 repository metadata in that delivery to emit only the in-scope side. The Source
-does not call GitHub or maintain a repository cache.
+does not call GitHub or maintain a repository cache. The only filter exception
+is an idempotent Issue/PR `closed` (or Issue `deleted`) tombstone: it is emitted
+even when the delivery's current repository name is excluded, so an item
+projected before a repository rename can still be removed. This exception emits
+deletes only and cannot introduce out-of-scope graph state.
 
 ## Graph contract
 
@@ -119,6 +123,35 @@ Repository and work-item actions upsert/update/delete their nodes, parent
 relations, and status state. Comment edits classify `changes.body.from` and the
 new body: changing Assignment ID replaces its node, while changing a Result's
 Assignment moves only `RESULT_FOR`. Review submit inserts; edit/dismiss updates.
+
+### Open-only work-item projection
+
+Only open Issues and Pull Requests are query-visible. `opened` and `reopened`
+deliveries insert the complete work-item node and its deterministic
+`IN_REPOSITORY` relation from payload data. A `closed` delivery deletes any
+deterministic status error and `ERROR_ON`, then deletes `IN_REPOSITORY` and the
+Issue/PR node. `deleted` and the old side of an Issue transfer use the same
+tombstone path. A transferred Issue is inserted on the new side only when the
+new Issue payload has `state: open`.
+
+Other Issue/PR actions are ignored when the payload state is closed.
+`issue_comment` deliveries (for both Issues and PR conversations) and
+`pull_request_review` deliveries are processed only when their embedded parent
+has `state: open`. Missing or unknown parent state is a payload-shape error.
+Every required state is present in GitHub's webhook payload; no GitHub API call,
+Issue/PR cache, or repository cache is used.
+
+Issue `pinned`/`unpinned` deliveries are ignored: the graph has no pin property,
+and GitHub's payload for those actions does not guarantee parent `state`.
+
+Closing a parent does not enumerate or delete its comment/review nodes or
+`COMMENT_ON`/`REVIEW_OF` relations because their IDs are not included in the
+close delivery. The absent parent makes those paths non-matchable, so active
+query rows retract. Reopening reinserts the same globally identified parent,
+which makes pre-existing child paths match again. Child deliveries received
+while the parent is closed are intentionally ignored, so closed-period child
+edits, deletions, or additions are not reflected until a later bootstrap. This
+is the explicit payload-only, cache-free prototype behavior.
 
 ## WorkGraph comments
 

--- a/components/sources/github-workgraph/README.md
+++ b/components/sources/github-workgraph/README.md
@@ -80,22 +80,44 @@ Assignment moves only `RESULT_FOR`. Review submit inserts; edit/dismiss updates.
 
 Only Issue/PR conversation comments are classified. The envelope is exact:
 
-````text
+````markdown
+<details>
+<summary>WorkGraph Assignment</summary>
+
 WorkGraphAssignment/v1
 
-Brief non-empty human summary.
+Validate the synthetic fixture Issue.
 
 ```json
-{ "assignmentId": "a-42", "agentProfile": "validator", "priority": 10,
+{
+  "assignmentId": "fixture-701-validation",
+  "agentProfile": "issue-validator",
+  "priority": 10,
   "taskType": "issue-validation",
-  "task": { "validationProfile": "default", "criteria": ["Reproduces"] } }
+  "task": {
+    "validationProfile": "default",
+    "criteria": [
+      "The Issue has a non-empty title",
+      "The Issue body is present"
+    ]
+  }
+}
 ```
+</details>
 ````
 
-The first line is `WorkGraphAssignment/v1` or `WorkGraphResult/v1`; another
-version after either family prefix is invalid. Exactly one ` ```json ` object,
-one closing ` ``` `, and only trailing whitespace are allowed. Every object
-rejects unknown fields; the marker supplies the version.
+Result comments use `<summary>WorkGraph Result</summary>` and
+`WorkGraphResult/v1`. The opening tag is literal `<details>` with no attributes,
+so GitHub collapses the body by default. Every separator is LF: there is one LF
+after the opening and summary lines, one blank line after the summary label,
+marker, and one-line non-empty human summary, and exactly one final LF after
+`</details>`.
+
+The fenced object must equal the canonical two-space serialization of the typed
+payload, including field order. CRLF, literal `\n` separators, compact JSON,
+additional or mismatched fences, wrapper attributes, missing or extra blank
+lines, prose outside the wrapper, and missing or extra final LFs are invalid.
+Every object rejects unknown fields; the marker supplies the version.
 
 | Type | Strict required JSON |
 |---|---|

--- a/components/sources/github-workgraph/src/config.rs
+++ b/components/sources/github-workgraph/src/config.rs
@@ -16,6 +16,8 @@ use anyhow::{ensure, Result};
 use drasi_lib::wal::CapacityPolicy;
 use drasi_lib::DurabilityConfig;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeSet;
 
 fn default_max_events() -> u64 {
     DurabilityConfig::default().max_events
@@ -37,6 +39,82 @@ pub(crate) struct DurabilityConfigDef {
 }
 
 pub const DEFAULT_BODY_LIMIT_BYTES: usize = 25 * 1024 * 1024;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RepositoryFilter {
+    names: BTreeSet<String>,
+}
+
+impl RepositoryFilter {
+    pub fn new(organization: &str, repositories: &[String]) -> Result<Self> {
+        let mut names = BTreeSet::new();
+        for (index, entry) in repositories.iter().enumerate() {
+            ensure!(
+                entry.trim() == entry && !entry.is_empty(),
+                "repositories[{index}] must be a non-empty repository name without surrounding whitespace"
+            );
+            let parts: Vec<_> = entry.split('/').collect();
+            let name = match parts.as_slice() {
+                [name] => *name,
+                [owner, name] => {
+                    ensure!(
+                        owner.eq_ignore_ascii_case(organization),
+                        "repositories[{index}] owner '{owner}' does not match configured organization '{organization}'"
+                    );
+                    *name
+                }
+                _ => {
+                    anyhow::bail!(
+                        "repositories[{index}] must be a repository name or 'organization/name'"
+                    )
+                }
+            };
+            ensure!(
+                !name.is_empty() && name != "." && name != "..",
+                "repositories[{index}] has an invalid repository name"
+            );
+            ensure!(
+                name.len() <= 100
+                    && name
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || b"-._".contains(&byte)),
+                "repositories[{index}] repository name must be at most 100 ASCII letters, digits, '.', '-', or '_'"
+            );
+            names.insert(name.to_ascii_lowercase());
+        }
+        Ok(Self { names })
+    }
+
+    pub fn includes_all(&self) -> bool {
+        self.names.is_empty()
+    }
+
+    pub fn includes_name(&self, name: &str) -> bool {
+        self.includes_all() || self.names.contains(&name.to_ascii_lowercase())
+    }
+
+    pub fn includes_repository(&self, repository: &Value) -> Result<bool> {
+        if self.includes_all() {
+            return Ok(true);
+        }
+        let name = repository
+            .get("name")
+            .and_then(Value::as_str)
+            .or_else(|| {
+                repository
+                    .get("full_name")
+                    .and_then(Value::as_str)
+                    .and_then(|full_name| full_name.split_once('/').map(|(_, name)| name))
+            })
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("repository has no non-empty 'name' or 'full_name'"))?;
+        Ok(self.includes_name(name))
+    }
+
+    pub fn canonical_names(&self) -> Vec<String> {
+        self.names.iter().cloned().collect()
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
@@ -64,6 +142,8 @@ impl Default for WebhookConfig {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct GitHubWorkGraphSourceConfig {
     pub organization: String,
+    #[serde(default)]
+    pub repositories: Vec<String>,
     pub webhook: WebhookConfig,
     #[serde(default, with = "DurabilityConfigDef")]
     pub durability: DurabilityConfig,
@@ -73,6 +153,7 @@ impl Default for GitHubWorkGraphSourceConfig {
     fn default() -> Self {
         Self {
             organization: String::new(),
+            repositories: Vec::new(),
             webhook: WebhookConfig::default(),
             durability: DurabilityConfig {
                 enabled: true,
@@ -105,6 +186,18 @@ impl GitHubWorkGraphSourceConfig {
             self.durability.capacity_policy == CapacityPolicy::RejectIncoming,
             "durability.capacityPolicy must be RejectIncoming"
         );
+        RepositoryFilter::new(org, &self.repositories)?;
         Ok(())
+    }
+
+    pub fn normalized(mut self) -> Result<Self> {
+        self.validate()?;
+        self.repositories =
+            RepositoryFilter::new(&self.organization, &self.repositories)?.canonical_names();
+        Ok(self)
+    }
+
+    pub fn repository_filter(&self) -> Result<RepositoryFilter> {
+        RepositoryFilter::new(&self.organization, &self.repositories)
     }
 }

--- a/components/sources/github-workgraph/src/descriptor.rs
+++ b/components/sources/github-workgraph/src/descriptor.rs
@@ -24,6 +24,9 @@ use utoipa::OpenApi;
 pub struct GitHubWorkGraphSourceConfigDto {
     #[schema(value_type = ConfigValueString)]
     pub organization: ConfigValueString,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schema(value_type = Vec<ConfigValueString>)]
+    pub repositories: Vec<ConfigValueString>,
     pub webhook: WebhookConfigDto,
     #[serde(default, with = "crate::config::DurabilityConfigDef")]
     #[schema(value_type = DurabilityConfigSchema)]
@@ -120,8 +123,10 @@ impl SourcePluginDescriptor for GitHubWorkGraphSourceDescriptor {
             _ => anyhow::bail!("'webhook.secret' must use SecretReference"),
         }
         let mapper = DtoMapper::new();
+        let repositories = mapper.resolve_string_vec(&dto.repositories).await?;
         let config = GitHubWorkGraphSourceConfig {
             organization: mapper.resolve_string(&dto.organization).await?,
+            repositories,
             webhook: WebhookConfig {
                 host: mapper.resolve_string(&dto.webhook.host).await?,
                 port: mapper.resolve_typed(&dto.webhook.port).await?,

--- a/components/sources/github-workgraph/src/mapping.rs
+++ b/components/sources/github-workgraph/src/mapping.rs
@@ -64,8 +64,8 @@ const SUPPORTED_EVENTS: &str = "repository issues issue_comment pull_request pul
 const REPOSITORY_ACTIONS: &str = "created edited renamed archived unarchived privatized \
      publicized deleted transferred";
 const ISSUE_ACTIONS: &str = "opened deleted transferred assigned closed demilestoned edited \
-     field_added field_removed labeled locked milestoned pinned reopened typed unassigned \
-     unlabeled unlocked unpinned untyped";
+     field_added field_removed labeled locked milestoned reopened typed unassigned unlabeled \
+     unlocked untyped";
 const ISSUE_COMMENT_ACTIONS: &str = "created edited deleted pinned unpinned";
 const PULL_REQUEST_ACTIONS: &str = "opened assigned auto_merge_disabled auto_merge_enabled \
      closed converted_to_draft demilestoned dequeued edited enqueued labeled locked milestoned \
@@ -168,6 +168,9 @@ impl<'a> Converter<'a> {
         if !self.delivery_in_scope(event_type, action, payload)? {
             return Ok(None);
         }
+        if !self.delivery_projects_open(event_type, action, payload)? {
+            return Ok(None);
+        }
         let d = &Delivery {
             action,
             payload,
@@ -193,6 +196,11 @@ impl<'a> Converter<'a> {
         let Some(filter) = self.repository_filter else {
             return Ok(true);
         };
+        if (event_type == "issues" && in_table("closed deleted", action))
+            || (event_type == "pull_request" && action == "closed")
+        {
+            return Ok(true);
+        }
         let current = self.repository_in_scope(payload.get("repository"))?;
         if event_type == "issues" && action == "transferred" {
             if current {
@@ -211,6 +219,45 @@ impl<'a> Converter<'a> {
             return Ok(current || previous);
         }
         Ok(current)
+    }
+
+    fn delivery_projects_open(
+        &self,
+        event_type: &str,
+        action: &str,
+        payload: &Value,
+    ) -> Result<bool, ConvertError> {
+        match event_type {
+            "repository" => Ok(true),
+            "issues" if in_table("closed deleted transferred", action) => Ok(true),
+            "pull_request" if action == "closed" => Ok(true),
+            "issues" => work_item_action_projects_open(
+                action,
+                payload
+                    .get("issue")
+                    .ok_or_else(|| invalid("missing 'issue'"))?,
+                "issue",
+            ),
+            "pull_request" => work_item_action_projects_open(
+                action,
+                payload
+                    .get("pull_request")
+                    .ok_or_else(|| invalid("missing 'pull_request'"))?,
+                "pull_request",
+            ),
+            "issue_comment" => item_is_open(
+                payload
+                    .get("issue")
+                    .ok_or_else(|| invalid("missing 'issue'"))?,
+                "issue",
+            ),
+            _ => item_is_open(
+                payload
+                    .get("pull_request")
+                    .ok_or_else(|| invalid("missing 'pull_request'"))?,
+                "pull_request",
+            ),
+        }
     }
 
     fn repository_in_scope(&self, repository: Option<&Value>) -> Result<bool, ConvertError> {
@@ -301,8 +348,8 @@ impl<'a> Converter<'a> {
         let repo = payload.get("repository");
         let repo_id = required_str(payload, "/repository/node_id")?;
         match action {
-            "deleted" => delete_work_item(cs, &item_id, &repo_id, label),
-            "opened" => insert_work_item(cs, item, repo, &item_id, &repo_id, label)?,
+            "closed" | "deleted" => delete_work_item(cs, &item_id, &repo_id, label),
+            "opened" | "reopened" => insert_work_item(cs, item, repo, &item_id, &repo_id, label)?,
             "transferred" => {
                 if owner_in_org(repo, self.organization) && self.repository_in_scope(repo)? {
                     delete_work_item(cs, &item_id, &repo_id, label);
@@ -315,6 +362,7 @@ impl<'a> Converter<'a> {
                 };
                 if owner_in_org(Some(new_repo), self.organization)
                     && self.repository_in_scope(Some(new_repo))?
+                    && item_is_open(new_item, "changes.new_issue")?
                 {
                     let new_id = required_str(new_item, "/node_id")?;
                     let new_repo_id = required_str(new_repo, "/node_id")?;
@@ -626,6 +674,30 @@ fn names<'a>(container: &'a Value, key: &str, field: &'a str) -> Option<Vec<&'a 
             .filter_map(|item| item.get(field).and_then(Value::as_str))
             .collect(),
     )
+}
+
+fn item_is_open(item: &Value, path: &str) -> Result<bool, ConvertError> {
+    match item.get("state").and_then(Value::as_str) {
+        Some("open") => Ok(true),
+        Some("closed") => Ok(false),
+        _ => Err(invalid(format!(
+            "'{path}.state' must be either 'open' or 'closed'"
+        ))),
+    }
+}
+
+fn work_item_action_projects_open(
+    action: &str,
+    item: &Value,
+    path: &str,
+) -> Result<bool, ConvertError> {
+    let is_open = item_is_open(item, path)?;
+    if !is_open && in_table("opened reopened", action) {
+        return Err(invalid(format!(
+            "'{path}.state' must be 'open' for action '{action}'"
+        )));
+    }
+    Ok(is_open)
 }
 
 fn label_details(item: &Value) -> Result<Option<ElementValue>, ConvertError> {

--- a/components/sources/github-workgraph/src/mapping.rs
+++ b/components/sources/github-workgraph/src/mapping.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::config::RepositoryFilter;
 use crate::workgraph::{
     assignment_element_id, classify, comment_error_element_id, status_error_element_id,
     Classification,
@@ -130,6 +131,7 @@ pub struct Converter<'a> {
     source_id: &'a str,
     organization: &'a str,
     effective_from: u64,
+    repository_filter: Option<&'a RepositoryFilter>,
 }
 
 impl<'a> Converter<'a> {
@@ -138,7 +140,13 @@ impl<'a> Converter<'a> {
             source_id,
             organization,
             effective_from,
+            repository_filter: None,
         }
+    }
+
+    pub fn with_repository_filter(mut self, repository_filter: &'a RepositoryFilter) -> Self {
+        self.repository_filter = Some(repository_filter);
+        self
     }
 
     pub fn convert(
@@ -157,6 +165,9 @@ impl<'a> Converter<'a> {
         if !is_known_action(event_type, action) {
             return Ok(None);
         }
+        if !self.delivery_in_scope(event_type, action, payload)? {
+            return Ok(None);
+        }
         let d = &Delivery {
             action,
             payload,
@@ -171,6 +182,45 @@ impl<'a> Converter<'a> {
             _ => self.review_event(&mut cs, d)?,
         }
         Ok(Some(cs.changes))
+    }
+
+    fn delivery_in_scope(
+        &self,
+        event_type: &str,
+        action: &str,
+        payload: &Value,
+    ) -> Result<bool, ConvertError> {
+        let Some(filter) = self.repository_filter else {
+            return Ok(true);
+        };
+        let current = self.repository_in_scope(payload.get("repository"))?;
+        if event_type == "issues" && action == "transferred" {
+            if current {
+                return Ok(true);
+            }
+            return match payload.pointer("/changes/new_repository") {
+                Some(repository) => self.repository_in_scope(Some(repository)),
+                None => Ok(false),
+            };
+        }
+        if event_type == "repository" && action == "renamed" {
+            let previous = payload
+                .pointer("/changes/repository/name/from")
+                .and_then(Value::as_str)
+                .is_some_and(|name| filter.includes_name(name));
+            return Ok(current || previous);
+        }
+        Ok(current)
+    }
+
+    fn repository_in_scope(&self, repository: Option<&Value>) -> Result<bool, ConvertError> {
+        let Some(filter) = self.repository_filter else {
+            return Ok(true);
+        };
+        let repository = repository.ok_or_else(|| invalid("missing 'repository'"))?;
+        filter
+            .includes_repository(repository)
+            .map_err(|error| invalid(error.to_string()))
     }
 
     fn validate_organization(&self, payload: &Value) -> Result<String, ConvertError> {
@@ -196,6 +246,31 @@ impl<'a> Converter<'a> {
         let repo_id = required_str(payload, "/repository/node_id")?;
         let in_org = owner_in_org(Some(repo), self.organization);
         let relation_id = rel_id(REL_IN_ORGANIZATION, &repo_id, org);
+        if action == "renamed" && self.repository_filter.is_some() {
+            let current = self.repository_in_scope(Some(repo))?;
+            let previous = payload
+                .pointer("/changes/repository/name/from")
+                .and_then(Value::as_str)
+                .is_some_and(|name| {
+                    self.repository_filter
+                        .is_some_and(|filter| filter.includes_name(name))
+                });
+            match (previous, current) {
+                (true, false) => {
+                    cs.delete(&relation_id, REL_IN_ORGANIZATION);
+                    cs.delete(&repo_id, NODE_REPOSITORY);
+                    return Ok(());
+                }
+                (false, true) => {
+                    cs.node(Update, org, NODE_ORGANIZATION, org_props(payload));
+                    cs.node(Insert, &repo_id, NODE_REPOSITORY, repository_props(repo));
+                    cs.relation(Insert, REL_IN_ORGANIZATION, &relation_id, &repo_id, org);
+                    return Ok(());
+                }
+                (false, false) => return Ok(()),
+                (true, true) => {}
+            }
+        }
         match action {
             "created" | "transferred" if action == "created" || in_org => {
                 let op = if action == "created" { Insert } else { Update };
@@ -229,7 +304,7 @@ impl<'a> Converter<'a> {
             "deleted" => delete_work_item(cs, &item_id, &repo_id, label),
             "opened" => insert_work_item(cs, item, repo, &item_id, &repo_id, label),
             "transferred" => {
-                if owner_in_org(repo, self.organization) {
+                if owner_in_org(repo, self.organization) && self.repository_in_scope(repo)? {
                     delete_work_item(cs, &item_id, &repo_id, label);
                 }
                 let (Some(new_item), Some(new_repo)) = (
@@ -238,7 +313,9 @@ impl<'a> Converter<'a> {
                 ) else {
                     return Ok(());
                 };
-                if owner_in_org(Some(new_repo), self.organization) {
+                if owner_in_org(Some(new_repo), self.organization)
+                    && self.repository_in_scope(Some(new_repo))?
+                {
                     let new_id = required_str(new_item, "/node_id")?;
                     let new_repo_id = required_str(new_repo, "/node_id")?;
                     insert_work_item(cs, new_item, Some(new_repo), &new_id, &new_repo_id, label);

--- a/components/sources/github-workgraph/src/mapping.rs
+++ b/components/sources/github-workgraph/src/mapping.rs
@@ -302,7 +302,7 @@ impl<'a> Converter<'a> {
         let repo_id = required_str(payload, "/repository/node_id")?;
         match action {
             "deleted" => delete_work_item(cs, &item_id, &repo_id, label),
-            "opened" => insert_work_item(cs, item, repo, &item_id, &repo_id, label),
+            "opened" => insert_work_item(cs, item, repo, &item_id, &repo_id, label)?,
             "transferred" => {
                 if owner_in_org(repo, self.organization) && self.repository_in_scope(repo)? {
                     delete_work_item(cs, &item_id, &repo_id, label);
@@ -318,11 +318,11 @@ impl<'a> Converter<'a> {
                 {
                     let new_id = required_str(new_item, "/node_id")?;
                     let new_repo_id = required_str(new_repo, "/node_id")?;
-                    insert_work_item(cs, new_item, Some(new_repo), &new_id, &new_repo_id, label);
+                    insert_work_item(cs, new_item, Some(new_repo), &new_id, &new_repo_id, label)?;
                 }
             }
             _ => {
-                cs.node(Update, &item_id, label, work_item_props(item, repo, label));
+                cs.node(Update, &item_id, label, work_item_props(item, repo, label)?);
                 status_changes(cs, Update, item, repo, &item_id, label);
             }
         }
@@ -423,11 +423,12 @@ fn insert_work_item(
     item_id: &str,
     repo_id: &str,
     label: &'static str,
-) {
-    cs.node(Insert, item_id, label, work_item_props(item, repo, label));
+) -> Mapped {
+    cs.node(Insert, item_id, label, work_item_props(item, repo, label)?);
     let id = rel_id(REL_IN_REPOSITORY, item_id, repo_id);
     cs.relation(Insert, REL_IN_REPOSITORY, &id, item_id, repo_id);
     status_changes(cs, Insert, item, repo, item_id, label);
+    Ok(())
 }
 
 fn delete_work_item(cs: &mut Changes, item_id: &str, repo_id: &str, label: &str) {
@@ -627,6 +628,35 @@ fn names<'a>(container: &'a Value, key: &str, field: &'a str) -> Option<Vec<&'a 
     )
 }
 
+fn label_details(item: &Value) -> Result<Option<ElementValue>, ConvertError> {
+    let Some(labels) = item.get("labels") else {
+        return Ok(None);
+    };
+    let labels = labels
+        .as_array()
+        .ok_or_else(|| invalid("'labels' must be an array"))?;
+    let mut details = Vec::with_capacity(labels.len());
+
+    for (index, label) in labels.iter().enumerate() {
+        let name = label
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| invalid(format!("'labels[{index}].name' must be nonempty text")))?;
+        let node_id = label
+            .get("node_id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| invalid(format!("'labels[{index}].node_id' must be nonempty text")))?;
+        details.push(ElementValue::from(&serde_json::json!({
+            "name": name,
+            "nodeId": node_id,
+        })));
+    }
+
+    Ok(Some(ElementValue::List(details)))
+}
+
 fn strings<'a>(values: impl Iterator<Item = &'a str>) -> ElementValue {
     ElementValue::List(values.map(|v| ElementValue::String(Arc::from(v))).collect())
 }
@@ -670,7 +700,11 @@ fn repository_props(repo: &Value) -> ElementPropertyMap {
     props
 }
 
-fn work_item_props(item: &Value, repo: Option<&Value>, label: &str) -> ElementPropertyMap {
+fn work_item_props(
+    item: &Value,
+    repo: Option<&Value>,
+    label: &str,
+) -> Result<ElementPropertyMap, ConvertError> {
     let is_issue = label == NODE_ISSUE;
     let mut props = ElementPropertyMap::new();
     props.table(item, WORK_ITEM_PROPS);
@@ -690,7 +724,10 @@ fn work_item_props(item: &Value, repo: Option<&Value>, label: &str) -> ElementPr
     if let Some(assignees) = names(item, "assignees", "login") {
         props.insert("assignees", strings(assignees.into_iter()));
     }
-    if let Some(labels) = names(item, "labels", "name") {
+    if let Some(details) = label_details(item)? {
+        props.insert("labelDetails", details);
+        let labels =
+            names(item, "labels", "name").expect("label details validate the labels array");
         props.insert("labels", strings(labels.into_iter()));
         match derive_status(item) {
             Status::One(full) => {
@@ -703,7 +740,7 @@ fn work_item_props(item: &Value, repo: Option<&Value>, label: &str) -> ElementPr
             }
         }
     }
-    props
+    Ok(props)
 }
 
 trait Props {

--- a/components/sources/github-workgraph/src/source.rs
+++ b/components/sources/github-workgraph/src/source.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::config::GitHubWorkGraphSourceConfig;
+use crate::config::{GitHubWorkGraphSourceConfig, RepositoryFilter};
 use crate::mapping::{NODE_LABELS, RELATION_LABELS};
 use crate::webhook::{serve, IngressParams};
 use anyhow::{anyhow, Context, Result};
@@ -45,6 +45,7 @@ async fn report(base: &SourceBase, status: ComponentStatus, message: &str) {
 pub struct GitHubWorkGraphSource {
     pub(crate) base: SourceBase,
     config: GitHubWorkGraphSourceConfig,
+    repository_filter: RepositoryFilter,
     wal: Arc<RwLock<Option<Arc<dyn WalProvider>>>>,
     notify: Arc<Notify>,
     replay_gate: Arc<Mutex<()>>,
@@ -139,6 +140,7 @@ impl Source for GitHubWorkGraphSource {
         let ingress = IngressParams {
             source_id: self.base.id.clone(),
             organization: self.config.organization.clone(),
+            repository_filter: self.repository_filter.clone(),
             path: self.config.webhook.path.clone(),
             secret: self.config.webhook.secret.clone(),
             body_limit_bytes: self.config.webhook.body_limit_bytes,
@@ -392,7 +394,8 @@ impl GitHubWorkGraphSourceBuilder {
         self
     }
     pub fn build(self) -> Result<GitHubWorkGraphSource> {
-        self.config.validate()?;
+        let config = self.config.normalized()?;
+        let repository_filter = config.repository_filter()?;
         let mut params = SourceBaseParams::new(&self.id)
             .with_dispatch_mode(DispatchMode::Channel)
             .with_auto_start(self.auto_start);
@@ -401,7 +404,8 @@ impl GitHubWorkGraphSourceBuilder {
         }
         Ok(GitHubWorkGraphSource {
             base: SourceBase::new(params)?,
-            config: self.config,
+            config,
+            repository_filter,
             wal: Arc::new(RwLock::new(None)),
             notify: Arc::new(Notify::new()),
             replay_gate: Arc::new(Mutex::new(())),

--- a/components/sources/github-workgraph/src/tests.rs
+++ b/components/sources/github-workgraph/src/tests.rs
@@ -477,7 +477,9 @@ fn canonical_envelopes_and_payloads_are_strictly_typed() {
     for body in [
         "plain",
         " WorkGraphResult/v1",
+        "Mention WorkGraphAssignment/v1 inline.",
         "<details>\n<summary>Release notes</summary>\n\nOrdinary prose.\n</details>\n",
+        "<details>\n<summary>Discussion</summary>\n\nI tried WorkGraphAssignment/v1 inline.\n</details>\n",
     ] {
         assert_eq!(classify(body), Classification::Ordinary);
     }

--- a/components/sources/github-workgraph/src/tests.rs
+++ b/components/sources/github-workgraph/src/tests.rs
@@ -715,6 +715,16 @@ fn envelope_errors_and_typed_schema_errors_remain_specific() {
         );
     }
 
+    let repeated_result_marker = RESULT.replacen(
+        "Evaluated both requested validation criteria.",
+        "Do not repeat WorkGraphResult/v1 in the summary.",
+        1,
+    );
+    assert_eq!(
+        invalid_code(&repeated_result_marker),
+        error_code::INVALID_ENVELOPE
+    );
+
     for patch in [
         json!({"assignmentId":"","agentProfile":"p","priority":0,"taskType":"issue-validation","task":{"validationProfile":"v","criteria":["c"]}}),
         json!({"assignmentId":"a","agentProfile":"p","priority":-1,"taskType":"issue-validation","task":{"validationProfile":"v","criteria":["c"]}}),
@@ -730,6 +740,7 @@ fn envelope_errors_and_typed_schema_errors_remain_specific() {
         json!({"assignmentId":"a","taskType":"issue-risk-profile","outcome":"partial","summary":"s","result":{"dimensions":[]}}),
         json!({"assignmentId":"a","taskType":"issue-risk-profile","outcome":"failed","summary":"s","result":{"dimensions":[{"dimension":"d","score":101,"rationale":"r"}]}}),
         json!({"assignmentId":"a","taskType":"issue-validation","outcome":"failed","summary":"","result":{"criteria":[]}}),
+        json!({"assignmentId":"a","taskType":"issue-validation","outcome":"failed","summary":"Do not repeat WorkGraphResult/v1 in the summary.","result":{"criteria":[{"criterion":"c","passed":true,"evidence":"e"}]}}),
         json!({"assignmentId":"a","taskType":"issue-validation","outcome":"failed","summary":"s","result":{"criteria":[{"criterion":"c","passed":true,"evidence":"e"}]},"resultId":"r"}),
     ] {
         assert_eq!(

--- a/components/sources/github-workgraph/src/tests.rs
+++ b/components/sources/github-workgraph/src/tests.rs
@@ -28,8 +28,114 @@ use drasi_lib::DurabilityConfig;
 use drasi_plugin_sdk::prelude::SourcePluginDescriptor;
 use serde_json::{json, Value};
 
-const ASSIGN: &str = "WorkGraphAssignment/v1\n\nValidate.\n\n```json\n{\"assignmentId\":\"a42\",\"agentProfile\":\"validator\",\"priority\":10,\"taskType\":\"issue-validation\",\"task\":{\"validationProfile\":\"default\",\"criteria\":[\"Reproduces\"]}}\n```";
-const RESULT: &str = "WorkGraphResult/v1\n\nDone.\n\n```json\n{\"assignmentId\":\"a42\",\"taskType\":\"issue-validation\",\"outcome\":\"succeeded\",\"summary\":\"Passed.\",\"result\":{\"criteria\":[{\"criterion\":\"Reproduces\",\"passed\":true,\"evidence\":\"Yes\"}]}}\n```";
+const ASSIGN: &str = r#"<details>
+<summary>WorkGraph Assignment</summary>
+
+WorkGraphAssignment/v1
+
+Validate the synthetic fixture Issue.
+
+```json
+{
+  "assignmentId": "fixture-701-validation",
+  "agentProfile": "issue-validator",
+  "priority": 10,
+  "taskType": "issue-validation",
+  "task": {
+    "validationProfile": "default",
+    "criteria": [
+      "The Issue has a non-empty title",
+      "The Issue body is present"
+    ]
+  }
+}
+```
+</details>
+"#;
+
+const RESULT: &str = r#"<details>
+<summary>WorkGraph Result</summary>
+
+WorkGraphResult/v1
+
+Evaluated both requested validation criteria.
+
+```json
+{
+  "assignmentId": "assignment-validation-001",
+  "taskType": "issue-validation",
+  "outcome": "succeeded",
+  "summary": "Evaluated both requested validation criteria.",
+  "result": {
+    "criteria": [
+      {
+        "criterion": "The issue defines acceptance criteria",
+        "passed": true,
+        "evidence": "The body contains an acceptance checklist."
+      },
+      {
+        "criterion": "The issue identifies an owner",
+        "passed": false,
+        "evidence": "The title and body do not identify an owner."
+      }
+    ]
+  }
+}
+```
+</details>
+"#;
+
+const RISK_ASSIGNMENT: &str = r#"<details>
+<summary>WorkGraph Assignment</summary>
+
+WorkGraphAssignment/v1
+
+Profile delivery risk.
+
+```json
+{
+  "assignmentId": "assignment-risk-001",
+  "agentProfile": "issue-risk-profiler",
+  "priority": 4,
+  "taskType": "issue-risk-profile",
+  "task": {
+    "riskProfile": "delivery",
+    "dimensions": [
+      "Security impact",
+      "Rollback complexity"
+    ]
+  }
+}
+```
+</details>
+"#;
+
+const RISK_RESULT: &str = r#"<details>
+<summary>WorkGraph Result</summary>
+
+WorkGraphResult/v1
+
+Scored both requested risk dimensions.
+
+```json
+{
+  "assignmentId": "assignment-risk-001",
+  "taskType": "issue-risk-profile",
+  "outcome": "blocked",
+  "summary": "Scored both requested risk dimensions.",
+  "result": {
+    "dimensions": [
+      {
+        "dimension": "Security impact",
+        "score": 100,
+        "rationale": "The change affects authorization checks."
+      }
+    ]
+  }
+}
+```
+</details>
+"#;
 
 fn org() -> Value {
     json!({"login":"acme","id":42,"node_id":"O_1","url":"https://api.github.com/orgs/acme"})
@@ -273,7 +379,7 @@ fn comments_create_edit_and_delete_every_class() {
     let assignment = convert("issue_comment", &comment_event("created", ASSIGN, false));
     assert_eq!(
         assignment[0].get_reference().element_id.as_ref(),
-        "workgraph-assignment:O_1:a42"
+        "workgraph-assignment:O_1:fixture-701-validation"
     );
     assert_eq!(
         prop(&assignment[0], "priority"),
@@ -283,8 +389,15 @@ fn comments_create_edit_and_delete_every_class() {
         prop(&assignment[0], "task"),
         Some(ElementValue::Object(_))
     ));
+    assert_eq!(text(&assignment[0], "authorLogin").as_deref(), Some("bot"));
+    assert_eq!(
+        text(&assignment[0], "sourceCommentNodeId").as_deref(),
+        Some("IC_9")
+    );
+    assert_eq!(label(&assignment[1]), "COMMENT_ON");
     let result = convert("issue_comment", &comment_event("created", RESULT, false));
     assert_eq!(result.len(), 3);
+    assert_eq!(label(&result[1]), "COMMENT_ON");
     assert_eq!(label(&result[2]), "RESULT_FOR");
     assert!(matches!(
         prop(&result[0], "result"),
@@ -295,25 +408,42 @@ fn comments_create_edit_and_delete_every_class() {
         &comment_event("created", "WorkGraphAssignment/v1\n\nbad", false),
     );
     assert_eq!(label(&invalid[0]), "WorkGraphError");
+    assert_eq!(label(&invalid[1]), "ERROR_ON");
     assert_eq!(
         text(&invalid[0], "sourceCommentBody").as_deref(),
         Some("WorkGraphAssignment/v1\n\nbad")
+    );
+    let malformed_result = RESULT.replacen("<details>", "<details open>", 1);
+    let invalid_result = convert(
+        "issue_comment",
+        &comment_event("created", &malformed_result, false),
+    );
+    assert_eq!(label(&invalid_result[0]), "WorkGraphError");
+    assert_eq!(label(&invalid_result[1]), "ERROR_ON");
+    assert_eq!(
+        text(&invalid_result[0], "sourceCommentBody").as_deref(),
+        Some(malformed_result.as_str())
     );
 
     let ordinary_to_assignment = changes("issue_comment", &edited("plain", ASSIGN));
     assert!(
         ordinary_to_assignment.starts_with("D:COMMENT_ON")
-            && ordinary_to_assignment.ends_with("workgraph-assignment:O_1:a42>I_42")
+            && ordinary_to_assignment
+                .ends_with("workgraph-assignment:O_1:fixture-701-validation>I_42")
     );
-    let renamed = ASSIGN.replace("a42", "a43");
+    let renamed = ASSIGN.replace("fixture-701-validation", "fixture-702-validation");
     let rename = changes("issue_comment", &edited(ASSIGN, &renamed));
     assert!(
-        rename.contains("D:WorkGraphAssignment:workgraph-assignment:O_1:a42")
-            && rename.contains("I:WorkGraphAssignment:workgraph-assignment:O_1:a43")
+        rename.contains("D:WorkGraphAssignment:workgraph-assignment:O_1:fixture-701-validation")
+            && rename
+                .contains("I:WorkGraphAssignment:workgraph-assignment:O_1:fixture-702-validation")
     );
     let retarget = changes(
         "issue_comment",
-        &edited(RESULT, &RESULT.replace("a42", "a43")),
+        &edited(
+            RESULT,
+            &RESULT.replace("assignment-validation-001", "assignment-validation-002"),
+        ),
     );
     assert!(retarget.contains("D:RESULT_FOR") && retarget.contains("I:RESULT_FOR"));
     let error_to_plain = changes(
@@ -331,96 +461,291 @@ fn invalid_code(body: &str) -> &'static str {
         other => panic!("expected invalid, got {other:?}"),
     }
 }
+
 fn envelope(marker: &str, value: Value) -> String {
-    format!("{marker}\n\nsummary\n\n```json\n{value}\n```")
+    let label = match marker {
+        "WorkGraphAssignment/v1" => "WorkGraph Assignment",
+        "WorkGraphResult/v1" => "WorkGraph Result",
+        other => panic!("unsupported test marker {other}"),
+    };
+    let json = serde_json::to_string_pretty(&value).unwrap();
+    format!(
+        "<details>\n<summary>{label}</summary>\n\n{marker}\n\nsummary\n\n```json\n{json}\n```\n</details>\n"
+    )
 }
 
 #[test]
-fn envelopes_and_payloads_are_strictly_typed() {
-    for body in ["plain", " WorkGraphResult/v1"] {
+fn canonical_envelopes_and_payloads_are_strictly_typed() {
+    for body in [
+        "plain",
+        " WorkGraphResult/v1",
+        "<details>\n<summary>Release notes</summary>\n\nOrdinary prose.\n</details>\n",
+    ] {
         assert_eq!(classify(body), Classification::Ordinary);
     }
-    for (body, code) in [
-        ("WorkGraphAssignment/", error_code::UNSUPPORTED_VERSION),
-        ("WorkGraphAssignment/v1 ", error_code::UNSUPPORTED_VERSION),
-        (
-            "WorkGraphAssignment/v2\n\ns\n\n```json\n{}\n```",
-            error_code::UNSUPPORTED_VERSION,
-        ),
-        (
-            "WorkGraphAssignment/v1\n\n```json\n{}\n```",
-            error_code::MISSING_HUMAN_SUMMARY,
-        ),
-        (
-            "WorkGraphAssignment/v1\n\ns",
-            error_code::MISSING_JSON_BLOCK,
-        ),
-        (
-            "WorkGraphAssignment/v1\n\ns\n\n```json\n{}\n```\n```yaml\nx\n```",
-            error_code::MULTIPLE_JSON_BLOCKS,
-        ),
-        (
-            "WorkGraphAssignment/v1\n\ns\n\n```json\n{}",
-            error_code::UNTERMINATED_JSON_BLOCK,
-        ),
-        (
-            "WorkGraphAssignment/v1\n\ns\n\n```json\n{}\n```\ntext",
-            error_code::UNEXPECTED_TRAILING_CONTENT,
-        ),
-        (
-            "WorkGraphAssignment/v1\n\ns\n\n```json\n[1,2]\n```",
-            error_code::JSON_NOT_OBJECT,
-        ),
-    ] {
-        assert_eq!(invalid_code(body), code);
-    }
+
+    let Classification::Assignment(assignment) = classify(ASSIGN) else {
+        panic!("canonical dogfood Assignment must parse");
+    };
+    assert_eq!(assignment.assignment_id, "fixture-701-validation");
+    assert_eq!(assignment.task_type, TaskType::IssueValidation);
+
+    let Classification::Result(result) = classify(RESULT) else {
+        panic!("canonical demo Result must parse");
+    };
+    assert_eq!(result.assignment_id, "assignment-validation-001");
+    assert_eq!(result.outcome, Outcome::Succeeded);
+    assert_eq!(result.task_type, TaskType::IssueValidation);
+
+    let Classification::Assignment(risk_assignment) = classify(RISK_ASSIGNMENT) else {
+        panic!("canonical risk Assignment must parse");
+    };
+    assert_eq!(risk_assignment.task_type, TaskType::IssueRiskProfile);
+
+    let Classification::Result(risk_result) = classify(RISK_RESULT) else {
+        panic!("canonical risk Result must parse");
+    };
+    assert_eq!(risk_result.outcome, Outcome::Blocked);
+    assert_eq!(risk_result.task_type, TaskType::IssueRiskProfile);
+
     assert!(matches!(
-        classify(&ASSIGN.replace('\n', "\r\n")),
+        classify(&ASSIGN.replacen(
+            "Validate the synthetic fixture Issue.",
+            "WorkGraphResult/v1",
+            1,
+        )),
         Classification::Assignment(_)
     ));
+    assert!(matches!(
+        classify(&RESULT.replacen(
+            "Evaluated both requested validation criteria.",
+            "WorkGraphAssignment/v1",
+            1,
+        )),
+        Classification::Result(_)
+    ));
 
-    let assignment = json!({"assignmentId":"a","agentProfile":"p","priority":0,
-        "taskType":"issue-validation","task":{"validationProfile":"v","criteria":["c"]}});
-    let risk = json!({"assignmentId":"a","agentProfile":"p","priority":1,
-        "taskType":"issue-risk-profile","task":{"riskProfile":"r","dimensions":["security"]}});
-    for value in [assignment.clone(), risk] {
-        assert!(matches!(
-            classify(&envelope("WorkGraphAssignment/v1", value)),
-            Classification::Assignment(_)
-        ));
+    assert_eq!(
+        assignment_element_id("O_1", "a:b /ü"),
+        "workgraph-assignment:O_1:a%3Ab%20%2F%C3%BC"
+    );
+    assert_eq!(encode_id_component("a:b"), "a%3Ab");
+}
+
+fn assert_malformed_variants(
+    body: &str,
+    label: &str,
+    other_label: &str,
+    marker: &str,
+    other_marker: &str,
+    human_summary: &str,
+) {
+    let prefix = format!("<details>\n<summary>{label}</summary>\n\n");
+    let json_start = body.find("```json\n").unwrap() + "```json\n".len();
+    let json_end = json_start + body[json_start..].find("\n```\n").unwrap();
+    let json_text = &body[json_start..json_end];
+    let compact_json =
+        serde_json::to_string(&serde_json::from_str::<Value>(json_text).unwrap()).unwrap();
+    let unwrapped = body
+        .strip_prefix(&prefix)
+        .unwrap()
+        .strip_suffix("</details>\n")
+        .unwrap()
+        .to_string();
+
+    let variants = [
+        ("unwrapped legacy envelope", unwrapped),
+        (
+            "open attribute",
+            body.replacen("<details>", "<details open>", 1),
+        ),
+        (
+            "arbitrary attribute",
+            body.replacen("<details>", "<details class=\"workgraph\">", 1),
+        ),
+        (
+            "wrong summary label",
+            body.replacen(
+                &format!("<summary>{label}</summary>"),
+                &format!("<summary>{other_label}</summary>"),
+                1,
+            ),
+        ),
+        (
+            "missing summary label",
+            body.replacen(&format!("<summary>{label}</summary>\n"), "", 1),
+        ),
+        ("wrong marker", body.replacen(marker, other_marker, 1)),
+        ("missing marker", body.replacen(marker, "", 1)),
+        ("CRLF bytes", body.replace('\n', "\r\n")),
+        ("literal newline escapes", body.replace('\n', "\\n")),
+        (
+            "extra LF after details",
+            body.replacen("<details>\n", "<details>\n\n", 1),
+        ),
+        (
+            "several extra LFs after details",
+            body.replacen("<details>\n", "<details>\n\n\n\n", 1),
+        ),
+        (
+            "missing blank after summary label",
+            body.replacen("</summary>\n\n", "</summary>\n", 1),
+        ),
+        (
+            "extra blank after summary label",
+            body.replacen("</summary>\n\n", "</summary>\n\n\n", 1),
+        ),
+        (
+            "missing blank after marker",
+            body.replacen(&format!("{marker}\n\n"), &format!("{marker}\n"), 1),
+        ),
+        (
+            "extra blank after marker",
+            body.replacen(&format!("{marker}\n\n"), &format!("{marker}\n\n\n"), 1),
+        ),
+        (
+            "missing blank after human summary",
+            body.replacen(
+                &format!("{human_summary}\n\n```json"),
+                &format!("{human_summary}\n```json"),
+                1,
+            ),
+        ),
+        (
+            "extra blank after human summary",
+            body.replacen(
+                &format!("{human_summary}\n\n```json"),
+                &format!("{human_summary}\n\n\n```json"),
+                1,
+            ),
+        ),
+        (
+            "multiline human summary",
+            body.replacen(human_summary, &format!("{human_summary}\ncontinued"), 1),
+        ),
+        ("empty human summary", body.replacen(human_summary, "", 1)),
+        ("compact JSON", body.replacen(json_text, &compact_json, 1)),
+        (
+            "mismatched opening fence",
+            body.replacen("```json\n", "```yaml\n", 1),
+        ),
+        (
+            "mismatched closing fence",
+            body.replacen("\n```\n</details>", "\n~~~\n</details>", 1),
+        ),
+        (
+            "extra fence",
+            body.replacen(
+                "\n```\n</details>",
+                "\n```\n```yaml\n{}\n```\n</details>",
+                1,
+            ),
+        ),
+        ("prose before wrapper", format!("Unexpected prose.\n{body}")),
+        ("prose after wrapper", format!("{body}Unexpected prose.\n")),
+        (
+            "unclosed wrapper",
+            body.strip_suffix("</details>\n").unwrap().to_string(),
+        ),
+        (
+            "missing final LF",
+            body.strip_suffix('\n').unwrap().to_string(),
+        ),
+        ("extra final LF", format!("{body}\n")),
+    ];
+
+    for (name, malformed) in variants {
+        assert!(
+            matches!(classify(&malformed), Classification::Invalid(_)),
+            "{name} must be a WorkGraphError for {marker}"
+        );
     }
+}
+
+#[test]
+fn assignment_and_result_envelopes_reject_every_noncanonical_boundary() {
+    assert_malformed_variants(
+        ASSIGN,
+        "WorkGraph Assignment",
+        "WorkGraph Result",
+        "WorkGraphAssignment/v1",
+        "WorkGraphResult/v1",
+        "Validate the synthetic fixture Issue.",
+    );
+    assert_malformed_variants(
+        RESULT,
+        "WorkGraph Result",
+        "WorkGraph Assignment",
+        "WorkGraphResult/v1",
+        "WorkGraphAssignment/v1",
+        "Evaluated both requested validation criteria.",
+    );
+}
+
+#[test]
+fn envelope_errors_and_typed_schema_errors_remain_specific() {
+    let unsupported_assignment = ASSIGN.replace("WorkGraphAssignment/v1", "WorkGraphAssignment/v2");
+    let unsupported_result = RESULT.replace("WorkGraphResult/v1", "WorkGraphResult/v2");
+    for body in [
+        "WorkGraphAssignment/",
+        "WorkGraphAssignment/v1 ",
+        &unsupported_assignment,
+        &unsupported_result,
+    ] {
+        assert_eq!(invalid_code(body), error_code::UNSUPPORTED_VERSION);
+    }
+
+    for body in [ASSIGN, RESULT] {
+        let json_start = body.find("```json\n").unwrap() + "```json\n".len();
+        let json_end = json_start + body[json_start..].find("\n```\n").unwrap();
+        let json_text = &body[json_start..json_end];
+        let compact =
+            serde_json::to_string(&serde_json::from_str::<Value>(json_text).unwrap()).unwrap();
+        assert_eq!(
+            invalid_code(&body.replacen(json_text, &compact, 1)),
+            error_code::NON_CANONICAL_JSON
+        );
+        assert_eq!(
+            invalid_code(&body.replacen(json_text, "not-json", 1)),
+            error_code::INVALID_JSON
+        );
+        assert_eq!(
+            invalid_code(&body.replacen(json_text, "[\n  1,\n  2\n]", 1)),
+            error_code::JSON_NOT_OBJECT
+        );
+    }
+
     for patch in [
         json!({"assignmentId":"","agentProfile":"p","priority":0,"taskType":"issue-validation","task":{"validationProfile":"v","criteria":["c"]}}),
         json!({"assignmentId":"a","agentProfile":"p","priority":-1,"taskType":"issue-validation","task":{"validationProfile":"v","criteria":["c"]}}),
         json!({"assignmentId":"a","agentProfile":"p","priority":0,"taskType":"issue-validation","task":{"validationProfile":"v","criteria":[]},"assignedBy":"x"}),
+        json!({"assignmentId":"a","agentProfile":"p","priority":0,"taskType":"unknown","task":{"validationProfile":"v","criteria":["c"]}}),
     ] {
         assert_eq!(
             invalid_code(&envelope("WorkGraphAssignment/v1", patch)),
             error_code::INVALID_ASSIGNMENT_PAYLOAD
         );
     }
-    let result = json!({"assignmentId":"a","taskType":"issue-risk-profile","outcome":"blocked",
-        "summary":"s","result":{"dimensions":[{"dimension":"security","score":100,"rationale":"r"}]}});
-    let Classification::Result(parsed) = classify(&envelope("WorkGraphResult/v1", result)) else {
-        panic!("valid result");
-    };
-    assert_eq!(parsed.outcome, Outcome::Blocked);
-    assert_eq!(parsed.task_type, TaskType::IssueRiskProfile);
     for bad in [
         json!({"assignmentId":"a","taskType":"issue-risk-profile","outcome":"partial","summary":"s","result":{"dimensions":[]}}),
         json!({"assignmentId":"a","taskType":"issue-risk-profile","outcome":"failed","summary":"s","result":{"dimensions":[{"dimension":"d","score":101,"rationale":"r"}]}}),
         json!({"assignmentId":"a","taskType":"issue-validation","outcome":"failed","summary":"","result":{"criteria":[]}}),
+        json!({"assignmentId":"a","taskType":"issue-validation","outcome":"failed","summary":"s","result":{"criteria":[{"criterion":"c","passed":true,"evidence":"e"}]},"resultId":"r"}),
     ] {
         assert_eq!(
             invalid_code(&envelope("WorkGraphResult/v1", bad)),
             error_code::INVALID_RESULT_PAYLOAD
         );
     }
+
     assert_eq!(
-        assignment_element_id("O_1", "a:b /ü"),
-        "workgraph-assignment:O_1:a%3Ab%20%2F%C3%BC"
+        invalid_code(&envelope(
+            "WorkGraphAssignment/v1",
+            json!({"assignmentId":"a","agentProfile":"p","priority":0,
+                "taskType":"issue-validation","task":{"validationProfile":"v","criteria":[]}})
+        )),
+        error_code::INVALID_ASSIGNMENT_PAYLOAD
     );
-    assert_eq!(encode_id_component("a:b"), "a%3Ab");
 }
 
 fn config() -> GitHubWorkGraphSourceConfig {

--- a/components/sources/github-workgraph/src/tests.rs
+++ b/components/sources/github-workgraph/src/tests.rs
@@ -42,11 +42,7 @@ Validate the synthetic fixture Issue.
   "priority": 10,
   "taskType": "issue-validation",
   "task": {
-    "validationProfile": "default",
-    "criteria": [
-      "The Issue has a non-empty title",
-      "The Issue body is present"
-    ]
+    "validationProfile": "new-issue-default"
   }
 }
 ```
@@ -385,10 +381,12 @@ fn comments_create_edit_and_delete_every_class() {
         prop(&assignment[0], "priority"),
         Some(ElementValue::Integer(10))
     );
-    assert!(matches!(
+    assert_eq!(
         prop(&assignment[0], "task"),
-        Some(ElementValue::Object(_))
-    ));
+        Some(ElementValue::from(&json!({
+            "validationProfile": "new-issue-default"
+        })))
+    );
     assert_eq!(text(&assignment[0], "authorLogin").as_deref(), Some("bot"));
     assert_eq!(
         text(&assignment[0], "sourceCommentNodeId").as_deref(),
@@ -726,16 +724,30 @@ fn envelope_errors_and_typed_schema_errors_remain_specific() {
     );
 
     for patch in [
-        json!({"assignmentId":"","agentProfile":"p","priority":0,"taskType":"issue-validation","task":{"validationProfile":"v","criteria":["c"]}}),
-        json!({"assignmentId":"a","agentProfile":"p","priority":-1,"taskType":"issue-validation","task":{"validationProfile":"v","criteria":["c"]}}),
-        json!({"assignmentId":"a","agentProfile":"p","priority":0,"taskType":"issue-validation","task":{"validationProfile":"v","criteria":[]},"assignedBy":"x"}),
-        json!({"assignmentId":"a","agentProfile":"p","priority":0,"taskType":"unknown","task":{"validationProfile":"v","criteria":["c"]}}),
+        json!({"assignmentId":"","agentProfile":"p","priority":0,"taskType":"issue-validation","task":{"validationProfile":"v"}}),
+        json!({"assignmentId":"a","agentProfile":"p","priority":-1,"taskType":"issue-validation","task":{"validationProfile":"v"}}),
+        json!({"assignmentId":"a","agentProfile":"p","priority":0,"taskType":"issue-validation","task":{"validationProfile":""}}),
+        json!({"assignmentId":"a","agentProfile":"p","priority":0,"taskType":"issue-validation","task":{}}),
+        json!({"assignmentId":"a","agentProfile":"p","priority":0,"taskType":"issue-validation","task":{"validationProfile":"v"},"assignedBy":"x"}),
+        json!({"assignmentId":"a","agentProfile":"p","priority":0,"taskType":"unknown","task":{"validationProfile":"v"}}),
     ] {
         assert_eq!(
             invalid_code(&envelope("WorkGraphAssignment/v1", patch)),
             error_code::INVALID_ASSIGNMENT_PAYLOAD
         );
     }
+    let stale_criteria = envelope(
+        "WorkGraphAssignment/v1",
+        json!({"assignmentId":"a","agentProfile":"p","priority":0,
+            "taskType":"issue-validation",
+            "task":{"validationProfile":"v","criteria":["c"]}}),
+    );
+    let Classification::Invalid(error) = classify(&stale_criteria) else {
+        panic!("legacy task.criteria must be rejected");
+    };
+    assert_eq!(error.code, error_code::INVALID_ASSIGNMENT_PAYLOAD);
+    assert!(error.message.contains("unknown field `criteria`"));
+
     for bad in [
         json!({"assignmentId":"a","taskType":"issue-risk-profile","outcome":"partial","summary":"s","result":{"dimensions":[]}}),
         json!({"assignmentId":"a","taskType":"issue-risk-profile","outcome":"failed","summary":"s","result":{"dimensions":[{"dimension":"d","score":101,"rationale":"r"}]}}),
@@ -753,7 +765,7 @@ fn envelope_errors_and_typed_schema_errors_remain_specific() {
         invalid_code(&envelope(
             "WorkGraphAssignment/v1",
             json!({"assignmentId":"a","agentProfile":"p","priority":0,
-                "taskType":"issue-validation","task":{"validationProfile":"v","criteria":[]}})
+                "taskType":"issue-validation","task":{"validationProfile":null}})
         )),
         error_code::INVALID_ASSIGNMENT_PAYLOAD
     );

--- a/components/sources/github-workgraph/src/tests.rs
+++ b/components/sources/github-workgraph/src/tests.rs
@@ -746,18 +746,6 @@ fn envelope_errors_and_typed_schema_errors_remain_specific() {
             error_code::INVALID_ASSIGNMENT_PAYLOAD
         );
     }
-    let stale_criteria = envelope(
-        "WorkGraphAssignment/v1",
-        json!({"assignmentId":"a","agentProfile":"p","priority":0,
-            "taskType":"issue-validation",
-            "task":{"validationProfile":"v","criteria":["c"]}}),
-    );
-    let Classification::Invalid(error) = classify(&stale_criteria) else {
-        panic!("legacy task.criteria must be rejected");
-    };
-    assert_eq!(error.code, error_code::INVALID_ASSIGNMENT_PAYLOAD);
-    assert!(error.message.contains("unknown field `criteria`"));
-
     for bad in [
         json!({"assignmentId":"a","taskType":"issue-risk-profile","outcome":"partial","summary":"s","result":{"dimensions":[]}}),
         json!({"assignmentId":"a","taskType":"issue-risk-profile","outcome":"failed","summary":"s","result":{"dimensions":[{"dimension":"d","score":101,"rationale":"r"}]}}),
@@ -779,6 +767,22 @@ fn envelope_errors_and_typed_schema_errors_remain_specific() {
         )),
         error_code::INVALID_ASSIGNMENT_PAYLOAD
     );
+}
+
+#[test]
+fn issue_validation_assignment_rejects_stale_criteria() {
+    let stale_criteria = envelope(
+        "WorkGraphAssignment/v1",
+        json!({"assignmentId":"a","agentProfile":"p","priority":0,
+            "taskType":"issue-validation",
+            "task":{"validationProfile":"v","criteria":["c"]}}),
+    );
+    let Classification::Invalid(error) = classify(&stale_criteria) else {
+        panic!("legacy task.criteria must be rejected");
+    };
+
+    assert_eq!(error.code, error_code::INVALID_ASSIGNMENT_PAYLOAD);
+    assert!(error.message.contains("unknown field `criteria`"));
 }
 
 fn config() -> GitHubWorkGraphSourceConfig {

--- a/components/sources/github-workgraph/src/tests.rs
+++ b/components/sources/github-workgraph/src/tests.rs
@@ -517,10 +517,9 @@ fn canonical_envelopes_and_payloads_are_strictly_typed() {
         Classification::Assignment(_)
     ));
     assert!(matches!(
-        classify(&RESULT.replacen(
+        classify(&RESULT.replace(
             "Evaluated both requested validation criteria.",
-            "WorkGraphAssignment/v1",
-            1,
+            "WorkGraphAssignment/v1"
         )),
         Classification::Result(_)
     ));
@@ -723,6 +722,15 @@ fn envelope_errors_and_typed_schema_errors_remain_specific() {
     assert_eq!(
         invalid_code(&repeated_result_marker),
         error_code::INVALID_ENVELOPE
+    );
+    let mismatched_result_summary = RESULT.replacen(
+        "Evaluated both requested validation criteria.",
+        "Changed only the human summary.",
+        1,
+    );
+    assert_eq!(
+        invalid_code(&mismatched_result_summary),
+        error_code::INVALID_RESULT_PAYLOAD
     );
 
     for patch in [

--- a/components/sources/github-workgraph/src/tests.rs
+++ b/components/sources/github-workgraph/src/tests.rs
@@ -22,11 +22,17 @@ use crate::workgraph::{
     assignment_element_id, classify, encode_id_component, error_code, Classification, Outcome,
     TaskType,
 };
+use drasi_core::evaluation::context::QueryVariables;
+use drasi_core::evaluation::functions::{Function, FunctionRegistry, Insert};
+use drasi_core::evaluation::variable_value::VariableValue;
+use drasi_core::evaluation::{ExpressionEvaluationContext, ExpressionEvaluator, InstantQueryClock};
+use drasi_core::in_memory_index::in_memory_result_index::InMemoryResultIndex;
 use drasi_core::models::{Element, ElementValue, SourceChange};
 use drasi_lib::wal::CapacityPolicy;
 use drasi_lib::DurabilityConfig;
 use drasi_plugin_sdk::prelude::SourcePluginDescriptor;
 use serde_json::{json, Value};
+use std::sync::Arc;
 
 const ASSIGN: &str = r#"<details>
 <summary>WorkGraph Assignment</summary>
@@ -142,7 +148,16 @@ fn repo() -> Value {
         "archived":false,"fork":false,"visibility":"public","default_branch":"main",
         "topics":["graph"],"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-02-01T00:00:00Z"})
 }
-fn issue(labels: Value) -> Value {
+fn issue(mut labels: Value) -> Value {
+    if let Some(labels) = labels.as_array_mut() {
+        for (index, label) in labels.iter_mut().enumerate() {
+            if let Some(label) = label.as_object_mut() {
+                label
+                    .entry("node_id")
+                    .or_insert_with(|| json!(format!("L_{index}")));
+            }
+        }
+    }
     json!({"node_id":"I_42","id":4242,"number":42,"title":"Broken","body":"It breaks.",
         "state":"open","state_reason":null,"locked":false,"created_at":"2024-03-01T00:00:00Z",
         "updated_at":"2024-03-02T00:00:00Z","closed_at":null,"labels":labels,
@@ -422,6 +437,13 @@ fn families_actions_ids_properties_and_directions() {
         "I:GitHubIssue:I_42|I:IN_REPOSITORY:IN_REPOSITORY:I_42:R_7:I_42>R_7"
     );
     assert_eq!(text(&mapped[0], "status").as_deref(), Some("ready"));
+    assert_eq!(
+        prop(&mapped[0], "labelDetails"),
+        Some(ElementValue::from(&json!([
+            {"name":"bug","nodeId":"L_0"},
+            {"name":"status:ready","nodeId":"L_1"}
+        ])))
+    );
     assert_eq!(text(&mapped[0], "authorId").as_deref(), Some("U_ada"));
     assert!(text(&mapped[0], "bodyDigest")
         .unwrap()
@@ -437,7 +459,7 @@ fn families_actions_ids_properties_and_directions() {
     transfer["changes"]["new_repository"]["owner"]["login"] = json!("other");
     assert!(!changes("issues", &transfer).contains("I:GitHubIssue:I_99"));
 
-    let mut pr = issue(json!([]));
+    let mut pr = issue(json!([{"name":"docs","node_id":"L_docs"}]));
     pr["node_id"] = json!("PR_5");
     pr["draft"] = json!(true);
     pr["head"] = json!({"ref":"feature","sha":"abc"});
@@ -445,6 +467,12 @@ fn families_actions_ids_properties_and_directions() {
     let mapped = convert("pull_request", &pr);
     assert_eq!(prop(&mapped[0], "isDraft"), Some(ElementValue::Bool(true)));
     assert_eq!(text(&mapped[0], "headRefName").as_deref(), Some("feature"));
+    assert_eq!(
+        prop(&mapped[0], "labelDetails"),
+        Some(ElementValue::from(
+            &json!([{"name":"docs","nodeId":"L_docs"}])
+        ))
+    );
     assert_eq!(
         changes("pull_request_review", &review("submitted")),
         "I:GitHubPullRequestReview:PRR_3|I:REVIEW_OF:REVIEW_OF:PRR_3:PR_5:PRR_3>PR_5"
@@ -514,6 +542,85 @@ fn status_is_exact_and_conflicts_are_snapshot_free() {
     let mapped = convert("issues", &unknown);
     assert_eq!(mapped.len(), 1);
     assert_eq!(prop(&mapped[0], "status"), None);
+}
+
+#[test]
+fn label_details_reject_missing_or_malformed_node_ids() {
+    let mut missing = item_event("opened", json!([{"name":"bug"}]));
+    missing["issue"]["labels"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("node_id");
+    assert_eq!(
+        Converter::new("gh", "acme", 1).convert("issues", &missing),
+        Err(ConvertError::InvalidPayload(
+            "'labels[0].node_id' must be nonempty text".into()
+        ))
+    );
+
+    for malformed in [json!(""), json!("   "), json!(42)] {
+        let mut payload = item_event("opened", json!([{"name":"bug"}]));
+        payload["issue"]["labels"][0]["node_id"] = malformed;
+        assert!(matches!(
+            Converter::new("gh", "acme", 1).convert("issues", &payload),
+            Err(ConvertError::InvalidPayload(message))
+                if message == "'labels[0].node_id' must be nonempty text"
+        ));
+    }
+
+    for malformed in [Value::Null, json!(""), json!("   "), json!(42)] {
+        let mut payload = item_event("opened", json!([{"name":"bug"}]));
+        payload["issue"]["labels"][0]["name"] = malformed;
+        assert!(matches!(
+            Converter::new("gh", "acme", 1).convert("issues", &payload),
+            Err(ConvertError::InvalidPayload(message))
+                if message == "'labels[0].name' must be nonempty text"
+        ));
+    }
+
+    let mut partial = item_event("edited", json!([]));
+    partial["issue"].as_object_mut().unwrap().remove("labels");
+    let mapped = convert("issues", &partial);
+    assert_eq!(prop(&mapped[0], "labels"), None);
+    assert_eq!(prop(&mapped[0], "labelDetails"), None);
+}
+
+#[tokio::test]
+async fn label_details_build_complete_label_ids_with_supported_cypher() {
+    let mapped = convert(
+        "issues",
+        &item_event("opened", json!([{"name":"bug"},{"name":"status:ready"}])),
+    );
+    let mut variables = QueryVariables::new();
+    variables.insert(
+        "issue".into(),
+        VariableValue::Element(Arc::new(element(&mapped[0]).clone())),
+    );
+    variables.insert(
+        "awaitingValidationLabelId".into(),
+        VariableValue::String("L_awaiting_validation".into()),
+    );
+
+    let expression = drasi_query_cypher::parse_expression(
+        "coll.insert([label IN issue.labelDetails WHERE NOT (label.name STARTS WITH 'status:') | label.nodeId], 0, $awaitingValidationLabelId)",
+    )
+    .unwrap();
+    let registry = Arc::new(FunctionRegistry::new());
+    registry.register_function("coll.insert", Function::Scalar(Arc::new(Insert {})));
+    let evaluator = ExpressionEvaluator::new(registry, Arc::new(InMemoryResultIndex::new()));
+    let context =
+        ExpressionEvaluationContext::new(&variables, Arc::new(InstantQueryClock::new(0, 0)));
+
+    assert_eq!(
+        evaluator
+            .evaluate_expression(&context, &expression)
+            .await
+            .unwrap(),
+        VariableValue::List(vec![
+            VariableValue::String("L_awaiting_validation".into()),
+            VariableValue::String("L_0".into()),
+        ])
+    );
 }
 
 #[test]

--- a/components/sources/github-workgraph/src/tests.rs
+++ b/components/sources/github-workgraph/src/tests.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::config::{GitHubWorkGraphSourceConfig, WebhookConfig};
+use crate::config::{GitHubWorkGraphSourceConfig, RepositoryFilter, WebhookConfig};
 use crate::descriptor::GitHubWorkGraphSourceDescriptor;
 use crate::mapping::{
     derive_status, ConvertError, Converter, Status, NODE_LABELS, RELATION_LABELS,
@@ -171,6 +171,11 @@ fn review(action: &str) -> Value {
         "commit_id":"abc","html_url":"https://gh/reviews/3",
         "user":{"login":"ada","node_id":"U_ada","id":1,"type":"User"}}})
 }
+fn in_repository(mut payload: Value, name: &str) -> Value {
+    payload["repository"]["name"] = json!(name);
+    payload["repository"]["full_name"] = json!(format!("acme/{name}"));
+    payload
+}
 fn convert(event: &str, payload: &Value) -> Vec<SourceChange> {
     Converter::new("gh", "acme", 1)
         .convert(event, payload)
@@ -239,6 +244,155 @@ fn edited(from: &str, to: &str) -> Value {
     let mut payload = comment_event("edited", to, false);
     payload["changes"] = json!({"body":{"from":from}});
     payload
+}
+
+#[test]
+fn repository_filter_is_stateless_across_supported_families() {
+    let filter = RepositoryFilter::new(
+        "acme",
+        &[
+            "AcMe/Widgets".to_string(),
+            "widgets".to_string(),
+            "WIDGETS".to_string(),
+        ],
+    )
+    .unwrap();
+    assert_eq!(filter.canonical_names(), vec!["widgets"]);
+
+    let mut pr = issue(json!([]));
+    pr["node_id"] = json!("PR_5");
+    let families = [
+        (
+            "repository",
+            json!({"action":"created","organization":org(),"repository":repo()}),
+        ),
+        ("issues", item_event("opened", json!([]))),
+        (
+            "pull_request",
+            json!({"action":"opened","organization":org(),"repository":repo(),"pull_request":pr}),
+        ),
+        ("issue_comment", comment_event("created", "ordinary", false)),
+        ("pull_request_review", review("submitted")),
+    ];
+    for (event, payload) in families {
+        let converter = Converter::new("gh", "acme", 1).with_repository_filter(&filter);
+        assert!(
+            converter.convert(event, &payload).unwrap().is_some(),
+            "{event} in the configured repository must be included"
+        );
+
+        let excluded = in_repository(payload, "gadgets");
+        assert!(
+            converter.convert(event, &excluded).unwrap().is_none(),
+            "{event} outside the configured repository must be ignored"
+        );
+    }
+
+    let empty = RepositoryFilter::new("acme", &[]).unwrap();
+    assert!(Converter::new("gh", "acme", 1)
+        .with_repository_filter(&empty)
+        .convert(
+            "issues",
+            &in_repository(item_event("opened", json!([])), "gadgets")
+        )
+        .unwrap()
+        .is_some());
+    assert!(Converter::new("gh", "acme", 1)
+        .with_repository_filter(&filter)
+        .convert("push", &json!({}))
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn repository_filter_handles_transfer_and_rename_boundaries_without_state() {
+    let filter = RepositoryFilter::new("acme", &["widgets".to_string()]).unwrap();
+
+    let incomplete_transfer = item_event("transferred", json!([]));
+    let changes = Converter::new("gh", "acme", 1)
+        .with_repository_filter(&filter)
+        .convert("issues", &incomplete_transfer)
+        .unwrap()
+        .unwrap();
+    assert!(changes.iter().any(|change| {
+        change.get_reference().element_id.as_ref() == "I_42"
+            && matches!(change, SourceChange::Delete { .. })
+    }));
+    assert!(Converter::new("gh", "acme", 1)
+        .with_repository_filter(&filter)
+        .convert("issues", &in_repository(incomplete_transfer, "gadgets"))
+        .unwrap()
+        .is_none());
+
+    let mut transferred_in = in_repository(item_event("transferred", json!([])), "gadgets");
+    transferred_in["changes"] = json!({
+        "new_issue":{"node_id":"I_99","number":99,"labels":[]},
+        "new_repository":{
+            "node_id":"R_8","name":"widgets","full_name":"acme/widgets",
+            "owner":{"login":"acme"}
+        }
+    });
+    let moved_in = Converter::new("gh", "acme", 1)
+        .with_repository_filter(&filter)
+        .convert("issues", &transferred_in)
+        .unwrap()
+        .unwrap();
+    assert!(moved_in.iter().any(|change| {
+        change.get_reference().element_id.as_ref() == "I_99"
+            && matches!(change, SourceChange::Insert { .. })
+    }));
+    assert!(!moved_in.iter().any(|change| {
+        change.get_reference().element_id.as_ref() == "I_42"
+            && matches!(change, SourceChange::Delete { .. })
+    }));
+
+    let mut transferred_out = item_event("transferred", json!([]));
+    transferred_out["changes"] = json!({
+        "new_issue":{"node_id":"I_99","number":99,"labels":[]},
+        "new_repository":{
+            "node_id":"R_8","name":"gadgets","full_name":"acme/gadgets",
+            "owner":{"login":"acme"}
+        }
+    });
+    let moved_out = Converter::new("gh", "acme", 1)
+        .with_repository_filter(&filter)
+        .convert("issues", &transferred_out)
+        .unwrap()
+        .unwrap();
+    assert!(moved_out.iter().any(|change| {
+        change.get_reference().element_id.as_ref() == "I_42"
+            && matches!(change, SourceChange::Delete { .. })
+    }));
+    assert!(!moved_out
+        .iter()
+        .any(|change| change.get_reference().element_id.as_ref() == "I_99"));
+
+    let renamed_out = in_repository(
+        json!({"action":"renamed","organization":org(),"repository":repo(),
+            "changes":{"repository":{"name":{"from":"widgets"}}}}),
+        "gadgets",
+    );
+    let changes = Converter::new("gh", "acme", 1)
+        .with_repository_filter(&filter)
+        .convert("repository", &renamed_out)
+        .unwrap()
+        .unwrap();
+    assert!(changes.iter().any(|change| {
+        change.get_reference().element_id.as_ref() == "R_7"
+            && matches!(change, SourceChange::Delete { .. })
+    }));
+
+    let renamed_in = json!({"action":"renamed","organization":org(),"repository":repo(),
+        "changes":{"repository":{"name":{"from":"gadgets"}}}});
+    let changes = Converter::new("gh", "acme", 1)
+        .with_repository_filter(&filter)
+        .convert("repository", &renamed_in)
+        .unwrap()
+        .unwrap();
+    assert!(changes.iter().any(|change| {
+        change.get_reference().element_id.as_ref() == "R_7"
+            && matches!(change, SourceChange::Insert { .. })
+    }));
 }
 
 #[test]
@@ -788,6 +942,7 @@ fn issue_validation_assignment_rejects_stale_criteria() {
 fn config() -> GitHubWorkGraphSourceConfig {
     GitHubWorkGraphSourceConfig {
         organization: "acme".into(),
+        repositories: Vec::new(),
         webhook: WebhookConfig {
             secret: "secret".into(),
             ..WebhookConfig::default()
@@ -809,6 +964,14 @@ fn config_and_signature_contracts() {
     }))
     .unwrap();
     assert_eq!(custom.durability.max_events, 123);
+    assert!(custom.repositories.is_empty());
+    let normalized = GitHubWorkGraphSourceConfig {
+        repositories: vec!["Widgets".into(), "acme/widgets".into(), "gadgets".into()],
+        ..config()
+    }
+    .normalized()
+    .unwrap();
+    assert_eq!(normalized.repositories, vec!["gadgets", "widgets"]);
     for bad in [
         json!({"organization":"","webhook":{"secret":"s"}}),
         json!({"organization":"acme/x","webhook":{"secret":"s"}}),
@@ -816,21 +979,37 @@ fn config_and_signature_contracts() {
         json!({"organization":"acme","webhook":{"secret":"s","path":"/:"}}),
         json!({"organization":"acme","webhook":{"secret":"s"},"token":"x"}),
         json!({"organization":"acme","webhook":{"secret":"s"},"durability":{"enabled":true,"max_events":123}}),
+        json!({"organization":"acme","repositories":[""],"webhook":{"secret":"s"}}),
+        json!({"organization":"acme","repositories":[" widgets"],"webhook":{"secret":"s"}}),
+        json!({"organization":"acme","repositories":["other/widgets"],"webhook":{"secret":"s"}}),
+        json!({"organization":"acme","repositories":["acme/widgets/extra"],"webhook":{"secret":"s"}}),
+        json!({"organization":"acme","repositories":["widgets#1"],"webhook":{"secret":"s"}}),
     ] {
         assert!(serde_json::from_value::<GitHubWorkGraphSourceConfig>(bad)
             .and_then(|value| value.validate().map_err(serde::de::Error::custom))
             .is_err());
     }
     let source = crate::GitHubWorkGraphSourceBuilder::new("gh")
-        .with_config(config())
+        .with_config(GitHubWorkGraphSourceConfig {
+            repositories: vec!["Widgets".into(), "acme/widgets".into()],
+            ..config()
+        })
         .build()
         .unwrap();
     assert_eq!(
         drasi_lib::Source::properties(&source)["webhook"]["secret"],
         json!("[REDACTED]")
     );
+    assert_eq!(
+        drasi_lib::Source::properties(&source)["repositories"],
+        json!(["widgets"])
+    );
     let schema = GitHubWorkGraphSourceDescriptor.config_schema_json();
-    assert!(schema.contains("\"maxEvents\"") && !schema.contains("\"max_events\""));
+    assert!(
+        schema.contains("\"maxEvents\"")
+            && schema.contains("\"repositories\"")
+            && !schema.contains("\"max_events\"")
+    );
     let signature = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17";
     assert!(verify_signature(b"It's a Secret to Everybody", b"Hello, World!", signature).is_ok());
     assert!(verify_signature(b"wrong", b"Hello, World!", signature).is_err());

--- a/components/sources/github-workgraph/src/tests.rs
+++ b/components/sources/github-workgraph/src/tests.rs
@@ -22,15 +22,17 @@ use crate::workgraph::{
     assignment_element_id, classify, encode_id_component, error_code, Classification, Outcome,
     TaskType,
 };
-use drasi_core::evaluation::context::QueryVariables;
+use drasi_core::evaluation::context::{QueryPartEvaluationContext, QueryVariables};
 use drasi_core::evaluation::functions::{Function, FunctionRegistry, Insert};
 use drasi_core::evaluation::variable_value::VariableValue;
 use drasi_core::evaluation::{ExpressionEvaluationContext, ExpressionEvaluator, InstantQueryClock};
 use drasi_core::in_memory_index::in_memory_result_index::InMemoryResultIndex;
 use drasi_core::models::{Element, ElementValue, SourceChange};
+use drasi_core::query::QueryBuilder;
 use drasi_lib::wal::CapacityPolicy;
 use drasi_lib::DurabilityConfig;
 use drasi_plugin_sdk::prelude::SourcePluginDescriptor;
+use drasi_query_cypher::CypherParser;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
@@ -168,6 +170,14 @@ fn issue(mut labels: Value) -> Value {
 fn item_event(action: &str, labels: Value) -> Value {
     json!({"action":action,"organization":org(),"repository":repo(),"issue":issue(labels)})
 }
+fn pull_request_event(action: &str, labels: Value) -> Value {
+    let mut pull_request = issue(labels);
+    pull_request["node_id"] = json!("PR_5");
+    pull_request["draft"] = json!(false);
+    pull_request["merged"] = json!(false);
+    json!({"action":action,"organization":org(),"repository":repo(),
+        "pull_request":pull_request})
+}
 fn comment_event(action: &str, body: &str, pr: bool) -> Value {
     let mut parent = issue(json!([]));
     if pr {
@@ -181,7 +191,7 @@ fn comment_event(action: &str, body: &str, pr: bool) -> Value {
 }
 fn review(action: &str) -> Value {
     json!({"action":action,"organization":org(),"repository":repo(),
-        "pull_request":{"node_id":"PR_5"},"review":{"node_id":"PRR_3","id":55,
+        "pull_request":{"node_id":"PR_5","state":"open"},"review":{"node_id":"PRR_3","id":55,
         "state":"approved","body":"LGTM","submitted_at":"2024-03-05T00:00:00Z",
         "commit_id":"abc","html_url":"https://gh/reviews/3",
         "user":{"login":"ada","node_id":"U_ada","id":1,"type":"User"}}})
@@ -341,7 +351,7 @@ fn repository_filter_handles_transfer_and_rename_boundaries_without_state() {
 
     let mut transferred_in = in_repository(item_event("transferred", json!([])), "gadgets");
     transferred_in["changes"] = json!({
-        "new_issue":{"node_id":"I_99","number":99,"labels":[]},
+        "new_issue":{"node_id":"I_99","number":99,"state":"open","labels":[]},
         "new_repository":{
             "node_id":"R_8","name":"widgets","full_name":"acme/widgets",
             "owner":{"login":"acme"}
@@ -363,7 +373,7 @@ fn repository_filter_handles_transfer_and_rename_boundaries_without_state() {
 
     let mut transferred_out = item_event("transferred", json!([]));
     transferred_out["changes"] = json!({
-        "new_issue":{"node_id":"I_99","number":99,"labels":[]},
+        "new_issue":{"node_id":"I_99","number":99,"state":"open","labels":[]},
         "new_repository":{
             "node_id":"R_8","name":"gadgets","full_name":"acme/gadgets",
             "owner":{"login":"acme"}
@@ -381,6 +391,24 @@ fn repository_filter_handles_transfer_and_rename_boundaries_without_state() {
     assert!(!moved_out
         .iter()
         .any(|change| change.get_reference().element_id.as_ref() == "I_99"));
+
+    let mut transferred_closed = in_repository(item_event("transferred", json!([])), "gadgets");
+    transferred_closed["changes"] = json!({
+        "new_issue":{"node_id":"I_100","number":100,"state":"closed","labels":[]},
+        "new_repository":{
+            "node_id":"R_8","name":"widgets","full_name":"acme/widgets",
+            "owner":{"login":"acme"}
+        }
+    });
+    let closed_move = Converter::new("gh", "acme", 1)
+        .with_repository_filter(&filter)
+        .convert("issues", &transferred_closed)
+        .unwrap()
+        .unwrap();
+    assert!(
+        closed_move.is_empty(),
+        "a closed Issue transferred into scope must not be projected"
+    );
 
     let renamed_out = in_repository(
         json!({"action":"renamed","organization":org(),"repository":repo(),
@@ -408,6 +436,287 @@ fn repository_filter_handles_transfer_and_rename_boundaries_without_state() {
         change.get_reference().element_id.as_ref() == "R_7"
             && matches!(change, SourceChange::Insert { .. })
     }));
+}
+
+#[test]
+fn open_only_projection_tombstones_reopens_and_gates_children() {
+    let converter = Converter::new("gh", "acme", 1);
+    for (event, key, id, node_label) in [
+        ("issues", "issue", "I_42", "GitHubIssue"),
+        ("pull_request", "pull_request", "PR_5", "GitHubPullRequest"),
+    ] {
+        let open = if event == "issues" {
+            item_event("opened", json!([]))
+        } else {
+            pull_request_event("opened", json!([]))
+        };
+        let mut closed = open.clone();
+        closed["action"] = json!("closed");
+        closed[key]["state"] = json!("closed");
+        let tombstones = converter.convert(event, &closed).unwrap().unwrap();
+        assert!(tombstones.iter().any(|change| {
+            change.get_reference().element_id.as_ref() == id
+                && label(change) == node_label
+                && matches!(change, SourceChange::Delete { .. })
+        }));
+        assert!(tombstones.iter().any(|change| {
+            label(change) == "IN_REPOSITORY" && matches!(change, SourceChange::Delete { .. })
+        }));
+        assert!(
+            tombstones
+                .iter()
+                .all(|change| !matches!(label(change).as_str(), "COMMENT_ON" | "REVIEW_OF")),
+            "close must not pretend to enumerate child relations"
+        );
+
+        let mut closed_edit = closed.clone();
+        closed_edit["action"] = json!("edited");
+        assert!(
+            converter.convert(event, &closed_edit).unwrap().is_none(),
+            "non-terminal events for closed work items must be ignored"
+        );
+
+        let mut reopened = closed;
+        reopened["action"] = json!("reopened");
+        reopened[key]["state"] = json!("open");
+        let reconstructed = converter.convert(event, &reopened).unwrap().unwrap();
+        assert!(reconstructed.iter().any(|change| {
+            change.get_reference().element_id.as_ref() == id
+                && label(change) == node_label
+                && matches!(change, SourceChange::Insert { .. })
+        }));
+        assert!(reconstructed.iter().any(|change| {
+            label(change) == "IN_REPOSITORY" && matches!(change, SourceChange::Insert { .. })
+        }));
+    }
+
+    for on_pull_request in [false, true] {
+        let open = comment_event("created", "ordinary", on_pull_request);
+        assert!(converter.convert("issue_comment", &open).unwrap().is_some());
+        let mut closed = open;
+        closed["issue"]["state"] = json!("closed");
+        assert!(converter
+            .convert("issue_comment", &closed)
+            .unwrap()
+            .is_none());
+    }
+
+    let open_review = review("submitted");
+    assert!(converter
+        .convert("pull_request_review", &open_review)
+        .unwrap()
+        .is_some());
+    let mut closed_review = open_review;
+    closed_review["pull_request"]["state"] = json!("closed");
+    assert!(converter
+        .convert("pull_request_review", &closed_review)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn open_only_projection_rejects_missing_or_invalid_parent_state() {
+    for (event, mut payload, pointer) in [
+        ("issues", item_event("edited", json!([])), "/issue/state"),
+        (
+            "pull_request",
+            pull_request_event("edited", json!([])),
+            "/pull_request/state",
+        ),
+        (
+            "issue_comment",
+            comment_event("created", "ordinary", false),
+            "/issue/state",
+        ),
+        (
+            "pull_request_review",
+            review("submitted"),
+            "/pull_request/state",
+        ),
+    ] {
+        *payload.pointer_mut(pointer).unwrap() = json!("unknown");
+        assert!(matches!(
+            Converter::new("gh", "acme", 1).convert(event, &payload),
+            Err(ConvertError::InvalidPayload(message)) if message.contains(".state")
+        ));
+    }
+
+    let mut missing_parent_state = comment_event("created", "ordinary", true);
+    missing_parent_state["issue"]
+        .as_object_mut()
+        .unwrap()
+        .remove("state");
+    assert_eq!(
+        Converter::new("gh", "acme", 1).convert("issue_comment", &missing_parent_state),
+        Err(ConvertError::InvalidPayload(
+            "'issue.state' must be either 'open' or 'closed'".into()
+        ))
+    );
+
+    let mut inconsistent_open = item_event("opened", json!([]));
+    inconsistent_open["issue"]["state"] = json!("closed");
+    assert_eq!(
+        Converter::new("gh", "acme", 1).convert("issues", &inconsistent_open),
+        Err(ConvertError::InvalidPayload(
+            "'issue.state' must be 'open' for action 'opened'".into()
+        ))
+    );
+
+    let mut transferred = item_event("transferred", json!([]));
+    transferred["changes"] = json!({
+        "new_issue":{"node_id":"I_99","number":99,"labels":[]},
+        "new_repository":{
+            "node_id":"R_8","name":"widgets","full_name":"acme/widgets",
+            "owner":{"login":"acme"}
+        }
+    });
+    assert_eq!(
+        Converter::new("gh", "acme", 1).convert("issues", &transferred),
+        Err(ConvertError::InvalidPayload(
+            "'changes.new_issue.state' must be either 'open' or 'closed'".into()
+        ))
+    );
+}
+
+#[test]
+fn repository_filter_allows_only_terminal_cleanup_outside_scope() {
+    let filter = RepositoryFilter::new("acme", &["widgets".to_string()]).unwrap();
+    let converter = Converter::new("gh", "acme", 1).with_repository_filter(&filter);
+
+    for (event, key) in [("issues", "issue"), ("pull_request", "pull_request")] {
+        let mut included_close = if event == "issues" {
+            item_event("closed", json!([]))
+        } else {
+            pull_request_event("closed", json!([]))
+        };
+        included_close[key]["state"] = json!("closed");
+        assert!(converter.convert(event, &included_close).unwrap().is_some());
+
+        let excluded_close = in_repository(included_close, "gadgets");
+        let tombstones = converter
+            .convert(event, &excluded_close)
+            .unwrap()
+            .expect("terminal cleanup bypasses the current repository name filter");
+        assert!(tombstones
+            .iter()
+            .all(|change| matches!(change, SourceChange::Delete { .. })));
+
+        let included_reopen = if event == "issues" {
+            item_event("reopened", json!([]))
+        } else {
+            pull_request_event("reopened", json!([]))
+        };
+        assert!(converter
+            .convert(event, &included_reopen)
+            .unwrap()
+            .is_some());
+
+        let excluded_reopen = in_repository(included_reopen, "gadgets");
+        assert!(converter
+            .convert(event, &excluded_reopen)
+            .unwrap()
+            .is_none());
+    }
+}
+
+#[test]
+fn state_less_issue_pin_actions_remain_ignored() {
+    for action in ["pinned", "unpinned"] {
+        let mut payload = item_event(action, json!([]));
+        payload["issue"].as_object_mut().unwrap().remove("state");
+        assert!(Converter::new("gh", "acme", 1)
+            .convert("issues", &payload)
+            .unwrap()
+            .is_none());
+    }
+}
+
+#[tokio::test]
+async fn closing_parent_retracts_child_match_and_reopen_restores_it() {
+    let registry = Arc::new(FunctionRegistry::new());
+    let parser = Arc::new(CypherParser::new(registry.clone()));
+    let query = QueryBuilder::new(
+        "MATCH (comment:GitHubIssueComment)-[:COMMENT_ON]->(issue:GitHubIssue) \
+         RETURN comment.nodeId AS commentId",
+        parser,
+    )
+    .with_function_registry(registry)
+    .build()
+    .await;
+
+    for change in convert("issues", &item_event("opened", json!([]))) {
+        query.process_source_change(change).await.unwrap();
+    }
+    let mut results = Vec::new();
+    for change in convert(
+        "issue_comment",
+        &comment_event("created", "ordinary", false),
+    ) {
+        results.extend(query.process_source_change(change).await.unwrap());
+    }
+    assert!(results
+        .iter()
+        .any(|result| matches!(result, QueryPartEvaluationContext::Adding { .. })));
+
+    let mut closed = item_event("closed", json!([]));
+    closed["issue"]["state"] = json!("closed");
+    let mut results = Vec::new();
+    for change in convert("issues", &closed) {
+        results.extend(query.process_source_change(change).await.unwrap());
+    }
+    assert!(results
+        .iter()
+        .any(|result| matches!(result, QueryPartEvaluationContext::Removing { .. })));
+
+    let reopened = item_event("reopened", json!([]));
+    let mut results = Vec::new();
+    for change in convert("issues", &reopened) {
+        results.extend(query.process_source_change(change).await.unwrap());
+    }
+    assert!(results
+        .iter()
+        .any(|result| matches!(result, QueryPartEvaluationContext::Adding { .. })));
+
+    let registry = Arc::new(FunctionRegistry::new());
+    let parser = Arc::new(CypherParser::new(registry.clone()));
+    let query = QueryBuilder::new(
+        "MATCH (review:GitHubPullRequestReview)-[:REVIEW_OF]->(pr:GitHubPullRequest) \
+         RETURN review.nodeId AS reviewId",
+        parser,
+    )
+    .with_function_registry(registry)
+    .build()
+    .await;
+
+    for change in convert("pull_request", &pull_request_event("opened", json!([]))) {
+        query.process_source_change(change).await.unwrap();
+    }
+    let mut results = Vec::new();
+    for change in convert("pull_request_review", &review("submitted")) {
+        results.extend(query.process_source_change(change).await.unwrap());
+    }
+    assert!(results
+        .iter()
+        .any(|result| matches!(result, QueryPartEvaluationContext::Adding { .. })));
+
+    let mut closed = pull_request_event("closed", json!([]));
+    closed["pull_request"]["state"] = json!("closed");
+    let mut results = Vec::new();
+    for change in convert("pull_request", &closed) {
+        results.extend(query.process_source_change(change).await.unwrap());
+    }
+    assert!(results
+        .iter()
+        .any(|result| matches!(result, QueryPartEvaluationContext::Removing { .. })));
+
+    let reopened = pull_request_event("reopened", json!([]));
+    let mut results = Vec::new();
+    for change in convert("pull_request", &reopened) {
+        results.extend(query.process_source_change(change).await.unwrap());
+    }
+    assert!(results
+        .iter()
+        .any(|result| matches!(result, QueryPartEvaluationContext::Adding { .. })));
 }
 
 #[test]
@@ -452,7 +761,7 @@ fn families_actions_ids_properties_and_directions() {
     assert!(changes("issues", &deleted).ends_with("D:GitHubIssue:I_42"));
 
     let mut transfer = item_event("transferred", json!([]));
-    transfer["changes"] = json!({"new_issue":{"node_id":"I_99","number":99,"labels":[]},
+    transfer["changes"] = json!({"new_issue":{"node_id":"I_99","number":99,"state":"open","labels":[]},
         "new_repository":{"node_id":"R_8","owner":{"login":"acme"}}});
     let moved = changes("issues", &transfer);
     assert!(moved.contains("D:GitHubIssue:I_42") && moved.contains("I:GitHubIssue:I_99"));

--- a/components/sources/github-workgraph/src/webhook.rs
+++ b/components/sources/github-workgraph/src/webhook.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::config::RepositoryFilter;
 use crate::mapping::{ConvertError, Converter};
 use anyhow::{anyhow, Context, Result};
 use axum::body::Bytes;
@@ -38,6 +39,7 @@ const DELIVERY_KEY_PREFIX: &str = "delivery:";
 pub struct IngressParams {
     pub source_id: String,
     pub organization: String,
+    pub repository_filter: RepositoryFilter,
     pub path: String,
     pub secret: String,
     pub body_limit_bytes: usize,
@@ -50,6 +52,7 @@ pub struct IngressParams {
 struct IngressState {
     source_id: String,
     organization: String,
+    repository_filter: RepositoryFilter,
     secret: Vec<u8>,
     wal: Arc<dyn WalProvider>,
     state_store: Arc<dyn StateStoreProvider>,
@@ -61,6 +64,7 @@ pub async fn serve(listener: TcpListener, params: IngressParams) -> Result<()> {
     let state = Arc::new(IngressState {
         source_id: params.source_id,
         organization: params.organization,
+        repository_filter: params.repository_filter,
         secret: params.secret.into_bytes(),
         wal: params.wal,
         state_store: params.state_store,
@@ -134,7 +138,8 @@ async fn handle_delivery(
         return Ok(None);
     }
     let effective_from = chrono::Utc::now().timestamp_millis().max(0) as u64;
-    let converter = Converter::new(source_id, &state.organization, effective_from);
+    let converter = Converter::new(source_id, &state.organization, effective_from)
+        .with_repository_filter(&state.repository_filter);
     let changes = match converter.convert(event_type, &payload) {
         Ok(Some(changes)) => changes,
         Ok(None) => {

--- a/components/sources/github-workgraph/src/workgraph.rs
+++ b/components/sources/github-workgraph/src/workgraph.rs
@@ -247,6 +247,10 @@ pub fn classify(body: &str) -> Classification {
             Err(message) => invalid(error_code::INVALID_ASSIGNMENT_PAYLOAD, message),
         },
         EnvelopeKind::Result => match parse_result(value) {
+            Ok(result) if result.summary != summary => invalid(
+                error_code::INVALID_RESULT_PAYLOAD,
+                "human summary must byte-equal Result payload summary",
+            ),
             Ok(result) if canonical_json(&result, &json_text) => {
                 Classification::Result(Box::new(result))
             }

--- a/components/sources/github-workgraph/src/workgraph.rs
+++ b/components/sources/github-workgraph/src/workgraph.rs
@@ -74,7 +74,7 @@ macro_rules! strict {
 }
 
 strict! {
-    struct IssueValidationTask { validation_profile: String, criteria: Vec<String> }
+    struct IssueValidationTask { validation_profile: String }
     struct IssueRiskProfileTask { risk_profile: String, dimensions: Vec<String> }
     struct IssueValidationResult { criteria: Vec<CriterionResult> }
     struct CriterionResult { criterion: String, passed: bool, evidence: String }
@@ -443,7 +443,7 @@ fn parse_assignment(value: serde_json::Value) -> Result<Assignment, String> {
     let task = match root.task_type {
         TaskType::IssueValidation => {
             let task: IssueValidationTask = typed(root.task)?;
-            non_empty_strings(&task.criteria, "task.criteria")?;
+            non_empty(&task.validation_profile, "task.validationProfile")?;
             AssignmentTask::IssueValidation(task)
         }
         TaskType::IssueRiskProfile => {

--- a/components/sources/github-workgraph/src/workgraph.rs
+++ b/components/sources/github-workgraph/src/workgraph.rs
@@ -218,10 +218,6 @@ pub fn classify(body: &str) -> Classification {
         return Classification::Ordinary;
     };
 
-    let kind = match kind {
-        Ok(kind) => kind,
-        Err(error) => return Classification::Invalid(error),
-    };
     let (summary, json_text) = match split_envelope(body, kind) {
         Ok(parts) => parts,
         Err(err) => return Classification::Invalid(err),
@@ -263,66 +259,40 @@ pub fn classify(body: &str) -> Classification {
     }
 }
 
-fn candidate_kind(body: &str) -> Option<Result<EnvelopeKind, EnvelopeError>> {
-    if body.starts_with(ASSIGNMENT_FAMILY) {
-        return Some(Ok(EnvelopeKind::Assignment));
-    }
-    if body.starts_with(RESULT_FAMILY) {
-        return Some(Ok(EnvelopeKind::Result));
-    }
-
-    let wrapper_start = body
-        .find("<details")
-        .or_else(|| body.find("<summary>WorkGraph "))
-        .or_else(|| body.find(DETAILS_CLOSE))?;
-    let wrapper = &body[wrapper_start..];
-    let header = wrapper.split(FENCE_OPEN).next().unwrap_or(wrapper);
-    let lines: Vec<&str> = header.split('\n').collect();
-    let assignment_marker = lines
-        .iter()
-        .position(|line| line.trim_end_matches('\r').starts_with(ASSIGNMENT_FAMILY));
-    let result_marker = lines
-        .iter()
-        .position(|line| line.trim_end_matches('\r').starts_with(RESULT_FAMILY));
-    match (assignment_marker, result_marker) {
-        (Some(assignment), Some(result)) if assignment < result => {
-            return Some(Ok(EnvelopeKind::Assignment));
+fn candidate_kind(body: &str) -> Option<EnvelopeKind> {
+    let logical_lines: Vec<&str> = body.lines().flat_map(|line| line.split("\\n")).collect();
+    for line in &logical_lines {
+        if line.starts_with(ASSIGNMENT_FAMILY) {
+            return Some(EnvelopeKind::Assignment);
         }
-        (Some(_), Some(_)) => return Some(Ok(EnvelopeKind::Result)),
-        (Some(_), None) => return Some(Ok(EnvelopeKind::Assignment)),
-        (None, Some(_)) => return Some(Ok(EnvelopeKind::Result)),
-        (None, None) => {}
+        if line.starts_with(RESULT_FAMILY) {
+            return Some(EnvelopeKind::Result);
+        }
     }
 
-    let assignment_summary = lines
+    let wrapper_hint = body.contains("<details")
+        || body.contains(DETAILS_CLOSE)
+        || body.contains("<summary>WorkGraph ");
+    if !wrapper_hint {
+        return None;
+    }
+
+    let assignment_summary = logical_lines
         .iter()
         .position(|line| line.trim_end_matches('\r') == ASSIGNMENT_SUMMARY);
-    let result_summary = lines
+    let result_summary = logical_lines
         .iter()
         .position(|line| line.trim_end_matches('\r') == RESULT_SUMMARY);
     match (assignment_summary, result_summary) {
         (Some(assignment), Some(result)) if assignment < result => {
-            return Some(Ok(EnvelopeKind::Assignment));
+            return Some(EnvelopeKind::Assignment);
         }
-        (Some(_), Some(_)) => return Some(Ok(EnvelopeKind::Result)),
-        (Some(_), None) => return Some(Ok(EnvelopeKind::Assignment)),
-        (None, Some(_)) => return Some(Ok(EnvelopeKind::Result)),
+        (Some(_), Some(_)) => return Some(EnvelopeKind::Result),
+        (Some(_), None) => return Some(EnvelopeKind::Assignment),
+        (None, Some(_)) => return Some(EnvelopeKind::Result),
         (None, None) => {}
     }
-
-    let escaped_lines = !wrapper.contains('\n') && wrapper.contains("\\n");
-    let assignment_marker = escaped_lines && wrapper.contains(ASSIGNMENT_FAMILY);
-    let result_marker = escaped_lines && wrapper.contains(RESULT_FAMILY);
-
-    match (assignment_marker, result_marker) {
-        (true, false) => Some(Ok(EnvelopeKind::Assignment)),
-        (false, true) => Some(Ok(EnvelopeKind::Result)),
-        (true, true) => Some(envelope_err(
-            error_code::INVALID_ENVELOPE,
-            "a WorkGraph comment cannot contain both Assignment and Result markers",
-        )),
-        (false, false) => None,
-    }
+    None
 }
 
 fn split_envelope(body: &str, kind: EnvelopeKind) -> Result<(String, String), EnvelopeError> {

--- a/components/sources/github-workgraph/src/workgraph.rs
+++ b/components/sources/github-workgraph/src/workgraph.rs
@@ -17,10 +17,17 @@ use serde::{Deserialize, Serialize};
 const ASSIGNMENT_FAMILY: &str = "WorkGraphAssignment/";
 const RESULT_FAMILY: &str = "WorkGraphResult/";
 const SUPPORTED_VERSION: &str = "v1";
+const DETAILS_OPEN: &str = "<details>";
+const DETAILS_CLOSE: &str = "</details>";
+const ASSIGNMENT_SUMMARY: &str = "<summary>WorkGraph Assignment</summary>";
+const RESULT_SUMMARY: &str = "<summary>WorkGraph Result</summary>";
+const ASSIGNMENT_MARKER: &str = "WorkGraphAssignment/v1";
+const RESULT_MARKER: &str = "WorkGraphResult/v1";
 const FENCE_OPEN: &str = "```json";
 const FENCE_CLOSE: &str = "```";
 
 pub mod error_code {
+    pub const INVALID_ENVELOPE: &str = "invalid-envelope";
     pub const UNSUPPORTED_VERSION: &str = "unsupported-workgraph-version";
     pub const MISSING_HUMAN_SUMMARY: &str = "missing-human-summary";
     pub const MISSING_JSON_BLOCK: &str = "missing-json-block";
@@ -29,6 +36,7 @@ pub mod error_code {
     pub const UNEXPECTED_TRAILING_CONTENT: &str = "unexpected-trailing-content";
     pub const INVALID_JSON: &str = "invalid-json";
     pub const JSON_NOT_OBJECT: &str = "json-not-object";
+    pub const NON_CANONICAL_JSON: &str = "non-canonical-json";
     pub const INVALID_ASSIGNMENT_PAYLOAD: &str = "invalid-assignment-payload";
     pub const INVALID_RESULT_PAYLOAD: &str = "invalid-result-payload";
 }
@@ -88,7 +96,8 @@ pub enum TaskResult {
     IssueRiskProfile(IssueRiskProfileResult),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Assignment {
     pub assignment_id: String,
     pub agent_profile: String,
@@ -97,7 +106,8 @@ pub struct Assignment {
     pub task: AssignmentTask,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WorkResult {
     pub assignment_id: String,
     pub task_type: TaskType,
@@ -174,25 +184,45 @@ struct ResultRoot {
     result: serde_json::Value,
 }
 
-pub fn classify(body: &str) -> Classification {
-    let normalized = body.replace("\r\n", "\n");
-    let mut lines = normalized.split('\n');
-    let Some(marker) = lines.next() else {
-        return Classification::Ordinary;
-    };
-    let (is_assignment, version) = if let Some(v) = marker.strip_prefix(ASSIGNMENT_FAMILY) {
-        (true, v)
-    } else if let Some(v) = marker.strip_prefix(RESULT_FAMILY) {
-        (false, v)
-    } else {
-        return Classification::Ordinary;
-    };
-    if version != SUPPORTED_VERSION {
-        let message = format!("unsupported WorkGraph version '{version}', expected 'v1'");
-        return invalid(error_code::UNSUPPORTED_VERSION, message);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnvelopeKind {
+    Assignment,
+    Result,
+}
+
+impl EnvelopeKind {
+    fn family(self) -> &'static str {
+        match self {
+            Self::Assignment => ASSIGNMENT_FAMILY,
+            Self::Result => RESULT_FAMILY,
+        }
     }
-    let rest: Vec<&str> = lines.collect();
-    let (summary, json_text) = match split_envelope(&rest) {
+
+    fn marker(self) -> &'static str {
+        match self {
+            Self::Assignment => ASSIGNMENT_MARKER,
+            Self::Result => RESULT_MARKER,
+        }
+    }
+
+    fn summary(self) -> &'static str {
+        match self {
+            Self::Assignment => ASSIGNMENT_SUMMARY,
+            Self::Result => RESULT_SUMMARY,
+        }
+    }
+}
+
+pub fn classify(body: &str) -> Classification {
+    let Some(kind) = candidate_kind(body) else {
+        return Classification::Ordinary;
+    };
+
+    let kind = match kind {
+        Ok(kind) => kind,
+        Err(error) => return Classification::Invalid(error),
+    };
+    let (summary, json_text) = match split_envelope(body, kind) {
         Ok(parts) => parts,
         Err(err) => return Classification::Invalid(err),
     };
@@ -208,45 +238,195 @@ pub fn classify(body: &str) -> Classification {
         let message = "the fenced JSON block must contain exactly one JSON object";
         return invalid(error_code::JSON_NOT_OBJECT, message);
     }
-    let parsed = if is_assignment {
-        parse_assignment(value)
-            .map(|a| Classification::Assignment(Box::new(a)))
-            .map_err(|m| (error_code::INVALID_ASSIGNMENT_PAYLOAD, m))
-    } else {
-        parse_result(value)
-            .map(|r| Classification::Result(Box::new(r)))
-            .map_err(|m| (error_code::INVALID_RESULT_PAYLOAD, m))
-    };
-    parsed.unwrap_or_else(|(code, m)| Classification::Invalid(EnvelopeError::new(code, m)))
+
+    match kind {
+        EnvelopeKind::Assignment => match parse_assignment(value) {
+            Ok(assignment) if canonical_json(&assignment, &json_text) => {
+                Classification::Assignment(Box::new(assignment))
+            }
+            Ok(_) => invalid(
+                error_code::NON_CANONICAL_JSON,
+                "the Assignment JSON must use the canonical two-space typed formatting",
+            ),
+            Err(message) => invalid(error_code::INVALID_ASSIGNMENT_PAYLOAD, message),
+        },
+        EnvelopeKind::Result => match parse_result(value) {
+            Ok(result) if canonical_json(&result, &json_text) => {
+                Classification::Result(Box::new(result))
+            }
+            Ok(_) => invalid(
+                error_code::NON_CANONICAL_JSON,
+                "the Result JSON must use the canonical two-space typed formatting",
+            ),
+            Err(message) => invalid(error_code::INVALID_RESULT_PAYLOAD, message),
+        },
+    }
 }
 
-fn split_envelope(lines: &[&str]) -> Result<(String, String), EnvelopeError> {
-    let missing = "exactly one fenced ```json block is required";
-    let unterminated = "the ```json block is not terminated by a ``` line";
-    let is_fence = |line: &&str| line.starts_with(FENCE_CLOSE);
-    let Some(open) = lines.iter().position(is_fence) else {
-        return envelope_err(error_code::MISSING_JSON_BLOCK, missing);
-    };
-    if lines[open] != FENCE_OPEN {
-        return envelope_err(error_code::MISSING_JSON_BLOCK, missing);
+fn candidate_kind(body: &str) -> Option<Result<EnvelopeKind, EnvelopeError>> {
+    if body.starts_with(ASSIGNMENT_FAMILY) {
+        return Some(Ok(EnvelopeKind::Assignment));
     }
-    let Some(close) = lines[open + 1..]
+    if body.starts_with(RESULT_FAMILY) {
+        return Some(Ok(EnvelopeKind::Result));
+    }
+
+    let wrapper_start = body
+        .find("<details")
+        .or_else(|| body.find("<summary>WorkGraph "))
+        .or_else(|| body.find(DETAILS_CLOSE))?;
+    let wrapper = &body[wrapper_start..];
+    let header = wrapper.split(FENCE_OPEN).next().unwrap_or(wrapper);
+    let lines: Vec<&str> = header.split('\n').collect();
+    let assignment_marker = lines
+        .iter()
+        .position(|line| line.trim_end_matches('\r').starts_with(ASSIGNMENT_FAMILY));
+    let result_marker = lines
+        .iter()
+        .position(|line| line.trim_end_matches('\r').starts_with(RESULT_FAMILY));
+    match (assignment_marker, result_marker) {
+        (Some(assignment), Some(result)) if assignment < result => {
+            return Some(Ok(EnvelopeKind::Assignment));
+        }
+        (Some(_), Some(_)) => return Some(Ok(EnvelopeKind::Result)),
+        (Some(_), None) => return Some(Ok(EnvelopeKind::Assignment)),
+        (None, Some(_)) => return Some(Ok(EnvelopeKind::Result)),
+        (None, None) => {}
+    }
+
+    let assignment_summary = lines
+        .iter()
+        .position(|line| line.trim_end_matches('\r') == ASSIGNMENT_SUMMARY);
+    let result_summary = lines
+        .iter()
+        .position(|line| line.trim_end_matches('\r') == RESULT_SUMMARY);
+    match (assignment_summary, result_summary) {
+        (Some(assignment), Some(result)) if assignment < result => {
+            return Some(Ok(EnvelopeKind::Assignment));
+        }
+        (Some(_), Some(_)) => return Some(Ok(EnvelopeKind::Result)),
+        (Some(_), None) => return Some(Ok(EnvelopeKind::Assignment)),
+        (None, Some(_)) => return Some(Ok(EnvelopeKind::Result)),
+        (None, None) => {}
+    }
+
+    let escaped_lines = !wrapper.contains('\n') && wrapper.contains("\\n");
+    let assignment_marker = escaped_lines && wrapper.contains(ASSIGNMENT_FAMILY);
+    let result_marker = escaped_lines && wrapper.contains(RESULT_FAMILY);
+
+    match (assignment_marker, result_marker) {
+        (true, false) => Some(Ok(EnvelopeKind::Assignment)),
+        (false, true) => Some(Ok(EnvelopeKind::Result)),
+        (true, true) => Some(envelope_err(
+            error_code::INVALID_ENVELOPE,
+            "a WorkGraph comment cannot contain both Assignment and Result markers",
+        )),
+        (false, false) => None,
+    }
+}
+
+fn split_envelope(body: &str, kind: EnvelopeKind) -> Result<(String, String), EnvelopeError> {
+    let invalid_format = || {
+        envelope_err(
+            error_code::INVALID_ENVELOPE,
+            "the WorkGraph details wrapper, labels, spacing, and LF bytes must be exact",
+        )
+    };
+    if body.contains('\r') {
+        return invalid_format();
+    }
+
+    if let Some(version) = marker_version(body, kind) {
+        if version != SUPPORTED_VERSION {
+            let message = format!("unsupported WorkGraph version '{version}', expected 'v1'");
+            return envelope_err(error_code::UNSUPPORTED_VERSION, message);
+        }
+    }
+
+    let lines: Vec<&str> = body.split('\n').collect();
+    if lines.first() != Some(&DETAILS_OPEN)
+        || lines.get(1) != Some(&kind.summary())
+        || lines.get(2) != Some(&"")
+        || lines.get(3) != Some(&kind.marker())
+        || lines.get(4) != Some(&"")
+    {
+        return invalid_format();
+    }
+
+    let Some(summary) = lines.get(5) else {
+        return envelope_err(
+            error_code::MISSING_HUMAN_SUMMARY,
+            "a non-empty one-line human summary is required",
+        );
+    };
+    if summary.trim().is_empty() || *summary == FENCE_OPEN {
+        return envelope_err(
+            error_code::MISSING_HUMAN_SUMMARY,
+            "a non-empty one-line human summary is required",
+        );
+    }
+    if lines.get(6) != Some(&"") {
+        return invalid_format();
+    }
+
+    let fence_lines: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| line.starts_with(FENCE_CLOSE).then_some(index))
+        .collect();
+    if lines.get(7) != Some(&FENCE_OPEN) {
+        let code = if fence_lines.is_empty() {
+            error_code::MISSING_JSON_BLOCK
+        } else {
+            error_code::INVALID_ENVELOPE
+        };
+        return envelope_err(code, "exactly one fenced ```json block is required");
+    }
+    if fence_lines.len() > 2 {
+        return envelope_err(
+            error_code::MULTIPLE_JSON_BLOCKS,
+            "only one fenced JSON block is allowed in a WorkGraph comment",
+        );
+    }
+
+    let Some(close) = lines[8..]
         .iter()
         .position(|line| *line == FENCE_CLOSE)
-        .map(|offset| open + 1 + offset)
+        .map(|offset| 8 + offset)
     else {
-        return envelope_err(error_code::UNTERMINATED_JSON_BLOCK, unterminated);
+        return envelope_err(
+            error_code::UNTERMINATED_JSON_BLOCK,
+            "the ```json block is not terminated by an exact ``` line",
+        );
     };
-    let tail = &lines[close + 1..];
-    if tail.iter().any(is_fence) {
+    if fence_lines.iter().any(|index| *index > close) {
         let message = "only one fenced block is allowed in a WorkGraph comment";
         return envelope_err(error_code::MULTIPLE_JSON_BLOCKS, message);
     }
-    if tail.iter().any(|line| !line.trim().is_empty()) {
-        let message = "only whitespace is allowed after the closing JSON fence";
-        return envelope_err(error_code::UNEXPECTED_TRAILING_CONTENT, message);
+
+    let tail = &lines[close + 1..];
+    if tail != [DETAILS_CLOSE, ""] {
+        let code = if tail.first() == Some(&DETAILS_CLOSE) {
+            error_code::UNEXPECTED_TRAILING_CONTENT
+        } else {
+            error_code::INVALID_ENVELOPE
+        };
+        return envelope_err(
+            code,
+            "the closing fence must be followed by </details> and exactly one final LF",
+        );
     }
-    Ok((lines[..open].join("\n"), lines[open + 1..close].join("\n")))
+
+    Ok(((*summary).to_string(), lines[8..close].join("\n")))
+}
+
+fn marker_version(body: &str, kind: EnvelopeKind) -> Option<&str> {
+    body.split('\n')
+        .find_map(|line| line.strip_prefix(kind.family()))
+}
+
+fn canonical_json<T: Serialize>(value: &T, json_text: &str) -> bool {
+    serde_json::to_string_pretty(value).is_ok_and(|canonical| canonical == json_text)
 }
 
 fn parse_assignment(value: serde_json::Value) -> Result<Assignment, String> {

--- a/components/sources/github-workgraph/src/workgraph.rs
+++ b/components/sources/github-workgraph/src/workgraph.rs
@@ -365,6 +365,12 @@ fn split_envelope(body: &str, kind: EnvelopeKind) -> Result<(String, String), En
             "a non-empty one-line human summary is required",
         );
     }
+    if kind == EnvelopeKind::Result && summary.contains(RESULT_MARKER) {
+        return envelope_err(
+            error_code::INVALID_ENVELOPE,
+            "the Result human summary must not contain the WorkGraphResult/v1 marker",
+        );
+    }
     if lines.get(6) != Some(&"") {
         return invalid_format();
     }
@@ -459,6 +465,10 @@ fn parse_result(value: serde_json::Value) -> Result<WorkResult, String> {
     let root: ResultRoot = typed(value)?;
     non_empty(&root.assignment_id, "assignmentId")?;
     non_empty(&root.summary, "summary")?;
+    require(
+        !root.summary.contains(RESULT_MARKER),
+        "summary must not contain the WorkGraphResult/v1 marker",
+    )?;
     let result = match root.task_type {
         TaskType::IssueValidation => {
             let result: IssueValidationResult = typed(root.result)?;

--- a/components/sources/github-workgraph/tests/integration_test.rs
+++ b/components/sources/github-workgraph/tests/integration_test.rs
@@ -78,6 +78,7 @@ impl Harness {
     fn build(max_events: u64, port: u16) -> GitHubWorkGraphSource {
         let config = GitHubWorkGraphSourceConfig {
             organization: "acme".into(),
+            repositories: Vec::new(),
             webhook: WebhookConfig {
                 host: "127.0.0.1".into(),
                 port,


### PR DESCRIPTION
## Summary

- require the exact collapsed-by-default `<details>` envelope, Assignment/Result summary label, LF-only spacing, one-line human summary, single JSON fence, strict typed payload, and exactly one final LF for both envelope types
- reject recognized legacy, attributed/open, mislabeled, CRLF, literal-`\n`, mis-spaced, multiline/empty-summary, noncanonical-JSON, fence, wrapper, trailing-prose, final-LF, and schema-invalid bodies as `WorkGraphError`
- reconcile current source PR #737 head `748add8d8b5bf46432aaeaf000b0501266e90e56` (including its `7c1739fd94040a6ecf1135edd36eb14eca63f27f` envelope parent): logical-line marker detection, inline ordinary-comment behavior, Result human/payload summary byte equality, exact final LF, and profile-only issue-validation Assignments
- reject `WorkGraphResult/v1` marker substrings in both the rendered Result human summary and typed Result `summary`
- require `issue-validation` Assignment tasks to contain only a non-empty `validationProfile`; reject legacy embedded `criteria` as unknown while leaving validation Result entries and risk-profile schemas unchanged
- preserve existing identities, relationships, authorship, provenance, and edit/delete behavior
- align Core fixtures byte-for-byte with canonical criteria-free dogfood Assignment removal commit/head `82ff6357dd37f5ad056a834cb1236b64a6900f7c` and active demo Result head `939f0aa96fe2dc83b8d91bf9a9e58b1f8447d943`; coordinate profile resolution with demo PR #33 head `f79f8cb4ca0bc00dac3d4f1e4763966970e857c9`
- add optional Source `repositories: string[]`; omitted/empty includes every repository, while bare names or same-organization `owner/name` entries normalize case-insensitively to sorted, deduplicated lowercase bare names
- apply the same repository scope to live repository/Issue/PR/comment/review webhook conversion and bootstrap; malformed/foreign-owner entries are rejected and rename/transfer boundary changes emit only the in-scope side
- keep filtering stateless: supported webhook deliveries already include repository metadata, and bootstrap filters its enumerated repository list before per-repository requests; no webhook API calls or repository cache are added
- retain `labels`, `status`, and `statusLabel` while adding ordered generic `labelDetails: [{name, nodeId}]` properties to Issues and Pull Requests from webhook label objects and GraphQL bootstrap label nodes
- require every present label entry to have nonempty string `name` and `node_id`; malformed live payloads reject and malformed bootstrap data fails without emitting a partial snapshot, while partial updates that omit `labels` retain existing behavior
- prove the supported complete-label-ID expression: `coll.insert([label IN issue.labelDetails WHERE NOT (label.name STARTS WITH 'status:') | label.nodeId], 0, $awaitingValidationLabelId)`
- keep label identity stateless: webhook payloads supply both values and bootstrap aliases the existing GraphQL label `id`; no label cache or webhook-side API request is added
- make the graph projection OPEN-only: bootstrap Issue/PR connections use `states: [OPEN]` on initial and every cursor page, and reject a closed item returned in violation of that invariant
- emit deterministic close/delete tombstones for the status error, `IN_REPOSITORY`, and Issue/PR node; reconstruct the complete node and relation on `reopened` using only webhook payload data
- process Issue/PR conversation comments and PR reviews only when their embedded parent state is open; missing/unknown state rejects, while state-less Issue pin/unpin actions are ignored because no pin property is projected
- keep terminal cleanup stateless across repository renames by allowing idempotent close/delete tombstones to bypass only the current repository-name filter; no out-of-scope insert or update can bypass the filter
- leave comment/review nodes and their deterministic relations in place on close because the delivery cannot enumerate child IDs; removing the parent retracts query matches, and reopening the same global parent ID restores prior child paths. Closed-period child deliveries are intentionally ignored until a later bootstrap

## Stack

Depends on #742 and targets `agentofreality-bridge-workgraph-durability` at exact base head `6cbb9e285ca6af7d4a54380924d4dcdd769e36f0`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p drasi-source-github-workgraph -p drasi-bootstrap-github-workgraph` (Source: 17 passed, 2 declared integration tests ignored; bootstrap: 22 passed)
- `cargo clippy -p drasi-source-github-workgraph -p drasi-bootstrap-github-workgraph --all-targets --all-features -- -D warnings`
- `cargo build -p drasi-source-github-workgraph --features dynamic-plugin`
- `cargo build -p drasi-bootstrap-github-workgraph --features dynamic-plugin`
- `cargo check -p drasi-host-sdk`
- `cargo check -p drasi-lib`
- producer fixture byte comparisons: Assignment SHA-256 `06160a174a1a660cb145c7dcd4b1b511564ec27863e31ffda8cb46fbbb46d37b`; Result SHA-256 `44d3b3e47bc55fd37f3579f770ec4ccd237007bcab859c0259e59d0b9e043eee`

## Dogfood build pin

`DRASI_CORE_COMMIT=47a44a1a66cb569138f5c37c6163a05ebad73784`