### PR TITLE
feat(reactions): validate HTTP response JSON

### DIFF
--- a/components/reactions/http/CHANGELOG.md
+++ b/components/reactions/http/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adaptive mode opts in via the `adaptive` config block (`adaptiveMinBatchSize`, `adaptiveMaxBatchSize`, `adaptiveWindowSize`, `adaptiveBatchTimeoutMs`) and coalesces items into `BatchEnvelope` payloads. Each batch item is a rendered per-query body template, or the default `DefaultChangeNotification` envelope when no body template applies; `outputTemplates` may be combined with adaptive batch mode (only the body template applies to batched items, since a batch is a single POST).
 - Configuration is validated at construction: `HttpReactionBuilder::build()` validates base URL, timeout, adaptive ranges, batch endpoint path, HTTP methods, headers, templates, and route keys.
+- Standard per-call specs support `rejectNonEmptyJsonPointer` to reject logical failures in JSON 2xx responses. Validation is bounded to 1 MiB, does not retry logical failures in process, and is rejected with adaptive mode rather than ignored.
 - Per-query routes resolve by full query id, then by the **last dotted segment** of the query id (`routes.my_query` matches a wire id of `source.my_query`), then by the shared default template.
 - Template render context includes `query_id`, `query_name`, `timestamp`, `metadata`, `operation`, and the applicable `before`, `after`, and `data` values.
 - New `from_query` builder alias for `with_query`.

--- a/components/reactions/http/CHANGELOG.md
+++ b/components/reactions/http/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adaptive mode opts in via the `adaptive` config block (`adaptiveMinBatchSize`, `adaptiveMaxBatchSize`, `adaptiveWindowSize`, `adaptiveBatchTimeoutMs`) and coalesces items into `BatchEnvelope` payloads. Each batch item is a rendered per-query body template, or the default `DefaultChangeNotification` envelope when no body template applies; `outputTemplates` may be combined with adaptive batch mode (only the body template applies to batched items, since a batch is a single POST).
 - Configuration is validated at construction: `HttpReactionBuilder::build()` validates base URL, timeout, adaptive ranges, batch endpoint path, HTTP methods, headers, templates, and route keys.
-- Standard per-call specs support `rejectNonEmptyJsonPointer` to reject logical failures in JSON 2xx responses. Validation is bounded to 1 MiB, does not retry logical failures in process, and is rejected with adaptive mode rather than ignored.
+- Standard per-call specs support `rejectNonEmptyJsonPointer` to reject logical failures in JSON 2xx responses. Validation is bounded to 1 MiB, classifies numeric zero from the exact response lexeme without changing shared JSON-number parsing, does not retry logical failures in process, and is rejected with adaptive mode rather than ignored.
 - Per-query routes resolve by full query id, then by the **last dotted segment** of the query id (`routes.my_query` matches a wire id of `source.my_query`), then by the shared default template.
 - Template render context includes `query_id`, `query_name`, `timestamp`, `metadata`, `operation`, and the applicable `before`, `after`, and `data` values.
 - New `from_query` builder alias for `with_query`.

--- a/components/reactions/http/Cargo.toml
+++ b/components/reactions/http/Cargo.toml
@@ -41,7 +41,7 @@ log = "0.4"
 handlebars = "5.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["arbitrary_precision"] }
+serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.0", features = ["full"] }
 chrono = "0.4"
 # TODO(#574): Pin the same crates.io drasi-plugin-sdk version as the target

--- a/components/reactions/http/Cargo.toml
+++ b/components/reactions/http/Cargo.toml
@@ -41,7 +41,7 @@ log = "0.4"
 handlebars = "5.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 tokio = { version = "1.0", features = ["full"] }
 chrono = "0.4"
 # TODO(#574): Pin the same crates.io drasi-plugin-sdk version as the target

--- a/components/reactions/http/README.md
+++ b/components/reactions/http/README.md
@@ -14,7 +14,8 @@ Changes can be distributed two ways:
   a `batchEndpoint`.
 
 Single-notification mode supports [Handlebars](https://handlebarsjs.com/) templating of
-the request URL, body, and headers, plus per-query routing and bearer-token authentication.
+the request URL, body, and headers, per-query routing, bearer-token authentication, and
+optional validation of successful JSON responses.
 Adaptive batch mode coalesces changes into a canonical `BatchEnvelope` POSTed to
 `batchEndpoint`; per-query **body** templates still apply to each item (the URL, method, and
 headers do not, because a batch is a single request).
@@ -235,7 +236,7 @@ optional unless noted; defaults are applied by the builder.
 | `base_url` | `String` | `http://localhost` | `with_base_url` | Base URL prepended to every relative per-call URL. |
 | `token` | `Option<String>` | `None` | `with_token` | Bearer token sent as `Authorization: Bearer <token>` on every request. |
 | `timeout_ms` | `u64` | `5000` | `with_timeout_ms` | Per-request HTTP timeout in milliseconds. |
-| `output_templates` | `Option<HttpOutputTemplates>` | `None` | `with_default_template`, `with_query_template`, `with_output_templates` | Per-query and default templates. In single-notification mode the URL, body, and headers are templated; in adaptive mode only the per-query **body** template applies to each batched item. See [Output templates](#output-templates-and-per-query-routing). |
+| `output_templates` | `Option<HttpOutputTemplates>` | `None` | `with_default_template`, `with_query_template`, `with_output_templates` | Per-query and default call specifications. In single-notification mode the URL, body, headers, and optional response validator apply; in adaptive mode only the per-query **body** template applies to each batched item. See [Output templates](#output-templates-and-per-query-routing). |
 | `adaptive` | `Option<AdaptiveBatchConfig>` | `None` | `with_adaptive` | When `Some`, enables [adaptive batching](#adaptive-batching) and requires `batch_endpoint`. When `None`, the reaction delivers one HTTP request per result. |
 | `batch_endpoint` | `Option<String>` | `None` | `with_batch_endpoint` | Path appended to `base_url`. Required with `adaptive`; every coalesced batch is POSTed to `{base_url}{batch_endpoint}` as a single payload. Invalid combinations fail at `build()` time. |
 | `recovery_policy` | `Option<ReactionRecoveryPolicy>` | `strict` | `with_recovery_policy` | Behavior on a **sustained** delivery failure. `strict` (default) fail-stops the reaction (`Error`) without advancing the checkpoint, so the un-acked work replays from the query outbox on restart; `auto_skip_gap` skips the failed batch and keeps running. In declarative config the key is `recoveryPolicy` (`strict` \| `auto_skip_gap`). |
@@ -270,7 +271,7 @@ Builder-only settings (not stored on `HttpReactionConfig`):
 ### `HttpCallSpec`
 
 `HttpCallSpec = TemplateSpec<HttpCallExt>` — a Handlebars body `template` plus an
-`HttpCallExt { url, method, headers }`.
+`HttpCallExt { url, method, headers, reject_non_empty_json_pointer }`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -278,6 +279,7 @@ Builder-only settings (not stored on `HttpReactionConfig`):
 | `extension.url` | `String` | _empty_ | Handlebars template for the URL. A relative value is appended to `base_url`; an absolute `http(s)://` value is allowed only if its scheme, host, and port match `base_url`. |
 | `extension.method` | `String` | `POST` | HTTP method: `GET`, `POST`, `PUT`, `PATCH`, or `DELETE` (case-insensitive). |
 | `extension.headers` | `HashMap<String, String>` | _empty_ | Additional headers. Values support Handlebars templates. |
+| `extension.reject_non_empty_json_pointer` | `Option<String>` | `None` | Literal RFC 6901 JSON pointer used to validate a 2xx response, for example `/errors`. See [Delivery failure handling](#delivery-failure-handling). Not templated, and rejected when adaptive mode is enabled. |
 
 ### `AdaptiveBatchConfig`
 
@@ -306,7 +308,7 @@ when it creates the reaction (the equivalent of `with_queries(...)`).
 | `token` | string \| ConfigValue | `with_token` | Bearer token. |
 | `timeoutMs` | number \| ConfigValue | `with_timeout_ms` | Default `5000`. |
 | `priorityQueueCapacity` | number \| ConfigValue | `with_priority_queue_capacity` | Inbound queue capacity (default `10000`). Declarative-only — a `ReactionBase` parameter, not a field of `HttpReactionConfig`. |
-| `outputTemplates` | object | `with_output_templates` | `defaultTemplate` + `routes`; each entry has `added` / `updated` / `deleted`, each with `template` / `url` / `method` / `headers`. |
+| `outputTemplates` | object | `with_output_templates` | `defaultTemplate` + `routes`; each entry has `added` / `updated` / `deleted`, each with `template` / `url` / `method` / `headers` / `rejectNonEmptyJsonPointer`. |
 | `adaptive` | object | `with_adaptive` | `adaptiveMinBatchSize`, `adaptiveMaxBatchSize`, `adaptiveWindowSize`, `adaptiveBatchTimeoutMs`. |
 | `batchEndpoint` | string \| ConfigValue | `with_batch_endpoint` | Required whenever `adaptive` is set. |
 
@@ -327,6 +329,20 @@ Single-notification example (per-query REST routing, token from an environment v
     }
   }
 }
+```
+
+For an API such as GitHub GraphQL that can report logical errors in an HTTP 2xx
+response, set the validator only on the calls that require it:
+
+```yaml
+outputTemplates:
+  routes:
+    work-items:
+      added:
+        url: /graphql
+        method: POST
+        template: '{"query":"mutation { ... }"}'
+        rejectNonEmptyJsonPointer: /errors
 ```
 
 Adaptive (batched) example:
@@ -374,6 +390,7 @@ let orders = HttpQueryConfig {
             url: "/orders".to_string(),
             method: "POST".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     }),
     deleted: Some(TemplateSpec {
@@ -382,6 +399,7 @@ let orders = HttpQueryConfig {
             url: "/orders/{{before.id}}".to_string(),
             method: "DELETE".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     }),
     ..Default::default()
@@ -396,8 +414,9 @@ dotted segments.
 ## Templating
 
 Templates use [Handlebars](https://handlebarsjs.com/) syntax and apply to the body
-`template`, the `url`, and header values. HTTP methods are static and validated at build
-time. The render context depends on the operation:
+`template`, the `url`, and header values. HTTP methods and
+`rejectNonEmptyJsonPointer` values are static and validated at build time. The render
+context depends on the operation:
 
 | Variable | Available for | Meaning |
 |----------|---------------|---------|
@@ -504,6 +523,9 @@ Content-Type: application/json
   rendered custom headers.
 - **Body** — the rendered `template`. When the template is empty (including the synthesized
   default), the body is the `DefaultChangeNotification` envelope shown above.
+- **Response validation** — when `rejectNonEmptyJsonPointer` is configured, the 2xx body
+  must be valid JSON no larger than 1 MiB and the pointer must be missing or resolve to an
+  accepted empty value.
 
 ### `BatchEnvelope` (batch-endpoint path)
 
@@ -548,7 +570,8 @@ throughput. The batcher:
 Use adaptive batching when your receiver can accept many changes in one request and the
 per-request overhead is the bottleneck. Per-query **body** templates still apply to each
 batched item; if each change must go to its own templated URL/method/headers, use
-single-notification mode instead.
+single-notification mode instead. Adaptive configuration that includes a per-call
+`rejectNonEmptyJsonPointer` fails validation rather than silently ignoring it.
 
 ---
 
@@ -571,11 +594,22 @@ behaviour is always on and cannot be disabled.
 
 ## Delivery failure handling
 
-The HTTP reaction is fire-and-forget: it does not persist delivery checkpoints or replay
-requests after process failure. Each outbound request is attempted up to three times for
-transient failures (network errors, 408, 409, 425, 429, and 5xx responses) with short
-exponential backoff. Non-retryable HTTP failures are logged as permanent failures and the
-reaction continues processing later events.
+Each outbound request is attempted up to three times for transport failures and retryable
+statuses (408, 409, 425, 429, and 5xx) with short exponential backoff. Auth/permission
+statuses (401, 403, and 407) are sustained delivery failures, while other non-retryable 4xx
+responses are permanent poison events that are dropped.
+
+When a per-call `rejectNonEmptyJsonPointer` is configured, every 2xx response body is read
+incrementally with a fixed 1 MiB limit and parsed as JSON. A missing pointer is accepted.
+The following resolved values are also accepted: `null`, `false`, numeric zero, an empty
+string, an empty array, or an empty object. Any other value, malformed JSON, a response-read
+failure, or a body over the limit is a sustained delivery failure. Logical response
+validation returns immediately after that single HTTP request and is never retried in
+process. Error messages identify the failure without including the downstream body.
+
+Under the default `strict` recovery policy, a sustained failure stops the reaction without
+advancing its checkpoint, so the event can replay from the query outbox after restart.
+`auto_skip_gap` instead advances past the failed event and keeps the reaction running.
 
 ---
 
@@ -628,6 +662,7 @@ let orders = HttpQueryConfig {
             url: "/orders".to_string(),
             method: "POST".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     }),
     updated: Some(TemplateSpec {
@@ -636,6 +671,7 @@ let orders = HttpQueryConfig {
             url: "/orders/{{after.id}}".to_string(),
             method: "PUT".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     }),
     deleted: Some(TemplateSpec {
@@ -644,6 +680,7 @@ let orders = HttpQueryConfig {
             url: "/orders/{{before.id}}".to_string(),
             method: "DELETE".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     }),
 };
@@ -690,6 +727,7 @@ let default_tmpl = HttpQueryConfig {
             url: "/events".to_string(),
             method: "POST".to_string(),
             headers,
+            ..Default::default()
         },
     }),
     ..Default::default()

--- a/components/reactions/http/README.md
+++ b/components/reactions/http/README.md
@@ -605,7 +605,9 @@ The following resolved values are also accepted: `null`, `false`, numeric zero, 
 string, an empty array, or an empty object. Any other value, malformed JSON, a response-read
 failure, or a body over the limit is a sustained delivery failure. Logical response
 validation returns immediately after that single HTTP request and is never retried in
-process. Error messages identify the failure without including the downstream body.
+process. Numeric zero is determined from the exact JSON significand, so exponent magnitude
+cannot make a nonzero value appear empty. Error messages identify the failure without
+including the downstream body.
 
 Under the default `strict` recovery policy, a sustained failure stops the reaction without
 advancing its checkpoint, so the event can replay from the query outbox after restart.

--- a/components/reactions/http/src/batch.rs
+++ b/components/reactions/http/src/batch.rs
@@ -28,7 +28,7 @@ use reqwest::{
 };
 
 use crate::output::BatchEnvelope;
-use crate::process::{send_with_retry, DeliveryOutcome};
+use crate::process::{send_with_retry, DeliveryOptions, DeliveryOutcome};
 
 /// POST a coalesced batch to `{base_url}{batch_endpoint}` as a single
 /// [`BatchEnvelope`] (`{ "batch": [ … ] }`).
@@ -69,7 +69,7 @@ pub(crate) async fn send_coalesced_batch(
         headers,
         body,
         reaction_name,
-        "batch HTTP request",
+        DeliveryOptions::new("batch HTTP request", None),
     )
     .await?;
 

--- a/components/reactions/http/src/config.rs
+++ b/components/reactions/http/src/config.rs
@@ -18,7 +18,8 @@
 //! on top of the shared template primitives in
 //! [`drasi_lib::reactions::common::templates`]. The `template` field
 //! inherited from [`TemplateSpec`] is the HTTP request body; `url`,
-//! `method`, and `headers` come from the flattened [`HttpCallExt`].
+//! `method`, `headers`, and response validation come from the flattened
+//! [`HttpCallExt`].
 
 use anyhow::Context;
 use reqwest::{
@@ -59,9 +60,15 @@ pub struct HttpCallExt {
     /// Header values support Handlebars templates.
     #[serde(default)]
     pub headers: HashMap<String, String>,
+
+    /// Reject a successful response when this RFC 6901 JSON pointer resolves
+    /// to a non-empty value. This value is literal and is not templated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reject_non_empty_json_pointer: Option<String>,
 }
 
-/// Spec for a single HTTP call: a body template plus URL, method, headers.
+/// Spec for a single HTTP call: a body template plus URL, method, headers, and
+/// optional response validation.
 pub type HttpCallSpec = TemplateSpec<HttpCallExt>;
 
 /// Per-query configuration: separate [`HttpCallSpec`] for each operation.
@@ -110,11 +117,12 @@ pub struct HttpReactionConfig {
 
     /// Optional per-query and default-template overrides.
     ///
-    /// In standard (per-result) mode the `url`, `method`, `headers`, and body
-    /// `template` all apply. In adaptive (batch) mode only the body `template`
-    /// is used to render each item placed in the
+    /// In standard (per-result) mode the `url`, `method`, `headers`, response
+    /// validator, and body `template` all apply. In adaptive (batch) mode only
+    /// the body `template` is used to render each item placed in the
     /// [`crate::output::BatchEnvelope`]; `url`/`method`/`headers` do not apply
-    /// because a batch is a single POST to `batch_endpoint`.
+    /// because a batch is a single POST to `batch_endpoint`. Configuring a
+    /// per-call response validator with adaptive mode is rejected.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_templates: Option<HttpOutputTemplates>,
 
@@ -296,6 +304,9 @@ fn validate_call_spec(spec: &HttpCallSpec) -> anyhow::Result<()> {
     validate_template_str(&spec.template).context("body template")?;
     validate_template_str(&spec.extension.url).context("url template")?;
     parse_http_method(&spec.extension.method).context("HTTP method")?;
+    if let Some(pointer) = &spec.extension.reject_non_empty_json_pointer {
+        validate_json_pointer(pointer).context("rejectNonEmptyJsonPointer")?;
+    }
     for (key, value) in &spec.extension.headers {
         HeaderName::from_bytes(key.as_bytes())
             .with_context(|| format!("invalid HTTP header name '{key}'"))?;
@@ -303,6 +314,30 @@ fn validate_call_spec(spec: &HttpCallSpec) -> anyhow::Result<()> {
         if !value.contains("{{") {
             HeaderValue::from_str(value)
                 .with_context(|| format!("invalid static value for HTTP header '{key}'"))?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_json_pointer(pointer: &str) -> anyhow::Result<()> {
+    if pointer.is_empty() {
+        anyhow::bail!("must not be empty");
+    }
+    if !pointer.starts_with('/') {
+        anyhow::bail!("must begin with '/'");
+    }
+
+    let bytes = pointer.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'~' {
+            index += 1;
+            continue;
+        }
+
+        match bytes.get(index + 1) {
+            Some(b'0' | b'1') => index += 2,
+            _ => anyhow::bail!("contains a malformed '~' escape; only '~0' and '~1' are valid"),
         }
     }
     Ok(())
@@ -320,6 +355,13 @@ fn validate_query_config(qc: &HttpQueryConfig) -> anyhow::Result<()> {
         validate_call_spec(spec).context("'deleted' template")?;
     }
     Ok(())
+}
+
+fn has_response_validator(qc: &HttpQueryConfig) -> bool {
+    [&qc.added, &qc.updated, &qc.deleted]
+        .into_iter()
+        .flatten()
+        .any(|spec| spec.extension.reject_non_empty_json_pointer.is_some())
 }
 
 impl HttpReactionConfig {
@@ -384,6 +426,20 @@ impl HttpReactionConfig {
                         "output template route '{key}' does not match any subscribed query id"
                     );
                 }
+            }
+
+            if self.adaptive.is_some()
+                && (templates
+                    .default_template
+                    .as_ref()
+                    .is_some_and(has_response_validator)
+                    || templates.routes.values().any(has_response_validator))
+            {
+                anyhow::bail!(
+                    "`rejectNonEmptyJsonPointer` is not supported in `adaptive` mode; \
+                     adaptive delivery sends a coalesced batch request and would ignore \
+                     per-call response validation"
+                );
             }
         }
 

--- a/components/reactions/http/src/descriptor.rs
+++ b/components/reactions/http/src/descriptor.rs
@@ -31,7 +31,8 @@ use crate::HttpReactionBuilder;
 // ---------------------------------------------------------------------------
 
 /// DTO for a single HTTP call spec. Mirrors `HttpCallSpec` on the wire:
-/// a Handlebars `template` (body) plus `url`, `method`, and `headers`.
+/// a Handlebars `template` (body) plus `url`, `method`, `headers`, and optional
+/// response validation.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[schema(as = reaction::http::HttpCallSpec)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
@@ -52,6 +53,11 @@ pub struct HttpCallSpecDto {
     /// Additional HTTP headers. Header values support Handlebars.
     #[serde(default)]
     pub headers: HashMap<String, String>,
+
+    /// RFC 6901 JSON pointer whose non-empty value rejects an otherwise
+    /// successful response. The pointer is literal, not a Handlebars template.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reject_non_empty_json_pointer: Option<String>,
 }
 
 /// DTO for per-query call configuration: one [`HttpCallSpecDto`] per operation.
@@ -183,6 +189,7 @@ fn map_call_spec(dto: &HttpCallSpecDto) -> crate::config::HttpCallSpec {
             url: dto.url.clone(),
             method: dto.method.clone(),
             headers: dto.headers.clone(),
+            reject_non_empty_json_pointer: dto.reject_non_empty_json_pointer.clone(),
         },
     }
 }
@@ -216,6 +223,7 @@ fn dto_call_spec(spec: &crate::config::HttpCallSpec) -> HttpCallSpecDto {
         url: spec.extension.url.clone(),
         method: spec.extension.method.clone(),
         headers: spec.extension.headers.clone(),
+        reject_non_empty_json_pointer: spec.extension.reject_non_empty_json_pointer.clone(),
     }
 }
 

--- a/components/reactions/http/src/process.rs
+++ b/components/reactions/http/src/process.rs
@@ -19,7 +19,7 @@ use handlebars::Handlebars;
 use log::{debug, error, warn};
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue},
-    Client, Method, StatusCode,
+    Client, Method, Response, StatusCode,
 };
 use serde_json::{Map, Value};
 use std::time::Duration;
@@ -31,6 +31,10 @@ use crate::output::{DefaultChangeNotification, Operation};
 
 const MAX_DELIVERY_ATTEMPTS: usize = 3;
 const INITIAL_RETRY_BACKOFF: Duration = Duration::from_millis(100);
+
+/// Maximum response body inspected by a configured JSON response validator.
+/// The limit is enforced while chunks are read, before JSON parsing.
+const MAX_VALIDATED_RESPONSE_BODY_BYTES: usize = 1024 * 1024;
 
 /// Maximum length of a downstream-supplied string (response body, rendered URL)
 /// allowed into a log line.
@@ -67,6 +71,24 @@ pub(crate) enum DeliveryOutcome {
     Delivered,
     /// The event was permanently undeliverable and dropped.
     Dropped,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DeliveryOptions<'a> {
+    description: &'a str,
+    reject_non_empty_json_pointer: Option<&'a str>,
+}
+
+impl<'a> DeliveryOptions<'a> {
+    pub(crate) const fn new(
+        description: &'a str,
+        reject_non_empty_json_pointer: Option<&'a str>,
+    ) -> Self {
+        Self {
+            description,
+            reject_non_empty_json_pointer,
+        }
+    }
 }
 
 /// Build a [`Handlebars`] registry pre-loaded with the `json` helper used
@@ -330,7 +352,10 @@ pub(crate) async fn process_result(
         headers,
         body,
         reaction_name,
-        "HTTP request",
+        DeliveryOptions::new(
+            "HTTP request",
+            call_spec.extension.reject_non_empty_json_pointer.as_deref(),
+        ),
     )
     .await
 }
@@ -372,7 +397,7 @@ pub(crate) async fn post_default_notification(
         headers,
         body,
         reaction_name,
-        "default-notification HTTP request",
+        DeliveryOptions::new("default-notification HTTP request", None),
     )
     .await
 }
@@ -384,8 +409,12 @@ pub(crate) async fn send_with_retry(
     headers: HeaderMap,
     body: String,
     reaction_name: &str,
-    description: &str,
+    options: DeliveryOptions<'_>,
 ) -> Result<DeliveryOutcome> {
+    let DeliveryOptions {
+        description,
+        reject_non_empty_json_pointer,
+    } = options;
     let mut backoff = INITIAL_RETRY_BACKOFF;
 
     for attempt in 1..=MAX_DELIVERY_ATTEMPTS {
@@ -405,6 +434,9 @@ pub(crate) async fn send_with_retry(
                 );
 
                 if status.is_success() {
+                    if let Some(pointer) = reject_non_empty_json_pointer {
+                        validate_success_response(response, pointer, description).await?;
+                    }
                     return Ok(DeliveryOutcome::Delivered);
                 }
 
@@ -473,6 +505,73 @@ pub(crate) async fn send_with_retry(
     }
 
     unreachable!("retry loop always returns")
+}
+
+async fn validate_success_response(
+    mut response: Response,
+    pointer: &str,
+    description: &str,
+) -> Result<()> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| {
+        anyhow!(
+            "{description} returned a 2xx response whose body could not be read for \
+             `rejectNonEmptyJsonPointer` validation: {}",
+            truncate_for_log(&e.to_string())
+        )
+    })? {
+        if chunk.len() > MAX_VALIDATED_RESPONSE_BODY_BYTES.saturating_sub(body.len()) {
+            return Err(anyhow!(
+                "{description} returned a 2xx response body exceeding the \
+                 {MAX_VALIDATED_RESPONSE_BODY_BYTES}-byte validation limit"
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    let document: Value = serde_json::from_slice(&body).map_err(|e| {
+        anyhow!(
+            "{description} returned invalid JSON required by \
+             `rejectNonEmptyJsonPointer` validation: {e}"
+        )
+    })?;
+
+    let Some(value) = document.pointer(pointer) else {
+        return Ok(());
+    };
+    if is_empty_json_value(value) {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "{description} response validation failed: JSON pointer '{}' resolved to a non-empty {}",
+        truncate_for_log(pointer),
+        json_value_kind(value)
+    ))
+}
+
+fn is_empty_json_value(value: &Value) -> bool {
+    match value {
+        Value::Null => true,
+        Value::Bool(value) => !value,
+        Value::Number(value) => {
+            value.as_i64() == Some(0) || value.as_u64() == Some(0) || value.as_f64() == Some(0.0)
+        }
+        Value::String(value) => value.is_empty(),
+        Value::Array(value) => value.is_empty(),
+        Value::Object(value) => value.is_empty(),
+    }
+}
+
+fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
 }
 
 /// How a non-2xx HTTP response status should be handled.

--- a/components/reactions/http/src/process.rs
+++ b/components/reactions/http/src/process.rs
@@ -554,13 +554,31 @@ fn is_empty_json_value(value: &Value) -> bool {
     match value {
         Value::Null => true,
         Value::Bool(value) => !value,
-        Value::Number(value) => {
-            value.as_i64() == Some(0) || value.as_u64() == Some(0) || value.as_f64() == Some(0.0)
-        }
+        Value::Number(value) => is_json_number_zero(value),
         Value::String(value) => value.is_empty(),
         Value::Array(value) => value.is_empty(),
         Value::Object(value) => value.is_empty(),
     }
+}
+
+fn is_json_number_zero(number: &serde_json::Number) -> bool {
+    let lexeme = number.as_str();
+    let significand = lexeme
+        .split_once('e')
+        .or_else(|| lexeme.split_once('E'))
+        .map_or(lexeme, |(significand, _)| significand);
+    let mut saw_digit = false;
+
+    for byte in significand.bytes() {
+        match byte {
+            b'0' => saw_digit = true,
+            b'1'..=b'9' => return false,
+            b'-' | b'.' => {}
+            _ => return false,
+        }
+    }
+
+    saw_digit
 }
 
 fn json_value_kind(value: &Value) -> &'static str {
@@ -724,6 +742,36 @@ mod tests {
                 !is_retryable_status(StatusCode::from_u16(code).unwrap()),
                 "{code} should NOT be retryable"
             );
+        }
+    }
+
+    #[test]
+    fn numeric_empty_values_use_exact_json_lexemes() {
+        for raw in [
+            "0",
+            "-0",
+            "0.0",
+            "-0.000",
+            "0e-400",
+            "0E+400",
+            "-0.000e+999",
+        ] {
+            let value: Value = serde_json::from_str(raw).expect("valid zero JSON number");
+            assert!(is_empty_json_value(&value), "{raw} should be zero");
+        }
+
+        for raw in [
+            "1",
+            "-1",
+            "1e-400",
+            "-1e-400",
+            "1e+400",
+            "-1e+400",
+            "0.0000000000000000000000000000000000001",
+            "1234567890123456789012345678901234567890",
+        ] {
+            let value: Value = serde_json::from_str(raw).expect("valid nonzero JSON number");
+            assert!(!is_empty_json_value(&value), "{raw} should be nonzero");
         }
     }
 

--- a/components/reactions/http/src/process.rs
+++ b/components/reactions/http/src/process.rs
@@ -21,8 +21,8 @@ use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue},
     Client, Method, Response, StatusCode,
 };
-use serde_json::{Map, Value};
-use std::time::Duration;
+use serde_json::{value::RawValue, Map, Value};
+use std::{collections::HashMap, time::Duration};
 
 use crate::config::{
     parse_http_method, resolve_http_url, HttpCallSpec, HttpReactionConfig, TemplateRouting,
@@ -529,40 +529,118 @@ async fn validate_success_response(
         body.extend_from_slice(&chunk);
     }
 
-    let document: Value = serde_json::from_slice(&body).map_err(|e| {
+    // RawValue validates the complete document while preserving number text only
+    // in this response path; normal serde_json::Value parsing remains unchanged.
+    let document: Box<RawValue> = serde_json::from_slice(&body).map_err(|e| {
         anyhow!(
             "{description} returned invalid JSON required by \
              `rejectNonEmptyJsonPointer` validation: {e}"
         )
     })?;
 
-    let Some(value) = document.pointer(pointer) else {
+    let Some(value) = resolve_raw_json_pointer(document, pointer).map_err(|e| {
+        anyhow!(
+            "{description} returned JSON that could not be inspected for \
+             `rejectNonEmptyJsonPointer` validation: {e}"
+        )
+    })?
+    else {
         return Ok(());
     };
-    if is_empty_json_value(value) {
+    let (is_empty, kind) = classify_raw_json_value(&value).map_err(|e| {
+        anyhow!(
+            "{description} returned JSON that could not be inspected for \
+             `rejectNonEmptyJsonPointer` validation: {e}"
+        )
+    })?;
+    if is_empty {
         return Ok(());
     }
 
     Err(anyhow!(
         "{description} response validation failed: JSON pointer '{}' resolved to a non-empty {}",
         truncate_for_log(pointer),
-        json_value_kind(value)
+        kind
     ))
 }
 
-fn is_empty_json_value(value: &Value) -> bool {
-    match value {
-        Value::Null => true,
-        Value::Bool(value) => !value,
-        Value::Number(value) => is_json_number_zero(value),
-        Value::String(value) => value.is_empty(),
-        Value::Array(value) => value.is_empty(),
-        Value::Object(value) => value.is_empty(),
+fn resolve_raw_json_pointer(
+    mut current: Box<RawValue>,
+    pointer: &str,
+) -> serde_json::Result<Option<Box<RawValue>>> {
+    if pointer.is_empty() {
+        return Ok(Some(current));
+    }
+
+    let Some(tokens) = pointer.strip_prefix('/') else {
+        return Ok(None);
+    };
+
+    for encoded_token in tokens.split('/') {
+        let token = encoded_token.replace("~1", "/").replace("~0", "~");
+        current = match current.get().trim_start().as_bytes().first() {
+            Some(b'{') => {
+                let mut object: HashMap<String, Box<RawValue>> =
+                    serde_json::from_str(current.get())?;
+                let Some(value) = object.remove(&token) else {
+                    return Ok(None);
+                };
+                value
+            }
+            Some(b'[') => {
+                let Some(index) = parse_json_pointer_array_index(&token) else {
+                    return Ok(None);
+                };
+                let array: Vec<Box<RawValue>> = serde_json::from_str(current.get())?;
+                let Some(value) = array.into_iter().nth(index) else {
+                    return Ok(None);
+                };
+                value
+            }
+            _ => return Ok(None),
+        };
+    }
+
+    Ok(Some(current))
+}
+
+fn parse_json_pointer_array_index(token: &str) -> Option<usize> {
+    if token == "0" {
+        return Some(0);
+    }
+    if token.is_empty()
+        || token.starts_with('0')
+        || !token.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+    token.parse().ok()
+}
+
+fn classify_raw_json_value(value: &RawValue) -> Result<(bool, &'static str)> {
+    let raw = value.get().trim();
+    match raw.as_bytes().first() {
+        Some(b'n') => Ok((true, "null")),
+        Some(b'f') => Ok((true, "boolean")),
+        Some(b't') => Ok((false, "boolean")),
+        Some(b'"') => {
+            let string: String = serde_json::from_str(raw)?;
+            Ok((string.is_empty(), "string"))
+        }
+        Some(b'[') => {
+            let array: Vec<Box<RawValue>> = serde_json::from_str(raw)?;
+            Ok((array.is_empty(), "array"))
+        }
+        Some(b'{') => {
+            let object: HashMap<String, Box<RawValue>> = serde_json::from_str(raw)?;
+            Ok((object.is_empty(), "object"))
+        }
+        Some(b'-' | b'0'..=b'9') => Ok((is_json_number_zero(raw), "number")),
+        _ => Err(anyhow!("validated JSON had an unrecognized value type")),
     }
 }
 
-fn is_json_number_zero(number: &serde_json::Number) -> bool {
-    let lexeme = number.as_str();
+fn is_json_number_zero(lexeme: &str) -> bool {
     let significand = lexeme
         .split_once('e')
         .or_else(|| lexeme.split_once('E'))
@@ -579,17 +657,6 @@ fn is_json_number_zero(number: &serde_json::Number) -> bool {
     }
 
     saw_digit
-}
-
-fn json_value_kind(value: &Value) -> &'static str {
-    match value {
-        Value::Null => "null",
-        Value::Bool(_) => "boolean",
-        Value::Number(_) => "number",
-        Value::String(_) => "string",
-        Value::Array(_) => "array",
-        Value::Object(_) => "object",
-    }
 }
 
 /// How a non-2xx HTTP response status should be handled.
@@ -746,7 +813,15 @@ mod tests {
     }
 
     #[test]
-    fn numeric_empty_values_use_exact_json_lexemes() {
+    fn raw_value_feature_does_not_change_normal_json_number_parsing() {
+        assert!(
+            serde_json::from_str::<Value>("1e400").is_err(),
+            "raw response inspection must not change normal serde_json::Value number semantics"
+        );
+    }
+
+    #[test]
+    fn raw_numeric_empty_values_use_exact_json_lexemes() {
         for raw in [
             "0",
             "-0",
@@ -756,8 +831,11 @@ mod tests {
             "0E+400",
             "-0.000e+999",
         ] {
-            let value: Value = serde_json::from_str(raw).expect("valid zero JSON number");
-            assert!(is_empty_json_value(&value), "{raw} should be zero");
+            let value: Box<RawValue> =
+                serde_json::from_str(raw).expect("valid raw zero JSON number");
+            let (is_empty, kind) = classify_raw_json_value(&value).expect("zero should classify");
+            assert_eq!(kind, "number");
+            assert!(is_empty, "{raw} should be zero");
         }
 
         for raw in [
@@ -770,9 +848,53 @@ mod tests {
             "0.0000000000000000000000000000000000001",
             "1234567890123456789012345678901234567890",
         ] {
-            let value: Value = serde_json::from_str(raw).expect("valid nonzero JSON number");
-            assert!(!is_empty_json_value(&value), "{raw} should be nonzero");
+            let value: Box<RawValue> =
+                serde_json::from_str(raw).expect("valid raw nonzero JSON number");
+            let (is_empty, kind) =
+                classify_raw_json_value(&value).expect("nonzero should classify");
+            assert_eq!(kind, "number");
+            assert!(!is_empty, "{raw} should be nonzero");
         }
+    }
+
+    #[test]
+    fn raw_json_pointer_preserves_rfc_6901_traversal_semantics() {
+        let document: Box<RawValue> = serde_json::from_str(
+            r#"{
+                "a/b": {
+                    "~key": [
+                        {"errors": 0},
+                        {"errors": 1e400}
+                    ]
+                },
+                "01": "object key"
+            }"#,
+        )
+        .expect("valid raw JSON document");
+
+        let value = resolve_raw_json_pointer(document, "/a~1b/~0key/1/errors")
+            .expect("pointer should resolve")
+            .expect("pointer target should exist");
+        assert_eq!(value.get(), "1e400");
+
+        let document: Box<RawValue> =
+            serde_json::from_str(r#"[10, 20]"#).expect("valid raw JSON array");
+        assert!(
+            resolve_raw_json_pointer(document, "/01")
+                .expect("array pointer should be inspected")
+                .is_none(),
+            "array indices with a leading zero are not valid RFC 6901 indices"
+        );
+
+        let document: Box<RawValue> =
+            serde_json::from_str(r#"{"01":"object key"}"#).expect("valid raw JSON object");
+        assert_eq!(
+            resolve_raw_json_pointer(document, "/01")
+                .expect("object pointer should resolve")
+                .expect("numeric object key should exist")
+                .get(),
+            r#""object key""#
+        );
     }
 
     #[test]

--- a/components/reactions/http/src/tests.rs
+++ b/components/reactions/http/src/tests.rs
@@ -126,6 +126,7 @@ fn builder_with_output_templates_round_trip() {
                     url: "/added".to_string(),
                     method: "POST".to_string(),
                     headers: HashMap::new(),
+                    reject_non_empty_json_pointer: Some("/errors".to_string()),
                 },
             }),
             updated: None,
@@ -150,6 +151,12 @@ fn builder_with_output_templates_round_trip() {
         .and_then(|v| v.as_object())
         .expect("routes object");
     assert!(routes.contains_key("q1"));
+    let added = &routes["q1"]["added"];
+    assert_eq!(
+        added.get("rejectNonEmptyJsonPointer"),
+        Some(&serde_json::json!("/errors"))
+    );
+    assert!(added.get("reject_non_empty_json_pointer").is_none());
 }
 
 #[test]
@@ -165,6 +172,7 @@ fn builder_with_query_template_adds_to_routes() {
                         url: "/q1".to_string(),
                         method: "POST".to_string(),
                         headers: HashMap::new(),
+                        ..Default::default()
                     },
                 }),
                 ..Default::default()
@@ -227,6 +235,32 @@ fn config_deserialize_with_output_templates() {
     let templates = c.output_templates.unwrap();
     assert!(templates.default_template.is_some());
     assert!(templates.routes.contains_key("q1"));
+}
+
+#[test]
+fn response_validator_serde_uses_exact_camel_case_key() {
+    let spec: crate::config::HttpCallSpec = serde_json::from_value(serde_json::json!({
+        "template": "{}",
+        "url": "/graphql",
+        "method": "POST",
+        "rejectNonEmptyJsonPointer": "/errors"
+    }))
+    .unwrap();
+    assert_eq!(
+        spec.extension.reject_non_empty_json_pointer.as_deref(),
+        Some("/errors")
+    );
+
+    let value = serde_json::to_value(&spec).unwrap();
+    assert_eq!(
+        value.get("rejectNonEmptyJsonPointer"),
+        Some(&serde_json::json!("/errors"))
+    );
+    assert!(value.get("reject_non_empty_json_pointer").is_none());
+    assert!(serde_json::from_value::<HttpCallExt>(
+        serde_json::json!({ "reject_non_empty_json_pointer": "/errors" })
+    )
+    .is_err());
 }
 
 #[test]
@@ -361,6 +395,7 @@ fn descriptor_kind_and_version() {
     assert!(schema.contains("HttpQueryConfig"));
     assert!(schema.contains("HttpCallSpec"));
     assert!(schema.contains("AdaptiveBatchConfig"));
+    assert!(schema.contains("\"rejectNonEmptyJsonPointer\""));
 }
 
 #[tokio::test]
@@ -422,6 +457,56 @@ async fn descriptor_creates_standard_reaction() {
     assert_eq!(
         p.get("baseUrl"),
         Some(&serde_json::Value::String("http://example.com".to_string()))
+    );
+}
+
+#[tokio::test]
+async fn descriptor_maps_and_validates_response_validator() {
+    use drasi_plugin_sdk::ReactionPluginDescriptor;
+    let d = crate::descriptor::HttpReactionDescriptor;
+    let cfg = serde_json::json!({
+        "baseUrl": "http://example.com",
+        "outputTemplates": {
+            "routes": {
+                "q1": {
+                    "added": {
+                        "url": "/graphql",
+                        "rejectNonEmptyJsonPointer": "/errors"
+                    }
+                }
+            }
+        }
+    });
+    let reaction = d
+        .create_reaction("my-r", vec!["q1".to_string()], &cfg, true)
+        .await
+        .expect("descriptor must understand the response validator");
+    assert_eq!(
+        reaction.properties()["outputTemplates"]["routes"]["q1"]["added"]
+            ["rejectNonEmptyJsonPointer"],
+        serde_json::json!("/errors")
+    );
+
+    let invalid = serde_json::json!({
+        "baseUrl": "http://example.com",
+        "outputTemplates": {
+            "routes": {
+                "q1": {
+                    "added": {
+                        "rejectNonEmptyJsonPointer": "/errors~2"
+                    }
+                }
+            }
+        }
+    });
+    let err = d
+        .create_reaction("my-r", vec!["q1".to_string()], &invalid, true)
+        .await
+        .err()
+        .expect("descriptor must pass the field into domain validation");
+    assert!(
+        format!("{err:#}").contains("rejectNonEmptyJsonPointer"),
+        "{err:#}"
     );
 }
 
@@ -516,6 +601,7 @@ fn spec_with(url: &str, template: &str, headers: HashMap<String, String>) -> Htt
                 url: url.to_string(),
                 method: "POST".to_string(),
                 headers,
+                ..Default::default()
             },
         }),
         ..Default::default()
@@ -576,6 +662,73 @@ fn build_succeeds_when_adaptive_combined_with_output_templates() {
         "adaptive + outputTemplates must build: {:?}",
         r.err()
     );
+}
+
+#[test]
+fn build_validates_rfc6901_response_pointer() {
+    for pointer in ["/errors", "/", "/a~1b/~0key"] {
+        let mut spec = spec_with("/graphql", "{}", HashMap::new());
+        spec.added
+            .as_mut()
+            .unwrap()
+            .extension
+            .reject_non_empty_json_pointer = Some(pointer.to_string());
+        assert!(
+            HttpReaction::builder("r")
+                .with_query("q1")
+                .with_query_template("q1", spec)
+                .build()
+                .is_ok(),
+            "{pointer} should be valid"
+        );
+    }
+
+    for pointer in [
+        "",
+        "errors",
+        "#/errors",
+        "/errors~",
+        "/errors~2",
+        "/errors~~0",
+    ] {
+        let mut spec = spec_with("/graphql", "{}", HashMap::new());
+        spec.added
+            .as_mut()
+            .unwrap()
+            .extension
+            .reject_non_empty_json_pointer = Some(pointer.to_string());
+        let err = HttpReaction::builder("r")
+            .with_query("q1")
+            .with_query_template("q1", spec)
+            .build()
+            .err()
+            .expect("invalid pointer must fail construction");
+        assert!(
+            format!("{err:#}").contains("rejectNonEmptyJsonPointer"),
+            "{pointer:?}: {err:#}"
+        );
+    }
+}
+
+#[test]
+fn build_rejects_response_validator_in_adaptive_mode() {
+    let mut spec = spec_with("/graphql", "{}", HashMap::new());
+    spec.added
+        .as_mut()
+        .unwrap()
+        .extension
+        .reject_non_empty_json_pointer = Some("/errors".to_string());
+    let err = HttpReaction::builder("r")
+        .with_query("q1")
+        .with_query_template("q1", spec)
+        .with_adaptive_defaults()
+        .with_batch_endpoint("/batch")
+        .build()
+        .err()
+        .expect("adaptive mode must not ignore a per-call response validator");
+    let message = format!("{err:#}");
+    assert!(message.contains("rejectNonEmptyJsonPointer"), "{message}");
+    assert!(message.contains("adaptive"), "{message}");
 }
 
 #[test]
@@ -1106,6 +1259,7 @@ fn validate_rejects_invalid_url_template_in_route() {
                     url: "/x/{{#if}}".to_string(), // unclosed block → compile error
                     method: "POST".to_string(),
                     headers: HashMap::new(),
+                    ..Default::default()
                 },
             }),
             ..Default::default()
@@ -1310,6 +1464,20 @@ async fn start_revalidates_and_sets_error_on_invalid_config() {
     let r = HttpReaction::new("r", vec!["q1".to_string()], cfg);
     assert!(r.start().await.is_err(), "start must reject invalid config");
     assert!(matches!(r.status().await, ComponentStatus::Error));
+}
+
+#[tokio::test]
+async fn start_rejects_invalid_response_pointer() {
+    let mut spec = spec_with("/graphql", "{}", HashMap::new());
+    spec.added
+        .as_mut()
+        .unwrap()
+        .extension
+        .reject_non_empty_json_pointer = Some("/errors~2".to_string());
+    let config = cfg_with_routes(None, HashMap::from([("q1".to_string(), spec)]));
+    let reaction = HttpReaction::new("r", vec!["q1".to_string()], config);
+    assert!(reaction.start().await.is_err());
+    assert!(matches!(reaction.status().await, ComponentStatus::Error));
 }
 
 // ---------------------------------------------------------------------------

--- a/components/reactions/http/tests/integration_tests.rs
+++ b/components/reactions/http/tests/integration_tests.rs
@@ -567,7 +567,8 @@ async fn response_validator_rejects_extreme_nonzero_numbers_without_retry() {
     let cases = [
         ("tiny-positive", r#"{"errors":1e-400}"#),
         ("tiny-negative", r#"{"errors":-1e-400}"#),
-        ("large-positive", r#"{"errors":1e+400}"#),
+        ("large-positive", r#"{"errors":1e400}"#),
+        ("large-positive-explicit-sign", r#"{"errors":1e+400}"#),
         (
             "small-decimal",
             r#"{"errors":0.0000000000000000000000000000000000001}"#,

--- a/components/reactions/http/tests/integration_tests.rs
+++ b/components/reactions/http/tests/integration_tests.rs
@@ -563,6 +563,76 @@ async fn response_validator_rejects_non_empty_values_without_retry() {
 }
 
 #[tokio::test]
+async fn response_validator_rejects_extreme_nonzero_numbers_without_retry() {
+    let cases = [
+        ("tiny-positive", r#"{"errors":1e-400}"#),
+        ("tiny-negative", r#"{"errors":-1e-400}"#),
+        ("large-positive", r#"{"errors":1e+400}"#),
+        (
+            "small-decimal",
+            r#"{"errors":0.0000000000000000000000000000000000001}"#,
+        ),
+    ];
+
+    for (name, response_body) in cases {
+        let server = mock_server::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_body))
+            .mount(&server)
+            .await;
+        let reaction = response_validator_reaction(name, server.uri(), Some("/errors"));
+        reaction.start().await.unwrap();
+        enqueue_add(&reaction, "q1", json!({"id": 1})).await;
+        assert!(
+            wait_for_status(&reaction, ComponentStatus::Error, 2000).await,
+            "{name} should fail-stop"
+        );
+        tokio::time::sleep(Duration::from_millis(400)).await;
+
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "{name} logical rejection must not retry"
+        );
+        reaction.stop().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn response_validator_accepts_exact_zero_number_forms() {
+    let cases = [
+        ("integer-zero", r#"{"errors":0}"#),
+        ("negative-zero", r#"{"errors":-0}"#),
+        ("decimal-zero", r#"{"errors":0.0}"#),
+        ("exponent-zero", r#"{"errors":0e-400}"#),
+        ("negative-exponent-zero", r#"{"errors":-0.000e+999}"#),
+    ];
+
+    for (name, response_body) in cases {
+        let server = mock_server::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(response_body))
+            .mount(&server)
+            .await;
+        let reaction = response_validator_reaction(name, server.uri(), Some("/errors"));
+        reaction.start().await.unwrap();
+        enqueue_add(&reaction, "q1", json!({"id": 1})).await;
+        wait_for_requests(&server, 1, 2000).await;
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+        assert_eq!(
+            reaction.status().await,
+            ComponentStatus::Running,
+            "{name} should be accepted as mathematical zero"
+        );
+        reaction.stop().await.unwrap();
+    }
+}
+
+#[tokio::test]
 async fn response_validator_rejects_malformed_json_and_oversized_body_once() {
     let cases = [
         (

--- a/components/reactions/http/tests/integration_tests.rs
+++ b/components/reactions/http/tests/integration_tests.rs
@@ -21,6 +21,7 @@ mod mock_source;
 
 use anyhow::Result;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,6 +34,9 @@ use drasi_reaction_http::{
 };
 use mock_source::{MockSource, PropertyMapBuilder};
 use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
@@ -98,6 +102,143 @@ async fn wait_for_requests(server: &wiremock::MockServer, expected: usize, max_m
         }
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
+}
+
+async fn wait_for_status(reaction: &HttpReaction, expected: ComponentStatus, max_ms: u64) -> bool {
+    let deadline = std::time::Instant::now() + Duration::from_millis(max_ms);
+    loop {
+        if reaction.status().await == expected {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+fn response_validator_config(path: &str, pointer: Option<&str>) -> HttpQueryConfig {
+    HttpQueryConfig {
+        added: Some(TemplateSpec {
+            template: String::new(),
+            extension: HttpCallExt {
+                url: path.to_string(),
+                method: "POST".to_string(),
+                headers: HashMap::new(),
+                reject_non_empty_json_pointer: pointer.map(str::to_string),
+            },
+        }),
+        ..Default::default()
+    }
+}
+
+fn response_validator_reaction(
+    id: &str,
+    base_url: String,
+    pointer: Option<&str>,
+) -> Arc<HttpReaction> {
+    Arc::new(
+        HttpReaction::builder(id)
+            .with_base_url(base_url)
+            .with_query("q1")
+            .with_query_template("q1", response_validator_config("/graphql", pointer))
+            .build()
+            .expect("response-validating reaction should build"),
+    )
+}
+
+struct RawResponseServer {
+    uri: String,
+    requests: Arc<AtomicUsize>,
+    task: JoinHandle<()>,
+}
+
+impl RawResponseServer {
+    async fn start(response: Vec<u8>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("raw response server should bind");
+        let address = listener
+            .local_addr()
+            .expect("raw response server should have a local address");
+        let requests = Arc::new(AtomicUsize::new(0));
+        let request_count = Arc::clone(&requests);
+        let task = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                request_count.fetch_add(1, Ordering::SeqCst);
+                read_http_request(&mut stream).await;
+                let _ = stream.write_all(&response).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+        Self {
+            uri: format!("http://{address}"),
+            requests,
+            task,
+        }
+    }
+}
+
+impl Drop for RawResponseServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn read_http_request(stream: &mut TcpStream) {
+    const MAX_TEST_REQUEST_BYTES: usize = 64 * 1024;
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    loop {
+        let Ok(read) = stream.read(&mut buffer).await else {
+            return;
+        };
+        if read == 0 {
+            return;
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if request.len() > MAX_TEST_REQUEST_BYTES {
+            return;
+        }
+
+        let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+            .and_then(|(_, value)| value.trim().parse::<usize>().ok())
+            .unwrap_or(0);
+        if request.len() >= header_end + 4 + content_length {
+            return;
+        }
+    }
+}
+
+async fn wait_for_raw_requests(server: &RawResponseServer, expected: usize) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while server.requests.load(Ordering::SeqCst) < expected {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for {expected} raw HTTP request(s)"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+fn chunked_response(body: &[u8], chunk_size: usize) -> Vec<u8> {
+    let mut response =
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+            .to_vec();
+    for chunk in body.chunks(chunk_size) {
+        response.extend_from_slice(format!("{:X}\r\n", chunk.len()).as_bytes());
+        response.extend_from_slice(chunk);
+        response.extend_from_slice(b"\r\n");
+    }
+    response.extend_from_slice(b"0\r\n\r\n");
+    response
 }
 
 #[tokio::test]
@@ -228,6 +369,7 @@ async fn standard_uses_per_query_template() {
             url: "/items/{{after.id}}".to_string(),
             method: "PUT".to_string(),
             headers,
+            ..Default::default()
         },
     };
     let r = Arc::new(
@@ -276,6 +418,7 @@ async fn standard_body_render_error_uses_default_envelope_on_configured_route() 
             url: "/items".to_string(),
             method: "POST".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     };
     let r = Arc::new(
@@ -342,6 +485,186 @@ async fn standard_authorization_header_sent_when_token_set() {
 }
 
 // ---------------------------------------------------------------------------
+// Standard mode: successful-response JSON validation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn response_validator_accepts_missing_and_empty_values() {
+    let cases = [
+        ("missing", json!({"data": {"ok": true}})),
+        ("null", json!({"errors": null})),
+        ("false", json!({"errors": false})),
+        ("zero", json!({"errors": 0})),
+        ("empty-string", json!({"errors": ""})),
+        ("empty-array", json!({"errors": []})),
+        ("empty-object", json!({"errors": {}})),
+    ];
+
+    for (name, response_body) in cases {
+        let server = mock_server::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .mount(&server)
+            .await;
+        let reaction = response_validator_reaction(name, server.uri(), Some("/errors"));
+        reaction.start().await.unwrap();
+        enqueue_add(&reaction, "q1", json!({"id": 1})).await;
+        wait_for_requests(&server, 1, 2000).await;
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "{name} should require exactly one request"
+        );
+        assert_eq!(
+            reaction.status().await,
+            ComponentStatus::Running,
+            "{name} should pass validation"
+        );
+        reaction.stop().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn response_validator_rejects_non_empty_values_without_retry() {
+    let cases = [
+        ("array", json!({"errors": [{"message": "nope"}]})),
+        ("object", json!({"errors": {"message": "nope"}})),
+        ("string", json!({"errors": "nope"})),
+        ("true", json!({"errors": true})),
+        ("nonzero", json!({"errors": 1})),
+    ];
+
+    for (name, response_body) in cases {
+        let server = mock_server::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .mount(&server)
+            .await;
+        let reaction = response_validator_reaction(name, server.uri(), Some("/errors"));
+        reaction.start().await.unwrap();
+        enqueue_add(&reaction, "q1", json!({"id": 1})).await;
+        assert!(
+            wait_for_status(&reaction, ComponentStatus::Error, 2000).await,
+            "{name} should fail-stop"
+        );
+        tokio::time::sleep(Duration::from_millis(400)).await;
+
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "{name} logical rejection must not retry"
+        );
+        reaction.stop().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn response_validator_rejects_malformed_json_and_oversized_body_once() {
+    let cases = [
+        (
+            "malformed",
+            ResponseTemplate::new(200).set_body_string("{not-json"),
+        ),
+        (
+            "oversized",
+            ResponseTemplate::new(200).set_body_bytes(vec![b' '; 1024 * 1024 + 1]),
+        ),
+    ];
+
+    for (name, response) in cases {
+        let server = mock_server::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(response)
+            .mount(&server)
+            .await;
+        let reaction = response_validator_reaction(name, server.uri(), Some("/errors"));
+        reaction.start().await.unwrap();
+        enqueue_add(&reaction, "q1", json!({"id": 1})).await;
+        assert!(
+            wait_for_status(&reaction, ComponentStatus::Error, 3000).await,
+            "{name} should fail-stop"
+        );
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "{name} response failure must not retry"
+        );
+        reaction.stop().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn omitted_response_validator_preserves_status_only_2xx_behavior() {
+    let server = mock_server::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{not-json"))
+        .mount(&server)
+        .await;
+    let reaction = response_validator_reaction("legacy", server.uri(), None);
+    reaction.start().await.unwrap();
+    enqueue_add(&reaction, "q1", json!({"id": 1})).await;
+    wait_for_requests(&server, 1, 2000).await;
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    assert_eq!(reaction.status().await, ComponentStatus::Running);
+    reaction.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn response_validator_bounds_chunked_body_without_retry() {
+    let body = vec![b' '; 1024 * 1024 + 1];
+    let server = RawResponseServer::start(chunked_response(&body, 16 * 1024)).await;
+    let reaction =
+        response_validator_reaction("chunked-overflow", server.uri.clone(), Some("/errors"));
+    reaction.start().await.unwrap();
+    enqueue_add(&reaction, "q1", json!({"id": 1})).await;
+    wait_for_raw_requests(&server, 1).await;
+    assert!(
+        wait_for_status(&reaction, ComponentStatus::Error, 3000).await,
+        "chunked response over the 1 MiB limit should fail-stop"
+    );
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    assert_eq!(
+        server.requests.load(Ordering::SeqCst),
+        1,
+        "chunked overflow must not retry"
+    );
+    reaction.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn response_validator_treats_truncated_body_as_read_failure_without_retry() {
+    let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 64\r\nConnection: close\r\n\r\n{\"errors\":[".to_vec();
+    let server = RawResponseServer::start(response).await;
+    let reaction =
+        response_validator_reaction("truncated-body", server.uri.clone(), Some("/errors"));
+    reaction.start().await.unwrap();
+    enqueue_add(&reaction, "q1", json!({"id": 1})).await;
+    wait_for_raw_requests(&server, 1).await;
+    assert!(
+        wait_for_status(&reaction, ComponentStatus::Error, 3000).await,
+        "truncated response body should fail-stop"
+    );
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    assert_eq!(
+        server.requests.load(Ordering::SeqCst),
+        1,
+        "response read failure must not retry"
+    );
+    reaction.stop().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // UPDATE / DELETE context building
 // ---------------------------------------------------------------------------
 
@@ -360,6 +683,7 @@ async fn standard_update_template_receives_before_and_after() {
             url: "/items/{{after.id}}".to_string(),
             method: "PUT".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     };
     let r = Arc::new(
@@ -409,6 +733,7 @@ async fn standard_delete_template_receives_before() {
             url: "/items/{{before.id}}".to_string(),
             method: "DELETE".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     };
     let r = Arc::new(
@@ -814,6 +1139,7 @@ async fn ssrf_guard_blocks_absolute_url_with_mismatched_host() {
             url: "http://evil.example.com/x".to_string(),
             method: "POST".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     };
     // DELETE template renders a safe relative URL — must be delivered, and
@@ -824,6 +1150,7 @@ async fn ssrf_guard_blocks_absolute_url_with_mismatched_host() {
             url: "/safe".to_string(),
             method: "POST".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     };
 
@@ -1152,6 +1479,7 @@ async fn template_context_exposes_query_id_metadata_and_operation() {
             url: "/ingest".to_string(),
             method: "POST".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     };
     let r = Arc::new(
@@ -1213,6 +1541,7 @@ async fn route_resolves_via_last_dotted_segment() {
             url: "/seg".to_string(),
             method: "POST".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     };
     let r = Arc::new(
@@ -1260,7 +1589,7 @@ async fn standard_retries_transient_failure_then_succeeds() {
         .await;
     Mock::given(method("POST"))
         .and(path("/changes/q1"))
-        .respond_with(ResponseTemplate::new(200))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": {}})))
         .mount(&server)
         .await;
 
@@ -1268,6 +1597,10 @@ async fn standard_retries_transient_failure_then_succeeds() {
         HttpReaction::builder("retry-then-ok")
             .with_base_url(server.uri())
             .with_query("q1")
+            .with_query_template(
+                "q1",
+                response_validator_config("/changes/q1", Some("/errors")),
+            )
             .build()
             .unwrap(),
     );
@@ -1297,6 +1630,10 @@ async fn standard_drops_permanent_4xx_and_continues() {
         HttpReaction::builder("perm-4xx")
             .with_base_url(server.uri())
             .with_query("q1")
+            .with_query_template(
+                "q1",
+                response_validator_config("/changes/q1", Some("/errors")),
+            )
             .build()
             .unwrap(),
     );
@@ -1336,6 +1673,10 @@ async fn standard_auth_rejection_fail_stops_and_does_not_drop_event() {
         HttpReaction::builder("auth-401")
             .with_base_url(server.uri())
             .with_query("q1")
+            .with_query_template(
+                "q1",
+                response_validator_config("/changes/q1", Some("/errors")),
+            )
             .build()
             .unwrap(),
     );
@@ -1421,6 +1762,7 @@ async fn standard_absolute_url_matching_base_is_allowed() {
             url: absolute,
             method: "POST".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     };
     let r = Arc::new(
@@ -1464,6 +1806,7 @@ async fn standard_url_render_failure_falls_back_to_changes_endpoint() {
             url: "/items/{{badhelper after.id}}".to_string(),
             method: "POST".to_string(),
             headers: HashMap::new(),
+            ..Default::default()
         },
     };
     let r = Arc::new(
@@ -1508,6 +1851,7 @@ async fn standard_header_render_failure_drops_only_that_header() {
             url: "/h".to_string(),
             method: "POST".to_string(),
             headers,
+            ..Default::default()
         },
     };
     let r = Arc::new(
@@ -1558,6 +1902,7 @@ async fn standard_routes_two_queries_to_distinct_endpoints() {
                 url: url.to_string(),
                 method: "POST".to_string(),
                 headers: HashMap::new(),
+                ..Default::default()
             },
         }),
         ..Default::default()

--- a/components/reactions/http/tests/recovery_e2e.rs
+++ b/components/reactions/http/tests/recovery_e2e.rs
@@ -169,6 +169,15 @@ async fn respond_with_json(server: &MockServer, request_path: &str, status: u16,
         .await;
 }
 
+async fn respond_with_body(server: &MockServer, request_path: &str, status: u16, body: &str) {
+    server.reset().await;
+    Mock::given(method("POST"))
+        .and(path(request_path.to_string()))
+        .respond_with(ResponseTemplate::new(status).set_body_string(body))
+        .mount(server)
+        .await;
+}
+
 fn extract_names(body: &Value, out: &mut Vec<String>) {
     if let Some(items) = body.get("batch").and_then(|b| b.as_array()) {
         for item in items {
@@ -507,13 +516,7 @@ async fn strict_fail_stops_on_sustained_failure_then_recovers_on_restart() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn strict_logical_2xx_failure_replays_without_in_process_retry() {
     let server = mock_server::start().await;
-    respond_with_json(
-        &server,
-        "/changes/e2e-query",
-        200,
-        json!({"errors": [{"message": "logical failure"}]}),
-    )
-    .await;
+    respond_with_body(&server, "/changes/e2e-query", 200, r#"{"errors":1e-400}"#).await;
     let store = Arc::new(MemoryStateStoreProvider::new());
     let (core, handle) = build_core_with_validator(
         server.uri(),

--- a/components/reactions/http/tests/recovery_e2e.rs
+++ b/components/reactions/http/tests/recovery_e2e.rs
@@ -31,6 +31,9 @@
 //! * `strict_fail_stops_on_sustained_failure_then_recovers_on_restart` — under the
 //!   default Strict policy a sustained 5xx outage stops the reaction without
 //!   losing the un-acked event, which is replayed once the downstream recovers.
+//! * `strict_logical_2xx_failure_replays_without_in_process_retry` — a configured
+//!   response validator fail-stops on a logical 2xx failure after one request and
+//!   leaves the event un-acked for replay.
 //! * `auto_skip_gap_keeps_running_and_skips_failed_batch` — under AutoSkipGap a
 //!   sustained outage is skipped and the reaction keeps delivering later events.
 //! * `adaptive_permanent_4xx_is_dropped_and_reaction_keeps_running` — in adaptive
@@ -47,8 +50,10 @@ use drasi_lib::channels::ComponentStatus;
 use drasi_lib::recovery::ReactionRecoveryPolicy;
 use drasi_lib::state_store::StateStoreProvider;
 use drasi_lib::{DrasiLib, MemoryStateStoreProvider, Query};
-use drasi_reaction_http::{AdaptiveBatchConfig, HttpReaction};
-use serde_json::Value;
+use drasi_reaction_http::{
+    AdaptiveBatchConfig, HttpCallExt, HttpQueryConfig, HttpReaction, TemplateSpec,
+};
+use serde_json::{json, Value};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -64,6 +69,16 @@ async fn build_core(
     store: Arc<dyn StateStoreProvider>,
     policy: ReactionRecoveryPolicy,
     adaptive: bool,
+) -> (Arc<DrasiLib>, mock_source::MockSourceHandle) {
+    build_core_with_validator(base_url, store, policy, adaptive, None).await
+}
+
+async fn build_core_with_validator(
+    base_url: String,
+    store: Arc<dyn StateStoreProvider>,
+    policy: ReactionRecoveryPolicy,
+    adaptive: bool,
+    reject_non_empty_json_pointer: Option<&str>,
 ) -> (Arc<DrasiLib>, mock_source::MockSourceHandle) {
     let (mock_source, handle) = mock_source::MockSource::new(SOURCE).expect("mock source");
 
@@ -87,6 +102,23 @@ async fn build_core(
                 adaptive_batch_timeout_ms: 50,
             })
             .with_batch_endpoint("/batch");
+    }
+    if let Some(pointer) = reject_non_empty_json_pointer {
+        builder = builder.with_query_template(
+            QUERY,
+            HttpQueryConfig {
+                added: Some(TemplateSpec {
+                    template: String::new(),
+                    extension: HttpCallExt {
+                        url: format!("/changes/{QUERY}"),
+                        method: "POST".to_string(),
+                        headers: Default::default(),
+                        reject_non_empty_json_pointer: Some(pointer.to_string()),
+                    },
+                }),
+                ..Default::default()
+            },
+        );
     }
     let reaction = builder.build().expect("reaction builder");
 
@@ -124,6 +156,15 @@ async fn respond_with(server: &MockServer, request_path: &str, status: u16) {
     Mock::given(method("POST"))
         .and(path(request_path.to_string()))
         .respond_with(ResponseTemplate::new(status))
+        .mount(server)
+        .await;
+}
+
+async fn respond_with_json(server: &MockServer, request_path: &str, status: u16, body: Value) {
+    server.reset().await;
+    Mock::given(method("POST"))
+        .and(path(request_path.to_string()))
+        .respond_with(ResponseTemplate::new(status).set_body_json(body))
         .mount(server)
         .await;
 }
@@ -456,6 +497,67 @@ async fn strict_fail_stops_on_sustained_failure_then_recovers_on_restart() {
         vec!["Alice"],
         "the un-acked event is replayed exactly once after recovery"
     );
+
+    core.stop().await.expect("stop core");
+}
+
+/// A logical failure in an HTTP 200 response is sustained delivery failure, not
+/// a retryable HTTP status. Strict therefore fail-stops after one request and
+/// leaves the checkpoint behind the event so an operator restart can replay it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn strict_logical_2xx_failure_replays_without_in_process_retry() {
+    let server = mock_server::start().await;
+    respond_with_json(
+        &server,
+        "/changes/e2e-query",
+        200,
+        json!({"errors": [{"message": "logical failure"}]}),
+    )
+    .await;
+    let store = Arc::new(MemoryStateStoreProvider::new());
+    let (core, handle) = build_core_with_validator(
+        server.uri(),
+        store,
+        ReactionRecoveryPolicy::Strict,
+        false,
+        Some("/errors"),
+    )
+    .await;
+    core.start().await.expect("start core");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    insert_person(&handle, "p1", "Alice").await;
+    assert!(
+        wait_for_reaction_status(&core, ComponentStatus::Error, Duration::from_secs(5)).await,
+        "logical 2xx rejection must fail-stop under Strict"
+    );
+    assert_eq!(
+        wait_for_name_count(&server, 1, Duration::from_secs(2)).await,
+        1
+    );
+    assert_no_extra_deliveries(&server, 1, Duration::from_millis(500)).await;
+
+    respond_with_json(
+        &server,
+        "/changes/e2e-query",
+        200,
+        json!({"data": {"ok": true}}),
+    )
+    .await;
+    core.start_reaction(REACTION)
+        .await
+        .expect("restart reaction from Error");
+
+    assert_eq!(
+        wait_for_name_count(&server, 1, Duration::from_secs(10)).await,
+        1
+    );
+    assert_eq!(
+        names_received(&server).await,
+        vec!["Alice"],
+        "the logical failure left the event un-acked for one replay"
+    );
+    assert_no_extra_deliveries(&server, 1, Duration::from_millis(500)).await;
 
     core.stop().await.expect("stop core");
 }


### PR DESCRIPTION
## Summary

- Add optional per-call `HttpCallExt.reject_non_empty_json_pointer` / `rejectNonEmptyJsonPointer` configuration, including serde, DTO/OpenAPI schema, DTO-domain mappings, embedded properties, README, and changelog coverage.
- Validate non-empty RFC 6901 pointers (including `~0` / `~1` escapes) at startup and reject per-call validators in adaptive mode instead of silently ignoring them.
- For configured 2xx responses, stream at most 1 MiB, require valid JSON, and reject when the pointer resolves to a non-empty value. Missing, `null`, `false`, mathematical numeric zero, empty string, empty array, and empty object are accepted.
- Preserve exact numeric semantics locally with `serde_json::value::RawValue`: recursive RFC 6901 traversal retains the selected number lexeme, so zero spellings remain empty while every nonzero value (including `1e400`, `1e-400`, and `-1e-400`) is rejected regardless of magnitude or exponent. Only `serde_json/raw_value` is enabled; `arbitrary_precision` is not enabled, and normal workspace `serde_json::Value` number parsing remains unchanged.
- Surface logical validation/read/JSON/size failures immediately after one HTTP request with no in-process retry. Strict recovery fail-stops without advancing the checkpoint so the event replays. Omitted validators retain legacy status-only 2xx handling, and non-2xx retry/permanent/auth classification is unchanged.
- Include exact WorkGraph Source/bootstrap head `43f28285d67bb2bc3aecb22c23df6c042d098664` from #746 unchanged. The combined tree preserves `workerConfig`, stable `Worker` / `Slot` projection and retirement, Assignment/Result v2 queue binding, Lease/Expiration lifecycle and trust folding, durable reconciliation, and push/bootstrap parity. Existing generic issue/task derived fields, lowercase state contracts, and bootstrap parity remain intact.

## Validation

- `cargo test -p drasi-reaction-http --lib` - 116 passed
- `cargo test -p drasi-reaction-http --test integration_tests` - 41 passed
- `cargo test -p drasi-reaction-http --test recovery_e2e` - 8 passed
- `cargo test -p drasi-reaction-http --test output_schema` - 1 passed
- `cargo test -p drasi-reaction-http --doc` - 2 passed
- 168 HTTP Reaction tests passed in total, including unchanged normal `Value("1e400")` rejection, exact-zero, extreme-nonzero, RFC 6901 traversal, one-request, and strict replay regressions.
- `cargo clippy -p drasi-reaction-http --all-targets --all-features -- -D warnings`
- Strict default-feature clippy for `drasi-lib`, `drasi-plugin-sdk`, and `drasi-host-sdk`
- `cargo build -p drasi-reaction-http --features dynamic-plugin`
- Loaded the built cdylib through an independently compiled `drasi-host-sdk` binary and verified unchanged host-side JSON-number parsing, exported descriptor schema, valid mapping/round-trip, malformed-pointer rejection, and adaptive-mode rejection.
- Verified the workspace serde_json feature graph contains `raw_value` and no `arbitrary_precision`.
- `cargo fmt --all -- --check`
- `git diff --check`

### Updated-base validation

After normally merging #746 head `43f28285d67bb2bc3aecb22c23df6c042d098664`:

- `cargo test -p drasi-source-github-workgraph -p drasi-bootstrap-github-workgraph` - 126 passed
- `cargo test -p drasi-source-github-workgraph --test integration_test -- --ignored` - 13 passed, covering worker push convergence/retirement, worker-file failures and concurrency, durable lease reconciliation/restart, lifecycle folding, and bootstrap handoff
- Exact raw-number HTTP unit regression - 1 passed
- Extreme-nonzero one-request HTTP integration regression - 1 passed
- Strict logical-2xx HTTP replay regression - 1 passed
- `cargo clippy -p drasi-source-github-workgraph -p drasi-bootstrap-github-workgraph -p drasi-reaction-http --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt -- --check`
- `git diff --check`
- HTTP subtree verified byte-for-byte unchanged from prior combined head `74958c966c50baa4079b3d340aa5d7c920b72576`; Source/bootstrap subtrees verified identical to #746 head `43f28285d67bb2bc3aecb22c23df6c042d098664`.

## Stack dependency

Depends directly on #746 (`agentofreality-potential-winner`) and contains exact head `43f28285d67bb2bc3aecb22c23df6c042d098664` through normal merge commit `67d0826ee6a575d0353c2c8d47ec207f21ba6bbb`. Its parents are prior combined PR #747 head `74958c966c50baa4079b3d340aa5d7c920b72576` and updated WorkGraph head `43f28285d67bb2bc3aecb22c23df6c042d098664`. No rebase, squash, amend, force-push, or other history rewriting was used. Keep this PR open and unmerged until the lower layer is ready; the next dispatcher PR should stack on exact combined SHA `67d0826ee6a575d0353c2c8d47ec207f21ba6bbb`.
