### PR TITLE
fix: remove vulnerable h2 0.3 dependency

### DIFF
--- a/components/identity/aws/Cargo.toml
+++ b/components/identity/aws/Cargo.toml
@@ -40,8 +40,15 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "sync"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 aws-config = "1.8"
-aws-sdk-rds = "1.133"
-aws-sdk-sts = "1.104"
+aws-sdk-rds = { version = "1.133", default-features = false, features = [
+    "default-https-client",
+    "rt-tokio",
+] }
+aws-sdk-sts = { version = "1.104", default-features = false, features = [
+    "default-https-client",
+    "rt-tokio",
+    "sigv4a",
+] }
 
 [features]
 dynamic-plugin = []

--- a/components/reactions/aws-sqs/Cargo.toml
+++ b/components/reactions/aws-sqs/Cargo.toml
@@ -39,7 +39,10 @@ async-trait = "0.1"
 # Pin AWS SDK crates below the 1.91 MSRV bump (introduced late Feb 2026) so cargo publish verification works on the 1.88 toolchain.
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-credential-types = "1"
-aws-sdk-sqs = "1"
+aws-sdk-sqs = { version = "1", default-features = false, features = [
+    "default-https-client",
+    "rt-tokio",
+] }
 chrono = "0.4"
 handlebars = "5.1"
 log = "0.4"

--- a/components/reactions/grpc/Cargo.toml
+++ b/components/reactions/grpc/Cargo.toml
@@ -40,8 +40,9 @@ drasi-lib.workspace = true
 anyhow = "1.0"
 async-trait = "0.1"
 log = "0.4"
-tonic = "0.11"
-prost = "0.12"
+tonic = "0.14"
+tonic-prost = "0.14"
+prost = "0.14"
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -49,7 +50,7 @@ serde_json = "1.0"
 rand = "0.8"
 chrono = "0.4"
 uuid = { version = "1.0", features = ["v4"] }
-prost-types = "0.12"
+prost-types = "0.14"
 ordered-float = "3.0"
 handlebars = "5.1"
 
@@ -66,7 +67,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 drasi-core.workspace = true
 
 [build-dependencies]
-tonic-build = "0.11"
+tonic-prost-build = "0.14"
 
 
 [features]

--- a/components/reactions/grpc/build.rs
+++ b/components/reactions/grpc/build.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
+    tonic_prost_build::configure()
         // Server stubs are generated so in-crate tests can stand up a mock
         // gRPC server; production code only uses the client.
         .build_server(true)
         .build_client(true)
-        .compile(&["proto/drasi/v1/reaction.proto"], &["proto"])?;
+        .compile_protos(&["proto/drasi/v1/reaction.proto"], &["proto"])?;
     Ok(())
 }

--- a/components/reactions/grpc/src/send.rs
+++ b/components/reactions/grpc/src/send.rs
@@ -325,7 +325,7 @@ fn categorize_error(error_str_lower: &str) -> &'static str {
 fn latest_item_timestamp(batch: &[ProtoQueryResultItem]) -> Option<prost_types::Timestamp> {
     batch
         .iter()
-        .filter_map(|item| item.timestamp.clone())
+        .filter_map(|item| item.timestamp)
         .max_by(|a, b| {
             a.seconds
                 .cmp(&b.seconds)

--- a/components/sources/grpc/Cargo.toml
+++ b/components/sources/grpc/Cargo.toml
@@ -41,17 +41,18 @@ tracing = "0.1"
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tonic = "0.11"
-prost = "0.12"
+tonic = "0.14"
+tonic-prost = "0.14"
+prost = "0.14"
 chrono = "0.4"
 uuid = { version = "1.0", features = ["v4"] }
 tokio-stream = "0.1"
-prost-types = "0.12"
+prost-types = "0.14"
 ordered-float = "3.0"
 bytes = "1"
 
 [build-dependencies]
-tonic-build = "0.11"
+tonic-prost-build = "0.14"
 
 [dev-dependencies]
 tempfile = "3"

--- a/components/sources/grpc/build.rs
+++ b/components/sources/grpc/build.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(false)
-        .compile(
+        .compile_protos(
             &["proto/drasi/v1/source.proto", "proto/drasi/v1/common.proto"],
             &["proto"],
         )?;


### PR DESCRIPTION
Fixes #762.

- Upgrade the gRPC plugins to Tonic and Prost 0.14.
- Configure AWS plugins to use the modern Hyper 1 transport.
- Remove vulnerable `h2 0.3` from the workspace dependency graph.
