### PR TITLE
fix(release): prevent dev-dependency publish deadlocks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,6 @@ jobs:
     uses: drasi-project/.github/.github/workflows/rust-unit-test.yaml@main
     with:
       test-command: |
+        cargo run -p xtask -- check-publish-dependency-cycles
         cargo test --workspace --exclude drasi-host-sdk
         make test-host-sdk

--- a/components/sources/mssql/Cargo.toml
+++ b/components/sources/mssql/Cargo.toml
@@ -58,7 +58,8 @@ testcontainers = "0.27"
 drasi-bootstrap-mssql = { workspace = true }
 drasi-reaction-application = { workspace = true }
 drasi-index-rocksdb = { workspace = true }
-drasi-host-sdk = { workspace = true }
+# Path-only so this dev dependency is omitted from the published manifest.
+drasi-host-sdk = { path = "../../host-sdk" }
 drasi-plugin-sdk = { workspace = true }
 tempfile = "3"
 bytes = "1"

--- a/lib-integration-tests/Cargo.toml
+++ b/lib-integration-tests/Cargo.toml
@@ -14,6 +14,8 @@ drasi-core.workspace = true
 drasi-source-postgres.workspace = true
 drasi-source-application.workspace = true
 drasi-reaction-application.workspace = true
+drasi-index-rocksdb = { workspace = true, features = ["plugin-descriptor"] }
+drasi-plugin-sdk.workspace = true
 
 tokio = { version = "1.6", features = ["full"] }
 testcontainers = "0.27"
@@ -25,3 +27,4 @@ serde_json = "1.0"
 anyhow = "1.0"
 tracing = "0.1"
 serial_test = "3"
+tempfile = "3"

--- a/lib-integration-tests/tests/static_rocksdb_index_e2e.rs
+++ b/lib-integration-tests/tests/static_rocksdb_index_e2e.rs
@@ -29,18 +29,120 @@
 //! `Arc<dyn IndexBackendPlugin>` (defined in `drasi-core`) is shared directly
 //! between the backend crate and `drasi-lib`.
 
-mod mock_source;
-
 use anyhow::Result;
+use async_trait::async_trait;
+use drasi_core::models::{
+    Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange,
+};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use drasi_index_rocksdb::RocksDbIndexDescriptor;
-use drasi_lib::{ComponentStatus, DrasiLib, Query, StorageBackendRef};
+use drasi_lib::{
+    ComponentStatus, DispatchMode, DrasiLib, Query, Source, SourceBase, SourceBaseParams,
+    SourceRuntimeContext, SourceSubscriptionSettings, StorageBackendRef, SubscriptionResponse,
+};
 use drasi_plugin_sdk::IndexBackendPluginDescriptor;
-use mock_source::{MockSource, MockSourceHandle, PropertyMapBuilder};
+use drasi_source_application::PropertyMapBuilder;
 use serde_json::json;
 use tempfile::TempDir;
+
+#[derive(Clone)]
+struct TestSourceHandle {
+    base: Arc<SourceBase>,
+}
+
+impl TestSourceHandle {
+    async fn send_node_insert(
+        &self,
+        element_id: impl Into<Arc<str>>,
+        labels: Vec<impl Into<Arc<str>>>,
+        properties: ElementPropertyMap,
+    ) -> Result<()> {
+        let element = Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference {
+                    source_id: Arc::from(self.base.get_id()),
+                    element_id: element_id.into(),
+                },
+                labels: Arc::from(labels.into_iter().map(Into::into).collect::<Vec<_>>()),
+                effective_from: chrono::Utc::now().timestamp_millis() as u64,
+            },
+            properties,
+        };
+        self.base
+            .dispatch_source_change(SourceChange::Insert { element })
+            .await
+    }
+}
+
+struct TestSource {
+    base: Arc<SourceBase>,
+}
+
+impl TestSource {
+    fn new(id: &str) -> Result<(Self, TestSourceHandle)> {
+        let base = Arc::new(SourceBase::new(SourceBaseParams::new(id))?);
+        let handle = TestSourceHandle { base: base.clone() };
+        Ok((Self { base }, handle))
+    }
+}
+
+#[async_trait]
+impl Source for TestSource {
+    fn id(&self) -> &str {
+        self.base.get_id()
+    }
+
+    fn type_name(&self) -> &str {
+        "test"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+
+    fn auto_start(&self) -> bool {
+        self.base.get_auto_start()
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.base
+            .set_status(ComponentStatus::Running, Some("Started".to_string()))
+            .await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base.stop_common().await
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn subscribe(
+        &self,
+        settings: SourceSubscriptionSettings,
+    ) -> Result<SubscriptionResponse> {
+        self.base
+            .subscribe_with_bootstrap(&settings, self.type_name())
+            .await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn initialize(&self, context: SourceRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    fn dispatch_mode(&self) -> DispatchMode {
+        DispatchMode::Channel
+    }
+}
 
 /// Build a RocksDB-backed index provider the way `drasi-server` would: from a
 /// JSON storage-backend config, via the statically-linked descriptor.
@@ -68,7 +170,11 @@ async fn build_provider_from_config(
         .expect("descriptor should build a RocksDB index backend from config")
 }
 
-async fn insert_person(handle: &MockSourceHandle, id: &str, name: &str, age: i64) -> Result<()> {
+fn test_source(id: &str) -> Result<(TestSource, TestSourceHandle)> {
+    TestSource::new(id)
+}
+
+async fn insert_person(handle: &TestSourceHandle, id: &str, name: &str, age: i64) -> Result<()> {
     let props = PropertyMapBuilder::new()
         .with_string("name", name)
         .with_integer("age", age)
@@ -137,7 +243,7 @@ async fn static_rocksdb_descriptor_drives_query() -> Result<()> {
 
     let provider = build_provider_from_config(&backend_config).await;
 
-    let (source, handle) = MockSource::new("people-src")?;
+    let (source, handle) = test_source("people-src")?;
 
     let core = Arc::new(
         DrasiLib::builder()
@@ -186,7 +292,7 @@ async fn static_rocksdb_index_persists_across_restart() -> Result<()> {
     });
 
     let provider = build_provider_from_config(&backend_config).await;
-    let (source, handle) = MockSource::new("people-src")?;
+    let (source, handle) = test_source("people-src")?;
     let core = Arc::new(
         DrasiLib::builder()
             .with_id("static-rocksdb")
@@ -267,7 +373,7 @@ async fn static_rocksdb_shutdown_releases_lock_for_same_process_reopen() -> Resu
 
     // ---- First engine: ingest rows, then shut down permanently. ----
     let provider1 = build_provider_from_config(&backend_config).await;
-    let (source1, handle1) = MockSource::new("people-src")?;
+    let (source1, handle1) = test_source("people-src")?;
     let core1 = Arc::new(
         DrasiLib::builder()
             .with_id("static-rocksdb-1")
@@ -304,7 +410,7 @@ async fn static_rocksdb_shutdown_releases_lock_for_same_process_reopen() -> Resu
     // A fresh provider on the same on-disk path; this open acquires the RocksDB
     // LOCK, which only succeeds if the first engine's `shutdown()` released it.
     let provider2 = build_provider_from_config(&backend_config).await;
-    let (source2, _handle2) = MockSource::new("people-src")?;
+    let (source2, _handle2) = test_source("people-src")?;
     let core2 = Arc::new(
         DrasiLib::builder()
             .with_id("static-rocksdb-2")
@@ -365,7 +471,7 @@ async fn static_rocksdb_default_provider_backs_unspecified_query() -> Result<()>
     });
 
     let provider = build_provider_from_config(&backend_config).await;
-    let (source, handle) = MockSource::new("people-src")?;
+    let (source, handle) = test_source("people-src")?;
     let core = Arc::new(
         DrasiLib::builder()
             .with_id("static-rocksdb")

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -107,16 +107,12 @@ rmp-serde = "1"
 tempfile = "3.8"
 mockall = "0.12"
 tokio-test = "0.4"
+tokio = { version = "1.0", features = ["rt-multi-thread"] }
 assert_matches = "1.5"
 serial_test = "3.0"
 pretty_assertions = "1.4"
 test-case = "3.3"
-drasi-index-rocksdb = { path = "../components/indexes/rocksdb", features = [
-    "plugin-descriptor",
-] }
-# Mirrors how drasi-server depends on the plugin SDK to drive index backends
-# through their descriptor/DTO when statically linking a backend crate.
-drasi-plugin-sdk = { workspace = true }
+drasi-index-rocksdb = { path = "../components/indexes/rocksdb" }
 
 # Additional testing dependencies
 rstest = "0.18"

--- a/lib/src/secret_store/mod.rs
+++ b/lib/src/secret_store/mod.rs
@@ -16,8 +16,8 @@
 //!
 //! A [`SecretStoreProvider`] resolves named secret references (e.g., `"DB_PASSWORD"`)
 //! into their actual string values. Plugin configuration DTOs use
-//! [`ConfigValue::Secret`](drasi_plugin_sdk::ConfigValue) references which are resolved
-//! through the configured secret store during plugin initialization.
+//! `ConfigValue::Secret` references from the plugin SDK, which are resolved through
+//! the configured secret store during plugin initialization.
 //!
 //! # Architecture
 //!

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,14 +12,9 @@ git_release_type = "prod"
 
 # Publishing settings
 publish = true
-# Skip the isolated `cargo publish` verification build. That build re-resolves
-# the crate's full dependency graph (including dev-dependencies) from crates.io.
-# release-plz orders publishing by [dependencies]/[build-dependencies] only and
-# ignores [dev-dependencies] (they may form cycles), so a crate can be published
-# before an internal crate it only dev-depends on has landed on crates.io,
-# causing the verify build to fail with "no matching version". The whole
-# workspace is already built and tested in CI on every PR, so this verify step
-# is redundant. Matches `cargo publish --no-verify` used in publish-crate.yml.
+# The workspace is already built and tested in CI, so skip Cargo's redundant
+# isolated verification build. This does not skip package preparation or
+# registry dependency resolution.
 publish_no_verify = true
 
 # PR settings

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -41,6 +41,18 @@ struct Package {
     description: Option<String>,
     #[serde(default)]
     license: Option<String>,
+    #[serde(default)]
+    publish: Option<Vec<String>>,
+    #[serde(default)]
+    dependencies: Vec<Dependency>,
+}
+
+#[derive(Deserialize, Clone)]
+struct Dependency {
+    name: String,
+    req: String,
+    kind: Option<String>,
+    path: Option<PathBuf>,
 }
 
 struct DiscoveryResult {
@@ -124,19 +136,25 @@ fn extract_os(triple: &str) -> &str {
     "unknown"
 }
 
-fn discover_dynamic_plugins() -> DiscoveryResult {
-    let output = Command::new("cargo")
-        .args(["metadata", "--format-version", "1"])
-        .output()
-        .expect("failed to run cargo metadata");
+fn load_cargo_metadata(no_deps: bool) -> CargoMetadata {
+    let mut command = Command::new("cargo");
+    command.args(["metadata", "--format-version", "1"]);
+    if no_deps {
+        command.arg("--no-deps");
+    }
+
+    let output = command.output().expect("failed to run cargo metadata");
 
     if !output.status.success() {
         eprintln!("{}", String::from_utf8_lossy(&output.stderr));
         std::process::exit(1);
     }
 
-    let metadata: CargoMetadata =
-        serde_json::from_slice(&output.stdout).expect("failed to parse cargo metadata");
+    serde_json::from_slice(&output.stdout).expect("failed to parse cargo metadata")
+}
+
+fn discover_dynamic_plugins() -> DiscoveryResult {
+    let metadata = load_cargo_metadata(false);
 
     let sdk_version = metadata
         .packages
@@ -180,6 +198,123 @@ fn discover_dynamic_plugins() -> DiscoveryResult {
     }
 }
 
+fn is_publishable(package: &Package) -> bool {
+    match &package.publish {
+        Some(registries) => !registries.is_empty(),
+        None => true,
+    }
+}
+
+fn find_dependency_path(
+    graph: &BTreeMap<String, BTreeSet<String>>,
+    start: &str,
+    target: &str,
+) -> Option<Vec<String>> {
+    let mut pending = vec![(start.to_string(), vec![start.to_string()])];
+    let mut visited = BTreeSet::new();
+
+    while let Some((current, path)) = pending.pop() {
+        if current == target {
+            return Some(path);
+        }
+        if !visited.insert(current.clone()) {
+            continue;
+        }
+
+        if let Some(dependencies) = graph.get(&current) {
+            for dependency in dependencies.iter().rev() {
+                let mut next_path = path.clone();
+                next_path.push(dependency.clone());
+                pending.push((dependency.clone(), next_path));
+            }
+        }
+    }
+
+    None
+}
+
+fn versioned_dev_dependency_cycles(packages: &[Package]) -> Vec<String> {
+    let publishable: BTreeSet<String> = packages
+        .iter()
+        .filter(|package| is_publishable(package))
+        .map(|package| package.name.clone())
+        .collect();
+
+    let mut normal_graph: BTreeMap<String, BTreeSet<String>> = publishable
+        .iter()
+        .map(|name| (name.clone(), BTreeSet::new()))
+        .collect();
+
+    for package in packages
+        .iter()
+        .filter(|package| publishable.contains(&package.name))
+    {
+        let dependencies = normal_graph
+            .get_mut(&package.name)
+            .expect("publishable package should be in dependency graph");
+        for dependency in &package.dependencies {
+            if dependency.path.is_some()
+                && publishable.contains(&dependency.name)
+                && matches!(
+                    dependency.kind.as_deref(),
+                    None | Some("normal") | Some("build")
+                )
+            {
+                dependencies.insert(dependency.name.clone());
+            }
+        }
+    }
+
+    let mut cycles = Vec::new();
+    for package in packages
+        .iter()
+        .filter(|package| publishable.contains(&package.name))
+    {
+        for dependency in &package.dependencies {
+            if dependency.kind.as_deref() != Some("dev")
+                || dependency.path.is_none()
+                || dependency.req == "*"
+                || !publishable.contains(&dependency.name)
+            {
+                continue;
+            }
+
+            if let Some(return_path) =
+                find_dependency_path(&normal_graph, &dependency.name, &package.name)
+            {
+                cycles.push(format!(
+                    "{} --dev {}--> {}",
+                    package.name,
+                    dependency.req,
+                    return_path.join(" -> ")
+                ));
+            }
+        }
+    }
+
+    cycles.sort();
+    cycles.dedup();
+    cycles
+}
+
+fn check_publish_dependency_cycles() {
+    let metadata = load_cargo_metadata(true);
+    let cycles = versioned_dev_dependency_cycles(&metadata.packages);
+    if cycles.is_empty() {
+        println!("No versioned dev-dependency cycles found in publishable packages.");
+        return;
+    }
+
+    eprintln!("Versioned dev-dependency cycles found in publishable packages:");
+    for cycle in cycles {
+        eprintln!("  {cycle}");
+    }
+    eprintln!(
+        "Move cross-crate tests to a publish-false test crate or use a path-only dev-dependency."
+    );
+    std::process::exit(1);
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
@@ -187,6 +322,7 @@ fn main() {
 
     match subcommand {
         Some("build-plugins") => build_plugins(&args[2..]),
+        Some("check-publish-dependency-cycles") => check_publish_dependency_cycles(),
         Some("list-plugins") => list_plugins(),
         Some("publish-plugins") => publish_plugins(&args[2..]),
         _ => {
@@ -195,6 +331,9 @@ fn main() {
             eprintln!("Commands:");
             eprintln!(
                 "  build-plugins [OPTIONS]    Build all dynamic plugins as cdylib shared libraries"
+            );
+            eprintln!(
+                "  check-publish-dependency-cycles  Check publishable packages for dev-dependency cycles"
             );
             eprintln!("  list-plugins               List all discovered dynamic plugin crates");
             eprintln!("  publish-plugins [OPTIONS]   Publish built plugins as OCI artifacts");
@@ -1164,6 +1303,125 @@ fn triple_to_arch_suffix(triple: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn package(name: &str, publishable: bool, dependencies: Vec<Dependency>) -> Package {
+        Package {
+            name: name.to_string(),
+            version: "0.1.0".to_string(),
+            manifest_path: PathBuf::from(format!("{name}/Cargo.toml")),
+            features: std::collections::HashMap::new(),
+            description: None,
+            license: None,
+            publish: if publishable { None } else { Some(Vec::new()) },
+            dependencies,
+        }
+    }
+
+    fn dependency(name: &str, req: &str, kind: Option<&str>) -> Dependency {
+        Dependency {
+            name: name.to_string(),
+            req: req.to_string(),
+            kind: kind.map(str::to_string),
+            path: Some(PathBuf::from(name)),
+        }
+    }
+
+    #[test]
+    fn detects_versioned_dev_dependency_cycle() {
+        let packages = vec![
+            package(
+                "drasi-lib",
+                true,
+                vec![dependency("drasi-plugin-sdk", "^0.11.0", Some("dev"))],
+            ),
+            package(
+                "drasi-plugin-sdk",
+                true,
+                vec![dependency("drasi-lib", "^0.9.0", None)],
+            ),
+        ];
+
+        assert_eq!(
+            versioned_dev_dependency_cycles(&packages),
+            ["drasi-lib --dev ^0.11.0--> drasi-plugin-sdk -> drasi-lib"]
+        );
+    }
+
+    #[test]
+    fn ignores_path_only_dev_dependency_cycle() {
+        let packages = vec![
+            package(
+                "drasi-lib",
+                true,
+                vec![dependency("drasi-plugin-sdk", "*", Some("dev"))],
+            ),
+            package(
+                "drasi-plugin-sdk",
+                true,
+                vec![dependency("drasi-lib", "^0.9.0", None)],
+            ),
+        ];
+
+        assert!(versioned_dev_dependency_cycles(&packages).is_empty());
+    }
+
+    #[test]
+    fn ignores_cycles_between_unpublished_packages() {
+        let packages = vec![
+            package(
+                "drasi-source-open511",
+                false,
+                vec![dependency("drasi-bootstrap-open511", "^0.1.0", Some("dev"))],
+            ),
+            package(
+                "drasi-bootstrap-open511",
+                false,
+                vec![dependency("drasi-source-open511", "^0.1.1", None)],
+            ),
+        ];
+
+        assert!(versioned_dev_dependency_cycles(&packages).is_empty());
+    }
+
+    #[test]
+    fn ignores_acyclic_versioned_dev_dependency() {
+        let packages = vec![
+            package(
+                "drasi-source",
+                true,
+                vec![dependency("drasi-bootstrap", "^0.1.0", Some("dev"))],
+            ),
+            package("drasi-bootstrap", true, Vec::new()),
+        ];
+
+        assert!(versioned_dev_dependency_cycles(&packages).is_empty());
+    }
+
+    #[test]
+    fn detects_return_path_through_build_dependency() {
+        let packages = vec![
+            package(
+                "drasi-lib",
+                true,
+                vec![dependency("drasi-plugin-sdk", "^0.11.0", Some("dev"))],
+            ),
+            package(
+                "drasi-plugin-sdk",
+                true,
+                vec![dependency("codegen", "^1.0.0", Some("build"))],
+            ),
+            package(
+                "codegen",
+                true,
+                vec![dependency("drasi-lib", "^0.9.0", None)],
+            ),
+        ];
+
+        assert_eq!(
+            versioned_dev_dependency_cycles(&packages),
+            ["drasi-lib --dev ^0.11.0--> drasi-plugin-sdk -> codegen -> drasi-lib"]
+        );
+    }
 
     #[test]
     fn strips_glibc_suffix_from_gnu_triples() {


### PR DESCRIPTION
# Description

Breaks the `drasi-lib` and `drasi-plugin-sdk` publish cycle by moving RocksDB descriptor tests to `lib-integration-tests` and removing the cyclic versioned dev-dependency.

Also makes the MSSQL host SDK test dependency path-only, corrects the `publish_no_verify` documentation, and adds a CI guard for versioned dev-dependency cycles among publishable crates.

## Type of change

- This pull request fixes a bug in Drasi and has an approved issue.

Fixes: #766