### PR TITLE
feat(index-rocksdb): scale CF buffers with write budget

### DIFF
--- a/components/indexes/rocksdb/src/descriptor.rs
+++ b/components/indexes/rocksdb/src/descriptor.rs
@@ -51,6 +51,8 @@ pub struct RocksDbIndexConfigDto {
     pub direct_io: ConfigValue<bool>,
 
     /// Combined capacity for cached blocks and memtable reservations, in bytes.
+    /// Half becomes the shared memtable budget from which per-CF flush
+    /// thresholds are derived; aggregate query pressure can flush them earlier.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<ConfigValueUsize>)]
     pub memory_budget_bytes: Option<ConfigValue<usize>>,

--- a/components/indexes/rocksdb/src/options.rs
+++ b/components/indexes/rocksdb/src/options.rs
@@ -26,9 +26,9 @@ pub struct RocksIndexOptions {
 impl RocksIndexOptions {
     /// Create options with the memory resources used to open and maintain the index.
     ///
-    /// Per-column-family write-buffer sizes are captured from the shared
-    /// manager's current budget and remain fixed for the lifetime of these
-    /// options.
+    /// Per-column-family write-buffer sizes are computed once from the shared
+    /// manager's budget when `new` is called. They remain fixed for the
+    /// lifetime of these options, even if the manager's budget changes later.
     pub fn new(archive_enabled: bool, direct_io: bool, memory_budget: RocksDbMemoryBudget) -> Self {
         let (large_write_buffer_size, small_write_buffer_size) =
             crate::sizing::write_buffer_sizes_for_budget(

--- a/components/indexes/rocksdb/src/options.rs
+++ b/components/indexes/rocksdb/src/options.rs
@@ -25,13 +25,22 @@ pub struct RocksIndexOptions {
 
 impl RocksIndexOptions {
     /// Create options with the memory resources used to open and maintain the index.
+    ///
+    /// Per-column-family write-buffer sizes are captured from the shared
+    /// manager's current budget and remain fixed for the lifetime of these
+    /// options.
     pub fn new(archive_enabled: bool, direct_io: bool, memory_budget: RocksDbMemoryBudget) -> Self {
+        let (large_write_buffer_size, small_write_buffer_size) =
+            crate::sizing::write_buffer_sizes_for_budget(
+                memory_budget.write_buffer_manager().get_buffer_size(),
+            );
+
         Self {
             archive_enabled,
             direct_io,
             memory_budget,
-            large_write_buffer_size: crate::sizing::DEFAULT_LARGE_WRITE_BUFFER_SIZE,
-            small_write_buffer_size: crate::sizing::DEFAULT_SMALL_WRITE_BUFFER_SIZE,
+            large_write_buffer_size,
+            small_write_buffer_size,
         }
     }
 

--- a/components/indexes/rocksdb/src/plugin.rs
+++ b/components/indexes/rocksdb/src/plugin.rs
@@ -174,6 +174,9 @@ impl RocksDbIndexProvider {
     ///
     /// Half of the capacity is available to memtables. Memtable reservations
     /// are charged to the same cache, so the two capacities are not additive.
+    /// Per-CF flush thresholds are derived from the memtable budget when each
+    /// query DB opens. They are not reservations: aggregate pressure across
+    /// query DBs can make the shared manager flush before those thresholds.
     pub fn with_memory_budget_bytes(
         mut self,
         total_budget_bytes: usize,

--- a/components/indexes/rocksdb/src/sizing.rs
+++ b/components/indexes/rocksdb/src/sizing.rs
@@ -22,30 +22,37 @@
 //! the memtable bloom filters on the point-lookup CFs are allocated at 2% of
 //! `write_buffer_size` (~1.3 MiB each at the 64 MiB default, ~5.2 MiB per
 //! query across the four such CFs), and any CF that accumulates more than the
-//! arena's 2 KiB inline block allocates a full arena block. Sizing both
-//! explicitly cuts the touched per-query floor roughly 5x and halves the
-//! memtable ceiling under load, at throughput parity (see issue #692 for
-//! measurements).
+//! arena's 2 KiB inline block allocates a full arena block. At the default
+//! 128 MiB shared budget, sizing both explicitly cuts the touched per-query
+//! floor roughly 5x and halves the memtable ceiling under load, at throughput
+//! parity (see issue #692 for measurements). Larger budgets trade some of
+//! those savings for fewer self-triggered flushes.
 //!
-//! Two buffer sizes, assigned by per-source-change byte volume:
+//! Two buffer sizes are derived from the shared write-buffer manager's budget
+//! and assigned by per-source-change byte volume. The large tier is one eighth
+//! of the budget, clamped to 16-64 MiB; the small tier is half the large tier.
+//! The default 128 MiB budget therefore preserves the original 16/8 MiB sizes,
+//! while a larger budget lets busy column families build larger memtables
+//! before self-triggering a flush:
 //!
-//! - **Large (16 MiB)**: `elements` (full element blob per change), `inbound` /
-//!   `outbound` (adjacency entries per relation change), `values`
-//!   (aggregation accumulators), `archive` (a full element version appended
-//!   per update when enabled), `outbox` and `live_results` (a serialized
-//!   result diff / row set update per result-producing change).
-//! - **Small (8 MiB)**: everything else: same write *frequency* in some cases
-//!   (`slots` is written per element upsert) but tiny values, or genuinely
-//!   quiet CFs (`metadata`, `fqueue`, `findex`, `stream_state`, `partial`,
-//!   `sorted-sets`, and the unused `default` CF).
+//! - **Large (16-64 MiB)**: `elements` (full element blob per change),
+//!   `inbound` / `outbound` (adjacency entries per relation change), `values`
+//!   (aggregation accumulators), `archive` (a full element version appended per
+//!   update when enabled), `outbox` and `live_results` (a serialized result
+//!   diff / row set update per result-producing change).
+//! - **Small (8-32 MiB)**: everything else: same write *frequency* in some
+//!   cases (`slots` is written per element upsert) but tiny values, or
+//!   genuinely quiet CFs (`metadata`, `fqueue`, `findex`, `stream_state`,
+//!   `partial`, `sorted-sets`, and the unused `default` CF).
 //!
 //! `arena_block_size` is derived, not configurable: `write_buffer_size / 64`,
 //! clamped to [64 KiB, 1 MiB]. Left unset, RocksDB sanitizes it to
 //! `min(1 MiB, write_buffer_size / 8)`, which puts a 1 MiB floor under every
-//! CF that sees any real write; the derived value keeps barely-active CFs at
-//! 128-256 KiB instead. Allocations larger than a quarter block (e.g. the
-//! memtable bloom filters) bypass the block pool as exact-size allocations,
-//! so small blocks waste nothing.
+//! CF that sees any real write. At the default budget, the derived value keeps
+//! barely-active CFs at 128-256 KiB instead; at the maximum tier sizes those
+//! blocks grow to 512 KiB for small CFs and 1 MiB for large CFs. Allocations
+//! larger than a quarter block (e.g. the memtable bloom filters) bypass the
+//! block pool as exact-size allocations, so small blocks waste nothing.
 //!
 //! Shared cache/table configuration and the flushed-memtable history bound are
 //! applied by [`crate::cf_options`] before this module overlays the per-CF
@@ -56,13 +63,18 @@ use rocksdb::{ColumnFamilyDescriptor, Options};
 
 use crate::RocksIndexOptions;
 
-/// Default `write_buffer_size` for column families with high byte volume per
-/// source change.
-pub(crate) const DEFAULT_LARGE_WRITE_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+const MIB: usize = 1024 * 1024;
 
-/// Default `write_buffer_size` for the remaining column families: quiet ones,
-/// and ones written often but with tiny values.
-pub(crate) const DEFAULT_SMALL_WRITE_BUFFER_SIZE: usize = 8 * 1024 * 1024;
+/// Floor for high-volume column families, preserving the original #692 size
+/// when the shared write-buffer budget is 128 MiB or smaller.
+const MIN_LARGE_WRITE_BUFFER_SIZE: usize = 16 * MIB;
+
+/// Ceiling for high-volume column families, limiting flush bursts and the
+/// eagerly allocated memtable bloom filters that scale with this value.
+const MAX_LARGE_WRITE_BUFFER_SIZE: usize = 64 * MIB;
+
+const LARGE_BUFFER_BUDGET_DIVISOR: usize = 8;
+const SMALL_BUFFER_DIVISOR: usize = 2;
 
 /// Column families that get the large write buffer. Everything not listed here
 /// (including the mandatory `default` CF) gets the small one. Names must
@@ -78,6 +90,15 @@ const LARGE_BUFFER_CFS: &[&str] = &[
     "outbox",
     "live_results",
 ];
+
+/// Derive the large and small per-CF write-buffer tiers from the aggregate
+/// write-buffer budget shared across query databases.
+pub(crate) fn write_buffer_sizes_for_budget(write_buffer_budget: usize) -> (usize, usize) {
+    let large_write_buffer_size = (write_buffer_budget / LARGE_BUFFER_BUDGET_DIVISOR)
+        .clamp(MIN_LARGE_WRITE_BUFFER_SIZE, MAX_LARGE_WRITE_BUFFER_SIZE);
+    let small_write_buffer_size = large_write_buffer_size / SMALL_BUFFER_DIVISOR;
+    (large_write_buffer_size, small_write_buffer_size)
+}
 
 /// Derive `arena_block_size` from a write buffer size:
 /// `write_buffer_size / 64`, clamped to [64 KiB, 1 MiB].
@@ -117,15 +138,36 @@ mod tests {
     use super::*;
 
     #[test]
+    fn write_buffer_sizes_scale_with_budget_within_bounds() {
+        assert_eq!(write_buffer_sizes_for_budget(64 * MIB), (16 * MIB, 8 * MIB));
+        assert_eq!(
+            write_buffer_sizes_for_budget(128 * MIB),
+            (16 * MIB, 8 * MIB)
+        );
+        assert_eq!(
+            write_buffer_sizes_for_budget(256 * MIB),
+            (32 * MIB, 16 * MIB)
+        );
+        assert_eq!(
+            write_buffer_sizes_for_budget(512 * MIB),
+            (64 * MIB, 32 * MIB)
+        );
+        assert_eq!(
+            write_buffer_sizes_for_budget(1024 * MIB),
+            (64 * MIB, 32 * MIB)
+        );
+    }
+
+    #[test]
     fn arena_block_size_derivation_is_clamped() {
         // 16 MiB / 64 = 256 KiB, inside the clamp range.
         assert_eq!(
-            arena_block_size_for(DEFAULT_LARGE_WRITE_BUFFER_SIZE),
+            arena_block_size_for(MIN_LARGE_WRITE_BUFFER_SIZE),
             256 * 1024
         );
         // 8 MiB / 64 = 128 KiB, inside the clamp range.
         assert_eq!(
-            arena_block_size_for(DEFAULT_SMALL_WRITE_BUFFER_SIZE),
+            arena_block_size_for(MIN_LARGE_WRITE_BUFFER_SIZE / SMALL_BUFFER_DIVISOR),
             128 * 1024
         );
         // Tiny buffers clamp up to 64 KiB.

--- a/components/indexes/rocksdb/src/sizing.rs
+++ b/components/indexes/rocksdb/src/sizing.rs
@@ -20,13 +20,14 @@
 //! database; a query DB holds fifteen column families, most of them small or
 //! idle, and pays fixed memory floors per CF that scale with the buffer size:
 //! the memtable bloom filters on the point-lookup CFs are allocated at 2% of
-//! `write_buffer_size` (~1.3 MiB each at the 64 MiB default, ~5.2 MiB per
-//! query across the four such CFs), and any CF that accumulates more than the
-//! arena's 2 KiB inline block allocates a full arena block. At the default
-//! 128 MiB shared budget, sizing both explicitly cuts the touched per-query
-//! floor roughly 5x and halves the memtable ceiling under load, at throughput
-//! parity (see issue #692 for measurements). Larger budgets trade some of
-//! those savings for fewer self-triggered flushes.
+//! `write_buffer_size`. Under RocksDB's 64 MiB per-CF default, they total about
+//! 5.2 MiB per query. Drasi's default 16/8 MiB tiers reduce that total to about
+//! 1.0 MiB, rising to about 3.8 MiB at the maximum 64/32 MiB tiers. Any CF that
+//! accumulates more than the arena's 2 KiB inline block allocates a full arena
+//! block. At the default 128 MiB shared budget, sizing both explicitly cuts the
+//! touched per-query floor roughly 5x and halves the memtable ceiling under
+//! load, at throughput parity (see issue #692 for measurements). Larger budgets
+//! trade some of those savings for fewer self-triggered flushes.
 //!
 //! Two buffer sizes are derived from the shared write-buffer manager's budget
 //! and assigned by per-source-change byte volume. The large tier is one eighth

--- a/components/indexes/rocksdb/src/sizing.rs
+++ b/components/indexes/rocksdb/src/sizing.rs
@@ -56,8 +56,14 @@
 //!
 //! Shared cache/table configuration and the flushed-memtable history bound are
 //! applied by [`crate::cf_options`] before this module overlays the per-CF
-//! write-buffer and arena sizing. The provider-wide write-buffer manager
-//! remains the aggregate backstop across query databases.
+//! write-buffer and arena sizing. Per-CF sizes are flush thresholds, not memory
+//! reservations, so their aggregate across CFs and query databases can exceed
+//! the shared budget. When active memtable usage approaches that budget, the
+//! provider-wide write-buffer manager may switch the oldest eligible memtable
+//! in the DB handling a write before that CF reaches its own threshold. Larger
+//! tiers therefore reduce self-triggered flushes most in lightly loaded or
+//! skewed fleets; under multi-query pressure the shared manager remains the
+//! aggregate authority.
 
 use rocksdb::{ColumnFamilyDescriptor, Options};
 

--- a/components/indexes/rocksdb/tests/cf_sizing_tests.rs
+++ b/components/indexes/rocksdb/tests/cf_sizing_tests.rs
@@ -148,11 +148,22 @@ fn effective_sizes_match_the_tier_policy_on_every_cf() {
 }
 
 #[tokio::test]
-async fn provider_derives_tier_sizes_from_its_memory_budget() {
+async fn provider_derives_tier_sizes_from_total_memory_budget() {
+    const TOTAL_MEMORY_BUDGET: usize = 512 * MIB;
+    const WRITE_BUFFER_BUDGET: usize = 256 * MIB;
+
     let dir = tempfile::tempdir().expect("tempdir");
     let provider = RocksDbIndexProvider::new(dir.path(), true, false)
-        .with_memory_budget_bytes(512 * MIB)
+        .with_memory_budget_bytes(TOTAL_MEMORY_BUDGET)
         .expect("valid memory budget");
+    assert_eq!(
+        provider
+            .memory_budget()
+            .write_buffer_manager()
+            .get_buffer_size(),
+        WRITE_BUFFER_BUDGET
+    );
+
     let created = provider
         .create_indexes("provider-test")
         .await

--- a/components/indexes/rocksdb/tests/cf_sizing_tests.rs
+++ b/components/indexes/rocksdb/tests/cf_sizing_tests.rs
@@ -56,8 +56,9 @@ const SMALL_BUFFER_CFS: &[&str] = &[
     "findex",
     "stream_state",
 ];
-const LARGE_WRITE_BUFFER_SIZE: u64 = 16 * 1024 * 1024;
-const SMALL_WRITE_BUFFER_SIZE: u64 = 8 * 1024 * 1024;
+const MIB: usize = 1024 * 1024;
+const DEFAULT_LARGE_WRITE_BUFFER_SIZE: u64 = 16 * MIB as u64;
+const DEFAULT_SMALL_WRITE_BUFFER_SIZE: u64 = 8 * MIB as u64;
 
 /// 1 MiB flushed-memtable history bound (WRITE_BUFFER_HISTORY_BYTES, kept
 /// crate-private; update both together if the bound ever changes).
@@ -94,13 +95,11 @@ fn effective_sizes(db_dir: &std::path::Path) -> HashMap<String, (u64, u64, u64)>
     sizes
 }
 
-#[test]
-fn effective_sizes_match_the_tier_policy_on_every_cf() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
-    let db = open_unified_db(dir.path().to_str().unwrap(), "sizing-test", &options).expect("open");
-
-    let sizes = effective_sizes(&dir.path().join("sizing-test"));
+fn assert_tier_sizes(
+    sizes: &HashMap<String, (u64, u64, u64)>,
+    large_write_buffer_size: u64,
+    small_write_buffer_size: u64,
+) {
     assert_eq!(
         sizes.len(),
         LARGE_BUFFER_CFS.len() + SMALL_BUFFER_CFS.len(),
@@ -112,8 +111,8 @@ fn effective_sizes_match_the_tier_policy_on_every_cf() {
         assert_eq!(
             sizes[*cf],
             (
-                LARGE_WRITE_BUFFER_SIZE,
-                LARGE_WRITE_BUFFER_SIZE / 64,
+                large_write_buffer_size,
+                large_write_buffer_size / 64,
                 HISTORY_BYTES
             ),
             "CF '{cf}'"
@@ -123,51 +122,68 @@ fn effective_sizes_match_the_tier_policy_on_every_cf() {
         assert_eq!(
             sizes[*cf],
             (
-                SMALL_WRITE_BUFFER_SIZE,
-                SMALL_WRITE_BUFFER_SIZE / 64,
+                small_write_buffer_size,
+                small_write_buffer_size / 64,
                 HISTORY_BYTES
             ),
             "CF '{cf}'"
         );
     }
+}
+
+#[test]
+fn effective_sizes_match_the_tier_policy_on_every_cf() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
+    let db = open_unified_db(dir.path().to_str().unwrap(), "sizing-test", &options).expect("open");
+
+    let sizes = effective_sizes(&dir.path().join("sizing-test"));
+    assert_tier_sizes(
+        &sizes,
+        DEFAULT_LARGE_WRITE_BUFFER_SIZE,
+        DEFAULT_SMALL_WRITE_BUFFER_SIZE,
+    );
 
     drop(db);
 }
 
 #[tokio::test]
-async fn provider_applies_the_internal_tier_policy() {
+async fn provider_derives_tier_sizes_from_its_memory_budget() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let provider = RocksDbIndexProvider::new(dir.path(), true, false);
+    let provider = RocksDbIndexProvider::new(dir.path(), true, false)
+        .with_memory_budget_bytes(512 * MIB)
+        .expect("valid memory budget");
     let created = provider
         .create_indexes("provider-test")
         .await
         .expect("create indexes");
 
     let sizes = effective_sizes(&dir.path().join("provider-test"));
-    assert_eq!(
-        sizes["elements"],
-        (
-            LARGE_WRITE_BUFFER_SIZE,
-            LARGE_WRITE_BUFFER_SIZE / 64,
-            HISTORY_BYTES
-        )
-    );
-    assert_eq!(
-        sizes["stream_state"],
-        (
-            SMALL_WRITE_BUFFER_SIZE,
-            SMALL_WRITE_BUFFER_SIZE / 64,
-            HISTORY_BYTES
-        )
-    );
+    assert_tier_sizes(&sizes, 32 * MIB as u64, 16 * MIB as u64);
 
     drop(created);
+}
+
+#[test]
+fn effective_sizes_cap_at_the_maximum_tier_sizes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let budget =
+        RocksDbMemoryBudget::new(1024 * MIB, 1024 * MIB, false).expect("valid memory budget");
+    let options = RocksIndexOptions::new(true, false, budget);
+    let db = open_unified_db(dir.path().to_str().unwrap(), "cap-test", &options).expect("open");
+
+    let sizes = effective_sizes(&dir.path().join("cap-test"));
+    assert_tier_sizes(&sizes, 64 * MIB as u64, 32 * MIB as u64);
+
+    drop(db);
 }
 
 #[tokio::test]
 async fn clear_recreates_cfs_with_the_sizing_policy() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
+    let budget =
+        RocksDbMemoryBudget::new(256 * MIB, 256 * MIB, false).expect("valid memory budget");
+    let options = RocksIndexOptions::new(true, false, budget);
     let db = open_unified_db(dir.path().to_str().unwrap(), "clear-test", &options).expect("open");
 
     let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
@@ -190,16 +206,8 @@ async fn clear_recreates_cfs_with_the_sizing_policy() {
 
     // create_cf persists a fresh OPTIONS file; the recreated CFs must retain
     // the internal tier sizing and history bound rather than RocksDB defaults.
-    let large = (
-        LARGE_WRITE_BUFFER_SIZE,
-        LARGE_WRITE_BUFFER_SIZE / 64,
-        HISTORY_BYTES,
-    );
-    let small = (
-        SMALL_WRITE_BUFFER_SIZE,
-        SMALL_WRITE_BUFFER_SIZE / 64,
-        HISTORY_BYTES,
-    );
+    let large = (32 * MIB as u64, 32 * MIB as u64 / 64, HISTORY_BYTES);
+    let small = (16 * MIB as u64, 16 * MIB as u64 / 64, HISTORY_BYTES);
     let sizes = effective_sizes(&dir.path().join("clear-test"));
     for cf in ["elements", "inbound", "outbound", "values", "archive"] {
         assert_eq!(sizes[cf], large, "CF '{cf}'");


### PR DESCRIPTION
## Summary

- derive per-CF write buffer sizes from the shared write-buffer budget
- preserve the existing 16/8 MiB tiers at the default 128 MiB write budget
- cap large and small tiers at 64/32 MiB
- retain resolved sizing when column families are recreated
- document how shared manager pressure can preempt per-CF thresholds
- update sizing documentation and regression coverage

## Validation

- `cargo test -p drasi-index-rocksdb`
- `cargo clippy -p drasi-index-rocksdb --all-targets --features plugin-descriptor -- -D warnings`
- `cargo fmt --all -- --check`

Two reversed-order, 600k-event query-perf runs:

| Write budget | Throughput | Flushes | Peak RSS |
|---:|---:|---:|---:|
| 128 MiB | 9,434 events/s | 12 | 72 MiB |
| 512 MiB | 8,779 events/s | 1 | 145 MiB |

The larger tier substantially reduced self-triggered flushes, with the expected memory tradeoff and lower throughput for this repeated-update workload.

Per-CF sizes are flush thresholds, not memory reservations. The provider-wide `WriteBufferManager` remains authoritative across CFs and query databases and can trigger a flush before an individual threshold under aggregate multi-query pressure. The measurement above uses a single query; multi-query fleets may reach shared pressure sooner.

Closes #710