### PR TITLE
feat: allow Publish Plugins workflow to publish a single plugin

### DIFF
--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -226,6 +226,8 @@ jobs:
 
       - name: Build plugins
         shell: bash
+        env:
+          INPUT_PLUGIN: ${{ inputs.plugin }}
         run: |
           # For -gnu targets, append the glibc-version suffix so cargo-zigbuild
           # pins the floor (e.g. x86_64-unknown-linux-gnu.2.28). xtask strips the
@@ -245,12 +247,14 @@ jobs:
             echo "${TOOLCHAIN_ENV}=${PWD}/ci/cmake/librdkafka-features.cmake" >> "$GITHUB_ENV"
             export "${TOOLCHAIN_ENV}=${PWD}/ci/cmake/librdkafka-features.cmake"
           fi
-          
-          ARGS=(build-plugins --release --target "$BUILD_TARGET")
-          if [ -n "${{ inputs.plugin }}" ]; then
-            ARGS+=(--plugin "${{ inputs.plugin }}")
+          if [ -n "$INPUT_PLUGIN" ] && ! [[ "$INPUT_PLUGIN" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid plugin format: $INPUT_PLUGIN" >&2; exit 1
           fi
-          
+          ARGS=(build-plugins --release --target "$BUILD_TARGET")
+          if [ -n "$INPUT_PLUGIN" ]; then
+            ARGS+=(--plugin "$INPUT_PLUGIN")
+          fi
+
           cargo run -p xtask -- "${ARGS[@]}"
 
       - name: Verify glibc floor (-gnu plugins)
@@ -309,6 +313,7 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_PRE_RELEASE: ${{ inputs.pre_release }}
           INPUT_SIGN: ${{ inputs.sign }}
+          INPUT_PLUGIN: ${{ inputs.plugin }}
           TARGET: ${{ matrix.target }}
           ARCH_SUFFIX: ${{ matrix.arch_suffix }}
         run: |
@@ -323,6 +328,9 @@ jobs:
           if ! [[ "$INPUT_REGISTRY" =~ ^[A-Za-z0-9._/:-]+$ ]]; then
             echo "Invalid registry format: $INPUT_REGISTRY" >&2; exit 1
           fi
+          if [ -n "$INPUT_PLUGIN" ] && ! [[ "$INPUT_PLUGIN" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid plugin format: $INPUT_PLUGIN" >&2; exit 1
+          fi
           # Build the args as an array so each element is passed verbatim (no
           # word-splitting or globbing).
           ARGS=(--release --target "$TARGET" --registry "$INPUT_REGISTRY" --arch-suffix "$ARCH_SUFFIX")
@@ -335,8 +343,8 @@ jobs:
           elif [ -n "$INPUT_PRE_RELEASE" ]; then
             ARGS+=(--pre-release "$INPUT_PRE_RELEASE")
           fi
-          if [ -n "${{ inputs.plugin }}" ]; then
-            ARGS+=(--plugin "${{ inputs.plugin }}")
+          if [ -n "$INPUT_PLUGIN" ]; then
+            ARGS+=(--plugin "$INPUT_PLUGIN")
           fi
           cargo run -p xtask -- publish-plugins "${ARGS[@]}"
 
@@ -347,6 +355,7 @@ jobs:
           INPUT_REGISTRY: ${{ inputs.registry }}
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_PRE_RELEASE: ${{ inputs.pre_release }}
+          INPUT_PLUGIN: ${{ inputs.plugin }}
           TARGET: ${{ matrix.target }}
           ARCH_SUFFIX: ${{ matrix.arch_suffix }}
         run: |
@@ -359,14 +368,17 @@ jobs:
           if ! [[ "$INPUT_REGISTRY" =~ ^[A-Za-z0-9._/:-]+$ ]]; then
             echo "Invalid registry format: $INPUT_REGISTRY" >&2; exit 1
           fi
+          if [ -n "$INPUT_PLUGIN" ] && ! [[ "$INPUT_PLUGIN" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid plugin format: $INPUT_PLUGIN" >&2; exit 1
+          fi
           ARGS=(--release --target "$TARGET" --registry "$INPUT_REGISTRY" --arch-suffix "$ARCH_SUFFIX" --dry-run)
           if [ -n "$INPUT_TAG" ]; then
             ARGS+=(--tag "$INPUT_TAG")
           elif [ -n "$INPUT_PRE_RELEASE" ]; then
             ARGS+=(--pre-release "$INPUT_PRE_RELEASE")
           fi
-          if [ -n "${{ inputs.plugin }}" ]; then
-            ARGS+=(--plugin "${{ inputs.plugin }}")
+          if [ -n "$INPUT_PLUGIN" ]; then
+            ARGS+=(--plugin "$INPUT_PLUGIN")
           fi
           cargo run -p xtask -- publish-plugins "${ARGS[@]}"
 
@@ -381,6 +393,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          # Use the same ref as the build jobs so list-plugins runs against the
+          # correct code on feature-branch preview builds.
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Install system dependencies
@@ -406,11 +421,16 @@ jobs:
           # is required. Configure a PACKAGES_ADMIN_TOKEN secret; we fall back
           # to GITHUB_TOKEN only so the step doesn't fail to start.
           GH_TOKEN: ${{ secrets.PACKAGES_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+          INPUT_PLUGIN: ${{ inputs.plugin }}
         run: |
           set -euo pipefail
           ORG="drasi-project"
 
           FAILED=0
+
+          if [ -n "$INPUT_PLUGIN" ] && ! [[ "$INPUT_PLUGIN" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid plugin format: $INPUT_PLUGIN" >&2; exit 1
+          fi
 
           set_public() {
             local pkg="$1"
@@ -432,8 +452,8 @@ jobs:
           # as "  <type>/<kind> v<version> (<path>)"; match only those so the
           # indented "SDK: ..." summary line is excluded.
           ARGS=(list-plugins)
-          if [ -n "${{ inputs.plugin }}" ]; then
-            ARGS+=(--plugin "${{ inputs.plugin }}")
+          if [ -n "$INPUT_PLUGIN" ]; then
+            ARGS+=(--plugin "$INPUT_PLUGIN")
           fi
           PLUGINS=$(cargo run -p xtask -- "${ARGS[@]}" \
             | { grep -E '^[[:space:]]+[a-z-]+/[^[:space:]]+ v[0-9]' || true; } \

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -3,6 +3,11 @@ name: Publish Plugins
 on:
   workflow_dispatch:
     inputs:
+      plugin:
+        description: 'Publish a single plugin (crate name or type/kind, e.g. drasi-source-otel or source/otel). Leave empty for all.'
+        required: false
+        type: string
+        default: ''
       pre_release:
         description: 'Pre-release label (e.g., "dev.1", "rc.1"). Leave empty for stable release.'
         required: false
@@ -40,6 +45,11 @@ on:
         default: ''
   workflow_call:
     inputs:
+      plugin:
+        description: 'Publish a single plugin (crate name or type/kind, e.g. drasi-source-otel or source/otel). Leave empty for all.'
+        required: false
+        type: string
+        default: ''
       pre_release:
         description: 'Pre-release label (e.g., "dev.1", "rc.1"). Leave empty for stable release.'
         required: false
@@ -235,7 +245,13 @@ jobs:
             echo "${TOOLCHAIN_ENV}=${PWD}/ci/cmake/librdkafka-features.cmake" >> "$GITHUB_ENV"
             export "${TOOLCHAIN_ENV}=${PWD}/ci/cmake/librdkafka-features.cmake"
           fi
-          cargo run -p xtask -- build-plugins --release --target "$BUILD_TARGET"
+          
+          ARGS=(build-plugins --release --target "$BUILD_TARGET")
+          if [ -n "${{ inputs.plugin }}" ]; then
+            ARGS+=(--plugin "${{ inputs.plugin }}")
+          fi
+          
+          cargo run -p xtask -- "${ARGS[@]}"
 
       - name: Verify glibc floor (-gnu plugins)
         if: matrix.zigbuild
@@ -319,6 +335,9 @@ jobs:
           elif [ -n "$INPUT_PRE_RELEASE" ]; then
             ARGS+=(--pre-release "$INPUT_PRE_RELEASE")
           fi
+          if [ -n "${{ inputs.plugin }}" ]; then
+            ARGS+=(--plugin "${{ inputs.plugin }}")
+          fi
           cargo run -p xtask -- publish-plugins "${ARGS[@]}"
 
       - name: Publish plugins (dry run)
@@ -345,6 +364,9 @@ jobs:
             ARGS+=(--tag "$INPUT_TAG")
           elif [ -n "$INPUT_PRE_RELEASE" ]; then
             ARGS+=(--pre-release "$INPUT_PRE_RELEASE")
+          fi
+          if [ -n "${{ inputs.plugin }}" ]; then
+            ARGS+=(--plugin "${{ inputs.plugin }}")
           fi
           cargo run -p xtask -- publish-plugins "${ARGS[@]}"
 
@@ -409,7 +431,11 @@ jobs:
           # Set each plugin package to public. list-plugins prints plugin lines
           # as "  <type>/<kind> v<version> (<path>)"; match only those so the
           # indented "SDK: ..." summary line is excluded.
-          PLUGINS=$(cargo run -p xtask -- list-plugins \
+          ARGS=(list-plugins)
+          if [ -n "${{ inputs.plugin }}" ]; then
+            ARGS+=(--plugin "${{ inputs.plugin }}")
+          fi
+          PLUGINS=$(cargo run -p xtask -- "${ARGS[@]}" \
             | { grep -E '^[[:space:]]+[a-z-]+/[^[:space:]]+ v[0-9]' || true; } \
             | awk '{print $1}')
           for PLUGIN in $PLUGINS; do

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -181,12 +181,12 @@ fn discover_dynamic_plugins(plugin_filter: Option<&str>) -> DiscoveryResult {
 
     let mut plugins: Vec<PluginInfo> = metadata
         .packages
-        .into_iter()
-        .filter(is_dynamic_plugin)
+        .iter()
+        .filter(|p| is_dynamic_plugin(p))
         .filter_map(|p| {
             let (plugin_type, kind) = parse_plugin_type_kind(&p.name)?;
             Some(PluginInfo {
-                package: p,
+                package: p.clone(),
                 plugin_type,
                 kind,
             })

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -209,7 +209,6 @@ fn discover_dynamic_plugins(plugin_filter: Option<&str>) -> DiscoveryResult {
         .collect();
     let build_batches = plugin_build_batches(&metadata.packages, &plugin_names);
 
-
     DiscoveryResult {
         plugins,
         build_batches,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -203,10 +203,7 @@ fn discover_dynamic_plugins(plugin_filter: Option<&str>) -> DiscoveryResult {
         }
     }
 
-    let plugin_names: BTreeSet<String> = plugins
-        .iter()
-        .map(|p| p.package.name.clone())
-        .collect();
+    let plugin_names: BTreeSet<String> = plugins.iter().map(|p| p.package.name.clone()).collect();
     let build_batches = plugin_build_batches(&metadata.packages, &plugin_names);
 
     DiscoveryResult {
@@ -968,10 +965,14 @@ fn publish_plugins(args: &[String]) {
     let mut plugins = discover_publishable_plugins(&plugins_dir);
     if let Some(filter) = parse_flag_value(args, "--plugin") {
         plugins.retain(|p| {
-            p.metadata.name == filter || format!("{}/{}", p.metadata.plugin_type, p.metadata.kind) == filter
+            p.metadata.name == filter
+                || format!("{}/{}", p.metadata.plugin_type, p.metadata.kind) == filter
         });
         if plugins.is_empty() {
-            eprintln!("Error: no plugin matched filter '{filter}' in {}", plugins_dir.display());
+            eprintln!(
+                "Error: no plugin matched filter '{filter}' in {}",
+                plugins_dir.display()
+            );
             std::process::exit(1);
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -157,7 +157,7 @@ fn load_cargo_metadata(no_deps: bool) -> CargoMetadata {
     serde_json::from_slice(&output.stdout).expect("failed to parse cargo metadata")
 }
 
-fn discover_dynamic_plugins() -> DiscoveryResult {
+fn discover_dynamic_plugins(plugin_filter: Option<&str>) -> DiscoveryResult {
     let metadata = load_cargo_metadata(false);
 
     let sdk_version = metadata
@@ -179,15 +179,7 @@ fn discover_dynamic_plugins() -> DiscoveryResult {
         .map(|p| p.version.clone())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let plugin_names: BTreeSet<String> = metadata
-        .packages
-        .iter()
-        .filter(|p| is_dynamic_plugin(p))
-        .map(|p| p.name.clone())
-        .collect();
-    let build_batches = plugin_build_batches(&metadata.packages, &plugin_names);
-
-    let plugins = metadata
+    let mut plugins: Vec<PluginInfo> = metadata
         .packages
         .into_iter()
         .filter(is_dynamic_plugin)
@@ -200,6 +192,23 @@ fn discover_dynamic_plugins() -> DiscoveryResult {
             })
         })
         .collect();
+
+    if let Some(filter) = plugin_filter {
+        plugins.retain(|p| {
+            p.package.name == filter || format!("{}/{}", p.plugin_type, p.kind) == filter
+        });
+        if plugins.is_empty() {
+            eprintln!("Error: no plugin matched filter '{filter}'");
+            std::process::exit(1);
+        }
+    }
+
+    let plugin_names: BTreeSet<String> = plugins
+        .iter()
+        .map(|p| p.package.name.clone())
+        .collect();
+    let build_batches = plugin_build_batches(&metadata.packages, &plugin_names);
+
 
     DiscoveryResult {
         plugins,
@@ -381,7 +390,7 @@ fn main() {
     match subcommand {
         Some("build-plugins") => build_plugins(&args[2..]),
         Some("check-publish-dependency-cycles") => check_publish_dependency_cycles(),
-        Some("list-plugins") => list_plugins(),
+        Some("list-plugins") => list_plugins(&args[2..]),
         Some("publish-plugins") => publish_plugins(&args[2..]),
         _ => {
             eprintln!("Usage: cargo xtask <command>");
@@ -393,8 +402,11 @@ fn main() {
             eprintln!(
                 "  check-publish-dependency-cycles  Check publishable packages for dev-dependency cycles"
             );
-            eprintln!("  list-plugins               List all discovered dynamic plugin crates");
-            eprintln!("  publish-plugins [OPTIONS]   Publish built plugins as OCI artifacts");
+            eprintln!("  list-plugins [OPTIONS]     List discovered dynamic plugin crates");
+            eprintln!("  publish-plugins [OPTIONS]  Publish built plugins as OCI artifacts");
+            eprintln!();
+            eprintln!("Common options (for build, list, and publish):");
+            eprintln!("  --plugin <ID>         Filter to a single plugin (e.g. 'source/otel' or 'drasi-source-otel')");
             eprintln!();
             eprintln!("build-plugins options:");
             eprintln!("  --release             Build in release mode");
@@ -420,8 +432,9 @@ fn main() {
     }
 }
 
-fn list_plugins() {
-    let result = discover_dynamic_plugins();
+fn list_plugins(args: &[String]) {
+    let plugin_filter = parse_flag_value(args, "--plugin");
+    let result = discover_dynamic_plugins(plugin_filter.as_deref());
     if result.plugins.is_empty() {
         println!("No dynamic plugins found.");
         return;
@@ -607,7 +620,8 @@ fn build_plugins(args: &[String]) {
         .as_deref()
         .map(has_glibc_suffix)
         .unwrap_or(false);
-    let result = discover_dynamic_plugins();
+    let plugin_filter = parse_flag_value(args, "--plugin");
+    let result = discover_dynamic_plugins(plugin_filter.as_deref());
 
     if result.plugins.is_empty() {
         println!("No dynamic plugins found.");
@@ -952,7 +966,16 @@ fn publish_plugins(args: &[String]) {
         std::process::exit(1);
     }
 
-    let plugins = discover_publishable_plugins(&plugins_dir);
+    let mut plugins = discover_publishable_plugins(&plugins_dir);
+    if let Some(filter) = parse_flag_value(args, "--plugin") {
+        plugins.retain(|p| {
+            p.metadata.name == filter || format!("{}/{}", p.metadata.plugin_type, p.metadata.kind) == filter
+        });
+        if plugins.is_empty() {
+            eprintln!("Error: no plugin matched filter '{filter}' in {}", plugins_dir.display());
+            std::process::exit(1);
+        }
+    }
     if plugins.is_empty() {
         eprintln!("No publishable plugins found in {}", plugins_dir.display());
         std::process::exit(1);


### PR DESCRIPTION
# Description

Currently, the `Publish Plugins` workflow always discovers and builds **every** dynamic plugin in the workspace. There is no way to target a single plugin. This becomes a problem when previewing a new plugin from a feature branch (e.g., `source/otel`) — you either have to republish all plugins (risking overwriting stable GHCR tags) or manually push the binary by hand.

This PR solves that by adding an optional `plugin` selector to both the `xtask` CLI and the GitHub Actions workflow.

### What changed

**`xtask/src/main.rs`**
- Added `--plugin <id>` flag support to `build-plugins`, `publish-plugins`, and `list-plugins` commands.
- The filter accepts either the **crate name** (e.g. `drasi-source-otel`) or the **type/kind format** (e.g. `source/otel`).
- If a filter is given but matches nothing, the command **fails immediately with a clear error** — no silent no-ops.
- If no filter is given, all plugins are discovered and processed exactly as before.

**`.github/workflows/publish-plugins.yml`**
- Added a new optional `plugin` string input to both `workflow_dispatch` and `workflow_call`.
- When set, the value is passed as `--plugin` to the `build-plugins`, `publish-plugins`, and `list-plugins` xtask invocations.
- The `set-public-visibility` step is also scoped to only the selected plugin, preventing unnecessary visibility changes to unrelated packages.
- **Default is empty string** — all existing runs (nightly, release-plz, manual without the field set) behave exactly as they did before. Zero breaking changes.

### Example usage

To preview only the OTel source plugin from a feature branch:

1. Go to **Actions → Publish Plugins → Run workflow**
2. Set `plugin` = `source/otel`
3. Set `pre_release` = `dev.1`
4. Set `ref` = your feature branch name

This will build and push **only** `ghcr.io/drasi-project/source/otel:0.1.0-dev.1` without touching any other plugin.

## Type of change

- This pull request adds or changes features of Drasi and has an approved issue (issue link required).

Fixes #776
