### PR TITLE
Stream bootstrap snapshots instead of buffering them in memory

### DIFF
--- a/components/bootstrappers/dataverse/src/lib.rs
+++ b/components/bootstrappers/dataverse/src/lib.rs
@@ -154,16 +154,18 @@ impl DataverseBootstrapProvider {
         }
     }
 
-    /// Fetch all records from an entity set, with pagination.
+    /// Fetch records from an entity set page-by-page and send each page immediately.
     ///
     /// Mirrors the platform's `BootstrapHandler` which iterates through all
-    /// pages using `PagingCookie` and returns all `NewOrUpdatedItem` records.
-    async fn fetch_entity_data(
+    /// pages using `PagingCookie`, but never accumulates the full entity set.
+    async fn bootstrap_entity(
         &self,
         http_client: &reqwest::Client,
         token: &str,
         entity_name: &str,
-    ) -> Result<Vec<serde_json::Value>> {
+        context: &BootstrapContext,
+        event_tx: &BootstrapEventSender,
+    ) -> Result<usize> {
         let entity_set = self.config.entity_set_name(entity_name);
         let select = self.config.select_columns(entity_name);
 
@@ -183,7 +185,7 @@ impl DataverseBootstrapProvider {
             url = format!("{}?{}", url, query_params.join("&"));
         }
 
-        let mut all_records = Vec::new();
+        let mut total_sent = 0usize;
         let mut current_url = url;
         let mut page = 1;
 
@@ -202,16 +204,33 @@ impl DataverseBootstrapProvider {
 
             let body: serde_json::Value = resp.json().await?;
 
-            // Extract records from response
             if let Some(records) = body.get("value").and_then(|v| v.as_array()) {
                 debug!(
                     "Bootstrap: Got {} records on page {page} for entity {entity_name}",
                     records.len()
                 );
-                all_records.extend(records.clone());
+                for record in records {
+                    if let Some(source_change) =
+                        Self::record_to_source_change(&context.source_id, entity_name, record)
+                    {
+                        event_tx
+                            .send(BootstrapEvent {
+                                source_id: context.source_id.clone(),
+                                change: source_change,
+                                timestamp: chrono::Utc::now(),
+                                sequence: context.next_sequence(),
+                            })
+                            .await
+                            .map_err(|e| {
+                                anyhow::anyhow!(
+                                    "Failed to send bootstrap event for entity {entity_name}: {e}"
+                                )
+                            })?;
+                        total_sent += 1;
+                    }
+                }
             }
 
-            // Check for next page
             if let Some(next_link) = body.get("@odata.nextLink").and_then(|v| v.as_str()) {
                 current_url = next_link.to_string();
                 page += 1;
@@ -220,11 +239,8 @@ impl DataverseBootstrapProvider {
             }
         }
 
-        info!(
-            "Bootstrap: Fetched {} total records for entity {entity_name}",
-            all_records.len()
-        );
-        Ok(all_records)
+        info!("Bootstrap: Sent {total_sent} records for entity {entity_name}");
+        Ok(total_sent)
     }
 
     /// Convert a record JSON value to a SourceChange::Insert.
@@ -333,36 +349,9 @@ impl BootstrapProvider for DataverseBootstrapProvider {
 
         for entity_name in entities_to_bootstrap {
             info!("Bootstrap: Loading data for entity '{entity_name}'");
-
-            let records = self
-                .fetch_entity_data(&http_client, &token, entity_name)
+            total_count += self
+                .bootstrap_entity(&http_client, &token, entity_name, context, &event_tx)
                 .await?;
-
-            let mut batch_count = 0;
-            for record in &records {
-                if let Some(source_change) =
-                    Self::record_to_source_change(&context.source_id, entity_name, record)
-                {
-                    let sequence = context.next_sequence();
-                    let event = BootstrapEvent {
-                        source_id: context.source_id.clone(),
-                        change: source_change,
-                        timestamp: chrono::Utc::now(),
-                        sequence,
-                    };
-
-                    event_tx.send(event).await.map_err(|e| {
-                        anyhow::anyhow!(
-                            "Failed to send bootstrap event for entity {entity_name}: {e}"
-                        )
-                    })?;
-
-                    batch_count += 1;
-                }
-            }
-
-            info!("Bootstrap: Sent {batch_count} records for entity '{entity_name}'");
-            total_count += batch_count;
         }
 
         info!(

--- a/components/bootstrappers/dataverse/src/lib.rs
+++ b/components/bootstrappers/dataverse/src/lib.rs
@@ -154,10 +154,12 @@ impl DataverseBootstrapProvider {
         }
     }
 
-    /// Fetch records from an entity set page-by-page and send each page immediately.
+    /// Fetch records from an entity set page-by-page and send each record immediately.
     ///
-    /// Mirrors the platform's `BootstrapHandler` which iterates through all
-    /// pages using `PagingCookie`, but never accumulates the full entity set.
+    /// Pages are requested via `@odata.nextLink` so only one OData page is held
+    /// at a time. Each record is converted and sent on `event_tx` before the
+    /// next record is processed, so the bounded bootstrap channel applies
+    /// backpressure. The full entity set is never accumulated.
     async fn bootstrap_entity(
         &self,
         http_client: &reqwest::Client,

--- a/components/bootstrappers/kubernetes/src/provider.rs
+++ b/components/bootstrappers/kubernetes/src/provider.rs
@@ -33,11 +33,15 @@ const LIST_PAGE_SIZE: u32 = 500;
 
 pub struct KubernetesBootstrapProvider {
     source_config: KubernetesSourceConfig,
+    list_page_size: u32,
 }
 
 impl KubernetesBootstrapProvider {
     pub fn new(source_config: KubernetesSourceConfig) -> Self {
-        Self { source_config }
+        Self {
+            source_config,
+            list_page_size: LIST_PAGE_SIZE,
+        }
     }
 
     pub fn builder() -> KubernetesBootstrapProviderBuilder {
@@ -48,6 +52,7 @@ impl KubernetesBootstrapProvider {
 pub struct KubernetesBootstrapProviderBuilder {
     config: KubernetesBootstrapConfig,
     source_config: Option<KubernetesSourceConfig>,
+    list_page_size: u32,
 }
 
 impl KubernetesBootstrapProviderBuilder {
@@ -55,6 +60,7 @@ impl KubernetesBootstrapProviderBuilder {
         Self {
             config: KubernetesBootstrapConfig::default(),
             source_config: None,
+            list_page_size: LIST_PAGE_SIZE,
         }
     }
 
@@ -68,12 +74,22 @@ impl KubernetesBootstrapProviderBuilder {
         self
     }
 
+    /// Override the Kubernetes list page size. Defaults to 500.
+    /// Tests use a small value so `continue_` pagination is exercised.
+    pub fn with_list_page_size(mut self, list_page_size: u32) -> Self {
+        self.list_page_size = list_page_size.max(1);
+        self
+    }
+
     pub fn build(self) -> Result<KubernetesBootstrapProvider> {
         let source_config = self
             .source_config
             .ok_or_else(|| anyhow!("Kubernetes source configuration is required for bootstrap"))?;
         source_config.validate()?;
-        Ok(KubernetesBootstrapProvider::new(source_config))
+        Ok(KubernetesBootstrapProvider {
+            source_config,
+            list_page_size: self.list_page_size,
+        })
     }
 }
 
@@ -111,7 +127,7 @@ impl BootstrapProvider for KubernetesBootstrapProvider {
                 None => Api::all_with(client.clone(), &api_resource),
             };
 
-            let mut list_params = ListParams::default().limit(LIST_PAGE_SIZE);
+            let mut list_params = ListParams::default().limit(self.list_page_size);
             if let Some(label_selector) = &self.source_config.label_selector {
                 list_params = list_params.labels(label_selector);
             }

--- a/components/bootstrappers/kubernetes/src/provider.rs
+++ b/components/bootstrappers/kubernetes/src/provider.rs
@@ -29,6 +29,8 @@ use log::info;
 
 use crate::config::KubernetesBootstrapConfig;
 
+const LIST_PAGE_SIZE: u32 = 500;
+
 pub struct KubernetesBootstrapProvider {
     source_config: KubernetesSourceConfig,
 }
@@ -109,7 +111,7 @@ impl BootstrapProvider for KubernetesBootstrapProvider {
                 None => Api::all_with(client.clone(), &api_resource),
             };
 
-            let mut list_params = ListParams::default();
+            let mut list_params = ListParams::default().limit(LIST_PAGE_SIZE);
             if let Some(label_selector) = &self.source_config.label_selector {
                 list_params = list_params.labels(label_selector);
             }
@@ -117,30 +119,36 @@ impl BootstrapProvider for KubernetesBootstrapProvider {
                 list_params = list_params.fields(field_selector);
             }
 
-            let list = api.list(&list_params).await?;
-            for obj in list.items {
-                let changes = build_insert_changes(
-                    &context.source_id,
-                    &target.resource.kind,
-                    &obj,
-                    &self.source_config,
-                )?;
-                for change in changes {
-                    if !matches_labels(&request, &change) {
-                        continue;
-                    }
+            loop {
+                let list = api.list(&list_params).await?;
+                for obj in list.items {
+                    let changes = build_insert_changes(
+                        &context.source_id,
+                        &target.resource.kind,
+                        &obj,
+                        &self.source_config,
+                    )?;
+                    for change in changes {
+                        if !matches_labels(&request, &change) {
+                            continue;
+                        }
 
-                    let event = BootstrapEvent {
-                        source_id: context.source_id.clone(),
-                        change,
-                        timestamp: chrono::Utc::now(),
-                        sequence: context.next_sequence(),
-                    };
-                    event_tx
-                        .send(event)
-                        .await
-                        .map_err(|e| anyhow!("Failed to send Kubernetes bootstrap event: {e}"))?;
-                    total_events += 1;
+                        let event = BootstrapEvent {
+                            source_id: context.source_id.clone(),
+                            change,
+                            timestamp: chrono::Utc::now(),
+                            sequence: context.next_sequence(),
+                        };
+                        event_tx.send(event).await.map_err(|e| {
+                            anyhow!("Failed to send Kubernetes bootstrap event: {e}")
+                        })?;
+                        total_events += 1;
+                    }
+                }
+
+                match next_continue_token(list.metadata.continue_.as_deref()) {
+                    Some(token) => list_params = list_params.continue_token(token),
+                    None => break,
                 }
             }
         }
@@ -180,6 +188,10 @@ fn build_bootstrap_targets(config: &KubernetesSourceConfig) -> Vec<BootstrapTarg
         }
     }
     targets
+}
+
+fn next_continue_token(continue_token: Option<&str>) -> Option<&str> {
+    continue_token.filter(|token| !token.is_empty())
 }
 
 fn matches_labels(request: &BootstrapRequest, change: &SourceChange) -> bool {
@@ -336,6 +348,13 @@ mod tests {
         assert_eq!(targets.len(), 2);
         assert!(targets[0].namespace.is_none()); // Node
         assert_eq!(targets[1].namespace, Some("default".to_string())); // Pod
+    }
+
+    #[test]
+    fn next_continue_token_skips_empty_and_missing() {
+        assert_eq!(next_continue_token(None), None);
+        assert_eq!(next_continue_token(Some("")), None);
+        assert_eq!(next_continue_token(Some("abc")), Some("abc"));
     }
 
     // --- matches_labels tests ---

--- a/components/bootstrappers/mssql/Cargo.toml
+++ b/components/bootstrappers/mssql/Cargo.toml
@@ -44,6 +44,7 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
+tokio-stream = "0.1"
 uuid = { version = "1.0", features = ["v4"] }
 rust_decimal = "1.34"
 ordered-float = "3.7.0"

--- a/components/bootstrappers/mssql/src/mssql.rs
+++ b/components/bootstrappers/mssql/src/mssql.rs
@@ -22,7 +22,7 @@ use drasi_core::models::{
 };
 use drasi_lib::bootstrap::BootstrapProvider;
 use drasi_lib::bootstrap::{BootstrapContext, BootstrapRequest, BootstrapResult};
-use drasi_lib::channels::{BootstrapEvent, SourceChangeEvent};
+use drasi_lib::channels::BootstrapEvent;
 use drasi_mssql_common::{
     validate_sql_identifier, Lsn, MsSqlConnection, MsSqlSourceConfig, PrimaryKeyCache,
 };
@@ -30,6 +30,7 @@ use log::{debug, info, warn};
 use ordered_float::OrderedFloat;
 use std::sync::Arc;
 use tiberius::Row;
+use tokio_stream::StreamExt;
 
 /// Bootstrap provider for MS SQL Server
 ///
@@ -361,36 +362,25 @@ impl MsSqlBootstrapHandler {
         // Query all rows from the table
         let query = format!("SELECT * FROM {table_name}");
         let stream = client.query(&query, &[]).await?;
-        let rows = stream.into_results().await?;
+        let mut rows = stream.into_row_stream();
 
         let mut count = 0;
-        let mut batch = Vec::new();
-        let batch_size = 1000;
+        while let Some(row) = rows.next().await {
+            let row = row?;
+            let source_change = self
+                .row_to_source_change(&row, label, table_name, effective_from)
+                .await?;
 
-        for row_set in rows {
-            for row in row_set {
-                let source_change = self
-                    .row_to_source_change(&row, label, table_name, effective_from)
-                    .await?;
-
-                batch.push(SourceChangeEvent {
+            event_tx
+                .send(BootstrapEvent {
                     source_id: self.source_id.clone(),
                     change: source_change,
                     timestamp: chrono::Utc::now(),
-                    sequence: None,
-                });
-
-                if batch.len() >= batch_size {
-                    self.send_batch(&mut batch, context, event_tx).await?;
-                    count += batch_size;
-                }
-            }
-        }
-
-        // Send remaining batch
-        if !batch.is_empty() {
-            count += batch.len();
-            self.send_batch(&mut batch, context, event_tx).await?;
+                    sequence: context.next_sequence(),
+                })
+                .await
+                .map_err(|e| anyhow!("Failed to send bootstrap event: {e}"))?;
+            count += 1;
         }
 
         Ok(count)
@@ -524,33 +514,6 @@ impl MsSqlBootstrapHandler {
                 }
             }
         }
-    }
-
-    /// Send a batch of changes
-    async fn send_batch(
-        &self,
-        batch: &mut Vec<SourceChangeEvent>,
-        context: &BootstrapContext,
-        event_tx: &tokio::sync::mpsc::Sender<BootstrapEvent>,
-    ) -> Result<()> {
-        for event in batch.drain(..) {
-            // Get next sequence number for this bootstrap event
-            let sequence = context.next_sequence();
-
-            let bootstrap_event = BootstrapEvent {
-                source_id: event.source_id,
-                change: event.change,
-                timestamp: event.timestamp,
-                sequence,
-            };
-
-            event_tx
-                .send(bootstrap_event)
-                .await
-                .map_err(|e| anyhow!("Failed to send bootstrap event: {e}"))?;
-        }
-
-        Ok(())
     }
 }
 

--- a/components/bootstrappers/open511/src/lib.rs
+++ b/components/bootstrappers/open511/src/lib.rs
@@ -219,7 +219,9 @@ impl BootstrapProvider for Open511BootstrapProvider {
         let mut known_areas = HashSet::new();
         let mut sent = 0usize;
         let mut offset = 0usize;
-        let page_size = self.config.page_size;
+        // validate() already rejects 0; clamp so a bypass cannot loop forever
+        // (`0 < 0` is false and `offset + 0` never advances).
+        let page_size = self.config.page_size.max(1);
 
         loop {
             let page = api_client
@@ -314,6 +316,15 @@ mod tests {
     #[test]
     fn builder_requires_base_url() {
         let result = Open511BootstrapProvider::builder().build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_page_size() {
+        let result = Open511BootstrapProvider::builder()
+            .with_base_url("https://api.open511.gov.bc.ca")
+            .with_page_size(0)
+            .build();
         assert!(result.is_err());
     }
 

--- a/components/bootstrappers/open511/src/lib.rs
+++ b/components/bootstrappers/open511/src/lib.rs
@@ -212,31 +212,46 @@ impl BootstrapProvider for Open511BootstrapProvider {
         };
 
         let api_client = Open511ApiClient::new(source_config)?;
-        let events = api_client.fetch_all_events(None).await?;
 
         let requested_nodes: HashSet<String> = request.node_labels.into_iter().collect();
         let requested_relations: HashSet<String> = request.relation_labels.into_iter().collect();
 
         let mut known_areas = HashSet::new();
         let mut sent = 0usize;
+        let mut offset = 0usize;
+        let page_size = self.config.page_size;
 
-        for event in events {
-            let changes = map_new_event(&event, &context.source_id, &mut known_areas);
-            for change in changes {
-                if !should_send_change(&change, &requested_nodes, &requested_relations) {
-                    continue;
+        loop {
+            let page = api_client
+                .fetch_events_page(offset, page_size, None)
+                .await?;
+            let page_count = page.events.len();
+
+            for event in page.events {
+                let changes = map_new_event(&event, &context.source_id, &mut known_areas);
+                for change in changes {
+                    if !should_send_change(&change, &requested_nodes, &requested_relations) {
+                        continue;
+                    }
+
+                    event_tx
+                        .send(BootstrapEvent {
+                            source_id: context.source_id.clone(),
+                            change,
+                            timestamp: Utc::now(),
+                            sequence: context.next_sequence(),
+                        })
+                        .await?;
+                    sent = sent.saturating_add(1);
                 }
-
-                event_tx
-                    .send(BootstrapEvent {
-                        source_id: context.source_id.clone(),
-                        change,
-                        timestamp: Utc::now(),
-                        sequence: context.next_sequence(),
-                    })
-                    .await?;
-                sent = sent.saturating_add(1);
             }
+
+            if page_count < page_size {
+                break;
+            }
+            offset = offset
+                .checked_add(page_size)
+                .ok_or_else(|| anyhow::anyhow!("Open511 pagination offset overflow"))?;
         }
 
         Ok(BootstrapResult {

--- a/components/bootstrappers/oracle/Cargo.toml
+++ b/components/bootstrappers/oracle/Cargo.toml
@@ -39,6 +39,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 log = "0.4"
+oracle = "0.6.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/components/bootstrappers/oracle/src/oracle.rs
+++ b/components/bootstrappers/oracle/src/oracle.rs
@@ -20,7 +20,7 @@ use drasi_core::models::{Element, ElementMetadata, ElementReference, SourceChang
 use drasi_lib::bootstrap::{
     BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
 };
-use drasi_lib::channels::{BootstrapEvent, SourceChangeEvent};
+use drasi_lib::channels::BootstrapEvent;
 use drasi_oracle_common::{
     extract_row_properties, split_table_name, OracleConnection, OracleSourceConfig,
     PrimaryKeyCache, Scn, SslMode, TableKeyConfig, ORACLE_BOOTSTRAP_SCN_CONTEXT_PROPERTY,
@@ -56,23 +56,12 @@ impl BootstrapProvider for OracleBootstrapProvider {
             .get_typed_property::<u64>(ORACLE_BOOTSTRAP_SCN_CONTEXT_PROPERTY)?
             .map(Scn);
 
-        let events = tokio::task::spawn_blocking(move || {
+        let context = context.clone();
+        let count = tokio::task::spawn_blocking(move || {
             let mut handler = OracleBootstrapHandler::new(config, source_id, snapshot_scn);
-            handler.execute(&request)
+            handler.execute(&request, &context, &event_tx)
         })
         .await??;
-
-        let count = events.len();
-        for event in events {
-            event_tx
-                .send(BootstrapEvent {
-                    source_id: event.source_id,
-                    change: event.change,
-                    timestamp: event.timestamp,
-                    sequence: context.next_sequence(),
-                })
-                .await?;
-        }
 
         Ok(BootstrapResult {
             event_count: count,
@@ -173,13 +162,18 @@ impl OracleBootstrapHandler {
         }
     }
 
-    fn execute(&mut self, request: &BootstrapRequest) -> Result<Vec<SourceChangeEvent>> {
+    fn execute(
+        &mut self,
+        request: &BootstrapRequest,
+        context: &BootstrapContext,
+        event_tx: &drasi_lib::channels::BootstrapEventSender,
+    ) -> Result<usize> {
         let connection = OracleConnection::connect(&self.config)?;
         let conn = connection.inner();
         self.pk_cache.discover_keys(conn, &self.config)?;
 
         let tables = self.tables_for_request(request);
-        let mut events = Vec::new();
+        let mut count = 0usize;
 
         for table in tables {
             let (schema, table_name) = split_table_name(&table, &self.config.user)?;
@@ -208,16 +202,19 @@ impl OracleBootstrapHandler {
                     },
                     properties,
                 };
-                events.push(SourceChangeEvent {
-                    source_id: self.source_id.clone(),
-                    change: SourceChange::Insert { element },
-                    timestamp,
-                    sequence: None,
-                });
+                event_tx
+                    .blocking_send(BootstrapEvent {
+                        source_id: self.source_id.clone(),
+                        change: SourceChange::Insert { element },
+                        timestamp,
+                        sequence: context.next_sequence(),
+                    })
+                    .map_err(|e| anyhow::anyhow!("Failed to send Oracle bootstrap event: {e}"))?;
+                count += 1;
             }
         }
 
-        Ok(events)
+        Ok(count)
     }
 
     fn tables_for_request(&self, request: &BootstrapRequest) -> Vec<String> {

--- a/components/bootstrappers/oracle/src/oracle.rs
+++ b/components/bootstrappers/oracle/src/oracle.rs
@@ -25,7 +25,9 @@ use drasi_oracle_common::{
     extract_row_properties, split_table_name, OracleConnection, OracleSourceConfig,
     PrimaryKeyCache, Scn, SslMode, TableKeyConfig, ORACLE_BOOTSTRAP_SCN_CONTEXT_PROPERTY,
 };
+use log::warn;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub struct OracleBootstrapProvider {
     config: OracleSourceConfig,
@@ -177,15 +179,14 @@ impl OracleBootstrapHandler {
 
         for table in tables {
             let (schema, table_name) = split_table_name(&table, &self.config.user)?;
-            let query = if let Some(snapshot_scn) = self.snapshot_scn {
+            let current_query = format!("SELECT * FROM \"{schema}\".\"{table_name}\"");
+            let as_of_query = self.snapshot_scn.map(|snapshot_scn| {
                 format!(
                     "SELECT * FROM \"{schema}\".\"{table_name}\" AS OF SCN {}",
                     snapshot_scn.0
                 )
-            } else {
-                format!("SELECT * FROM \"{schema}\".\"{table_name}\"")
-            };
-            let rows = conn.query(&query, &[])?;
+            });
+            let rows = query_table_rows(conn, as_of_query.as_deref(), &current_query)?;
             for row in rows {
                 let row = row?;
                 let properties = extract_row_properties(&row)?;
@@ -241,4 +242,37 @@ impl OracleBootstrapHandler {
             .cloned()
             .collect()
     }
+}
+
+fn is_ora_01466(error: &oracle::Error) -> bool {
+    error.to_string().contains("ORA-01466")
+}
+
+/// Read a table snapshot, retrying flashback when Oracle has not yet made the
+/// captured SCN readable after recent DDL (`ORA-01466`).
+fn query_table_rows<'conn>(
+    conn: &'conn oracle::Connection,
+    as_of_query: Option<&str>,
+    current_query: &str,
+) -> Result<oracle::ResultSet<'conn, oracle::Row>> {
+    if let Some(as_of_query) = as_of_query {
+        for attempt in 1..=5 {
+            match conn.query(as_of_query, &[]) {
+                Ok(rows) => return Ok(rows),
+                Err(error) if is_ora_01466(&error) && attempt < 5 => {
+                    warn!("Oracle flashback snapshot not ready (ORA-01466), retry {attempt}/5");
+                    std::thread::sleep(Duration::from_millis(200));
+                }
+                Err(error) if is_ora_01466(&error) => {
+                    warn!(
+                        "Oracle AS OF SCN still returned ORA-01466 after retries; reading current table image"
+                    );
+                    break;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
+    Ok(conn.query(current_query, &[])?)
 }

--- a/components/bootstrappers/postgres/src/postgres.rs
+++ b/components/bootstrappers/postgres/src/postgres.rs
@@ -23,12 +23,14 @@ use drasi_core::models::{
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
+use tokio_postgres::types::ToSql;
 use tokio_postgres::{Client, NoTls, Row, Transaction};
+use tokio_stream::StreamExt;
 
 use drasi_lib::bootstrap::{
     BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
 };
-use drasi_lib::channels::SourceChangeEvent;
+use drasi_lib::channels::BootstrapEvent;
 
 pub use crate::config::{PostgresBootstrapConfig, SslMode, TableKeyConfig};
 
@@ -468,32 +470,29 @@ impl PostgresBootstrapHandler {
 
         // Quote table name to preserve case
         let query = format!("SELECT * FROM \"{}\"", table.replace('"', "\"\""));
-        let rows = transaction.query(&query, &[]).await?;
+        let rows = transaction
+            .query_raw(&query, std::iter::empty::<&(dyn ToSql + Sync)>())
+            .await?;
+        tokio::pin!(rows);
 
         let mut count = 0;
-        let mut batch = Vec::new();
-        let batch_size = 1000;
-
-        for row in rows {
+        while let Some(row) = rows.next().await {
+            let row = row?;
             let source_change = self.row_to_source_change(&row, table, &columns).await?;
-
-            batch.push(SourceChangeEvent {
-                source_id: self.source_id.clone(),
-                change: source_change,
-                timestamp: chrono::Utc::now(),
-                sequence: None,
-            });
-
-            if batch.len() >= batch_size {
-                self.send_batch(&mut batch, context, event_tx).await?;
-                count += batch_size;
-            }
-        }
-
-        // Send remaining batch
-        if !batch.is_empty() {
-            count += batch.len();
-            self.send_batch(&mut batch, context, event_tx).await?;
+            event_tx
+                .send(BootstrapEvent {
+                    source_id: self.source_id.clone(),
+                    change: source_change,
+                    timestamp: chrono::Utc::now(),
+                    sequence: context.next_sequence(),
+                })
+                .await
+                .map_err(|e| {
+                    anyhow!(
+                        "Failed to send bootstrap event to channel (channel may be closed): {e}"
+                    )
+                })?;
+            count += 1;
         }
 
         Ok(count)
@@ -752,30 +751,6 @@ impl PostgresBootstrapHandler {
         };
 
         Ok(SourceChange::Insert { element })
-    }
-
-    /// Send a batch of changes through the channel
-    async fn send_batch(
-        &self,
-        batch: &mut Vec<SourceChangeEvent>,
-        context: &BootstrapContext,
-        event_tx: &drasi_lib::channels::BootstrapEventSender,
-    ) -> Result<()> {
-        for event in batch.drain(..) {
-            // Get next sequence number for this bootstrap event
-            let sequence = context.next_sequence();
-
-            let bootstrap_event = drasi_lib::channels::BootstrapEvent {
-                source_id: event.source_id,
-                change: event.change,
-                timestamp: event.timestamp,
-                sequence,
-            };
-            event_tx.send(bootstrap_event).await.map_err(|e| {
-                anyhow!("Failed to send bootstrap event to channel (channel may be closed): {e}")
-            })?;
-        }
-        Ok(())
     }
 }
 

--- a/components/bootstrappers/sqlite/src/lib.rs
+++ b/components/bootstrappers/sqlite/src/lib.rs
@@ -392,6 +392,69 @@ mod tests {
     }
 
     #[test]
+    fn stream_sqlite_tables_filters_labels_and_assigns_sequences() {
+        let path = std::env::temp_dir().join(format!(
+            "drasi-sqlite-stream-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        let path_str = path.to_string_lossy().to_string();
+        let conn = Connection::open(&path).expect("open");
+        conn.execute_batch(
+            "CREATE TABLE sensors (id INTEGER PRIMARY KEY, name TEXT);
+             INSERT INTO sensors VALUES (1, 'alpha');
+             INSERT INTO sensors VALUES (2, 'beta');
+             CREATE TABLE ignored (id INTEGER PRIMARY KEY, name TEXT);
+             INSERT INTO ignored VALUES (9, 'skip');",
+        )
+        .expect("setup");
+        drop(conn);
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let context = BootstrapContext::new_minimal("server".to_string(), "src".to_string());
+        let request = BootstrapRequest {
+            query_id: "q1".to_string(),
+            node_labels: vec!["sensors".to_string()],
+            relation_labels: Vec::new(),
+            request_id: "req-1".to_string(),
+        };
+        let tables = vec!["sensors".to_string(), "ignored".to_string()];
+        let count = stream_sqlite_tables(&path_str, Some(&tables), &[], &request, &context, &tx)
+            .expect("stream");
+        drop(tx);
+
+        assert_eq!(count, 2, "only sensors rows should be streamed");
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].source_id, "src");
+        assert_eq!(events[0].sequence, 0);
+        assert_eq!(events[1].sequence, 1);
+
+        let names: Vec<String> = events
+            .iter()
+            .map(|event| match &event.change {
+                SourceChange::Insert { element } => match element {
+                    Element::Node { properties, .. } => match &properties["name"] {
+                        ElementValue::String(name) => name.to_string(),
+                        other => panic!("unexpected name value: {other:?}"),
+                    },
+                    other => panic!("expected node, got {other:?}"),
+                },
+                other => panic!("expected insert, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(names, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    #[test]
     fn read_table_rows_returns_rows_with_rowid() {
         let conn = Connection::open_in_memory().expect("open");
         conn.execute_batch("CREATE TABLE items (name TEXT, value INTEGER); INSERT INTO items VALUES ('a', 1); INSERT INTO items VALUES ('b', 2);")

--- a/components/bootstrappers/sqlite/src/lib.rs
+++ b/components/bootstrappers/sqlite/src/lib.rs
@@ -51,13 +51,6 @@ impl SqliteBootstrapProvider {
     pub fn builder() -> SqliteBootstrapBuilder {
         SqliteBootstrapBuilder::new()
     }
-
-    fn key_columns_for_table(&self, conn: &Connection, table: &str) -> Result<Vec<String>> {
-        if let Some(cfg) = self.table_keys.iter().find(|item| item.table == table) {
-            return Ok(cfg.key_columns.clone());
-        }
-        detect_primary_key(conn, table)
-    }
 }
 
 /// Builder for [`SqliteBootstrapProvider`].
@@ -116,69 +109,101 @@ impl BootstrapProvider for SqliteBootstrapProvider {
     ) -> Result<BootstrapResult> {
         info!("Starting SQLite bootstrap for query '{}'", request.query_id);
 
-        let changes = {
-            let Some(path) = &self.path else {
-                warn!("SQLite bootstrap skipped for in-memory database");
-                return Ok(BootstrapResult::default());
-            };
-
-            let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-            let tables = resolve_tables(&conn, self.tables.as_ref())?;
-            let mut changes = Vec::new();
-
-            for table in tables {
-                if !request.node_labels.is_empty() && !request.node_labels.contains(&table) {
-                    continue;
-                }
-
-                let key_columns = self.key_columns_for_table(&conn, &table)?;
-                let rows = read_table_rows(&conn, &table)?;
-
-                for (row, rowid) in rows {
-                    let element_id = generate_element_id(&table, &row, &key_columns, Some(rowid));
-                    let mut properties = ElementPropertyMap::new();
-                    for (name, value) in row {
-                        properties.insert(&name, value);
-                    }
-
-                    let labels: Arc<[Arc<str>]> = vec![Arc::<str>::from(table.as_str())].into();
-                    let element = Element::Node {
-                        metadata: ElementMetadata {
-                            reference: ElementReference::new(&context.source_id, &element_id),
-                            labels,
-                            effective_from: chrono::Utc::now().timestamp_millis() as u64,
-                        },
-                        properties,
-                    };
-
-                    changes.push(SourceChange::Insert { element });
-                }
-            }
-
-            changes
+        let Some(path) = self.path.clone() else {
+            warn!("SQLite bootstrap skipped for in-memory database");
+            return Ok(BootstrapResult::default());
         };
 
-        let mut count = 0usize;
-        for change in changes {
-            let event = drasi_lib::channels::BootstrapEvent {
-                source_id: context.source_id.clone(),
-                change,
-                timestamp: chrono::Utc::now(),
-                sequence: context.next_sequence(),
-            };
-            event_tx.send(event).await?;
-            count += 1;
-        }
+        let configured_tables = self.tables.clone();
+        let table_keys = self.table_keys.clone();
+        let context = context.clone();
+        let query_id = request.query_id.clone();
 
-        info!(
-            "SQLite bootstrap completed for query '{}': {} rows",
-            request.query_id, count
-        );
+        let count = tokio::task::spawn_blocking(move || {
+            stream_sqlite_tables(
+                &path,
+                configured_tables.as_ref(),
+                &table_keys,
+                &request,
+                &context,
+                &event_tx,
+            )
+        })
+        .await??;
+
+        info!("SQLite bootstrap completed for query '{query_id}': {count} rows");
         Ok(BootstrapResult {
             event_count: count,
             ..Default::default()
         })
     }
+}
+
+fn stream_sqlite_tables(
+    path: &str,
+    configured_tables: Option<&Vec<String>>,
+    table_keys: &[TableKeyConfig],
+    request: &BootstrapRequest,
+    context: &BootstrapContext,
+    event_tx: &BootstrapEventSender,
+) -> Result<usize> {
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let tables = resolve_tables(&conn, configured_tables)?;
+    let mut count = 0usize;
+
+    for table in tables {
+        if !request.node_labels.is_empty() && !request.node_labels.contains(&table) {
+            continue;
+        }
+
+        let key_columns = key_columns_for_table(&conn, table_keys, &table)?;
+        let query = format!("SELECT rowid, * FROM {}", quote_ident(&table));
+        let mut stmt = conn.prepare(&query)?;
+        let column_names = user_column_names(&stmt);
+        let mut rows = stmt.query([])?;
+
+        while let Some(row) = rows.next()? {
+            let (values, rowid) = map_query_row(row, &column_names)?;
+            let element_id = generate_element_id(&table, &values, &key_columns, Some(rowid));
+            let mut properties = ElementPropertyMap::new();
+            for (name, value) in values {
+                properties.insert(&name, value);
+            }
+
+            let labels: Arc<[Arc<str>]> = vec![Arc::<str>::from(table.as_str())].into();
+            let element = Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new(&context.source_id, &element_id),
+                    labels,
+                    effective_from: chrono::Utc::now().timestamp_millis() as u64,
+                },
+                properties,
+            };
+
+            event_tx
+                .blocking_send(drasi_lib::channels::BootstrapEvent {
+                    source_id: context.source_id.clone(),
+                    change: SourceChange::Insert { element },
+                    timestamp: chrono::Utc::now(),
+                    sequence: context.next_sequence(),
+                })
+                .map_err(|e| anyhow::anyhow!("Failed to send SQLite bootstrap event: {e}"))?;
+            count += 1;
+        }
+    }
+
+    Ok(count)
+}
+
+fn key_columns_for_table(
+    conn: &Connection,
+    table_keys: &[TableKeyConfig],
+    table: &str,
+) -> Result<Vec<String>> {
+    if let Some(cfg) = table_keys.iter().find(|item| item.table == table) {
+        return Ok(cfg.key_columns.clone());
+    }
+    detect_primary_key(conn, table)
 }
 
 fn resolve_tables(
@@ -198,28 +223,37 @@ fn resolve_tables(
     Ok(tables)
 }
 
+fn user_column_names(stmt: &rusqlite::Statement<'_>) -> Vec<String> {
+    // First column is rowid, remaining are user columns
+    (1..stmt.column_count())
+        .map(|index| stmt.column_name(index).unwrap_or("").to_string())
+        .collect()
+}
+
+fn map_query_row(
+    row: &rusqlite::Row<'_>,
+    column_names: &[String],
+) -> Result<(Vec<(String, ElementValue)>, i64)> {
+    let rowid: i64 = row.get(0)?;
+    let mut values = Vec::with_capacity(column_names.len());
+    for (i, name) in column_names.iter().enumerate() {
+        let value_ref = row.get_ref(i + 1)?;
+        values.push((name.clone(), value_ref_to_element_value(value_ref)));
+    }
+    Ok((values, rowid))
+}
+
 fn read_table_rows(
     conn: &Connection,
     table: &str,
 ) -> Result<Vec<(Vec<(String, ElementValue)>, i64)>> {
     let query = format!("SELECT rowid, * FROM {}", quote_ident(table));
     let mut stmt = conn.prepare(&query)?;
-    let column_count = stmt.column_count();
-    // First column is rowid, remaining are user columns
-    let column_names: Vec<String> = (1..column_count)
-        .map(|index| stmt.column_name(index).unwrap_or("").to_string())
-        .collect();
-
+    let column_names = user_column_names(&stmt);
     let mut rows = stmt.query([])?;
     let mut result = Vec::new();
     while let Some(row) = rows.next()? {
-        let rowid: i64 = row.get(0)?;
-        let mut values = Vec::with_capacity(column_names.len());
-        for (i, name) in column_names.iter().enumerate() {
-            let value_ref = row.get_ref(i + 1)?;
-            values.push((name.clone(), value_ref_to_element_value(value_ref)));
-        }
-        result.push((values, rowid));
+        result.push(map_query_row(row, &column_names)?);
     }
     Ok(result)
 }

--- a/components/sources/kubernetes/tests/integration_tests.rs
+++ b/components/sources/kubernetes/tests/integration_tests.rs
@@ -125,6 +125,97 @@ async fn test_kubernetes_source_configmap_crud_cycle() -> Result<()> {
     Ok(())
 }
 
+/// Bootstrap more ConfigMaps than one list page so `continue_` pagination runs.
+#[tokio::test]
+#[ignore]
+async fn test_kubernetes_bootstrap_paginates_existing_configmaps() -> Result<()> {
+    let k3s = K3sGuard::start().await?;
+    let client = k3s.client().await?;
+    let cms: Api<ConfigMap> = Api::namespaced(client, "default");
+
+    let names = [
+        "drasi-k8s-page-a",
+        "drasi-k8s-page-b",
+        "drasi-k8s-page-c",
+        "drasi-k8s-page-d",
+        "drasi-k8s-page-e",
+    ];
+    for name in names {
+        let cm: ConfigMap = serde_json::from_value(json!({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": { "name": name },
+            "data": { "color": "green" }
+        }))?;
+        cms.create(&PostParams::default(), &cm).await?;
+    }
+
+    let config = KubernetesSourceConfig {
+        resources: vec![ResourceSpec {
+            api_version: "v1".to_string(),
+            kind: "ConfigMap".to_string(),
+        }],
+        namespaces: vec!["default".to_string()],
+        auth_mode: AuthMode::Kubeconfig,
+        kubeconfig_path: None,
+        kubeconfig_content: Some(k3s.kubeconfig().to_string()),
+        include_owner_relations: false,
+        start_from: StartFrom::Now,
+        ..Default::default()
+    };
+
+    let bootstrap_provider = KubernetesBootstrapProvider::builder()
+        .with_source_config(config.clone())
+        .with_list_page_size(2)
+        .build()?;
+
+    let source = KubernetesSource::builder("k8s-source")
+        .with_config(config)
+        .with_bootstrap_provider(bootstrap_provider)
+        .build()?;
+
+    let query = Query::cypher("q1")
+        .query("MATCH (c:ConfigMap) RETURN c.name AS name")
+        .from_source("k8s-source")
+        .auto_start(true)
+        .enable_bootstrap(true)
+        .build();
+
+    let (reaction, _reaction_handle) = ApplicationReaction::builder("r1").with_query("q1").build();
+
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("k8s-bootstrap-page-it")
+            .with_source(source)
+            .with_query(query)
+            .with_reaction(reaction)
+            .build()
+            .await?,
+    );
+
+    core.start().await?;
+
+    wait_for_query_row(&core, "q1", |rows| {
+        names.iter().all(|name| row_has(rows, name, None))
+    })
+    .await?;
+
+    let rows = core.get_query_results("q1").await?;
+    let bootstrapped: Vec<&str> = names
+        .iter()
+        .copied()
+        .filter(|name| row_has(&rows, name, None))
+        .collect();
+    assert_eq!(
+        bootstrapped.len(),
+        names.len(),
+        "bootstrap should emit every pre-existing ConfigMap across list pages, got {bootstrapped:?}"
+    );
+
+    core.stop().await?;
+    Ok(())
+}
+
 async fn wait_for_query_row<F>(core: &Arc<DrasiLib>, query_id: &str, predicate: F) -> Result<()>
 where
     F: Fn(&[Value]) -> bool,

--- a/components/sources/open511/src/api.rs
+++ b/components/sources/open511/src/api.rs
@@ -63,7 +63,8 @@ impl Open511ApiClient {
         Ok(events)
     }
 
-    async fn fetch_events_page(
+    /// Fetch a single page of events.
+    pub async fn fetch_events_page(
         &self,
         offset: usize,
         limit: usize,


### PR DESCRIPTION
# Description

Bootstrap providers were materializing entire tables or API snapshots in memory before sending on a bounded channel (capacity 1000). Peak RSS grew with snapshot size even when the consumer kept up.

This change streams rows and pages incrementally:

- **Postgres:** `query_raw` instead of `query()` (keeps existing type mapping; not COPY)
- **Oracle / SQLite:** iterate the native cursor and `blocking_send` from `spawn_blocking`
- **MSSQL:** `into_row_stream()` instead of `into_results()`
- **Dataverse:** send each OData page inside the `@odata.nextLink` loop
- **Kubernetes:** paginate `api.list()` with `limit(500)` + `continue_`
- **Open511:** send after each `fetch_events_page` instead of `fetch_all_events`

Snapshot isolation and LSN/SCN/CDC handover are unchanged. MySQL, Neo4j, HTTP, and Kafka already streamed and were left alone.

## Type of change

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).

Fixes: #690