### PR TITLE
Add minimal GitHub WorkGraph dispatcher reaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ members = [
   "components/reactions/storedproc-mysql",
   "components/reactions/storedproc-postgres",
   "components/reactions/snapshot-test",
+  "components/reactions/github-workgraph",
 
   # Identity Provider Plugins
   "components/identity/azure",
@@ -185,6 +186,7 @@ drasi-reaction-http = { version = "0.3.2", path = "components/reactions/http" }
 drasi-reaction-grpc = { version = "0.4.2", path = "components/reactions/grpc" }
 drasi-reaction-file = { version = "0.1.3", path = "components/reactions/file" }
 drasi-reaction-eventgrid = { version = "0.1.0", path = "components/reactions/eventgrid" }
+drasi-reaction-github-workgraph = { version = "0.1.0", path = "components/reactions/github-workgraph" }
 drasi-reaction-aws-sqs = { version = "0.1.3", path = "components/reactions/aws-sqs" }
 drasi-mssql-common = { version = "0.2.9", path = "components/mssql-common" }
 drasi-mysql-common = { version = "0.2.7", path = "components/mysql-common" }

--- a/components/reactions/github-workgraph/Cargo.toml
+++ b/components/reactions/github-workgraph/Cargo.toml
@@ -1,0 +1,50 @@
+# Copyright 2026 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "drasi-reaction-github-workgraph"
+version = "0.1.0"
+edition = "2021"
+authors = ["Drasi Project"]
+description = "GitHub WorkGraph queue dispatcher reaction for Drasi"
+license = "Apache-2.0"
+repository = "https://github.com/drasi-project/drasi-core"
+keywords = ["drasi", "plugin", "reaction", "github", "workgraph"]
+categories = ["network-programming"]
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+drasi-lib.workspace = true
+drasi-plugin-sdk.workspace = true
+anyhow = "1.0"
+async-trait = "0.1"
+chrono = "0.4"
+log = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+utoipa.workspace = true
+uuid = { version = "1.0", features = ["v7"] }
+
+[dev-dependencies]
+wiremock = "0.6"
+
+[features]
+dynamic-plugin = []

--- a/components/reactions/github-workgraph/Makefile
+++ b/components/reactions/github-workgraph/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build test lint
+
+build:
+	cargo build -p drasi-reaction-github-workgraph
+
+test:
+	cargo test -p drasi-reaction-github-workgraph
+
+lint:
+	cargo clippy -p drasi-reaction-github-workgraph --all-targets --all-features -- -D warnings

--- a/components/reactions/github-workgraph/README.md
+++ b/components/reactions/github-workgraph/README.md
@@ -1,0 +1,68 @@
+# GitHub WorkGraph Dispatcher Reaction
+
+The GitHub WorkGraph reaction dispatches tasks from one capacity query to free
+worker slots. It preserves the query's ordering and writes the canonical
+`WorkGraphTaskLease/v1` mapping as a GitHub issue comment.
+
+## Configuration
+
+The reaction must subscribe to exactly one query.
+
+```yaml
+reactions:
+  - id: workgraph-dispatcher
+    kind: github-workgraph-dispatcher
+    queries:
+      - workgraph-capacity
+    properties:
+      token:
+        kind: Secret
+        name: github-workgraph-token
+      apiBaseUrl: https://api.github.com
+```
+
+`token` must be able to create issue comments in every task repository.
+`apiBaseUrl` is optional and can be changed for GitHub Enterprise Server. The
+resolved token is used only for bearer authentication and is not logged.
+
+## Capacity row
+
+The query may return additional fields, but every current row must contain:
+
+```json
+{
+  "repositoryOwner": "acme",
+  "repositoryName": "workgraph",
+  "workerId": "validator-1",
+  "leaseDurationSeconds": 900,
+  "activeLeaseIds": [],
+  "freeSlotIds": [
+    "validator-1/1",
+    "validator-1/2"
+  ],
+  "dispatchableTasks": [
+    {
+      "taskNodeId": "I_kwDOExample1",
+      "taskNumber": 101,
+      "repositoryOwner": "acme",
+      "repositoryName": "tasks",
+      "assignmentCommentNodeId": "IC_kwDOAssignment1",
+      "workerId": "validator-1"
+    }
+  ]
+}
+```
+
+The reaction filters slots and tasks already held by its short-lived in-process
+pending map, then pairs the remaining `freeSlotIds` and `dispatchableTasks`
+positionally without sorting. A pending entry is removed only when a later row
+for the same repository and worker includes its exact lease ID in
+`activeLeaseIds`.
+
+After a successful issue-comment request, the pending entry prevents a repeated
+capacity row from assigning either the same slot or the same task again while
+the source and query catch up. Pending state is intentionally not durable.
+
+Malformed rows and unsuccessful GitHub requests put the reaction in an error
+state. The reaction does not retry, scan existing comments, reconcile startup
+state, or claim exactly-once delivery.

--- a/components/reactions/github-workgraph/README.md
+++ b/components/reactions/github-workgraph/README.md
@@ -1,7 +1,7 @@
 # GitHub WorkGraph Dispatcher Reaction
 
 The GitHub WorkGraph reaction dispatches tasks from one capacity query to free
-worker slots. It preserves the query's ordering and writes the canonical
+worker slots. It orders capacity deterministically and writes the canonical
 `WorkGraphTaskLease/v1` mapping as a GitHub issue comment.
 
 ## Configuration
@@ -47,17 +47,19 @@ The query may return additional fields, but every current row must contain:
       "repositoryOwner": "acme",
       "repositoryName": "tasks",
       "assignmentCommentNodeId": "IC_kwDOAssignment1",
-      "workerId": "validator-1"
+      "workerId": "validator-1",
+      "queuePriority": 0,
+      "assignmentCreatedAt": "2026-08-19T22:00:00Z"
     }
   ]
 }
 ```
 
 The reaction filters slots and tasks already held by its short-lived in-process
-pending map, then pairs the remaining `freeSlotIds` and `dispatchableTasks`
-positionally without sorting. A pending entry is removed only when a later row
-for the same repository and worker includes its exact lease ID in
-`activeLeaseIds`.
+pending map, orders slots by numeric slot suffix and full slot ID, orders tasks
+by `queuePriority`, `assignmentCreatedAt`, and `taskNodeId`, then pairs them
+positionally. A pending entry is removed only when a later row for the same
+repository and worker includes its exact lease ID in `activeLeaseIds`.
 
 After a successful issue-comment request, the pending entry prevents a repeated
 capacity row from assigning either the same slot or the same task again while

--- a/components/reactions/github-workgraph/src/config.rs
+++ b/components/reactions/github-workgraph/src/config.rs
@@ -1,0 +1,57 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{ensure, Context, Result};
+use serde::Serialize;
+
+pub const DEFAULT_API_BASE_URL: &str = "https://api.github.com";
+
+/// Runtime configuration for the GitHub WorkGraph dispatcher.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubWorkGraphReactionConfig {
+    #[serde(skip_serializing)]
+    pub token: String,
+    pub api_base_url: String,
+}
+
+impl GitHubWorkGraphReactionConfig {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+            api_base_url: DEFAULT_API_BASE_URL.to_string(),
+        }
+    }
+
+    pub fn with_api_base_url(mut self, api_base_url: impl Into<String>) -> Self {
+        self.api_base_url = api_base_url.into();
+        self
+    }
+
+    pub(crate) fn validate(&self, query_ids: &[String]) -> Result<()> {
+        ensure!(
+            query_ids.len() == 1,
+            "GitHub WorkGraph reaction requires exactly one capacity query"
+        );
+        ensure!(!self.token.trim().is_empty(), "token cannot be empty");
+
+        let url = reqwest::Url::parse(self.api_base_url.trim())
+            .context("apiBaseUrl must be a valid URL")?;
+        ensure!(
+            matches!(url.scheme(), "http" | "https"),
+            "apiBaseUrl scheme must be http or https"
+        );
+        Ok(())
+    }
+}

--- a/components/reactions/github-workgraph/src/descriptor.rs
+++ b/components/reactions/github-workgraph/src/descriptor.rs
@@ -1,0 +1,108 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use drasi_lib::reactions::Reaction;
+use drasi_plugin_sdk::prelude::*;
+use utoipa::OpenApi;
+
+use crate::config::DEFAULT_API_BASE_URL;
+use crate::{GitHubWorkGraphReaction, GitHubWorkGraphReactionConfig};
+
+fn default_api_base_url() -> ConfigValue<String> {
+    ConfigValue::Static(DEFAULT_API_BASE_URL.to_string())
+}
+
+#[derive(Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[schema(as = reaction::github_workgraph::GitHubWorkGraphReactionConfig)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GitHubWorkGraphReactionConfigDto {
+    /// GitHub token with permission to create issue comments.
+    #[schema(value_type = ConfigValueString)]
+    pub token: ConfigValue<String>,
+
+    /// GitHub REST API base URL.
+    #[serde(default = "default_api_base_url")]
+    #[schema(value_type = ConfigValueString)]
+    pub api_base_url: ConfigValue<String>,
+}
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(GitHubWorkGraphReactionConfigDto)))]
+struct GitHubWorkGraphReactionSchemas;
+
+pub struct GitHubWorkGraphReactionDescriptor;
+
+#[async_trait]
+impl ReactionPluginDescriptor for GitHubWorkGraphReactionDescriptor {
+    fn kind(&self) -> &str {
+        "github-workgraph-dispatcher"
+    }
+
+    fn config_version(&self) -> &str {
+        "1.0.0"
+    }
+
+    fn config_schema_name(&self) -> &str {
+        "reaction.github_workgraph.GitHubWorkGraphReactionConfig"
+    }
+
+    fn display_name(&self) -> &str {
+        "GitHub WorkGraph Dispatcher"
+    }
+
+    fn display_description(&self) -> &str {
+        "Dispatches WorkGraph tasks to available worker slots."
+    }
+
+    fn display_icon(&self) -> &str {
+        "github"
+    }
+
+    fn config_schema_json(&self) -> String {
+        let api = GitHubWorkGraphReactionSchemas::openapi();
+        let schemas = serde_json::to_value(
+            &api.components
+                .as_ref()
+                .expect("OpenAPI components missing")
+                .schemas,
+        )
+        .expect("failed to serialize config schema");
+
+        drasi_plugin_sdk::schema_ui::SchemaUiAnnotator::new(
+            schemas,
+            "reaction.github_workgraph.GitHubWorkGraphReactionConfig",
+        )
+        .expect("root schema not found")
+        .field("token", |field| field.order(1).widget("password"))
+        .field("apiBaseUrl", |field| field.order(2))
+        .annotate()
+    }
+
+    async fn create_reaction(
+        &self,
+        id: &str,
+        query_ids: Vec<String>,
+        config_json: &serde_json::Value,
+        auto_start: bool,
+    ) -> anyhow::Result<Box<dyn Reaction>> {
+        let dto: GitHubWorkGraphReactionConfigDto = serde_json::from_value(config_json.clone())?;
+        let mapper = DtoMapper::new();
+        let config = GitHubWorkGraphReactionConfig::new(mapper.resolve_string(&dto.token).await?)
+            .with_api_base_url(mapper.resolve_string(&dto.api_base_url).await?);
+
+        let mut reaction = GitHubWorkGraphReaction::new(id, query_ids, config, auto_start)?;
+        reaction.base.set_raw_config(config_json.clone());
+        Ok(Box::new(reaction))
+    }
+}

--- a/components/reactions/github-workgraph/src/lib.rs
+++ b/components/reactions/github-workgraph/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unexpected_cfgs)]
+
+//! GitHub WorkGraph queue dispatcher reaction.
+
+mod config;
+pub mod descriptor;
+mod model;
+mod reaction;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::GitHubWorkGraphReactionConfig;
+pub use reaction::GitHubWorkGraphReaction;
+
+#[cfg(feature = "dynamic-plugin")]
+drasi_plugin_sdk::export_plugin!(
+    plugin_id = "github-workgraph-dispatcher-reaction",
+    core_version = env!("CARGO_PKG_VERSION"),
+    lib_version = env!("CARGO_PKG_VERSION"),
+    plugin_version = env!("CARGO_PKG_VERSION"),
+    source_descriptors = [],
+    reaction_descriptors = [descriptor::GitHubWorkGraphReactionDescriptor],
+    bootstrap_descriptors = [],
+);

--- a/components/reactions/github-workgraph/src/model.rs
+++ b/components/reactions/github-workgraph/src/model.rs
@@ -1,0 +1,99 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CapacityRow {
+    pub repository_owner: String,
+    pub repository_name: String,
+    pub worker_id: String,
+    pub lease_duration_seconds: i64,
+    pub active_lease_ids: Vec<String>,
+    pub free_slot_ids: Vec<String>,
+    pub dispatchable_tasks: Vec<DispatchableTask>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DispatchableTask {
+    pub task_node_id: String,
+    pub task_number: u64,
+    pub repository_owner: String,
+    pub repository_name: String,
+    pub assignment_comment_node_id: String,
+    pub worker_id: String,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct PendingScope {
+    pub repository_owner: String,
+    pub repository_name: String,
+    pub worker_id: String,
+}
+
+impl From<&CapacityRow> for PendingScope {
+    fn from(row: &CapacityRow) -> Self {
+        Self {
+            repository_owner: row.repository_owner.clone(),
+            repository_name: row.repository_name.clone(),
+            worker_id: row.worker_id.clone(),
+        }
+    }
+}
+
+pub(crate) struct PendingLease {
+    pub scope: PendingScope,
+    pub slot_id: String,
+    pub task_node_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskLease {
+    lease_id: String,
+    assignment_comment_node_id: String,
+    worker_id: String,
+    slot_id: String,
+    acquired_at: String,
+    expires_at: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct IssueComment {
+    pub body: String,
+}
+
+pub(crate) fn lease_comment(
+    lease_id: &str,
+    slot_id: &str,
+    task: &DispatchableTask,
+    acquired_at: DateTime<Utc>,
+    lease_duration_seconds: i64,
+) -> Result<String> {
+    let expires_at = acquired_at + chrono::Duration::seconds(lease_duration_seconds);
+    let lease = TaskLease {
+        lease_id: lease_id.to_string(),
+        assignment_comment_node_id: task.assignment_comment_node_id.clone(),
+        worker_id: task.worker_id.clone(),
+        slot_id: slot_id.to_string(),
+        acquired_at: acquired_at.to_rfc3339_opts(SecondsFormat::Secs, true),
+        expires_at: expires_at.to_rfc3339_opts(SecondsFormat::Secs, true),
+    };
+    let json = serde_json::to_string_pretty(&lease)?;
+    Ok(format!("WorkGraphTaskLease/v1\n\n```json\n{json}\n```\n"))
+}

--- a/components/reactions/github-workgraph/src/model.rs
+++ b/components/reactions/github-workgraph/src/model.rs
@@ -37,6 +37,8 @@ pub(crate) struct DispatchableTask {
     pub repository_name: String,
     pub assignment_comment_node_id: String,
     pub worker_id: String,
+    pub queue_priority: i64,
+    pub assignment_created_at: DateTime<Utc>,
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/components/reactions/github-workgraph/src/reaction.rs
+++ b/components/reactions/github-workgraph/src/reaction.rs
@@ -1,0 +1,288 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{ensure, Context, Result};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use drasi_lib::channels::{ComponentStatus, QueryResult, ResultDiff};
+use drasi_lib::managers::log_component_start;
+use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
+use drasi_lib::Reaction;
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
+use reqwest::Client;
+use uuid::Uuid;
+
+use crate::config::GitHubWorkGraphReactionConfig;
+use crate::model::{
+    lease_comment, CapacityRow, DispatchableTask, IssueComment, PendingLease, PendingScope,
+};
+
+pub struct GitHubWorkGraphReaction {
+    pub(crate) base: ReactionBase,
+    config: GitHubWorkGraphReactionConfig,
+}
+
+impl GitHubWorkGraphReaction {
+    pub fn new(
+        id: impl Into<String>,
+        query_ids: Vec<String>,
+        config: GitHubWorkGraphReactionConfig,
+        auto_start: bool,
+    ) -> Result<Self> {
+        config.validate(&query_ids)?;
+        let params = ReactionBaseParams::new(id.into(), query_ids).with_auto_start(auto_start);
+        Ok(Self {
+            base: ReactionBase::new(params),
+            config,
+        })
+    }
+
+    pub(crate) fn build_client(&self) -> Result<Client> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", self.config.token))
+                .context("invalid GitHub token header value")?,
+        );
+        headers.insert(
+            USER_AGENT,
+            HeaderValue::from_static("drasi-reaction-github-workgraph"),
+        );
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        headers.insert(
+            "x-github-api-version",
+            HeaderValue::from_static("2022-11-28"),
+        );
+        Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("failed to build GitHub HTTP client")
+    }
+}
+
+pub(crate) struct DispatcherEngine {
+    client: Client,
+    api_base_url: String,
+    pending: HashMap<String, PendingLease>,
+}
+
+impl DispatcherEngine {
+    pub(crate) fn new(client: Client, api_base_url: impl Into<String>) -> Self {
+        Self {
+            client,
+            api_base_url: api_base_url.into().trim_end_matches('/').to_string(),
+            pending: HashMap::new(),
+        }
+    }
+
+    pub(crate) async fn process_query_result(&mut self, result: &QueryResult) -> Result<()> {
+        for diff in &result.results {
+            let value = match diff {
+                ResultDiff::Add { data, .. } => data,
+                ResultDiff::Update { after, .. } | ResultDiff::Aggregation { after, .. } => after,
+                ResultDiff::Delete { .. } | ResultDiff::Noop => continue,
+            };
+            let row: CapacityRow = serde_json::from_value(value.clone()).with_context(|| {
+                format!("malformed capacity row from query '{}'", result.query_id)
+            })?;
+            self.process_row(row).await?;
+        }
+        Ok(())
+    }
+
+    async fn process_row(&mut self, row: CapacityRow) -> Result<()> {
+        ensure!(
+            row.lease_duration_seconds > 0,
+            "leaseDurationSeconds must be positive"
+        );
+        let scope = PendingScope::from(&row);
+        let active: HashSet<&str> = row.active_lease_ids.iter().map(String::as_str).collect();
+        self.pending.retain(|lease_id, pending| {
+            pending.scope != scope || !active.contains(lease_id.as_str())
+        });
+
+        let slots: Vec<String> = row
+            .free_slot_ids
+            .iter()
+            .filter(|slot_id| {
+                !self
+                    .pending
+                    .values()
+                    .any(|pending| pending.slot_id == slot_id.as_str())
+            })
+            .cloned()
+            .collect();
+        let tasks: Vec<DispatchableTask> = row
+            .dispatchable_tasks
+            .iter()
+            .filter(|task| {
+                !self
+                    .pending
+                    .values()
+                    .any(|pending| pending.task_node_id == task.task_node_id)
+            })
+            .cloned()
+            .collect();
+
+        for (slot_id, task) in slots.iter().zip(tasks.iter()) {
+            ensure!(
+                task.worker_id == row.worker_id,
+                "dispatchable task workerId does not match capacity row workerId"
+            );
+            ensure!(
+                task.repository_owner == row.repository_owner
+                    && task.repository_name == row.repository_name,
+                "dispatchable task repository does not match capacity row repository"
+            );
+            let lease_id = Uuid::now_v7().to_string();
+            self.post_lease(
+                &lease_id,
+                slot_id,
+                task,
+                Utc::now(),
+                row.lease_duration_seconds,
+            )
+            .await?;
+            self.pending.insert(
+                lease_id,
+                PendingLease {
+                    scope: scope.clone(),
+                    slot_id: slot_id.clone(),
+                    task_node_id: task.task_node_id.clone(),
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn post_lease(
+        &self,
+        lease_id: &str,
+        slot_id: &str,
+        task: &DispatchableTask,
+        acquired_at: DateTime<Utc>,
+        lease_duration_seconds: i64,
+    ) -> Result<()> {
+        let body = lease_comment(lease_id, slot_id, task, acquired_at, lease_duration_seconds)?;
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}/comments",
+            self.api_base_url, task.repository_owner, task.repository_name, task.task_number
+        );
+        self.client
+            .post(url)
+            .json(&IssueComment { body })
+            .send()
+            .await
+            .context("failed to create GitHub issue comment")?
+            .error_for_status()
+            .context("GitHub issue comment was rejected")?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending(&self) -> &HashMap<String, PendingLease> {
+        &self.pending
+    }
+}
+
+#[async_trait]
+impl Reaction for GitHubWorkGraphReaction {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "github-workgraph-dispatcher"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        self.base.properties_or_serialize(&self.config)
+    }
+
+    fn query_ids(&self) -> Vec<String> {
+        self.base.queries.clone()
+    }
+
+    fn auto_start(&self) -> bool {
+        self.base.get_auto_start()
+    }
+
+    async fn initialize(&self, context: drasi_lib::context::ReactionRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.config.validate(&self.base.queries)?;
+        log_component_start("GitHub WorkGraph Reaction", &self.base.id);
+        self.base
+            .set_status(
+                ComponentStatus::Starting,
+                Some("Starting GitHub WorkGraph reaction".to_string()),
+            )
+            .await;
+
+        let client = self.build_client()?;
+        let mut shutdown_rx = self.base.create_shutdown_channel().await;
+        let priority_queue = self.base.priority_queue.clone();
+        let status = self.base.status_handle();
+        let reaction_id = self.base.id.clone();
+        let mut engine = DispatcherEngine::new(client, self.config.api_base_url.clone());
+
+        self.base
+            .set_status(
+                ComponentStatus::Running,
+                Some("GitHub WorkGraph reaction started".to_string()),
+            )
+            .await;
+
+        let processing_task = tokio::spawn(async move {
+            loop {
+                let result = tokio::select! {
+                    biased;
+                    _ = &mut shutdown_rx => break,
+                    result = priority_queue.dequeue() => result,
+                };
+                if let Err(error) = engine.process_query_result(result.as_ref()).await {
+                    log::error!("[{reaction_id}] GitHub WorkGraph dispatch failed: {error:#}");
+                    status
+                        .set_status(
+                            ComponentStatus::Error,
+                            Some(format!("GitHub WorkGraph dispatch failed: {error:#}")),
+                        )
+                        .await;
+                    break;
+                }
+            }
+        });
+        self.base.set_processing_task(processing_task).await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base.stop_common().await
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+        self.base.enqueue_query_result(result).await
+    }
+}

--- a/components/reactions/github-workgraph/src/reaction.rs
+++ b/components/reactions/github-workgraph/src/reaction.rs
@@ -117,7 +117,7 @@ impl DispatcherEngine {
             pending.scope != scope || !active.contains(lease_id.as_str())
         });
 
-        let slots: Vec<String> = row
+        let mut slots: Vec<(u64, String)> = row
             .free_slot_ids
             .iter()
             .filter(|slot_id| {
@@ -126,9 +126,31 @@ impl DispatcherEngine {
                     .values()
                     .any(|pending| pending.slot_id == slot_id.as_str())
             })
-            .cloned()
-            .collect();
-        let tasks: Vec<DispatchableTask> = row
+            .map(|slot_id| {
+                let (worker_id, suffix) = slot_id
+                    .rsplit_once('/')
+                    .context("free slot ID must end with a numeric slot suffix")?;
+                ensure!(
+                    !worker_id.is_empty(),
+                    "free slot ID must include a worker ID"
+                );
+                ensure!(
+                    worker_id == row.worker_id,
+                    "free slot ID worker prefix does not match capacity row workerId"
+                );
+                let slot_number = suffix
+                    .parse::<u64>()
+                    .context("free slot ID must end with a numeric slot suffix")?;
+                ensure!(slot_number > 0, "free slot ID suffix must be positive");
+                Ok((slot_number, slot_id.clone()))
+            })
+            .collect::<Result<_>>()?;
+        slots.sort_by(|(left_number, left_id), (right_number, right_id)| {
+            left_number
+                .cmp(right_number)
+                .then_with(|| left_id.cmp(right_id))
+        });
+        let mut tasks: Vec<DispatchableTask> = row
             .dispatchable_tasks
             .iter()
             .filter(|task| {
@@ -139,8 +161,14 @@ impl DispatcherEngine {
             })
             .cloned()
             .collect();
+        tasks.sort_by(|left, right| {
+            left.queue_priority
+                .cmp(&right.queue_priority)
+                .then_with(|| left.assignment_created_at.cmp(&right.assignment_created_at))
+                .then_with(|| left.task_node_id.cmp(&right.task_node_id))
+        });
 
-        for (slot_id, task) in slots.iter().zip(tasks.iter()) {
+        for ((_, slot_id), task) in slots.iter().zip(tasks.iter()) {
             ensure!(
                 task.worker_id == row.worker_id,
                 "dispatchable task workerId does not match capacity row workerId"

--- a/components/reactions/github-workgraph/src/tests.rs
+++ b/components/reactions/github-workgraph/src/tests.rs
@@ -1,0 +1,351 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use chrono::{TimeZone, Utc};
+use drasi_lib::channels::{QueryResult, ResultDiff};
+use drasi_lib::Reaction;
+use drasi_plugin_sdk::ReactionPluginDescriptor;
+use serde_json::{json, Value};
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::descriptor::GitHubWorkGraphReactionDescriptor;
+use crate::model::{lease_comment, DispatchableTask};
+use crate::reaction::DispatcherEngine;
+use crate::{GitHubWorkGraphReaction, GitHubWorkGraphReactionConfig};
+
+fn task(number: u64, node_id: &str) -> Value {
+    task_in_scope(number, node_id, "queue-owner", "queue-repo", "worker-a")
+}
+
+fn task_in_scope(
+    number: u64,
+    node_id: &str,
+    repository_owner: &str,
+    repository_name: &str,
+    worker_id: &str,
+) -> Value {
+    json!({
+        "taskNodeId": node_id,
+        "taskNumber": number,
+        "repositoryOwner": repository_owner,
+        "repositoryName": repository_name,
+        "assignmentCommentNodeId": format!("IC-{node_id}"),
+        "workerId": worker_id,
+        "unusedMetadata": {"ignored": true}
+    })
+}
+
+fn row(active: &[String], slots: &[&str], tasks: Vec<Value>) -> Value {
+    row_in_scope(
+        "queue-owner",
+        "queue-repo",
+        "worker-a",
+        active,
+        slots,
+        tasks,
+    )
+}
+
+fn row_in_scope(
+    repository_owner: &str,
+    repository_name: &str,
+    worker_id: &str,
+    active: &[String],
+    slots: &[&str],
+    tasks: Vec<Value>,
+) -> Value {
+    json!({
+        "repositoryOwner": repository_owner,
+        "repositoryName": repository_name,
+        "workerId": worker_id,
+        "leaseDurationSeconds": 900,
+        "activeLeaseIds": active,
+        "freeSlotIds": slots,
+        "dispatchableTasks": tasks,
+        "agentProfile": "issue-validator",
+        "configuredSlotCount": 2,
+        "activeLeaseCount": active.len(),
+        "dispatchableTaskIds": ["ignored"]
+    })
+}
+
+fn result(value: Value) -> QueryResult {
+    QueryResult::new(
+        "capacity".to_string(),
+        1,
+        Utc::now(),
+        vec![ResultDiff::Aggregation {
+            before: None,
+            after: value,
+            row_signature: 1,
+        }],
+        HashMap::new(),
+    )
+}
+
+fn engine(server: &MockServer) -> DispatcherEngine {
+    let config = GitHubWorkGraphReactionConfig::new("test-token").with_api_base_url(server.uri());
+    let reaction =
+        GitHubWorkGraphReaction::new("dispatcher", vec!["capacity".into()], config, true)
+            .expect("valid reaction");
+    DispatcherEngine::new(reaction.build_client().expect("valid client"), server.uri())
+}
+
+#[test]
+fn canonical_comment_body_is_exact() {
+    let task = DispatchableTask {
+        task_node_id: "I_task".into(),
+        task_number: 42,
+        repository_owner: "acme".into(),
+        repository_name: "widgets".into(),
+        assignment_comment_node_id: "IC_assignment".into(),
+        worker_id: "validator-1".into(),
+    };
+    let acquired = Utc
+        .with_ymd_and_hms(2026, 8, 19, 22, 0, 0)
+        .single()
+        .unwrap();
+    let body = lease_comment(
+        "0198d8c4-7c28-7d43-a8dd-e9f5be8c1b21",
+        "validator-1/1",
+        &task,
+        acquired,
+        900,
+    )
+    .unwrap();
+
+    assert_eq!(
+        body,
+        "WorkGraphTaskLease/v1\n\n```json\n{\n  \"leaseId\": \
+         \"0198d8c4-7c28-7d43-a8dd-e9f5be8c1b21\",\n  \"assignmentCommentNodeId\": \
+         \"IC_assignment\",\n  \"workerId\": \"validator-1\",\n  \"slotId\": \
+         \"validator-1/1\",\n  \"acquiredAt\": \"2026-08-19T22:00:00Z\",\n  \"expiresAt\": \
+         \"2026-08-19T22:15:00Z\"\n}\n```\n"
+    );
+}
+
+#[tokio::test]
+async fn pairs_in_supplied_order_and_sends_exact_request_shape() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(201))
+        .expect(2)
+        .mount(&server)
+        .await;
+    let mut engine = engine(&server);
+
+    engine
+        .process_query_result(&result(row(
+            &[],
+            &["worker-a/2", "worker-a/1", "worker-a/3"],
+            vec![task(22, "I_second"), task(11, "I_first")],
+        )))
+        .await
+        .unwrap();
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(
+        requests[0].url.path(),
+        "/repos/queue-owner/queue-repo/issues/22/comments"
+    );
+    assert_eq!(
+        requests[1].url.path(),
+        "/repos/queue-owner/queue-repo/issues/11/comments"
+    );
+    assert_eq!(
+        requests[0]
+            .headers
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "Bearer test-token"
+    );
+    assert_eq!(
+        requests[0].headers.get("accept").unwrap().to_str().unwrap(),
+        "application/vnd.github+json"
+    );
+    let first: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    let first_body = first["body"].as_str().unwrap();
+    assert!(first_body.contains("\"slotId\": \"worker-a/2\""));
+    assert!(first_body.contains("\"assignmentCommentNodeId\": \"IC-I_second\""));
+    assert!(first_body.starts_with("WorkGraphTaskLease/v1\n\n```json\n"));
+    assert!(first_body.ends_with("\n```\n"));
+}
+
+#[tokio::test]
+async fn pending_suppresses_repeats_until_exact_active_lease_acknowledgment() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+    let mut engine = engine(&server);
+    let capacity = row(&[], &["worker-a/1"], vec![task(42, "I_task")]);
+
+    engine
+        .process_query_result(&result(capacity.clone()))
+        .await
+        .unwrap();
+    engine
+        .process_query_result(&result(capacity.clone()))
+        .await
+        .unwrap();
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    assert_eq!(engine.pending().len(), 1);
+
+    let lease_id = engine.pending().keys().next().unwrap().clone();
+    engine
+        .process_query_result(&result(row_in_scope(
+            "other-owner",
+            "other-repo",
+            "worker-b",
+            std::slice::from_ref(&lease_id),
+            &["worker-a/1"],
+            vec![task_in_scope(
+                42,
+                "I_task",
+                "other-owner",
+                "other-repo",
+                "worker-b",
+            )],
+        )))
+        .await
+        .unwrap();
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    assert_eq!(engine.pending().len(), 1);
+
+    engine
+        .process_query_result(&result(row(&[lease_id], &[], vec![])))
+        .await
+        .unwrap();
+    assert!(engine.pending().is_empty());
+
+    engine
+        .process_query_result(&result(capacity))
+        .await
+        .unwrap();
+    assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    assert_eq!(engine.pending().len(), 1);
+}
+
+#[test]
+fn embedded_properties_do_not_expose_resolved_token() {
+    let reaction = GitHubWorkGraphReaction::new(
+        "dispatcher",
+        vec!["capacity".into()],
+        GitHubWorkGraphReactionConfig::new("literal-resolved-token"),
+        true,
+    )
+    .unwrap();
+
+    assert!(!reaction.properties().contains_key("token"));
+    assert_eq!(
+        reaction.properties().get("apiBaseUrl"),
+        Some(&json!("https://api.github.com"))
+    );
+}
+
+#[tokio::test]
+async fn malformed_rows_and_http_errors_surface_without_pending_entries() {
+    let server = MockServer::start().await;
+    let mut engine = engine(&server);
+    let malformed = json!({
+        "repositoryOwner": "queue-owner",
+        "repositoryName": "queue-repo",
+        "workerId": "worker-a"
+    });
+    let error = engine
+        .process_query_result(&result(malformed))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("malformed capacity row"));
+    assert!(engine.pending().is_empty());
+
+    let error = engine
+        .process_query_result(&result(row(
+            &[],
+            &["worker-a/1"],
+            vec![task_in_scope(
+                42,
+                "I_task",
+                "queue-owner",
+                "queue-repo",
+                "worker-b",
+            )],
+        )))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("workerId does not match"));
+
+    let error = engine
+        .process_query_result(&result(row(
+            &[],
+            &["worker-a/1"],
+            vec![task_in_scope(
+                42,
+                "I_task",
+                "other-owner",
+                "other-repo",
+                "worker-a",
+            )],
+        )))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("repository does not match"));
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(422))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let error = engine
+        .process_query_result(&result(row(&[], &["worker-a/1"], vec![task(42, "I_task")])))
+        .await
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("GitHub issue comment was rejected"));
+    assert!(engine.pending().is_empty());
+}
+
+#[tokio::test]
+async fn descriptor_requires_exactly_one_query_and_preserves_raw_token_reference() {
+    let descriptor = GitHubWorkGraphReactionDescriptor;
+    let config = json!({
+        "token": "${WORKGRAPH_TOKEN:-test-token}",
+        "apiBaseUrl": "https://api.github.com"
+    });
+    for queries in [vec![], vec!["one".into(), "two".into()]] {
+        let error = descriptor
+            .create_reaction("dispatcher", queries, &config, true)
+            .await
+            .err()
+            .expect("invalid query count");
+        assert!(error.to_string().contains("exactly one capacity query"));
+    }
+
+    let reaction = descriptor
+        .create_reaction("dispatcher", vec!["capacity".into()], &config, true)
+        .await
+        .unwrap();
+    assert_eq!(
+        reaction.properties().get("token"),
+        Some(&json!("${WORKGRAPH_TOKEN:-test-token}"))
+    );
+}

--- a/components/reactions/github-workgraph/src/tests.rs
+++ b/components/reactions/github-workgraph/src/tests.rs
@@ -31,6 +31,13 @@ fn task(number: u64, node_id: &str) -> Value {
     task_in_scope(number, node_id, "queue-owner", "queue-repo", "worker-a")
 }
 
+fn ordered_task(number: u64, node_id: &str, priority: i64, created_at: &str) -> Value {
+    let mut task = task(number, node_id);
+    task["queuePriority"] = json!(priority);
+    task["assignmentCreatedAt"] = json!(created_at);
+    task
+}
+
 fn task_in_scope(
     number: u64,
     node_id: &str,
@@ -45,6 +52,8 @@ fn task_in_scope(
         "repositoryName": repository_name,
         "assignmentCommentNodeId": format!("IC-{node_id}"),
         "workerId": worker_id,
+        "queuePriority": 0,
+        "assignmentCreatedAt": "2026-08-19T22:00:00Z",
         "unusedMetadata": {"ignored": true}
     })
 }
@@ -114,6 +123,11 @@ fn canonical_comment_body_is_exact() {
         repository_name: "widgets".into(),
         assignment_comment_node_id: "IC_assignment".into(),
         worker_id: "validator-1".into(),
+        queue_priority: 0,
+        assignment_created_at: Utc
+            .with_ymd_and_hms(2026, 8, 19, 21, 0, 0)
+            .single()
+            .unwrap(),
     };
     let acquired = Utc
         .with_ymd_and_hms(2026, 8, 19, 22, 0, 0)
@@ -139,11 +153,11 @@ fn canonical_comment_body_is_exact() {
 }
 
 #[tokio::test]
-async fn pairs_in_supplied_order_and_sends_exact_request_shape() {
+async fn pairs_in_deterministic_order_and_sends_exact_request_shape() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .respond_with(ResponseTemplate::new(201))
-        .expect(2)
+        .expect(4)
         .mount(&server)
         .await;
     let mut engine = engine(&server);
@@ -151,22 +165,25 @@ async fn pairs_in_supplied_order_and_sends_exact_request_shape() {
     engine
         .process_query_result(&result(row(
             &[],
-            &["worker-a/2", "worker-a/1", "worker-a/3"],
-            vec![task(22, "I_second"), task(11, "I_first")],
+            &["worker-a/10", "worker-a/3", "worker-a/1", "worker-a/2"],
+            vec![
+                ordered_task(40, "I_priority_late", 1, "2026-08-19T21:00:00Z"),
+                ordered_task(30, "I_time_late", 0, "2026-08-19T23:00:00Z"),
+                ordered_task(20, "I_node_b", 0, "2026-08-19T22:00:00Z"),
+                ordered_task(10, "I_node_a", 0, "2026-08-19T22:00:00Z"),
+            ],
         )))
         .await
         .unwrap();
 
     let requests = server.received_requests().await.unwrap();
-    assert_eq!(requests.len(), 2);
-    assert_eq!(
-        requests[0].url.path(),
-        "/repos/queue-owner/queue-repo/issues/22/comments"
-    );
-    assert_eq!(
-        requests[1].url.path(),
-        "/repos/queue-owner/queue-repo/issues/11/comments"
-    );
+    assert_eq!(requests.len(), 4);
+    for (request, task_number) in requests.iter().zip([10, 20, 30, 40]) {
+        assert_eq!(
+            request.url.path(),
+            format!("/repos/queue-owner/queue-repo/issues/{task_number}/comments")
+        );
+    }
     assert_eq!(
         requests[0]
             .headers
@@ -182,8 +199,8 @@ async fn pairs_in_supplied_order_and_sends_exact_request_shape() {
     );
     let first: Value = serde_json::from_slice(&requests[0].body).unwrap();
     let first_body = first["body"].as_str().unwrap();
-    assert!(first_body.contains("\"slotId\": \"worker-a/2\""));
-    assert!(first_body.contains("\"assignmentCommentNodeId\": \"IC-I_second\""));
+    assert!(first_body.contains("\"slotId\": \"worker-a/1\""));
+    assert!(first_body.contains("\"assignmentCommentNodeId\": \"IC-I_node_a\""));
     assert!(first_body.starts_with("WorkGraphTaskLease/v1\n\n```json\n"));
     assert!(first_body.ends_with("\n```\n"));
 }
@@ -276,6 +293,30 @@ async fn malformed_rows_and_http_errors_surface_without_pending_entries() {
         .unwrap_err();
     assert!(error.to_string().contains("malformed capacity row"));
     assert!(engine.pending().is_empty());
+
+    let error = engine
+        .process_query_result(&result(row(
+            &[],
+            &["worker-a/not-a-number"],
+            vec![task(42, "I_task")],
+        )))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("numeric slot suffix"));
+
+    let error = engine
+        .process_query_result(&result(row(&[], &["worker-b/1"], vec![task(42, "I_task")])))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("worker prefix"));
+
+    let mut invalid_timestamp = task(42, "I_task");
+    invalid_timestamp["assignmentCreatedAt"] = json!("not-a-timestamp");
+    let error = engine
+        .process_query_result(&result(row(&[], &["worker-a/1"], vec![invalid_timestamp])))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("malformed capacity row"));
 
     let error = engine
         .process_query_result(&result(row(


### PR DESCRIPTION
## Summary

- add the `github-workgraph-dispatcher` dynamic Reaction plugin
- consume exactly one capacity query, sort free slots by numeric suffix/full slot ID and tasks by `(queuePriority, assignmentCreatedAt, taskNodeId)`, and pair remaining entries positionally
- write canonical `WorkGraphTaskLease/v1` mappings as GitHub issue comments
- resolve the GitHub token through `ConfigValue` without logging or serializing the resolved runtime value

## Intentionally minimal semantics

The dispatcher keeps only a small in-process pending map. Pending slot and task suppression is global, while an entry is removed only when the matching repository/worker row reports its exact lease ID in `activeLeaseIds`.

There is deliberately no durable inbox, custom cursor or watermark, transaction/reservation state machine, retry protocol, GitHub comment scanning, startup reconciliation, pagination or rate-limit subsystem, custom state-store/checkpoint machinery, or exactly-once claim. Malformed rows and unsuccessful GitHub requests surface as Reaction errors.

## Tests and validation

Six focused tests cover canonical comment formatting, deterministic multi-slot/task pairing from shuffled input, repeated-row suppression, scoped exact lease acknowledgment with cross-scope suppression, malformed ordering/mismatched row and HTTP errors, embedded token redaction, and descriptor query/raw-config behavior.

Validated with:

- `cargo test -p drasi-reaction-github-workgraph`
- `cargo clippy -p drasi-reaction-github-workgraph --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- dynamic-plugin feature build
- `cargo run -p xtask -- list-plugins`
