### PR TITLE
perf: batch dependency-safe plugin builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,6 @@ jobs:
     uses: drasi-project/.github/.github/workflows/rust-unit-test.yaml@main
     with:
       test-command: |
+        cargo run -p xtask -- check-publish-dependency-cycles
         cargo test --workspace --exclude drasi-host-sdk
         make test-host-sdk

--- a/components/sources/mssql/Cargo.toml
+++ b/components/sources/mssql/Cargo.toml
@@ -58,7 +58,8 @@ testcontainers = "0.27"
 drasi-bootstrap-mssql = { workspace = true }
 drasi-reaction-application = { workspace = true }
 drasi-index-rocksdb = { workspace = true }
-drasi-host-sdk = { workspace = true }
+# Path-only so this dev dependency is omitted from the published manifest.
+drasi-host-sdk = { path = "../../host-sdk" }
 drasi-plugin-sdk = { workspace = true }
 tempfile = "3"
 bytes = "1"

--- a/lib-integration-tests/Cargo.toml
+++ b/lib-integration-tests/Cargo.toml
@@ -14,6 +14,8 @@ drasi-core.workspace = true
 drasi-source-postgres.workspace = true
 drasi-source-application.workspace = true
 drasi-reaction-application.workspace = true
+drasi-index-rocksdb = { workspace = true, features = ["plugin-descriptor"] }
+drasi-plugin-sdk.workspace = true
 
 tokio = { version = "1.6", features = ["full"] }
 testcontainers = "0.27"
@@ -25,3 +27,4 @@ serde_json = "1.0"
 anyhow = "1.0"
 tracing = "0.1"
 serial_test = "3"
+tempfile = "3"

--- a/lib-integration-tests/tests/static_rocksdb_index_e2e.rs
+++ b/lib-integration-tests/tests/static_rocksdb_index_e2e.rs
@@ -29,18 +29,120 @@
 //! `Arc<dyn IndexBackendPlugin>` (defined in `drasi-core`) is shared directly
 //! between the backend crate and `drasi-lib`.
 
-mod mock_source;
-
 use anyhow::Result;
+use async_trait::async_trait;
+use drasi_core::models::{
+    Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange,
+};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use drasi_index_rocksdb::RocksDbIndexDescriptor;
-use drasi_lib::{ComponentStatus, DrasiLib, Query, StorageBackendRef};
+use drasi_lib::{
+    ComponentStatus, DispatchMode, DrasiLib, Query, Source, SourceBase, SourceBaseParams,
+    SourceRuntimeContext, SourceSubscriptionSettings, StorageBackendRef, SubscriptionResponse,
+};
 use drasi_plugin_sdk::IndexBackendPluginDescriptor;
-use mock_source::{MockSource, MockSourceHandle, PropertyMapBuilder};
+use drasi_source_application::PropertyMapBuilder;
 use serde_json::json;
 use tempfile::TempDir;
+
+#[derive(Clone)]
+struct TestSourceHandle {
+    base: Arc<SourceBase>,
+}
+
+impl TestSourceHandle {
+    async fn send_node_insert(
+        &self,
+        element_id: impl Into<Arc<str>>,
+        labels: Vec<impl Into<Arc<str>>>,
+        properties: ElementPropertyMap,
+    ) -> Result<()> {
+        let element = Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference {
+                    source_id: Arc::from(self.base.get_id()),
+                    element_id: element_id.into(),
+                },
+                labels: Arc::from(labels.into_iter().map(Into::into).collect::<Vec<_>>()),
+                effective_from: chrono::Utc::now().timestamp_millis() as u64,
+            },
+            properties,
+        };
+        self.base
+            .dispatch_source_change(SourceChange::Insert { element })
+            .await
+    }
+}
+
+struct TestSource {
+    base: Arc<SourceBase>,
+}
+
+impl TestSource {
+    fn new(id: &str) -> Result<(Self, TestSourceHandle)> {
+        let base = Arc::new(SourceBase::new(SourceBaseParams::new(id))?);
+        let handle = TestSourceHandle { base: base.clone() };
+        Ok((Self { base }, handle))
+    }
+}
+
+#[async_trait]
+impl Source for TestSource {
+    fn id(&self) -> &str {
+        self.base.get_id()
+    }
+
+    fn type_name(&self) -> &str {
+        "test"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+
+    fn auto_start(&self) -> bool {
+        self.base.get_auto_start()
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.base
+            .set_status(ComponentStatus::Running, Some("Started".to_string()))
+            .await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base.stop_common().await
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn subscribe(
+        &self,
+        settings: SourceSubscriptionSettings,
+    ) -> Result<SubscriptionResponse> {
+        self.base
+            .subscribe_with_bootstrap(&settings, self.type_name())
+            .await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn initialize(&self, context: SourceRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    fn dispatch_mode(&self) -> DispatchMode {
+        DispatchMode::Channel
+    }
+}
 
 /// Build a RocksDB-backed index provider the way `drasi-server` would: from a
 /// JSON storage-backend config, via the statically-linked descriptor.
@@ -68,7 +170,11 @@ async fn build_provider_from_config(
         .expect("descriptor should build a RocksDB index backend from config")
 }
 
-async fn insert_person(handle: &MockSourceHandle, id: &str, name: &str, age: i64) -> Result<()> {
+fn test_source(id: &str) -> Result<(TestSource, TestSourceHandle)> {
+    TestSource::new(id)
+}
+
+async fn insert_person(handle: &TestSourceHandle, id: &str, name: &str, age: i64) -> Result<()> {
     let props = PropertyMapBuilder::new()
         .with_string("name", name)
         .with_integer("age", age)
@@ -137,7 +243,7 @@ async fn static_rocksdb_descriptor_drives_query() -> Result<()> {
 
     let provider = build_provider_from_config(&backend_config).await;
 
-    let (source, handle) = MockSource::new("people-src")?;
+    let (source, handle) = test_source("people-src")?;
 
     let core = Arc::new(
         DrasiLib::builder()
@@ -186,7 +292,7 @@ async fn static_rocksdb_index_persists_across_restart() -> Result<()> {
     });
 
     let provider = build_provider_from_config(&backend_config).await;
-    let (source, handle) = MockSource::new("people-src")?;
+    let (source, handle) = test_source("people-src")?;
     let core = Arc::new(
         DrasiLib::builder()
             .with_id("static-rocksdb")
@@ -267,7 +373,7 @@ async fn static_rocksdb_shutdown_releases_lock_for_same_process_reopen() -> Resu
 
     // ---- First engine: ingest rows, then shut down permanently. ----
     let provider1 = build_provider_from_config(&backend_config).await;
-    let (source1, handle1) = MockSource::new("people-src")?;
+    let (source1, handle1) = test_source("people-src")?;
     let core1 = Arc::new(
         DrasiLib::builder()
             .with_id("static-rocksdb-1")
@@ -304,7 +410,7 @@ async fn static_rocksdb_shutdown_releases_lock_for_same_process_reopen() -> Resu
     // A fresh provider on the same on-disk path; this open acquires the RocksDB
     // LOCK, which only succeeds if the first engine's `shutdown()` released it.
     let provider2 = build_provider_from_config(&backend_config).await;
-    let (source2, _handle2) = MockSource::new("people-src")?;
+    let (source2, _handle2) = test_source("people-src")?;
     let core2 = Arc::new(
         DrasiLib::builder()
             .with_id("static-rocksdb-2")
@@ -365,7 +471,7 @@ async fn static_rocksdb_default_provider_backs_unspecified_query() -> Result<()>
     });
 
     let provider = build_provider_from_config(&backend_config).await;
-    let (source, handle) = MockSource::new("people-src")?;
+    let (source, handle) = test_source("people-src")?;
     let core = Arc::new(
         DrasiLib::builder()
             .with_id("static-rocksdb")

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -107,16 +107,12 @@ rmp-serde = "1"
 tempfile = "3.8"
 mockall = "0.12"
 tokio-test = "0.4"
+tokio = { version = "1.0", features = ["rt-multi-thread"] }
 assert_matches = "1.5"
 serial_test = "3.0"
 pretty_assertions = "1.4"
 test-case = "3.3"
-drasi-index-rocksdb = { path = "../components/indexes/rocksdb", features = [
-    "plugin-descriptor",
-] }
-# Mirrors how drasi-server depends on the plugin SDK to drive index backends
-# through their descriptor/DTO when statically linking a backend crate.
-drasi-plugin-sdk = { workspace = true }
+drasi-index-rocksdb = { path = "../components/indexes/rocksdb" }
 
 # Additional testing dependencies
 rstest = "0.18"

--- a/lib/src/secret_store/mod.rs
+++ b/lib/src/secret_store/mod.rs
@@ -16,8 +16,8 @@
 //!
 //! A [`SecretStoreProvider`] resolves named secret references (e.g., `"DB_PASSWORD"`)
 //! into their actual string values. Plugin configuration DTOs use
-//! [`ConfigValue::Secret`](drasi_plugin_sdk::ConfigValue) references which are resolved
-//! through the configured secret store during plugin initialization.
+//! `ConfigValue::Secret` references from the plugin SDK, which are resolved through
+//! the configured secret store during plugin initialization.
 //!
 //! # Architecture
 //!

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,14 +12,9 @@ git_release_type = "prod"
 
 # Publishing settings
 publish = true
-# Skip the isolated `cargo publish` verification build. That build re-resolves
-# the crate's full dependency graph (including dev-dependencies) from crates.io.
-# release-plz orders publishing by [dependencies]/[build-dependencies] only and
-# ignores [dev-dependencies] (they may form cycles), so a crate can be published
-# before an internal crate it only dev-depends on has landed on crates.io,
-# causing the verify build to fail with "no matching version". The whole
-# workspace is already built and tested in CI on every PR, so this verify step
-# is redundant. Matches `cargo publish --no-verify` used in publish-crate.yml.
+# The workspace is already built and tested in CI, so skip Cargo's redundant
+# isolated verification build. This does not skip package preparation or
+# registry dependency resolution.
 publish_no_verify = true
 
 # PR settings

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,19 +15,16 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use serde::Deserialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 use std::thread;
 
 #[derive(Deserialize)]
 struct CargoMetadata {
     packages: Vec<Package>,
     target_directory: PathBuf,
-    #[allow(dead_code)]
     workspace_root: PathBuf,
 }
 
@@ -41,11 +38,25 @@ struct Package {
     description: Option<String>,
     #[serde(default)]
     license: Option<String>,
+    #[serde(default)]
+    publish: Option<Vec<String>>,
+    #[serde(default)]
+    dependencies: Vec<Dependency>,
+}
+
+#[derive(Deserialize, Clone)]
+struct Dependency {
+    name: String,
+    req: String,
+    kind: Option<String>,
+    path: Option<PathBuf>,
 }
 
 struct DiscoveryResult {
     plugins: Vec<PluginInfo>,
+    build_batches: Vec<Vec<String>>,
     target_directory: PathBuf,
+    workspace_root: PathBuf,
     sdk_version: String,
     core_version: String,
     lib_version: String,
@@ -124,19 +135,25 @@ fn extract_os(triple: &str) -> &str {
     "unknown"
 }
 
-fn discover_dynamic_plugins() -> DiscoveryResult {
-    let output = Command::new("cargo")
-        .args(["metadata", "--format-version", "1"])
-        .output()
-        .expect("failed to run cargo metadata");
+fn load_cargo_metadata(no_deps: bool) -> CargoMetadata {
+    let mut command = Command::new("cargo");
+    command.args(["metadata", "--format-version", "1"]);
+    if no_deps {
+        command.arg("--no-deps");
+    }
+
+    let output = command.output().expect("failed to run cargo metadata");
 
     if !output.status.success() {
         eprintln!("{}", String::from_utf8_lossy(&output.stderr));
         std::process::exit(1);
     }
 
-    let metadata: CargoMetadata =
-        serde_json::from_slice(&output.stdout).expect("failed to parse cargo metadata");
+    serde_json::from_slice(&output.stdout).expect("failed to parse cargo metadata")
+}
+
+fn discover_dynamic_plugins() -> DiscoveryResult {
+    let metadata = load_cargo_metadata(false);
 
     let sdk_version = metadata
         .packages
@@ -157,6 +174,15 @@ fn discover_dynamic_plugins() -> DiscoveryResult {
         .map(|p| p.version.clone())
         .unwrap_or_else(|| "unknown".to_string());
 
+    let plugin_names: BTreeSet<String> = metadata
+        .packages
+        .iter()
+        .filter(|p| p.features.contains_key("dynamic-plugin"))
+        .filter(|p| parse_plugin_type_kind(&p.name).is_some())
+        .map(|p| p.name.clone())
+        .collect();
+    let build_batches = plugin_build_batches(&metadata.packages, &plugin_names);
+
     let plugins = metadata
         .packages
         .into_iter()
@@ -173,11 +199,168 @@ fn discover_dynamic_plugins() -> DiscoveryResult {
 
     DiscoveryResult {
         plugins,
+        build_batches,
         target_directory: metadata.target_directory,
+        workspace_root: metadata.workspace_root,
         sdk_version,
         core_version,
         lib_version,
     }
+}
+
+fn is_publishable(package: &Package) -> bool {
+    match &package.publish {
+        Some(registries) => !registries.is_empty(),
+        None => true,
+    }
+}
+
+fn find_dependency_path(
+    graph: &BTreeMap<String, BTreeSet<String>>,
+    start: &str,
+    target: &str,
+) -> Option<Vec<String>> {
+    let mut pending = vec![(start.to_string(), vec![start.to_string()])];
+    let mut visited = BTreeSet::new();
+
+    while let Some((current, path)) = pending.pop() {
+        if current == target {
+            return Some(path);
+        }
+        if !visited.insert(current.clone()) {
+            continue;
+        }
+
+        if let Some(dependencies) = graph.get(&current) {
+            for dependency in dependencies.iter().rev() {
+                let mut next_path = path.clone();
+                next_path.push(dependency.clone());
+                pending.push((dependency.clone(), next_path));
+            }
+        }
+    }
+
+    None
+}
+
+fn plugin_build_batches(packages: &[Package], plugin_names: &BTreeSet<String>) -> Vec<Vec<String>> {
+    let mut graph: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for package in packages {
+        let dependencies = graph.entry(package.name.clone()).or_default();
+        dependencies.extend(
+            package
+                .dependencies
+                .iter()
+                .filter(|dependency| dependency.path.is_some())
+                .filter(|dependency| {
+                    matches!(
+                        dependency.kind.as_deref(),
+                        None | Some("normal") | Some("build")
+                    )
+                })
+                .map(|dependency| dependency.name.clone()),
+        );
+    }
+
+    let conflicts = |left: &str, right: &str| {
+        find_dependency_path(&graph, left, right).is_some()
+            || find_dependency_path(&graph, right, left).is_some()
+    };
+
+    let mut batches: Vec<Vec<String>> = Vec::new();
+    for plugin in plugin_names {
+        if let Some(batch) = batches
+            .iter_mut()
+            .find(|batch| batch.iter().all(|other| !conflicts(plugin, other)))
+        {
+            batch.push(plugin.clone());
+        } else {
+            batches.push(vec![plugin.clone()]);
+        }
+    }
+    batches
+}
+
+fn versioned_dev_dependency_cycles(packages: &[Package]) -> Vec<String> {
+    let publishable: BTreeSet<String> = packages
+        .iter()
+        .filter(|package| is_publishable(package))
+        .map(|package| package.name.clone())
+        .collect();
+
+    let mut normal_graph: BTreeMap<String, BTreeSet<String>> = publishable
+        .iter()
+        .map(|name| (name.clone(), BTreeSet::new()))
+        .collect();
+
+    for package in packages
+        .iter()
+        .filter(|package| publishable.contains(&package.name))
+    {
+        let dependencies = normal_graph
+            .get_mut(&package.name)
+            .expect("publishable package should be in dependency graph");
+        for dependency in &package.dependencies {
+            if dependency.path.is_some()
+                && publishable.contains(&dependency.name)
+                && matches!(
+                    dependency.kind.as_deref(),
+                    None | Some("normal") | Some("build")
+                )
+            {
+                dependencies.insert(dependency.name.clone());
+            }
+        }
+    }
+
+    let mut cycles = Vec::new();
+    for package in packages
+        .iter()
+        .filter(|package| publishable.contains(&package.name))
+    {
+        for dependency in &package.dependencies {
+            if dependency.kind.as_deref() != Some("dev")
+                || dependency.path.is_none()
+                || dependency.req == "*"
+                || !publishable.contains(&dependency.name)
+            {
+                continue;
+            }
+
+            if let Some(return_path) =
+                find_dependency_path(&normal_graph, &dependency.name, &package.name)
+            {
+                cycles.push(format!(
+                    "{} --dev {}--> {}",
+                    package.name,
+                    dependency.req,
+                    return_path.join(" -> ")
+                ));
+            }
+        }
+    }
+
+    cycles.sort();
+    cycles.dedup();
+    cycles
+}
+
+fn check_publish_dependency_cycles() {
+    let metadata = load_cargo_metadata(true);
+    let cycles = versioned_dev_dependency_cycles(&metadata.packages);
+    if cycles.is_empty() {
+        println!("No versioned dev-dependency cycles found in publishable packages.");
+        return;
+    }
+
+    eprintln!("Versioned dev-dependency cycles found in publishable packages:");
+    for cycle in cycles {
+        eprintln!("  {cycle}");
+    }
+    eprintln!(
+        "Move cross-crate tests to a publish-false test crate or use a path-only dev-dependency."
+    );
+    std::process::exit(1);
 }
 
 fn main() {
@@ -187,6 +370,7 @@ fn main() {
 
     match subcommand {
         Some("build-plugins") => build_plugins(&args[2..]),
+        Some("check-publish-dependency-cycles") => check_publish_dependency_cycles(),
         Some("list-plugins") => list_plugins(),
         Some("publish-plugins") => publish_plugins(&args[2..]),
         _ => {
@@ -195,6 +379,9 @@ fn main() {
             eprintln!("Commands:");
             eprintln!(
                 "  build-plugins [OPTIONS]    Build all dynamic plugins as cdylib shared libraries"
+            );
+            eprintln!(
+                "  check-publish-dependency-cycles  Check publishable packages for dev-dependency cycles"
             );
             eprintln!("  list-plugins               List all discovered dynamic plugin crates");
             eprintln!("  publish-plugins [OPTIONS]   Publish built plugins as OCI artifacts");
@@ -340,6 +527,52 @@ fn build_command(build_tool: &str) -> Command {
     cmd
 }
 
+struct PluginBuildOptions<'a> {
+    build_tool: &'a str,
+    use_zigbuild: bool,
+    workspace_root: &'a Path,
+    target_directory: &'a Path,
+    plugins: &'a [String],
+    target: Option<&'a str>,
+    release: bool,
+    jobs: usize,
+}
+
+fn plugin_build_command(options: PluginBuildOptions<'_>) -> Command {
+    let mut cmd = build_command(options.build_tool);
+    cmd.current_dir(options.workspace_root);
+    if !options.use_zigbuild {
+        cmd.arg("build");
+    }
+    cmd.arg("--lib");
+    for plugin in options.plugins {
+        cmd.args(["-p", plugin]);
+    }
+
+    let features = options
+        .plugins
+        .iter()
+        .map(|name| format!("{name}/dynamic-plugin"))
+        .collect::<Vec<_>>()
+        .join(",");
+    cmd.args(["--features", &features]);
+
+    let target_directory = options
+        .target_directory
+        .strip_prefix(options.workspace_root)
+        .unwrap_or(options.target_directory);
+    cmd.arg("--target-dir").arg(target_directory);
+
+    if let Some(target) = options.target {
+        cmd.args(["--target", target]);
+    }
+    if options.release {
+        cmd.arg("--release");
+    }
+    cmd.args(["--jobs", &options.jobs.to_string()]);
+    cmd
+}
+
 fn parse_flag_value(args: &[String], flag: &str) -> Option<String> {
     for (i, arg) in args.iter().enumerate() {
         if arg == flag {
@@ -372,13 +605,16 @@ fn build_plugins(args: &[String]) {
     }
 
     let mode = if release { "release" } else { "debug" };
-    let target_dir = result.target_directory;
+    let target_dir = result.target_directory.clone();
 
     let build_dir = match &target {
         Some(t) => target_dir.join(t).join(mode),
         None => target_dir.join(mode),
     };
     let plugins_dir = build_dir.join("plugins");
+    if plugins_dir.exists() {
+        fs::remove_dir_all(&plugins_dir).expect("failed to clear plugins directory");
+    }
 
     let target_triple = target.clone().unwrap_or_else(host_target_triple);
 
@@ -444,114 +680,34 @@ fn build_plugins(args: &[String]) {
         jobs
     );
 
-    let failed = Arc::new(AtomicBool::new(false));
-    let target_dir = Arc::new(target_dir);
-    let target = Arc::new(target);
     // The value passed to `--target` on the build command. For zigbuild this is
     // the glibc-suffixed triple; otherwise it matches the canonical `target`.
-    let cmd_target = Arc::new(build_target.clone().or_else(|| (*target).clone()));
-    let build_tool_str = build_tool.to_string();
-    let plugins: Vec<_> = result
-        .plugins
-        .iter()
-        .map(|p| (p.package.name.clone(), p.package.manifest_path.clone()))
-        .collect();
-
-    if use_cross {
-        // cross must run from workspace root using -p, and sequentially
-        // (each invocation starts a Docker container)
-        for (name, _manifest) in &plugins {
-            if failed.load(Ordering::Relaxed) {
-                break;
-            }
-            println!("  Building {name}...");
-
-            let feature_flag = format!("{name}/dynamic-plugin");
-            let mut cmd = build_command(&build_tool_str);
-            cmd.args(["build", "--lib", "-p", name, "--features", &feature_flag]);
-
-            if let Some(t) = cmd_target.as_ref() {
-                cmd.args(["--target", t]);
-            }
-            if release {
-                cmd.arg("--release");
-            }
-
-            let status = cmd.status().expect("failed to run cross build");
-            if !status.success() {
-                eprintln!("Failed to build {name}");
-                failed.store(true, Ordering::Relaxed);
-            } else {
-                println!("  Built {name}");
-            }
+    let cmd_target = build_target.clone().or_else(|| target.clone());
+    println!(
+        "=== Split into {} dependency-safe Cargo batches ===",
+        result.build_batches.len()
+    );
+    for (index, batch) in result.build_batches.iter().enumerate() {
+        println!(
+            "=== Building batch {}/{} ({} plugins) ===",
+            index + 1,
+            result.build_batches.len(),
+            batch.len()
+        );
+        let mut cmd = plugin_build_command(PluginBuildOptions {
+            build_tool,
+            use_zigbuild,
+            workspace_root: &result.workspace_root,
+            target_directory: &result.target_directory,
+            plugins: batch,
+            target: cmd_target.as_deref(),
+            release,
+            jobs,
+        });
+        if !cmd.status().expect("failed to run plugin build").success() {
+            eprintln!("=== Plugin build failed in batch {} ===", index + 1);
+            std::process::exit(1);
         }
-    } else {
-        // cargo / cargo zigbuild: parallel builds with --manifest-path
-        let build_tool = Arc::new(build_tool_str);
-
-        for chunk in plugins.chunks(jobs) {
-            if failed.load(Ordering::Relaxed) {
-                break;
-            }
-
-            let handles: Vec<_> = chunk
-                .iter()
-                .map(|(name, manifest)| {
-                    let name = name.clone();
-                    let manifest = manifest.clone();
-                    let failed = Arc::clone(&failed);
-                    let target_dir = Arc::clone(&target_dir);
-                    let cmd_target = Arc::clone(&cmd_target);
-                    let build_tool = Arc::clone(&build_tool);
-
-                    thread::spawn(move || {
-                        println!("  Building {name}...");
-
-                        let mut cmd = build_command(build_tool.as_str());
-                        // `cargo zigbuild` is itself the build subcommand
-                        // (equivalent to `cargo build`), so only plain `cargo`
-                        // needs an explicit `build` here.
-                        if !use_zigbuild {
-                            cmd.arg("build");
-                        }
-                        cmd.args([
-                            "--lib",
-                            "--manifest-path",
-                            manifest.to_str().expect("invalid manifest path"),
-                            "--target-dir",
-                            target_dir.to_str().expect("invalid target dir"),
-                            "--features",
-                            "dynamic-plugin",
-                        ]);
-
-                        if let Some(t) = cmd_target.as_ref() {
-                            cmd.args(["--target", t]);
-                        }
-
-                        if release {
-                            cmd.arg("--release");
-                        }
-
-                        let status = cmd.status().expect("failed to run build command");
-                        if !status.success() {
-                            eprintln!("Failed to build {name}");
-                            failed.store(true, Ordering::Relaxed);
-                        } else {
-                            println!("  Built {name}");
-                        }
-                    })
-                })
-                .collect();
-
-            for h in handles {
-                h.join().expect("build thread panicked");
-            }
-        }
-    }
-
-    if failed.load(Ordering::Relaxed) {
-        eprintln!("=== Plugin build failed ===");
-        std::process::exit(1);
     }
 
     // Move plugin shared libraries to plugins/ subdirectory and generate metadata
@@ -1165,6 +1321,125 @@ fn triple_to_arch_suffix(triple: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    fn package(name: &str, publishable: bool, dependencies: Vec<Dependency>) -> Package {
+        Package {
+            name: name.to_string(),
+            version: "0.1.0".to_string(),
+            manifest_path: PathBuf::from(format!("{name}/Cargo.toml")),
+            features: std::collections::HashMap::new(),
+            description: None,
+            license: None,
+            publish: if publishable { None } else { Some(Vec::new()) },
+            dependencies,
+        }
+    }
+
+    fn dependency(name: &str, req: &str, kind: Option<&str>) -> Dependency {
+        Dependency {
+            name: name.to_string(),
+            req: req.to_string(),
+            kind: kind.map(str::to_string),
+            path: Some(PathBuf::from(name)),
+        }
+    }
+
+    #[test]
+    fn detects_versioned_dev_dependency_cycle() {
+        let packages = vec![
+            package(
+                "drasi-lib",
+                true,
+                vec![dependency("drasi-plugin-sdk", "^0.11.0", Some("dev"))],
+            ),
+            package(
+                "drasi-plugin-sdk",
+                true,
+                vec![dependency("drasi-lib", "^0.9.0", None)],
+            ),
+        ];
+
+        assert_eq!(
+            versioned_dev_dependency_cycles(&packages),
+            ["drasi-lib --dev ^0.11.0--> drasi-plugin-sdk -> drasi-lib"]
+        );
+    }
+
+    #[test]
+    fn ignores_path_only_dev_dependency_cycle() {
+        let packages = vec![
+            package(
+                "drasi-lib",
+                true,
+                vec![dependency("drasi-plugin-sdk", "*", Some("dev"))],
+            ),
+            package(
+                "drasi-plugin-sdk",
+                true,
+                vec![dependency("drasi-lib", "^0.9.0", None)],
+            ),
+        ];
+
+        assert!(versioned_dev_dependency_cycles(&packages).is_empty());
+    }
+
+    #[test]
+    fn ignores_cycles_between_unpublished_packages() {
+        let packages = vec![
+            package(
+                "drasi-source-open511",
+                false,
+                vec![dependency("drasi-bootstrap-open511", "^0.1.0", Some("dev"))],
+            ),
+            package(
+                "drasi-bootstrap-open511",
+                false,
+                vec![dependency("drasi-source-open511", "^0.1.1", None)],
+            ),
+        ];
+
+        assert!(versioned_dev_dependency_cycles(&packages).is_empty());
+    }
+
+    #[test]
+    fn ignores_acyclic_versioned_dev_dependency() {
+        let packages = vec![
+            package(
+                "drasi-source",
+                true,
+                vec![dependency("drasi-bootstrap", "^0.1.0", Some("dev"))],
+            ),
+            package("drasi-bootstrap", true, Vec::new()),
+        ];
+
+        assert!(versioned_dev_dependency_cycles(&packages).is_empty());
+    }
+
+    #[test]
+    fn detects_return_path_through_build_dependency() {
+        let packages = vec![
+            package(
+                "drasi-lib",
+                true,
+                vec![dependency("drasi-plugin-sdk", "^0.11.0", Some("dev"))],
+            ),
+            package(
+                "drasi-plugin-sdk",
+                true,
+                vec![dependency("codegen", "^1.0.0", Some("build"))],
+            ),
+            package(
+                "codegen",
+                true,
+                vec![dependency("drasi-lib", "^0.9.0", None)],
+            ),
+        ];
+
+        assert_eq!(
+            versioned_dev_dependency_cycles(&packages),
+            ["drasi-lib --dev ^0.11.0--> drasi-plugin-sdk -> codegen -> drasi-lib"]
+        );
+    }
+
     #[test]
     fn strips_glibc_suffix_from_gnu_triples() {
         assert_eq!(
@@ -1211,6 +1486,123 @@ mod tests {
         assert_eq!(zig.get_program(), "cargo");
         let args: Vec<_> = zig.get_args().collect();
         assert_eq!(args, ["zigbuild"]);
+    }
+
+    #[test]
+    fn plugin_build_command_batches_packages_and_features() {
+        let plugins = vec![
+            "drasi-source-http".to_string(),
+            "drasi-reaction-http".to_string(),
+        ];
+        let command = plugin_build_command(PluginBuildOptions {
+            build_tool: "cargo zigbuild",
+            use_zigbuild: true,
+            workspace_root: Path::new("/workspace"),
+            target_directory: Path::new("/workspace/target"),
+            plugins: &plugins,
+            target: Some("x86_64-unknown-linux-gnu.2.28"),
+            release: true,
+            jobs: 8,
+        });
+        let args: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args,
+            [
+                "zigbuild",
+                "--lib",
+                "-p",
+                "drasi-source-http",
+                "-p",
+                "drasi-reaction-http",
+                "--features",
+                "drasi-source-http/dynamic-plugin,drasi-reaction-http/dynamic-plugin",
+                "--target-dir",
+                "target",
+                "--target",
+                "x86_64-unknown-linux-gnu.2.28",
+                "--release",
+                "--jobs",
+                "8",
+            ]
+        );
+        assert_eq!(command.get_current_dir(), Some(Path::new("/workspace")));
+    }
+
+    #[test]
+    fn plugin_build_command_supports_plain_cargo_and_cross() {
+        let plugins = vec!["drasi-source-http".to_string()];
+        for build_tool in ["cargo", "cross"] {
+            let command = plugin_build_command(PluginBuildOptions {
+                build_tool,
+                use_zigbuild: false,
+                workspace_root: Path::new("/workspace"),
+                target_directory: Path::new("/cache/drasi-target"),
+                plugins: &plugins,
+                target: None,
+                release: false,
+                jobs: 4,
+            });
+            let args: Vec<_> = command
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect();
+
+            assert_eq!(command.get_program(), build_tool);
+            assert_eq!(
+                args,
+                [
+                    "build",
+                    "--lib",
+                    "-p",
+                    "drasi-source-http",
+                    "--features",
+                    "drasi-source-http/dynamic-plugin",
+                    "--target-dir",
+                    "/cache/drasi-target",
+                    "--jobs",
+                    "4",
+                ]
+            );
+            assert_eq!(command.get_current_dir(), Some(Path::new("/workspace")));
+        }
+    }
+
+    #[test]
+    fn plugin_build_batches_separate_transitive_plugin_dependencies() {
+        let packages = vec![
+            package(
+                "drasi-bootstrap-example",
+                true,
+                vec![dependency("example-common", "*", None)],
+            ),
+            package(
+                "example-common",
+                true,
+                vec![dependency("drasi-source-example", "*", Some("build"))],
+            ),
+            package("drasi-source-example", true, Vec::new()),
+            package("drasi-reaction-example", true, Vec::new()),
+        ];
+        let plugin_names = BTreeSet::from([
+            "drasi-bootstrap-example".to_string(),
+            "drasi-reaction-example".to_string(),
+            "drasi-source-example".to_string(),
+        ]);
+
+        assert_eq!(
+            plugin_build_batches(&packages, &plugin_names),
+            [
+                vec![
+                    "drasi-bootstrap-example".to_string(),
+                    "drasi-reaction-example".to_string(),
+                ],
+                vec!["drasi-source-example".to_string()],
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Description

Build dynamic plugins in dependency-safe Cargo batches instead of invoking Cargo once per plugin.

The dependency graph keeps plugins with transitive normal or build dependencies in separate batches, preventing duplicate FFI exports from Cargo feature unification. The current workspace is built in two batches containing 51 and 6 plugins.

The fork dry-run matrix passed all eight targets:

| Configuration | Duration |
|---|---:|
| Per-plugin baseline | 1h 38m 57s |
| Dependency-safe batching | 33m 36s |

This reduces matrix time by 66%.

- Baseline: https://github.com/amansinghoriginal/drasi-core/actions/runs/32454045849
- Batched: https://github.com/amansinghoriginal/drasi-core/actions/runs/32454035094

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi.

Fixes: #770
