### PR TITLE
Retry crates.io rate-limited releases

### DIFF
--- a/.github/scripts/release-with-retry.sh
+++ b/.github/scripts/release-with-retry.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+max_attempts="${RELEASE_PUBLISH_MAX_ATTEMPTS:-60}"
+max_duration_seconds="${RELEASE_PUBLISH_MAX_DURATION_SECONDS:-7200}"
+safety_buffer_seconds="${RELEASE_PUBLISH_SAFETY_BUFFER_SECONDS:-10}"
+fallback_base_seconds="${RELEASE_PUBLISH_FALLBACK_BASE_SECONDS:-30}"
+fallback_max_seconds="${RELEASE_PUBLISH_FALLBACK_MAX_SECONDS:-300}"
+
+if [[ "$#" -eq 0 ]]; then
+    echo "usage: $0 <command> [args...]" >&2
+    exit 2
+fi
+
+for value in \
+    "$max_attempts" \
+    "$max_duration_seconds" \
+    "$safety_buffer_seconds" \
+    "$fallback_base_seconds" \
+    "$fallback_max_seconds"; do
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+        echo "retry settings must be non-negative integers" >&2
+        exit 2
+    fi
+done
+
+if ((
+    max_attempts < 1 ||
+        max_duration_seconds < 1 ||
+        fallback_base_seconds < 1 ||
+        fallback_max_seconds < fallback_base_seconds
+)); then
+    echo "max attempts, duration, and fallback delays must be valid positive values" >&2
+    exit 2
+fi
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+current_epoch() {
+    if [[ -n "${RELEASE_PUBLISH_NOW_EPOCH:-}" ]]; then
+        printf '%s\n' "$RELEASE_PUBLISH_NOW_EPOCH"
+    else
+        date +%s
+    fi
+}
+
+parse_retry_epoch() {
+    local log_file="$1"
+    local retry_at
+
+    retry_at="$(
+        sed -n 's/^.*Please try again after \(.* GMT\) and see.*$/\1/p' "$log_file" |
+            tail -n 1
+    )"
+    if [[ -z "$retry_at" ]]; then
+        return 1
+    fi
+
+    date -u -d "$retry_at" +%s 2>/dev/null ||
+        date -j -u -f '%a, %d %b %Y %H:%M:%S %Z' "$retry_at" +%s 2>/dev/null
+}
+
+fallback_delay() {
+    local attempt="$1"
+    local exponent=$((attempt - 1))
+    local delay="$fallback_base_seconds"
+
+    while ((exponent > 0 && delay < fallback_max_seconds)); do
+        delay=$((delay * 2))
+        exponent=$((exponent - 1))
+    done
+
+    if ((delay > fallback_max_seconds)); then
+        delay="$fallback_max_seconds"
+    fi
+    printf '%s\n' "$delay"
+}
+
+sleep_for() {
+    local delay="$1"
+    if [[ "${RELEASE_PUBLISH_DISABLE_SLEEP:-false}" != "true" ]]; then
+        sleep "$delay"
+    fi
+}
+
+started_at="$(current_epoch)"
+attempt=1
+
+while true; do
+    attempt_log="$work_dir/attempt-$attempt.log"
+    echo "Release publish attempt $attempt of $max_attempts"
+
+    set +e
+    "$@" 2>&1 | tee "$attempt_log"
+    status="${PIPESTATUS[0]}"
+    set -e
+
+    if [[ "$status" -eq 0 ]]; then
+        exit 0
+    fi
+
+    if ! grep -q '429 Too Many Requests' "$attempt_log" ||
+        ! grep -q 'https://crates.io/docs/rate-limits' "$attempt_log"; then
+        echo "Release failed with a non-rate-limit error; not retrying." >&2
+        exit "$status"
+    fi
+
+    now="$(current_epoch)"
+    elapsed=$((now - started_at))
+    if ((attempt >= max_attempts || elapsed >= max_duration_seconds)); then
+        echo "Release retry limit reached after $attempt attempts and ${elapsed}s." >&2
+        exit "$status"
+    fi
+
+    if retry_epoch="$(parse_retry_epoch "$attempt_log")"; then
+        delay=$((retry_epoch - now + safety_buffer_seconds))
+        if ((delay < safety_buffer_seconds)); then
+            delay="$safety_buffer_seconds"
+        fi
+    else
+        delay="$(fallback_delay "$attempt")"
+    fi
+
+    if ((elapsed + delay >= max_duration_seconds)); then
+        echo "Release retry would exceed the ${max_duration_seconds}s duration limit." >&2
+        exit "$status"
+    fi
+
+    echo "Crates.io rate limit reached; retrying in ${delay}s."
+    sleep_for "$delay"
+    attempt=$((attempt + 1))
+done

--- a/.github/scripts/release-with-retry.sh
+++ b/.github/scripts/release-with-retry.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+#
+# Retry a release command only when crates.io returns HTTP 429.
+# Usage: release-with-retry.sh <command> [args...]
+#
+# Runtime limits are configurable with RELEASE_PUBLISH_MAX_ATTEMPTS,
+# RELEASE_PUBLISH_MAX_DURATION_SECONDS, RELEASE_PUBLISH_SAFETY_BUFFER_SECONDS,
+# RELEASE_PUBLISH_FALLBACK_BASE_SECONDS, and RELEASE_PUBLISH_FALLBACK_MAX_SECONDS.
+# RELEASE_PUBLISH_NOW_EPOCH and RELEASE_PUBLISH_DISABLE_SLEEP are test overrides.
 
 set -euo pipefail
 
@@ -62,6 +70,11 @@ parse_retry_epoch() {
         date -j -u -f '%a, %d %b %Y %H:%M:%S %Z' "$retry_at" +%s 2>/dev/null
 }
 
+is_crates_io_rate_limit() {
+    local log_file="$1"
+    grep -qE '429 Too Many Requests.*https://crates\.io/docs/rate-limits' "$log_file"
+}
+
 fallback_delay() {
     local attempt="$1"
     local exponent=$((attempt - 1))
@@ -101,8 +114,7 @@ while true; do
         exit 0
     fi
 
-    if ! grep -q '429 Too Many Requests' "$attempt_log" ||
-        ! grep -q 'https://crates.io/docs/rate-limits' "$attempt_log"; then
+    if ! is_crates_io_rate_limit "$attempt_log"; then
         echo "Release failed with a non-rate-limit error; not retrying." >&2
         exit "$status"
     fi

--- a/.github/scripts/release-with-retry.test.sh
+++ b/.github/scripts/release-with-retry.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+retry_script="$script_dir/release-with-retry.sh"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+mock_release="$test_dir/mock-release.sh"
+cat >"$mock_release" <<'EOF'
+#!/usr/bin/env bash
+
+count=0
+if [[ -f "$MOCK_COUNT_FILE" ]]; then
+    count="$(cat "$MOCK_COUNT_FILE")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$MOCK_COUNT_FILE"
+
+case "$MOCK_SCENARIO" in
+    success)
+        exit 0
+        ;;
+    non-429)
+        echo "authentication failed" >&2
+        exit 42
+        ;;
+    foreign-429)
+        echo "status 429 Too Many Requests from api.github.com" >&2
+        exit 43
+        ;;
+    retry-after)
+        if [[ "$count" -eq 1 ]]; then
+            echo "status 429 Too Many Requests: Please try again after Wed, 26 Aug 2026 01:02:32 GMT and see https://crates.io/docs/rate-limits" >&2
+            exit 1
+        fi
+        exit 0
+        ;;
+    fallback)
+        if [[ "$count" -le 2 ]]; then
+            echo "status 429 Too Many Requests: https://crates.io/docs/rate-limits" >&2
+            exit 1
+        fi
+        exit 0
+        ;;
+    always-429)
+        echo "status 429 Too Many Requests: https://crates.io/docs/rate-limits" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$mock_release"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local text="$1"
+    local expected="$2"
+    [[ "$text" == *"$expected"* ]] || fail "expected output to contain: $expected"
+}
+
+run_mock() {
+    local scenario="$1"
+    local count_file="$2"
+    shift 2
+
+    env \
+        MOCK_SCENARIO="$scenario" \
+        MOCK_COUNT_FILE="$count_file" \
+        RELEASE_PUBLISH_DISABLE_SLEEP=true \
+        "$@" \
+        "$retry_script" "$mock_release"
+}
+
+count_file="$test_dir/success-count"
+run_mock success "$count_file" >/dev/null
+[[ "$(cat "$count_file")" -eq 1 ]] || fail "success should run once"
+
+count_file="$test_dir/non-429-count"
+set +e
+output="$(run_mock non-429 "$count_file" 2>&1)"
+status="$?"
+set -e
+[[ "$status" -eq 42 ]] || fail "non-429 status should be preserved"
+[[ "$(cat "$count_file")" -eq 1 ]] || fail "non-429 failure should not retry"
+assert_contains "$output" "not retrying"
+
+count_file="$test_dir/foreign-429-count"
+set +e
+output="$(run_mock foreign-429 "$count_file" 2>&1)"
+status="$?"
+set -e
+[[ "$status" -eq 43 ]] || fail "non-crates.io 429 status should be preserved"
+[[ "$(cat "$count_file")" -eq 1 ]] || fail "non-crates.io 429 should not retry"
+assert_contains "$output" "not retrying"
+
+count_file="$test_dir/retry-after-count"
+output="$(
+    run_mock retry-after "$count_file" \
+        RELEASE_PUBLISH_NOW_EPOCH=1787706092 \
+        RELEASE_PUBLISH_SAFETY_BUFFER_SECONDS=10 \
+        RELEASE_PUBLISH_FALLBACK_BASE_SECONDS=999 \
+        RELEASE_PUBLISH_FALLBACK_MAX_SECONDS=999
+)"
+[[ "$(cat "$count_file")" -eq 2 ]] || fail "retry-after should retry once"
+assert_contains "$output" "retrying in 70s"
+
+count_file="$test_dir/duration-count"
+set +e
+output="$(
+    run_mock retry-after "$count_file" \
+        RELEASE_PUBLISH_NOW_EPOCH=1787706092 \
+        RELEASE_PUBLISH_MAX_DURATION_SECONDS=30 \
+        RELEASE_PUBLISH_SAFETY_BUFFER_SECONDS=10 2>&1
+)"
+status="$?"
+set -e
+[[ "$status" -ne 0 ]] || fail "duration limit should fail"
+[[ "$(cat "$count_file")" -eq 1 ]] || fail "duration limit should stop before retry"
+assert_contains "$output" "would exceed"
+
+count_file="$test_dir/exact-duration-count"
+set +e
+output="$(
+    run_mock retry-after "$count_file" \
+        RELEASE_PUBLISH_NOW_EPOCH=1787706092 \
+        RELEASE_PUBLISH_MAX_DURATION_SECONDS=70 \
+        RELEASE_PUBLISH_SAFETY_BUFFER_SECONDS=10 2>&1
+)"
+status="$?"
+set -e
+[[ "$status" -ne 0 ]] || fail "exact duration limit should fail"
+[[ "$(cat "$count_file")" -eq 1 ]] || fail "exact duration limit should stop before retry"
+assert_contains "$output" "would exceed"
+
+count_file="$test_dir/fallback-count"
+output="$(
+    run_mock fallback "$count_file" \
+        RELEASE_PUBLISH_FALLBACK_BASE_SECONDS=5 \
+        RELEASE_PUBLISH_FALLBACK_MAX_SECONDS=20
+)"
+[[ "$(cat "$count_file")" -eq 3 ]] || fail "fallback should retry twice"
+assert_contains "$output" "retrying in 5s"
+assert_contains "$output" "retrying in 10s"
+
+count_file="$test_dir/max-attempts-count"
+set +e
+output="$(
+    run_mock always-429 "$count_file" \
+        RELEASE_PUBLISH_MAX_ATTEMPTS=2 \
+        RELEASE_PUBLISH_FALLBACK_BASE_SECONDS=1 2>&1
+)"
+status="$?"
+set -e
+[[ "$status" -ne 0 ]] || fail "attempt limit should fail"
+[[ "$(cat "$count_file")" -eq 2 ]] || fail "attempt limit should stop at two"
+assert_contains "$output" "retry limit reached"
+
+echo "release-with-retry tests passed"

--- a/.github/scripts/release-with-retry.test.sh
+++ b/.github/scripts/release-with-retry.test.sh
@@ -30,6 +30,11 @@ case "$MOCK_SCENARIO" in
         echo "status 429 Too Many Requests from api.github.com" >&2
         exit 43
         ;;
+    split-markers)
+        echo "status 429 Too Many Requests from api.github.com" >&2
+        echo "See https://crates.io/docs/rate-limits for unrelated documentation" >&2
+        exit 44
+        ;;
     retry-after)
         if [[ "$count" -eq 1 ]]; then
             echo "status 429 Too Many Requests: Please try again after Wed, 26 Aug 2026 01:02:32 GMT and see https://crates.io/docs/rate-limits" >&2
@@ -98,6 +103,15 @@ set -e
 [[ "$(cat "$count_file")" -eq 1 ]] || fail "non-crates.io 429 should not retry"
 assert_contains "$output" "not retrying"
 
+count_file="$test_dir/split-markers-count"
+set +e
+output="$(run_mock split-markers "$count_file" 2>&1)"
+status="$?"
+set -e
+[[ "$status" -eq 44 ]] || fail "split-marker status should be preserved"
+[[ "$(cat "$count_file")" -eq 1 ]] || fail "split markers should not retry"
+assert_contains "$output" "not retrying"
+
 count_file="$test_dir/retry-after-count"
 output="$(
     run_mock retry-after "$count_file" \
@@ -108,6 +122,15 @@ output="$(
 )"
 [[ "$(cat "$count_file")" -eq 2 ]] || fail "retry-after should retry once"
 assert_contains "$output" "retrying in 70s"
+
+count_file="$test_dir/expired-retry-after-count"
+output="$(
+    run_mock retry-after "$count_file" \
+        RELEASE_PUBLISH_NOW_EPOCH=1787706212 \
+        RELEASE_PUBLISH_SAFETY_BUFFER_SECONDS=10
+)"
+[[ "$(cat "$count_file")" -eq 2 ]] || fail "expired retry-after should retry once"
+assert_contains "$output" "retrying in 10s"
 
 count_file="$test_dir/duration-count"
 set +e

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,6 +30,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 150
     environment: drasi-core-release
     outputs:
       # 'true' only when this run actually published crates (release commit or
@@ -41,6 +42,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+
+      - name: Test release retry wrapper
+        run: .github/scripts/release-with-retry.test.sh
 
       - name: Install release tools
         uses: ./.github/actions/install-release-tools
@@ -72,7 +76,7 @@ jobs:
 
       - name: Publish crates
         if: ${{ (steps.check_release.outputs.is_release == 'true' || inputs.force_publish == true) && inputs.dry_run != true }}
-        run: release-plz release --git-token "$GITHUB_TOKEN" --backend github
+        run: .github/scripts/release-with-retry.sh release-plz release --git-token "$GITHUB_TOKEN" --backend github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,6 +30,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest-8-cores
+    # Allows the 120-minute retry window plus setup and publishing overhead.
     timeout-minutes: 150
     environment: drasi-core-release
     outputs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     uses: drasi-project/.github/.github/workflows/rust-unit-test.yaml@main
     with:
       test-command: |
+        .github/scripts/release-with-retry.test.sh
         cargo run -p xtask -- check-publish-dependency-cycles
         cargo test --workspace --exclude drasi-host-sdk
         make test-host-sdk


### PR DESCRIPTION
## Summary

- retry release-plz only for crates.io HTTP 429 responses
- honor the provided retry timestamp with bounded exponential fallback
- cap retry attempts and duration, with wrapper tests in PR CI

## Testing

- `.github/scripts/release-with-retry.test.sh`
- `bash -n .github/scripts/release-with-retry.sh .github/scripts/release-with-retry.test.sh`
- workflow YAML parsing

Fixes #783