### PR TITLE
fix(dashboard): remove duplicate escapeHtml so the UI can load

### DIFF
--- a/components/reactions/dashboard/static/js/widgets.js
+++ b/components/reactions/dashboard/static/js/widgets.js
@@ -478,10 +478,13 @@ function asRows(rt) {
   return Array.isArray(rt?.rows) ? rt.rows : [];
 }
 
-function escapeHtml(str) {
-  const div = document.createElement("div");
-  div.textContent = str;
-  return div.innerHTML;
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function getLatestValue(rt, field) {
@@ -856,15 +859,6 @@ function idFromRef(ref) {
   if (!text) return null;
   const match = text.match(/^([^:]*):(.*)$/);
   return match ? match[2].trim() : text;
-}
-
-function escapeHtml(value) {
-  return String(value ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 function scalarId(value) {


### PR DESCRIPTION
# Description

Published `reaction/dashboard:0.1.5` serves `static/js/widgets.js` with two `function escapeHtml` declarations in the same ES module. The browser throws `Identifier 'escapeHtml' has already been declared`, so the module never evaluates, `app.js` never calls `refreshDashboards()`, and the UI shows an empty dashboard list even when `GET /api/dashboards` returns seeded dashboards. WebSocket status stays Disconnected.

This is a regression from PR #738 / dashboard 0.1.5 (the graph widget added a second `escapeHtml`).

This PR keeps a single string-replace `escapeHtml` (works for non-DOM tooltip strings and null) and deletes the duplicate DOM-div version. Call sites already used the shared helper.

## Type of change

- This pull request fixes a bug in Drasi.

Fixes: regression of #738

## How to verify

1. Open the dashboard UI.
2. Confirm the dashboard list is not empty when `GET /api/dashboards` returns dashboards.
3. Confirm the page console no longer reports `Identifier 'escapeHtml' has already been declared`.
4. `node components/reactions/dashboard/tests/*.js` passes.