### PR TITLE
feat(lib): add internal change envelope contracts

### DIFF
--- a/lib/src/change/adapters.rs
+++ b/lib/src/change/adapters.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 
 use super::{
-    canonical::{encode_query_variables, CanonicalEncodingError},
+    canonical::{encode_query_variables, encode_source_change, CanonicalEncodingError},
     graph_change_schema, query_result_schema, AddedRecord, ChangeContractError, ChangeEnvelope,
     ChangeSet, ChangeSetId, DeletedRecord, GraphRecord, RecordData, RecordIdentity,
     StableIdBuilder, SystemMetadata, SystemMetadataExtensions, UpdateMetadata, UpdateSemantics,
@@ -42,8 +42,6 @@ pub(crate) enum ChangeAdapterError {
     Contract(#[from] ChangeContractError),
     #[error("source control events cannot be represented as graph changes")]
     UnsupportedSourceControl,
-    #[error("failed to encode source change identity: {0}")]
-    SourceIdentityEncoding(#[from] rmp_serde::encode::Error),
     #[error("expected a {expected} change envelope")]
     WrongSchema { expected: &'static str },
     #[error("graph envelope must contain exactly one supported source change")]
@@ -153,7 +151,7 @@ pub(crate) fn source_event_to_envelope(
         ),
     };
 
-    let encoded_change = rmp_serde::to_vec_named(change)?;
+    let encoded_change = encode_source_change(change)?;
     let mut identity = StableIdBuilder::new("drasi.internal.graph-change-set/v1");
     identity.string("source-id", &wrapper.source_id);
     identity.optional_u64("sequence", wrapper.sequence);

--- a/lib/src/change/adapters.rs
+++ b/lib/src/change/adapters.rs
@@ -1,0 +1,523 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use drasi_core::{
+    evaluation::{
+        context::{QueryPartEvaluationContext, QueryVariables},
+        variable_value::VariableValue,
+    },
+    models::SourceChange,
+};
+
+use crate::{
+    channels::{QueryResult, ResultDiff, SourceEvent, SourceEventWrapper},
+    profiling::ProfilingMetadata,
+};
+
+use super::{
+    graph_change_schema, query_result_schema, AddedRecord, ChangeContractError, ChangeEnvelope,
+    ChangeSet, ChangeSetId, DeletedRecord, GraphRecord, RecordData, RecordIdentity,
+    StableIdBuilder, SystemMetadata, SystemMetadataExtensions, UpdateMetadata, UpdateSemantics,
+    UpdatedRecord,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ChangeAdapterError {
+    #[error(transparent)]
+    Contract(#[from] ChangeContractError),
+    #[error("source control events cannot be represented as graph changes")]
+    UnsupportedSourceControl,
+    #[error("failed to encode source change identity: {0}")]
+    SourceIdentityEncoding(#[from] rmp_serde::encode::Error),
+    #[error("expected a {expected} change envelope")]
+    WrongSchema { expected: &'static str },
+    #[error("graph envelope must contain exactly one supported source change")]
+    InvalidGraphEnvelope,
+    #[error("query envelope is missing its query identity")]
+    MissingQueryId,
+    #[error("query envelope is missing its result sequence")]
+    MissingQuerySequence,
+    #[error("query update at ordinal {ordinal} is missing its before image")]
+    MissingQueryBeforeImage { ordinal: usize },
+    #[error("record at ordinal {ordinal} is incompatible with the boundary codec")]
+    IncompatibleRecord { ordinal: usize },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QueryEnvelopeMetadata {
+    query_id: Arc<str>,
+    source_id: Option<Arc<str>>,
+    sequence: u64,
+    timestamp: DateTime<Utc>,
+    metadata: HashMap<String, serde_json::Value>,
+    profiling: Option<ProfilingMetadata>,
+    extensions: SystemMetadataExtensions,
+}
+
+impl QueryEnvelopeMetadata {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        query_id: impl Into<Arc<str>>,
+        source_id: Option<Arc<str>>,
+        sequence: u64,
+        timestamp: DateTime<Utc>,
+        metadata: HashMap<String, serde_json::Value>,
+        profiling: Option<ProfilingMetadata>,
+    ) -> Self {
+        Self {
+            query_id: query_id.into(),
+            source_id,
+            sequence,
+            timestamp,
+            metadata,
+            profiling,
+            extensions: SystemMetadataExtensions::default(),
+        }
+    }
+
+    pub(crate) fn with_extensions(mut self, extensions: SystemMetadataExtensions) -> Self {
+        self.extensions = extensions;
+        self
+    }
+}
+
+pub(crate) fn source_event_to_envelope(
+    wrapper: &SourceEventWrapper,
+    extensions: SystemMetadataExtensions,
+) -> Result<ChangeEnvelope, ChangeAdapterError> {
+    let SourceEvent::Change(change) = &wrapper.event else {
+        return Err(ChangeAdapterError::UnsupportedSourceControl);
+    };
+
+    let (added, updated, deleted) = match change {
+        SourceChange::Insert { element } => (
+            vec![AddedRecord::new(
+                0,
+                RecordIdentity::GraphElement(element.get_reference().clone()),
+                RecordData::Graph(GraphRecord::Element(Arc::new(element.clone()))),
+            )],
+            vec![],
+            vec![],
+        ),
+        SourceChange::Update { element } => (
+            vec![],
+            vec![UpdatedRecord::new(
+                0,
+                RecordIdentity::GraphElement(element.get_reference().clone()),
+                None,
+                RecordData::Graph(GraphRecord::Element(Arc::new(element.clone()))),
+                UpdateSemantics::Patch,
+                UpdateMetadata::None,
+            )],
+            vec![],
+        ),
+        SourceChange::Delete { metadata } => (
+            vec![],
+            vec![],
+            vec![DeletedRecord::new(
+                0,
+                RecordIdentity::GraphElement(metadata.reference.clone()),
+                Some(RecordData::Graph(GraphRecord::Metadata(Arc::new(
+                    metadata.clone(),
+                )))),
+            )],
+        ),
+        SourceChange::Future { future_ref } => (
+            vec![],
+            vec![UpdatedRecord::new(
+                0,
+                RecordIdentity::GraphElement(future_ref.element_ref.clone()),
+                None,
+                RecordData::Graph(GraphRecord::Future(Arc::new(future_ref.clone()))),
+                UpdateSemantics::Patch,
+                UpdateMetadata::None,
+            )],
+            vec![],
+        ),
+    };
+
+    let encoded_change = rmp_serde::to_vec_named(change)?;
+    let mut identity = StableIdBuilder::new("drasi.internal.graph-change-set/v1");
+    identity.string("source-id", &wrapper.source_id);
+    identity.optional_u64("sequence", wrapper.sequence);
+    identity.optional_bytes(
+        "source-position",
+        wrapper.source_position.as_ref().map(bytes::Bytes::as_ref),
+    );
+    identity.bytes("source-change", &encoded_change);
+    let change_set = ChangeSet::try_new(
+        ChangeSetId::new(identity.finish()),
+        graph_change_schema(),
+        added,
+        updated,
+        deleted,
+    )?;
+    let system = SystemMetadata::new(
+        Some(Arc::from(wrapper.source_id.as_str())),
+        None,
+        wrapper.sequence,
+        wrapper.source_position.clone(),
+        wrapper.timestamp,
+        wrapper.profiling.clone(),
+        extensions,
+    );
+
+    Ok(ChangeEnvelope::new(change_set, system, HashMap::new()))
+}
+
+pub(crate) fn source_event_from_envelope(
+    envelope: &ChangeEnvelope,
+) -> Result<SourceEventWrapper, ChangeAdapterError> {
+    if envelope.change_set().schema().kind() != super::ChangeSchemaKind::GraphChange {
+        return Err(ChangeAdapterError::WrongSchema {
+            expected: "graph-change",
+        });
+    }
+
+    let change_set = envelope.change_set();
+    let change = match (
+        change_set.added().first(),
+        change_set.updated().first(),
+        change_set.deleted().first(),
+        change_set.added().len() + change_set.updated().len() + change_set.deleted().len(),
+    ) {
+        (Some(added), None, None, 1) => match added.after() {
+            RecordData::Graph(GraphRecord::Element(element)) => SourceChange::Insert {
+                element: element.as_ref().clone(),
+            },
+            _ => return Err(ChangeAdapterError::InvalidGraphEnvelope),
+        },
+        (None, Some(updated), None, 1) => match updated.after() {
+            RecordData::Graph(GraphRecord::Element(element))
+                if updated.semantics() == UpdateSemantics::Patch =>
+            {
+                SourceChange::Update {
+                    element: element.as_ref().clone(),
+                }
+            }
+            RecordData::Graph(GraphRecord::Future(future))
+                if updated.semantics() == UpdateSemantics::Patch =>
+            {
+                SourceChange::Future {
+                    future_ref: future.as_ref().clone(),
+                }
+            }
+            _ => return Err(ChangeAdapterError::InvalidGraphEnvelope),
+        },
+        (None, None, Some(deleted), 1) => match deleted.before() {
+            Some(RecordData::Graph(GraphRecord::Metadata(metadata))) => SourceChange::Delete {
+                metadata: metadata.as_ref().clone(),
+            },
+            Some(RecordData::Graph(GraphRecord::Element(element))) => SourceChange::Delete {
+                metadata: element.get_metadata().clone(),
+            },
+            _ => return Err(ChangeAdapterError::InvalidGraphEnvelope),
+        },
+        _ => return Err(ChangeAdapterError::InvalidGraphEnvelope),
+    };
+
+    let system = envelope.system();
+    let source_id = system
+        .source_id()
+        .ok_or(ChangeAdapterError::InvalidGraphEnvelope)?;
+
+    Ok(SourceEventWrapper {
+        source_id: source_id.to_string(),
+        event: SourceEvent::Change(change),
+        timestamp: system.timestamp(),
+        profiling: system.profiling().cloned(),
+        sequence: system.sequence(),
+        source_position: system.source_position().cloned(),
+    })
+}
+
+pub(crate) fn query_evaluation_to_envelope(
+    results: &[QueryPartEvaluationContext],
+    metadata: QueryEnvelopeMetadata,
+) -> Result<Option<ChangeEnvelope>, ChangeAdapterError> {
+    let mut added = Vec::new();
+    let mut updated = Vec::new();
+    let mut deleted = Vec::new();
+
+    for (ordinal, result) in results.iter().enumerate() {
+        match result {
+            QueryPartEvaluationContext::Adding {
+                after,
+                row_signature,
+            } => added.push(AddedRecord::new(
+                ordinal,
+                RecordIdentity::QueryRow(*row_signature),
+                RecordData::QueryRow(Arc::new(after.clone())),
+            )),
+            QueryPartEvaluationContext::Updating {
+                before,
+                after,
+                row_signature,
+            } => updated.push(UpdatedRecord::new(
+                ordinal,
+                RecordIdentity::QueryRow(*row_signature),
+                Some(RecordData::QueryRow(Arc::new(before.clone()))),
+                RecordData::QueryRow(Arc::new(after.clone())),
+                UpdateSemantics::Replace,
+                UpdateMetadata::QueryUpdate {
+                    grouping_keys: None,
+                },
+            )),
+            QueryPartEvaluationContext::Removing {
+                before,
+                row_signature,
+            } => deleted.push(DeletedRecord::new(
+                ordinal,
+                RecordIdentity::QueryRow(*row_signature),
+                Some(RecordData::QueryRow(Arc::new(before.clone()))),
+            )),
+            QueryPartEvaluationContext::Aggregation {
+                before,
+                after,
+                grouping_keys,
+                default_before,
+                default_after,
+                row_signature,
+            } => updated.push(UpdatedRecord::new(
+                ordinal,
+                RecordIdentity::QueryRow(*row_signature),
+                before
+                    .as_ref()
+                    .map(|before| RecordData::QueryRow(Arc::new(before.clone()))),
+                RecordData::QueryRow(Arc::new(after.clone())),
+                UpdateSemantics::Replace,
+                UpdateMetadata::QueryAggregation {
+                    grouping_keys: grouping_keys
+                        .iter()
+                        .map(|key| Arc::from(key.as_str()))
+                        .collect::<Vec<_>>()
+                        .into(),
+                    default_before: *default_before,
+                    default_after: *default_after,
+                },
+            )),
+            QueryPartEvaluationContext::Noop => {}
+        }
+    }
+
+    if added.is_empty() && updated.is_empty() && deleted.is_empty() {
+        return Ok(None);
+    }
+
+    let mut identity = StableIdBuilder::new("drasi.internal.query-change-set/v1");
+    identity.string("query-id", &metadata.query_id);
+    identity.u64("sequence", metadata.sequence);
+    let change_set = ChangeSet::try_new(
+        ChangeSetId::new(identity.finish()),
+        query_result_schema(),
+        added,
+        updated,
+        deleted,
+    )?;
+    let system = SystemMetadata::new(
+        metadata.source_id,
+        Some(metadata.query_id),
+        Some(metadata.sequence),
+        None,
+        metadata.timestamp,
+        metadata.profiling,
+        metadata.extensions,
+    );
+
+    Ok(Some(ChangeEnvelope::new(
+        change_set,
+        system,
+        metadata.metadata,
+    )))
+}
+
+pub(crate) fn query_result_from_envelope(
+    envelope: &ChangeEnvelope,
+) -> Result<QueryResult, ChangeAdapterError> {
+    if envelope.change_set().schema().kind() != super::ChangeSchemaKind::QueryResult {
+        return Err(ChangeAdapterError::WrongSchema {
+            expected: "query-result",
+        });
+    }
+
+    let mut ordered = Vec::new();
+    for added in envelope.change_set().added() {
+        let RecordIdentity::QueryRow(row_signature) = added.identity() else {
+            return Err(ChangeAdapterError::IncompatibleRecord {
+                ordinal: added.ordinal(),
+            });
+        };
+        let RecordData::QueryRow(after) = added.after() else {
+            return Err(ChangeAdapterError::IncompatibleRecord {
+                ordinal: added.ordinal(),
+            });
+        };
+        ordered.push((
+            added.ordinal(),
+            ResultDiff::Add {
+                data: query_variables_to_json(after),
+                row_signature: *row_signature,
+            },
+        ));
+    }
+
+    for updated in envelope.change_set().updated() {
+        let RecordIdentity::QueryRow(row_signature) = updated.identity() else {
+            return Err(ChangeAdapterError::IncompatibleRecord {
+                ordinal: updated.ordinal(),
+            });
+        };
+        let RecordData::QueryRow(after) = updated.after() else {
+            return Err(ChangeAdapterError::IncompatibleRecord {
+                ordinal: updated.ordinal(),
+            });
+        };
+        let after = query_variables_to_json(after);
+        let result = match updated.metadata() {
+            UpdateMetadata::QueryUpdate { grouping_keys } => {
+                let Some(RecordData::QueryRow(before)) = updated.before() else {
+                    return Err(ChangeAdapterError::MissingQueryBeforeImage {
+                        ordinal: updated.ordinal(),
+                    });
+                };
+                ResultDiff::Update {
+                    data: after.clone(),
+                    before: query_variables_to_json(before),
+                    after,
+                    grouping_keys: grouping_keys
+                        .as_ref()
+                        .map(|keys| keys.iter().map(|key| key.to_string()).collect::<Vec<_>>()),
+                    row_signature: *row_signature,
+                }
+            }
+            UpdateMetadata::QueryAggregation { .. } => ResultDiff::Aggregation {
+                before: match updated.before() {
+                    Some(RecordData::QueryRow(before)) => Some(query_variables_to_json(before)),
+                    None => None,
+                    _ => {
+                        return Err(ChangeAdapterError::IncompatibleRecord {
+                            ordinal: updated.ordinal(),
+                        });
+                    }
+                },
+                after,
+                row_signature: *row_signature,
+            },
+            UpdateMetadata::None => {
+                return Err(ChangeAdapterError::IncompatibleRecord {
+                    ordinal: updated.ordinal(),
+                });
+            }
+        };
+        ordered.push((updated.ordinal(), result));
+    }
+
+    for deleted in envelope.change_set().deleted() {
+        let RecordIdentity::QueryRow(row_signature) = deleted.identity() else {
+            return Err(ChangeAdapterError::IncompatibleRecord {
+                ordinal: deleted.ordinal(),
+            });
+        };
+        let Some(RecordData::QueryRow(before)) = deleted.before() else {
+            return Err(ChangeAdapterError::IncompatibleRecord {
+                ordinal: deleted.ordinal(),
+            });
+        };
+        ordered.push((
+            deleted.ordinal(),
+            ResultDiff::Delete {
+                data: query_variables_to_json(before),
+                row_signature: *row_signature,
+            },
+        ));
+    }
+    ordered.sort_by_key(|(ordinal, _)| *ordinal);
+
+    let system = envelope.system();
+    let query_id = system
+        .query_id()
+        .ok_or(ChangeAdapterError::MissingQueryId)?;
+    let sequence = system
+        .sequence()
+        .ok_or(ChangeAdapterError::MissingQuerySequence)?;
+
+    Ok(QueryResult {
+        query_id: query_id.to_string(),
+        sequence,
+        timestamp: system.timestamp(),
+        results: ordered.into_iter().map(|(_, result)| result).collect(),
+        metadata: envelope.metadata().clone(),
+        profiling: system.profiling().cloned(),
+    })
+}
+
+fn query_variables_to_json(variables: &QueryVariables) -> serde_json::Value {
+    serde_json::Value::Object(
+        variables
+            .iter()
+            .map(|(key, value)| (key.to_string(), query_value_to_json(value)))
+            .collect(),
+    )
+}
+
+fn query_value_to_json(value: &VariableValue) -> serde_json::Value {
+    match value {
+        VariableValue::Null => serde_json::Value::Null,
+        VariableValue::Bool(value) => serde_json::Value::Bool(*value),
+        VariableValue::Float(value) => {
+            if value.is_f64() {
+                let value = value.to_string();
+                value
+                    .parse::<f64>()
+                    .ok()
+                    .and_then(serde_json::Number::from_f64)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or_else(|| serde_json::Value::String(value))
+            } else {
+                serde_json::Value::String(value.to_string())
+            }
+        }
+        VariableValue::Integer(value) => {
+            if let Some(value) = value.as_i64() {
+                serde_json::Value::Number(value.into())
+            } else if let Some(value) = value.as_u64() {
+                serde_json::Value::Number(value.into())
+            } else {
+                serde_json::Value::String(value.to_string())
+            }
+        }
+        VariableValue::String(value) => serde_json::Value::String(value.clone()),
+        VariableValue::List(values) => {
+            serde_json::Value::Array(values.iter().map(query_value_to_json).collect())
+        }
+        VariableValue::Object(values) => serde_json::Value::Object(
+            values
+                .iter()
+                .map(|(key, value)| (key.clone(), query_value_to_json(value)))
+                .collect(),
+        ),
+        VariableValue::Date(value) => serde_json::Value::String(value.to_string()),
+        VariableValue::LocalTime(value) => serde_json::Value::String(value.to_string()),
+        VariableValue::ZonedTime(value) => serde_json::Value::String(value.to_string()),
+        VariableValue::LocalDateTime(value) => serde_json::Value::String(value.to_string()),
+        VariableValue::ZonedDateTime(value) => {
+            serde_json::Value::String(value.datetime().to_rfc3339())
+        }
+        VariableValue::Duration(value) => serde_json::Value::String(value.to_string()),
+        _ => serde_json::Value::String(format!("{value:?}")),
+    }
+}

--- a/lib/src/change/adapters.rs
+++ b/lib/src/change/adapters.rs
@@ -29,6 +29,7 @@ use crate::{
 };
 
 use super::{
+    canonical::{encode_query_variables, CanonicalEncodingError},
     graph_change_schema, query_result_schema, AddedRecord, ChangeContractError, ChangeEnvelope,
     ChangeSet, ChangeSetId, DeletedRecord, GraphRecord, RecordData, RecordIdentity,
     StableIdBuilder, SystemMetadata, SystemMetadataExtensions, UpdateMetadata, UpdateSemantics,
@@ -55,6 +56,8 @@ pub(crate) enum ChangeAdapterError {
     MissingQueryBeforeImage { ordinal: usize },
     #[error("record at ordinal {ordinal} is incompatible with the boundary codec")]
     IncompatibleRecord { ordinal: usize },
+    #[error(transparent)]
+    CanonicalEncoding(#[from] CanonicalEncodingError),
 }
 
 #[derive(Debug, Clone)]
@@ -278,7 +281,7 @@ pub(crate) fn query_evaluation_to_envelope(
                 identity.u64("result-ordinal", ordinal as u64);
                 identity.string("result-kind", "add");
                 identity.u64("row-signature", *row_signature);
-                hash_query_variables(&mut identity, "after", after);
+                hash_query_variables(&mut identity, "after", after)?;
                 added.push(AddedRecord::new(
                     ordinal,
                     RecordIdentity::QueryRow(*row_signature),
@@ -293,8 +296,8 @@ pub(crate) fn query_evaluation_to_envelope(
                 identity.u64("result-ordinal", ordinal as u64);
                 identity.string("result-kind", "update");
                 identity.u64("row-signature", *row_signature);
-                hash_query_variables(&mut identity, "before", before);
-                hash_query_variables(&mut identity, "after", after);
+                hash_query_variables(&mut identity, "before", before)?;
+                hash_query_variables(&mut identity, "after", after)?;
                 updated.push(UpdatedRecord::new(
                     ordinal,
                     RecordIdentity::QueryRow(*row_signature),
@@ -313,7 +316,7 @@ pub(crate) fn query_evaluation_to_envelope(
                 identity.u64("result-ordinal", ordinal as u64);
                 identity.string("result-kind", "delete");
                 identity.u64("row-signature", *row_signature);
-                hash_query_variables(&mut identity, "before", before);
+                hash_query_variables(&mut identity, "before", before)?;
                 deleted.push(DeletedRecord::new(
                     ordinal,
                     RecordIdentity::QueryRow(*row_signature),
@@ -333,9 +336,9 @@ pub(crate) fn query_evaluation_to_envelope(
                 identity.u64("row-signature", *row_signature);
                 identity.bool("before-present", before.is_some());
                 if let Some(before) = before {
-                    hash_query_variables(&mut identity, "before", before);
+                    hash_query_variables(&mut identity, "before", before)?;
                 }
-                hash_query_variables(&mut identity, "after", after);
+                hash_query_variables(&mut identity, "after", after)?;
                 identity.u64("grouping-key-count", grouping_keys.len() as u64);
                 for grouping_key in grouping_keys {
                     identity.string("grouping-key", grouping_key);
@@ -393,15 +396,13 @@ pub(crate) fn query_evaluation_to_envelope(
     )))
 }
 
-fn hash_query_variables(identity: &mut StableIdBuilder, section: &str, variables: &QueryVariables) {
-    identity.string("query-variable-section", section);
-    identity.u64("query-variable-count", variables.len() as u64);
-    // QueryVariables and every object-valued VariableValue use BTreeMap, so key
-    // iteration is canonical. VariableValue's typed Hash preserves variant data.
-    for (key, value) in variables {
-        identity.string("query-variable-key", key);
-        identity.typed_hash("query-variable-value", value);
-    }
+fn hash_query_variables(
+    identity: &mut StableIdBuilder,
+    section: &str,
+    variables: &QueryVariables,
+) -> Result<(), CanonicalEncodingError> {
+    identity.bytes(section, &encode_query_variables(variables)?);
+    Ok(())
 }
 
 pub(crate) fn query_result_from_envelope(

--- a/lib/src/change/adapters.rs
+++ b/lib/src/change/adapters.rs
@@ -252,39 +252,74 @@ pub(crate) fn query_evaluation_to_envelope(
     let mut added = Vec::new();
     let mut updated = Vec::new();
     let mut deleted = Vec::new();
+    let mut identity = StableIdBuilder::new("drasi.internal.query-change-set/v2");
+    identity.string("query-id", &metadata.query_id);
+    identity.u64("sequence", metadata.sequence);
+    identity.u64(
+        "schema-fingerprint",
+        query_result_schema().fingerprint().value(),
+    );
+    identity.optional_u64("graph-epoch", metadata.extensions.graph_epoch());
+    identity.optional_u64("config-epoch", metadata.extensions.config_epoch());
+    identity.u64(
+        "result-count",
+        results
+            .iter()
+            .filter(|result| !matches!(result, QueryPartEvaluationContext::Noop))
+            .count() as u64,
+    );
 
     for (ordinal, result) in results.iter().enumerate() {
         match result {
             QueryPartEvaluationContext::Adding {
                 after,
                 row_signature,
-            } => added.push(AddedRecord::new(
-                ordinal,
-                RecordIdentity::QueryRow(*row_signature),
-                RecordData::QueryRow(Arc::new(after.clone())),
-            )),
+            } => {
+                identity.u64("result-ordinal", ordinal as u64);
+                identity.string("result-kind", "add");
+                identity.u64("row-signature", *row_signature);
+                hash_query_variables(&mut identity, "after", after);
+                added.push(AddedRecord::new(
+                    ordinal,
+                    RecordIdentity::QueryRow(*row_signature),
+                    RecordData::QueryRow(Arc::new(after.clone())),
+                ));
+            }
             QueryPartEvaluationContext::Updating {
                 before,
                 after,
                 row_signature,
-            } => updated.push(UpdatedRecord::new(
-                ordinal,
-                RecordIdentity::QueryRow(*row_signature),
-                Some(RecordData::QueryRow(Arc::new(before.clone()))),
-                RecordData::QueryRow(Arc::new(after.clone())),
-                UpdateSemantics::Replace,
-                UpdateMetadata::QueryUpdate {
-                    grouping_keys: None,
-                },
-            )),
+            } => {
+                identity.u64("result-ordinal", ordinal as u64);
+                identity.string("result-kind", "update");
+                identity.u64("row-signature", *row_signature);
+                hash_query_variables(&mut identity, "before", before);
+                hash_query_variables(&mut identity, "after", after);
+                updated.push(UpdatedRecord::new(
+                    ordinal,
+                    RecordIdentity::QueryRow(*row_signature),
+                    Some(RecordData::QueryRow(Arc::new(before.clone()))),
+                    RecordData::QueryRow(Arc::new(after.clone())),
+                    UpdateSemantics::Replace,
+                    UpdateMetadata::QueryUpdate {
+                        grouping_keys: None,
+                    },
+                ));
+            }
             QueryPartEvaluationContext::Removing {
                 before,
                 row_signature,
-            } => deleted.push(DeletedRecord::new(
-                ordinal,
-                RecordIdentity::QueryRow(*row_signature),
-                Some(RecordData::QueryRow(Arc::new(before.clone()))),
-            )),
+            } => {
+                identity.u64("result-ordinal", ordinal as u64);
+                identity.string("result-kind", "delete");
+                identity.u64("row-signature", *row_signature);
+                hash_query_variables(&mut identity, "before", before);
+                deleted.push(DeletedRecord::new(
+                    ordinal,
+                    RecordIdentity::QueryRow(*row_signature),
+                    Some(RecordData::QueryRow(Arc::new(before.clone()))),
+                ));
+            }
             QueryPartEvaluationContext::Aggregation {
                 before,
                 after,
@@ -292,24 +327,40 @@ pub(crate) fn query_evaluation_to_envelope(
                 default_before,
                 default_after,
                 row_signature,
-            } => updated.push(UpdatedRecord::new(
-                ordinal,
-                RecordIdentity::QueryRow(*row_signature),
-                before
-                    .as_ref()
-                    .map(|before| RecordData::QueryRow(Arc::new(before.clone()))),
-                RecordData::QueryRow(Arc::new(after.clone())),
-                UpdateSemantics::Replace,
-                UpdateMetadata::QueryAggregation {
-                    grouping_keys: grouping_keys
-                        .iter()
-                        .map(|key| Arc::from(key.as_str()))
-                        .collect::<Vec<_>>()
-                        .into(),
-                    default_before: *default_before,
-                    default_after: *default_after,
-                },
-            )),
+            } => {
+                identity.u64("result-ordinal", ordinal as u64);
+                identity.string("result-kind", "aggregation");
+                identity.u64("row-signature", *row_signature);
+                identity.bool("before-present", before.is_some());
+                if let Some(before) = before {
+                    hash_query_variables(&mut identity, "before", before);
+                }
+                hash_query_variables(&mut identity, "after", after);
+                identity.u64("grouping-key-count", grouping_keys.len() as u64);
+                for grouping_key in grouping_keys {
+                    identity.string("grouping-key", grouping_key);
+                }
+                identity.bool("default-before", *default_before);
+                identity.bool("default-after", *default_after);
+                updated.push(UpdatedRecord::new(
+                    ordinal,
+                    RecordIdentity::QueryRow(*row_signature),
+                    before
+                        .as_ref()
+                        .map(|before| RecordData::QueryRow(Arc::new(before.clone()))),
+                    RecordData::QueryRow(Arc::new(after.clone())),
+                    UpdateSemantics::Replace,
+                    UpdateMetadata::QueryAggregation {
+                        grouping_keys: grouping_keys
+                            .iter()
+                            .map(|key| Arc::from(key.as_str()))
+                            .collect::<Vec<_>>()
+                            .into(),
+                        default_before: *default_before,
+                        default_after: *default_after,
+                    },
+                ));
+            }
             QueryPartEvaluationContext::Noop => {}
         }
     }
@@ -318,9 +369,6 @@ pub(crate) fn query_evaluation_to_envelope(
         return Ok(None);
     }
 
-    let mut identity = StableIdBuilder::new("drasi.internal.query-change-set/v1");
-    identity.string("query-id", &metadata.query_id);
-    identity.u64("sequence", metadata.sequence);
     let change_set = ChangeSet::try_new(
         ChangeSetId::new(identity.finish()),
         query_result_schema(),
@@ -343,6 +391,17 @@ pub(crate) fn query_evaluation_to_envelope(
         system,
         metadata.metadata,
     )))
+}
+
+fn hash_query_variables(identity: &mut StableIdBuilder, section: &str, variables: &QueryVariables) {
+    identity.string("query-variable-section", section);
+    identity.u64("query-variable-count", variables.len() as u64);
+    // QueryVariables and every object-valued VariableValue use BTreeMap, so key
+    // iteration is canonical. VariableValue's typed Hash preserves variant data.
+    for (key, value) in variables {
+        identity.string("query-variable-key", key);
+        identity.typed_hash("query-variable-value", value);
+    }
 }
 
 pub(crate) fn query_result_from_envelope(

--- a/lib/src/change/canonical.rs
+++ b/lib/src/change/canonical.rs
@@ -244,7 +244,6 @@ impl CanonicalEncoder {
     fn fixed_datetime(&mut self, value: &chrono::DateTime<chrono::FixedOffset>) {
         self.i64(value.timestamp());
         self.u32(value.timestamp_subsec_nanos());
-        self.i32(value.offset().local_minus_utc());
     }
 
     fn list_range(&mut self, value: &ListRange) {

--- a/lib/src/change/canonical.rs
+++ b/lib/src/change/canonical.rs
@@ -24,14 +24,17 @@ use drasi_core::{
         context::QueryVariables,
         variable_value::{ListRange, RangeBound, VariableValue},
     },
-    models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue},
+    models::{
+        Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
+    },
 };
 use drasi_query_ast::ast::{
     BinaryExpression, Expression as AstExpression, Literal, UnaryExpression,
 };
 use std::hash::{Hash, Hasher};
 
-const MAGIC: &[u8] = b"DRASI-QV";
+const QUERY_MAGIC: &[u8] = b"DRASI-QV";
+const GRAPH_MAGIC: &[u8] = b"DRASI-GC";
 const VERSION: u8 = 1;
 
 #[derive(Debug, thiserror::Error)]
@@ -46,9 +49,19 @@ pub(crate) fn encode_query_variables(
     variables: &QueryVariables,
 ) -> Result<Vec<u8>, CanonicalEncodingError> {
     let mut encoder = CanonicalEncoder::default();
-    encoder.raw(MAGIC);
+    encoder.raw(QUERY_MAGIC);
     encoder.u8(VERSION);
     encoder.query_variables(variables)?;
+    Ok(encoder.into_bytes())
+}
+
+pub(crate) fn encode_source_change(
+    change: &SourceChange,
+) -> Result<Vec<u8>, CanonicalEncodingError> {
+    let mut encoder = CanonicalEncoder::default();
+    encoder.raw(GRAPH_MAGIC);
+    encoder.u8(VERSION);
+    encoder.source_change(change)?;
     Ok(encoder.into_bytes())
 }
 
@@ -249,6 +262,31 @@ impl CanonicalEncoder {
         }
     }
 
+    fn source_change(&mut self, value: &SourceChange) -> Result<(), CanonicalEncodingError> {
+        match value {
+            SourceChange::Insert { element } => {
+                self.u8(0x00);
+                self.element(element)?;
+            }
+            SourceChange::Update { element } => {
+                self.u8(0x01);
+                self.element(element)?;
+            }
+            SourceChange::Delete { metadata } => {
+                self.u8(0x02);
+                self.element_metadata(metadata);
+            }
+            SourceChange::Future { future_ref } => {
+                self.u8(0x03);
+                self.element_reference(&future_ref.element_ref);
+                self.u64(future_ref.original_time);
+                self.u64(future_ref.due_time);
+                self.u64(future_ref.group_signature);
+            }
+        }
+        Ok(())
+    }
+
     fn element(&mut self, value: &Element) -> Result<(), CanonicalEncodingError> {
         match value {
             Element::Node {
@@ -313,7 +351,7 @@ impl CanonicalEncoder {
             }
             ElementValue::Float(value) => {
                 self.u8(0x02);
-                self.u64(canonical_f64_bits(value.into_inner()));
+                self.u64(canonical_ordered_f64_bits(value.into_inner()));
             }
             ElementValue::Integer(value) => {
                 self.u8(0x03);
@@ -518,7 +556,7 @@ impl CanonicalEncoder {
             }
             Literal::Real(value) => {
                 self.u8(0x01);
-                self.u64(canonical_f64_bits(*value));
+                self.u64(canonical_raw_f64_bits(*value));
             }
             Literal::Boolean(value) => {
                 self.u8(0x02);
@@ -585,11 +623,19 @@ fn query_float_bits(
         .ok_or(CanonicalEncodingError::InvalidFloat)
 }
 
-fn canonical_f64_bits(value: f64) -> u64 {
+fn canonical_raw_f64_bits(value: f64) -> u64 {
     if value == 0.0 {
         0.0f64.to_bits()
     } else {
         value.to_bits()
+    }
+}
+
+fn canonical_ordered_f64_bits(value: f64) -> u64 {
+    if value.is_nan() {
+        f64::NAN.to_bits()
+    } else {
+        canonical_raw_f64_bits(value)
     }
 }
 

--- a/lib/src/change/canonical.rs
+++ b/lib/src/change/canonical.rs
@@ -1,0 +1,599 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Versioned canonical bytes for query-value identity hashing.
+//!
+//! Variant tags and presence markers are one byte. Lengths and numeric fields
+//! are fixed-width big-endian values; strings are UTF-8 prefixed by a `u64`
+//! byte length. Maps use their `BTreeMap` key order and lists retain input order.
+
+use chrono::{Datelike, Timelike};
+use drasi_core::{
+    evaluation::{
+        context::QueryVariables,
+        variable_value::{ListRange, RangeBound, VariableValue},
+    },
+    models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue},
+};
+use drasi_query_ast::ast::{
+    BinaryExpression, Expression as AstExpression, Literal, UnaryExpression,
+};
+
+const MAGIC: &[u8] = b"DRASI-QV";
+const VERSION: u8 = 1;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CanonicalEncodingError {
+    #[error("query float has no canonical IEEE-754 representation: {value}")]
+    InvalidFloat { value: String },
+    #[error("query integer has no signed or unsigned representation")]
+    InvalidInteger,
+}
+
+pub(crate) fn encode_query_variables(
+    variables: &QueryVariables,
+) -> Result<Vec<u8>, CanonicalEncodingError> {
+    let mut encoder = CanonicalEncoder::default();
+    encoder.raw(MAGIC);
+    encoder.u8(VERSION);
+    encoder.query_variables(variables)?;
+    Ok(encoder.into_bytes())
+}
+
+#[derive(Default)]
+struct CanonicalEncoder {
+    bytes: Vec<u8>,
+}
+
+impl CanonicalEncoder {
+    fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    fn raw(&mut self, value: &[u8]) {
+        self.bytes.extend_from_slice(value);
+    }
+
+    fn u8(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    fn u32(&mut self, value: u32) {
+        self.raw(&value.to_be_bytes());
+    }
+
+    fn i32(&mut self, value: i32) {
+        self.raw(&value.to_be_bytes());
+    }
+
+    fn u64(&mut self, value: u64) {
+        self.raw(&value.to_be_bytes());
+    }
+
+    fn i64(&mut self, value: i64) {
+        self.raw(&value.to_be_bytes());
+    }
+
+    fn length(&mut self, value: usize) {
+        self.u64(value as u64);
+    }
+
+    fn bytes(&mut self, value: &[u8]) {
+        self.length(value.len());
+        self.raw(value);
+    }
+
+    fn string(&mut self, value: &str) {
+        self.bytes(value.as_bytes());
+    }
+
+    fn optional_string(&mut self, value: Option<&str>) {
+        match value {
+            Some(value) => {
+                self.u8(1);
+                self.string(value);
+            }
+            None => self.u8(0),
+        }
+    }
+
+    fn query_variables(
+        &mut self,
+        variables: &QueryVariables,
+    ) -> Result<(), CanonicalEncodingError> {
+        self.length(variables.len());
+        for (key, value) in variables {
+            self.string(key);
+            self.variable_value(value)?;
+        }
+        Ok(())
+    }
+
+    fn variable_value(&mut self, value: &VariableValue) -> Result<(), CanonicalEncodingError> {
+        match value {
+            VariableValue::Null => self.u8(0x00),
+            VariableValue::Bool(value) => {
+                self.u8(0x01);
+                self.u8(u8::from(*value));
+            }
+            VariableValue::Float(value) => {
+                self.u8(0x02);
+                self.u64(query_float_bits(value)?);
+            }
+            VariableValue::Integer(value) => {
+                if let Some(value) = value.as_u64() {
+                    self.u8(0x03);
+                    self.u64(value);
+                } else if let Some(value) = value.as_i64() {
+                    self.u8(0x04);
+                    self.i64(value);
+                } else {
+                    return Err(CanonicalEncodingError::InvalidInteger);
+                }
+            }
+            VariableValue::String(value) => {
+                self.u8(0x05);
+                self.string(value);
+            }
+            VariableValue::List(values) => {
+                self.u8(0x06);
+                self.length(values.len());
+                for value in values {
+                    self.variable_value(value)?;
+                }
+            }
+            VariableValue::Object(values) => {
+                self.u8(0x07);
+                self.length(values.len());
+                for (key, value) in values {
+                    self.string(key);
+                    self.variable_value(value)?;
+                }
+            }
+            VariableValue::Date(value) => {
+                self.u8(0x08);
+                self.date(value);
+            }
+            VariableValue::LocalTime(value) => {
+                self.u8(0x09);
+                self.time(value);
+            }
+            VariableValue::ZonedTime(value) => {
+                self.u8(0x0a);
+                self.time(value.time());
+                self.i32(value.offset().local_minus_utc());
+            }
+            VariableValue::LocalDateTime(value) => {
+                self.u8(0x0b);
+                self.date(&value.date());
+                self.time(&value.time());
+            }
+            VariableValue::ZonedDateTime(value) => {
+                self.u8(0x0c);
+                self.fixed_datetime(value.datetime());
+                self.optional_string(value.timezone_name().as_deref());
+            }
+            VariableValue::Duration(value) => {
+                self.u8(0x0d);
+                self.i64(value.duration().num_seconds());
+                self.i32(value.duration().subsec_nanos());
+                self.i64(*value.year());
+                self.i64(*value.month());
+            }
+            VariableValue::Expression(value) => {
+                self.u8(0x0e);
+                self.expression(value)?;
+            }
+            VariableValue::ListRange(value) => {
+                self.u8(0x0f);
+                self.list_range(value);
+            }
+            VariableValue::Element(value) => {
+                self.u8(0x10);
+                self.element(value)?;
+            }
+            VariableValue::ElementMetadata(value) => {
+                self.u8(0x11);
+                self.element_metadata(value);
+            }
+            VariableValue::ElementReference(value) => {
+                self.u8(0x12);
+                self.element_reference(value);
+            }
+            VariableValue::Awaiting => self.u8(0x13),
+        }
+        Ok(())
+    }
+
+    fn date(&mut self, value: &chrono::NaiveDate) {
+        self.i32(value.year());
+        self.u8(value.month() as u8);
+        self.u8(value.day() as u8);
+    }
+
+    fn time(&mut self, value: &chrono::NaiveTime) {
+        self.u32(value.num_seconds_from_midnight());
+        self.u32(value.nanosecond());
+    }
+
+    fn fixed_datetime(&mut self, value: &chrono::DateTime<chrono::FixedOffset>) {
+        self.i64(value.timestamp());
+        self.u32(value.timestamp_subsec_nanos());
+        self.i32(value.offset().local_minus_utc());
+    }
+
+    fn list_range(&mut self, value: &ListRange) {
+        self.range_bound(&value.start);
+        self.range_bound(&value.end);
+    }
+
+    fn range_bound(&mut self, value: &RangeBound) {
+        match value {
+            RangeBound::Index(value) => {
+                self.u8(0x00);
+                self.i64(*value);
+            }
+            RangeBound::Unbounded => self.u8(0x01),
+        }
+    }
+
+    fn element(&mut self, value: &Element) -> Result<(), CanonicalEncodingError> {
+        match value {
+            Element::Node {
+                metadata,
+                properties,
+            } => {
+                self.u8(0x00);
+                self.element_metadata(metadata);
+                self.element_properties(properties)?;
+            }
+            Element::Relation {
+                metadata,
+                in_node,
+                out_node,
+                properties,
+            } => {
+                self.u8(0x01);
+                self.element_metadata(metadata);
+                self.element_reference(in_node);
+                self.element_reference(out_node);
+                self.element_properties(properties)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn element_metadata(&mut self, value: &ElementMetadata) {
+        self.element_reference(&value.reference);
+        self.length(value.labels.len());
+        for label in value.labels.iter() {
+            self.string(label);
+        }
+        self.u64(value.effective_from);
+    }
+
+    fn element_reference(&mut self, value: &ElementReference) {
+        self.string(&value.source_id);
+        self.string(&value.element_id);
+    }
+
+    fn element_properties(
+        &mut self,
+        value: &ElementPropertyMap,
+    ) -> Result<(), CanonicalEncodingError> {
+        let entries: Vec<_> = value
+            .map_iter(|key, value| (key.clone(), value.clone()))
+            .collect();
+        self.length(entries.len());
+        for (key, value) in entries {
+            self.string(&key);
+            self.element_value(&value)?;
+        }
+        Ok(())
+    }
+
+    fn element_value(&mut self, value: &ElementValue) -> Result<(), CanonicalEncodingError> {
+        match value {
+            ElementValue::Null => self.u8(0x00),
+            ElementValue::Bool(value) => {
+                self.u8(0x01);
+                self.u8(u8::from(*value));
+            }
+            ElementValue::Float(value) => {
+                self.u8(0x02);
+                self.u64(canonical_f64_bits(value.into_inner()));
+            }
+            ElementValue::Integer(value) => {
+                self.u8(0x03);
+                self.i64(*value);
+            }
+            ElementValue::String(value) => {
+                self.u8(0x04);
+                self.string(value);
+            }
+            ElementValue::List(values) => {
+                self.u8(0x05);
+                self.length(values.len());
+                for value in values {
+                    self.element_value(value)?;
+                }
+            }
+            ElementValue::Object(values) => {
+                self.u8(0x06);
+                self.element_properties(values)?;
+            }
+            ElementValue::LocalDateTime(value) => {
+                self.u8(0x07);
+                self.date(&value.date());
+                self.time(&value.time());
+            }
+            ElementValue::ZonedDateTime(value) => {
+                self.u8(0x08);
+                self.fixed_datetime(value);
+            }
+        }
+        Ok(())
+    }
+
+    fn expression(&mut self, value: &AstExpression) -> Result<(), CanonicalEncodingError> {
+        match value {
+            AstExpression::UnaryExpression(value) => {
+                self.u8(0x00);
+                self.unary_expression(value)?;
+            }
+            AstExpression::BinaryExpression(value) => {
+                self.u8(0x01);
+                self.binary_expression(value)?;
+            }
+            AstExpression::FunctionExpression(value) => {
+                self.u8(0x02);
+                self.string(&value.name);
+                self.length(value.args.len());
+                for argument in &value.args {
+                    self.expression(argument)?;
+                }
+                self.u64(value.position_in_query as u64);
+            }
+            AstExpression::CaseExpression(value) => {
+                self.u8(0x03);
+                self.optional_expression(value.match_.as_deref())?;
+                self.length(value.when.len());
+                for (when, then) in &value.when {
+                    self.expression(when)?;
+                    self.expression(then)?;
+                }
+                self.optional_expression(value.else_.as_deref())?;
+            }
+            AstExpression::ListExpression(value) => {
+                self.u8(0x04);
+                self.length(value.elements.len());
+                for element in &value.elements {
+                    self.expression(element)?;
+                }
+            }
+            AstExpression::ObjectExpression(value) => {
+                self.u8(0x05);
+                self.length(value.elements.len());
+                for (key, expression) in &value.elements {
+                    self.string(key);
+                    self.expression(expression)?;
+                }
+            }
+            AstExpression::IteratorExpression(value) => {
+                self.u8(0x06);
+                self.string(&value.item_identifier);
+                self.expression(&value.list_expression)?;
+                self.optional_expression(value.filter.as_deref())?;
+                self.optional_expression(value.map_expression.as_deref())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn optional_expression(
+        &mut self,
+        value: Option<&AstExpression>,
+    ) -> Result<(), CanonicalEncodingError> {
+        match value {
+            Some(value) => {
+                self.u8(1);
+                self.expression(value)?;
+            }
+            None => self.u8(0),
+        }
+        Ok(())
+    }
+
+    fn unary_expression(&mut self, value: &UnaryExpression) -> Result<(), CanonicalEncodingError> {
+        match value {
+            UnaryExpression::Not(value) => {
+                self.u8(0x00);
+                self.expression(value)?;
+            }
+            UnaryExpression::Exists(value) => {
+                self.u8(0x01);
+                self.expression(value)?;
+            }
+            UnaryExpression::IsNull(value) => {
+                self.u8(0x02);
+                self.expression(value)?;
+            }
+            UnaryExpression::IsNotNull(value) => {
+                self.u8(0x03);
+                self.expression(value)?;
+            }
+            UnaryExpression::Literal(value) => {
+                self.u8(0x04);
+                self.literal(value)?;
+            }
+            UnaryExpression::Property { name, key } => {
+                self.u8(0x05);
+                self.string(name);
+                self.string(key);
+            }
+            UnaryExpression::ExpressionProperty { exp, key } => {
+                self.u8(0x06);
+                self.expression(exp)?;
+                self.string(key);
+            }
+            UnaryExpression::Parameter(value) => {
+                self.u8(0x07);
+                self.string(value);
+            }
+            UnaryExpression::Identifier(value) => {
+                self.u8(0x08);
+                self.string(value);
+            }
+            UnaryExpression::Variable { name, value } => {
+                self.u8(0x09);
+                self.string(name);
+                self.expression(value)?;
+            }
+            UnaryExpression::Alias { source, alias } => {
+                self.u8(0x0a);
+                self.expression(source)?;
+                self.string(alias);
+            }
+            UnaryExpression::ListRange {
+                start_bound,
+                end_bound,
+            } => {
+                self.u8(0x0b);
+                self.optional_expression(start_bound.as_deref())?;
+                self.optional_expression(end_bound.as_deref())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn binary_expression(
+        &mut self,
+        value: &BinaryExpression,
+    ) -> Result<(), CanonicalEncodingError> {
+        let (tag, left, right) = match value {
+            BinaryExpression::And(left, right) => (0x00, left, right),
+            BinaryExpression::Or(left, right) => (0x01, left, right),
+            BinaryExpression::Eq(left, right) => (0x02, left, right),
+            BinaryExpression::Ne(left, right) => (0x03, left, right),
+            BinaryExpression::Lt(left, right) => (0x04, left, right),
+            BinaryExpression::Le(left, right) => (0x05, left, right),
+            BinaryExpression::Gt(left, right) => (0x06, left, right),
+            BinaryExpression::Ge(left, right) => (0x07, left, right),
+            BinaryExpression::In(left, right) => (0x08, left, right),
+            BinaryExpression::Add(left, right) => (0x09, left, right),
+            BinaryExpression::Subtract(left, right) => (0x0a, left, right),
+            BinaryExpression::Multiply(left, right) => (0x0b, left, right),
+            BinaryExpression::Divide(left, right) => (0x0c, left, right),
+            BinaryExpression::Modulo(left, right) => (0x0d, left, right),
+            BinaryExpression::Exponent(left, right) => (0x0e, left, right),
+            BinaryExpression::HasLabel(left, right) => (0x0f, left, right),
+            BinaryExpression::Index(left, right) => (0x10, left, right),
+            BinaryExpression::StartsWith(left, right) => (0x11, left, right),
+            BinaryExpression::EndsWith(left, right) => (0x12, left, right),
+            BinaryExpression::Contains(left, right) => (0x13, left, right),
+        };
+        self.u8(tag);
+        self.expression(left)?;
+        self.expression(right)?;
+        Ok(())
+    }
+
+    fn literal(&mut self, value: &Literal) -> Result<(), CanonicalEncodingError> {
+        match value {
+            Literal::Integer(value) => {
+                self.u8(0x00);
+                self.i64(*value);
+            }
+            Literal::Real(value) => {
+                self.u8(0x01);
+                self.u64(canonical_f64_bits(*value));
+            }
+            Literal::Boolean(value) => {
+                self.u8(0x02);
+                self.u8(u8::from(*value));
+            }
+            Literal::Text(value) => {
+                self.u8(0x03);
+                self.string(value);
+            }
+            Literal::Date(value) => {
+                self.u8(0x04);
+                self.string(value);
+            }
+            Literal::LocalTime(value) => {
+                self.u8(0x05);
+                self.string(value);
+            }
+            Literal::ZonedTime(value) => {
+                self.u8(0x06);
+                self.string(value);
+            }
+            Literal::LocalDateTime(value) => {
+                self.u8(0x07);
+                self.string(value);
+            }
+            Literal::ZonedDateTime(value) => {
+                self.u8(0x08);
+                self.string(value);
+            }
+            Literal::Duration(value) => {
+                self.u8(0x09);
+                self.string(value);
+            }
+            Literal::Object(values) => {
+                self.u8(0x0a);
+                self.length(values.len());
+                // Literal objects use Vec storage, so normalize their map key order here.
+                let mut entries: Vec<_> = values.iter().collect();
+                entries.sort_by_key(|(key, _)| key.clone());
+                for (key, value) in entries {
+                    self.string(key);
+                    self.literal(value)?;
+                }
+            }
+            Literal::Expression(value) => {
+                self.u8(0x0b);
+                self.expression(value)?;
+            }
+            Literal::Null => self.u8(0x0c),
+        }
+        Ok(())
+    }
+}
+
+fn query_float_bits(
+    value: &drasi_core::evaluation::variable_value::float::Float,
+) -> Result<u64, CanonicalEncodingError> {
+    let display = value.to_string();
+    let value = match display.as_str() {
+        "NaN" => f64::NAN,
+        "inf" => f64::INFINITY,
+        "-inf" => f64::NEG_INFINITY,
+        _ => display
+            .parse::<f64>()
+            .map_err(|_| CanonicalEncodingError::InvalidFloat { value: display })?,
+    };
+    Ok(canonical_f64_bits(value))
+}
+
+fn canonical_f64_bits(value: f64) -> u64 {
+    // Signed zero compares equal; NaN payload bits are not exposed by the query value API.
+    if value == 0.0 {
+        0.0f64.to_bits()
+    } else if value.is_nan() {
+        f64::NAN.to_bits()
+    } else {
+        value.to_bits()
+    }
+}

--- a/lib/src/change/canonical.rs
+++ b/lib/src/change/canonical.rs
@@ -29,14 +29,15 @@ use drasi_core::{
 use drasi_query_ast::ast::{
     BinaryExpression, Expression as AstExpression, Literal, UnaryExpression,
 };
+use std::hash::{Hash, Hasher};
 
 const MAGIC: &[u8] = b"DRASI-QV";
 const VERSION: u8 = 1;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CanonicalEncodingError {
-    #[error("query float has no canonical IEEE-754 representation: {value}")]
-    InvalidFloat { value: String },
+    #[error("query Float did not expose exactly one semantic IEEE-754 bit pattern")]
+    InvalidFloat,
     #[error("query integer has no signed or unsigned representation")]
     InvalidInteger,
 }
@@ -575,25 +576,51 @@ impl CanonicalEncoder {
 fn query_float_bits(
     value: &drasi_core::evaluation::variable_value::float::Float,
 ) -> Result<u64, CanonicalEncodingError> {
-    let display = value.to_string();
-    let value = match display.as_str() {
-        "NaN" => f64::NAN,
-        "inf" => f64::INFINITY,
-        "-inf" => f64::NEG_INFINITY,
-        _ => display
-            .parse::<f64>()
-            .map_err(|_| CanonicalEncodingError::InvalidFloat { value: display })?,
-    };
-    Ok(canonical_f64_bits(value))
+    // Float's explicit Hash implementation is its only lossless public projection:
+    // it emits one u64 containing raw bits, except that equal signed zeros normalize.
+    let mut capture = FloatBitsCapture::default();
+    value.hash(&mut capture);
+    capture
+        .into_bits()
+        .ok_or(CanonicalEncodingError::InvalidFloat)
 }
 
 fn canonical_f64_bits(value: f64) -> u64 {
-    // Signed zero compares equal; NaN payload bits are not exposed by the query value API.
     if value == 0.0 {
         0.0f64.to_bits()
-    } else if value.is_nan() {
-        f64::NAN.to_bits()
     } else {
         value.to_bits()
+    }
+}
+
+#[derive(Default)]
+struct FloatBitsCapture {
+    bits: Option<u64>,
+    invalid_write: bool,
+}
+
+impl FloatBitsCapture {
+    fn into_bits(self) -> Option<u64> {
+        if self.invalid_write {
+            None
+        } else {
+            self.bits
+        }
+    }
+}
+
+impl Hasher for FloatBitsCapture {
+    fn finish(&self) -> u64 {
+        self.bits.unwrap_or_default()
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        self.invalid_write = true;
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        if self.bits.replace(value).is_some() {
+            self.invalid_write = true;
+        }
     }
 }

--- a/lib/src/change/mod.rs
+++ b/lib/src/change/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use adapters::{
     source_event_to_envelope, ChangeAdapterError, QueryEnvelopeMetadata,
 };
 #[cfg(test)]
-pub(crate) use canonical::encode_query_variables;
+pub(crate) use canonical::{encode_query_variables, encode_source_change};
 
 use std::{
     collections::{HashMap, HashSet},

--- a/lib/src/change/mod.rs
+++ b/lib/src/change/mod.rs
@@ -1,0 +1,1085 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Internal immutable change contracts.
+//!
+//! These types intentionally remain crate-private. The compatibility adapters are
+//! not connected to the live pipeline until the next migration layer.
+
+mod adapters;
+
+pub(crate) use adapters::{
+    query_evaluation_to_envelope, query_result_from_envelope, source_event_from_envelope,
+    source_event_to_envelope, ChangeAdapterError, QueryEnvelopeMetadata,
+};
+
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    sync::{Arc, OnceLock},
+};
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use drasi_core::{
+    evaluation::context::QueryVariables,
+    interface::FutureElementRef,
+    models::{Element, ElementMetadata, ElementReference},
+};
+
+use crate::profiling::ProfilingMetadata;
+
+pub(crate) type ChangeSetRef = Arc<ChangeSet>;
+pub(crate) type SchemaRef = Arc<ChangeSchema>;
+
+const GRAPH_SCHEMA_DESCRIPTOR: &str =
+    "drasi.internal.graph-change/v1;element|metadata|future;add|patch|delete";
+const QUERY_SCHEMA_DESCRIPTOR: &str =
+    "drasi.internal.query-result/v1;query-variables;add|replace|delete|aggregation";
+
+const fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325;
+    let mut index = 0;
+    while index < bytes.len() {
+        hash ^= bytes[index] as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        index += 1;
+    }
+    hash
+}
+
+const GRAPH_SCHEMA_FINGERPRINT: u64 = fnv1a(GRAPH_SCHEMA_DESCRIPTOR.as_bytes());
+const QUERY_SCHEMA_FINGERPRINT: u64 = fnv1a(QUERY_SCHEMA_DESCRIPTOR.as_bytes());
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ChangeSchemaKind {
+    GraphChange,
+    QueryResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct SchemaVersion(u32);
+
+impl SchemaVersion {
+    pub(crate) const fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    pub(crate) const fn value(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct SchemaFingerprint(u64);
+
+impl SchemaFingerprint {
+    pub(crate) const fn value(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ChangeSchema {
+    id: &'static str,
+    version: SchemaVersion,
+    fingerprint: SchemaFingerprint,
+    kind: ChangeSchemaKind,
+}
+
+impl ChangeSchema {
+    pub(crate) fn id(&self) -> &'static str {
+        self.id
+    }
+
+    pub(crate) const fn version(&self) -> SchemaVersion {
+        self.version
+    }
+
+    pub(crate) const fn fingerprint(&self) -> SchemaFingerprint {
+        self.fingerprint
+    }
+
+    pub(crate) const fn kind(&self) -> ChangeSchemaKind {
+        self.kind
+    }
+}
+
+pub(crate) fn graph_change_schema() -> SchemaRef {
+    static SCHEMA: OnceLock<SchemaRef> = OnceLock::new();
+    SCHEMA
+        .get_or_init(|| {
+            Arc::new(ChangeSchema {
+                id: "drasi.internal.graph-change",
+                version: SchemaVersion::new(1),
+                fingerprint: SchemaFingerprint(GRAPH_SCHEMA_FINGERPRINT),
+                kind: ChangeSchemaKind::GraphChange,
+            })
+        })
+        .clone()
+}
+
+pub(crate) fn query_result_schema() -> SchemaRef {
+    static SCHEMA: OnceLock<SchemaRef> = OnceLock::new();
+    SCHEMA
+        .get_or_init(|| {
+            Arc::new(ChangeSchema {
+                id: "drasi.internal.query-result",
+                version: SchemaVersion::new(1),
+                fingerprint: SchemaFingerprint(QUERY_SCHEMA_FINGERPRINT),
+                kind: ChangeSchemaKind::QueryResult,
+            })
+        })
+        .clone()
+}
+
+macro_rules! identity_type {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub(crate) struct $name(u64);
+
+        impl $name {
+            pub(crate) const fn new(value: u64) -> Self {
+                Self(value)
+            }
+
+            pub(crate) const fn value(self) -> u64 {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "{:016x}", self.0)
+            }
+        }
+    };
+}
+
+identity_type!(ChangeSetId);
+identity_type!(EnvelopeId);
+identity_type!(ContextRootId);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum RecordIdentity {
+    GraphElement(ElementReference),
+    QueryRow(u64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum GraphRecord {
+    Element(Arc<Element>),
+    Metadata(Arc<ElementMetadata>),
+    Future(Arc<FutureElementRef>),
+}
+
+impl GraphRecord {
+    fn reference(&self) -> &ElementReference {
+        match self {
+            Self::Element(element) => element.get_reference(),
+            Self::Metadata(metadata) => &metadata.reference,
+            Self::Future(future) => &future.element_ref,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum RecordData {
+    Graph(GraphRecord),
+    QueryRow(Arc<QueryVariables>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum UpdateSemantics {
+    Patch,
+    Replace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum UpdateMetadata {
+    None,
+    QueryUpdate {
+        grouping_keys: Option<Arc<[Arc<str>]>>,
+    },
+    QueryAggregation {
+        grouping_keys: Arc<[Arc<str>]>,
+        default_before: bool,
+        default_after: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct AddedRecord {
+    ordinal: usize,
+    identity: RecordIdentity,
+    after: RecordData,
+}
+
+impl AddedRecord {
+    pub(crate) fn new(ordinal: usize, identity: RecordIdentity, after: RecordData) -> Self {
+        Self {
+            ordinal,
+            identity,
+            after,
+        }
+    }
+
+    pub(crate) const fn ordinal(&self) -> usize {
+        self.ordinal
+    }
+
+    pub(crate) fn identity(&self) -> &RecordIdentity {
+        &self.identity
+    }
+
+    pub(crate) fn after(&self) -> &RecordData {
+        &self.after
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct UpdatedRecord {
+    ordinal: usize,
+    identity: RecordIdentity,
+    before: Option<RecordData>,
+    after: RecordData,
+    semantics: UpdateSemantics,
+    metadata: UpdateMetadata,
+}
+
+impl UpdatedRecord {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        ordinal: usize,
+        identity: RecordIdentity,
+        before: Option<RecordData>,
+        after: RecordData,
+        semantics: UpdateSemantics,
+        metadata: UpdateMetadata,
+    ) -> Self {
+        Self {
+            ordinal,
+            identity,
+            before,
+            after,
+            semantics,
+            metadata,
+        }
+    }
+
+    pub(crate) const fn ordinal(&self) -> usize {
+        self.ordinal
+    }
+
+    pub(crate) fn identity(&self) -> &RecordIdentity {
+        &self.identity
+    }
+
+    pub(crate) fn before(&self) -> Option<&RecordData> {
+        self.before.as_ref()
+    }
+
+    pub(crate) fn after(&self) -> &RecordData {
+        &self.after
+    }
+
+    pub(crate) const fn semantics(&self) -> UpdateSemantics {
+        self.semantics
+    }
+
+    pub(crate) fn metadata(&self) -> &UpdateMetadata {
+        &self.metadata
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DeletedRecord {
+    ordinal: usize,
+    identity: RecordIdentity,
+    before: Option<RecordData>,
+}
+
+impl DeletedRecord {
+    pub(crate) fn new(
+        ordinal: usize,
+        identity: RecordIdentity,
+        before: Option<RecordData>,
+    ) -> Self {
+        Self {
+            ordinal,
+            identity,
+            before,
+        }
+    }
+
+    pub(crate) const fn ordinal(&self) -> usize {
+        self.ordinal
+    }
+
+    pub(crate) fn identity(&self) -> &RecordIdentity {
+        &self.identity
+    }
+
+    pub(crate) fn before(&self) -> Option<&RecordData> {
+        self.before.as_ref()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ChangeContractError {
+    #[error("{operation} record at ordinal {ordinal} is incompatible with schema {schema_id}")]
+    SchemaMismatch {
+        schema_id: &'static str,
+        operation: &'static str,
+        ordinal: usize,
+    },
+    #[error("{operation} graph record at ordinal {ordinal} has a mismatched identity")]
+    IdentityMismatch {
+        operation: &'static str,
+        ordinal: usize,
+    },
+    #[error("change ordinal {ordinal} occurs more than once")]
+    DuplicateOrdinal { ordinal: usize },
+}
+
+#[derive(Debug)]
+pub(crate) struct ChangeSet {
+    id: ChangeSetId,
+    schema: SchemaRef,
+    added: Arc<[AddedRecord]>,
+    updated: Arc<[UpdatedRecord]>,
+    deleted: Arc<[DeletedRecord]>,
+}
+
+impl ChangeSet {
+    pub(crate) fn try_new(
+        id: ChangeSetId,
+        schema: SchemaRef,
+        added: Vec<AddedRecord>,
+        updated: Vec<UpdatedRecord>,
+        deleted: Vec<DeletedRecord>,
+    ) -> Result<ChangeSetRef, ChangeContractError> {
+        let mut ordinals = HashSet::new();
+        for record in &added {
+            Self::validate_added(&schema, record)?;
+            Self::insert_ordinal(&mut ordinals, record.ordinal)?;
+        }
+        for record in &updated {
+            Self::validate_updated(&schema, record)?;
+            Self::insert_ordinal(&mut ordinals, record.ordinal)?;
+        }
+        for record in &deleted {
+            Self::validate_deleted(&schema, record)?;
+            Self::insert_ordinal(&mut ordinals, record.ordinal)?;
+        }
+
+        Ok(Arc::new(Self {
+            id,
+            schema,
+            added: added.into(),
+            updated: updated.into(),
+            deleted: deleted.into(),
+        }))
+    }
+
+    fn insert_ordinal(
+        ordinals: &mut HashSet<usize>,
+        ordinal: usize,
+    ) -> Result<(), ChangeContractError> {
+        if ordinals.insert(ordinal) {
+            Ok(())
+        } else {
+            Err(ChangeContractError::DuplicateOrdinal { ordinal })
+        }
+    }
+
+    fn validate_graph_identity(
+        operation: &'static str,
+        ordinal: usize,
+        identity: &RecordIdentity,
+        record: &GraphRecord,
+    ) -> Result<(), ChangeContractError> {
+        match identity {
+            RecordIdentity::GraphElement(identity) if identity == record.reference() => Ok(()),
+            _ => Err(ChangeContractError::IdentityMismatch { operation, ordinal }),
+        }
+    }
+
+    fn schema_mismatch(
+        schema: &ChangeSchema,
+        operation: &'static str,
+        ordinal: usize,
+    ) -> ChangeContractError {
+        ChangeContractError::SchemaMismatch {
+            schema_id: schema.id(),
+            operation,
+            ordinal,
+        }
+    }
+
+    fn validate_added(
+        schema: &ChangeSchema,
+        record: &AddedRecord,
+    ) -> Result<(), ChangeContractError> {
+        match (schema.kind(), &record.identity, &record.after) {
+            (
+                ChangeSchemaKind::GraphChange,
+                identity,
+                RecordData::Graph(graph @ GraphRecord::Element(_)),
+            ) => Self::validate_graph_identity("added", record.ordinal, identity, graph),
+            (
+                ChangeSchemaKind::QueryResult,
+                RecordIdentity::QueryRow(_),
+                RecordData::QueryRow(_),
+            ) => Ok(()),
+            _ => Err(Self::schema_mismatch(schema, "added", record.ordinal)),
+        }
+    }
+
+    fn validate_updated(
+        schema: &ChangeSchema,
+        record: &UpdatedRecord,
+    ) -> Result<(), ChangeContractError> {
+        match (schema.kind(), &record.identity, &record.after) {
+            (
+                ChangeSchemaKind::GraphChange,
+                identity,
+                RecordData::Graph(graph @ (GraphRecord::Element(_) | GraphRecord::Future(_))),
+            ) if record.semantics == UpdateSemantics::Patch
+                && matches!(
+                    record.before,
+                    None | Some(RecordData::Graph(GraphRecord::Element(_)))
+                        | Some(RecordData::Graph(GraphRecord::Metadata(_)))
+                ) =>
+            {
+                Self::validate_graph_identity("updated", record.ordinal, identity, graph)
+            }
+            (
+                ChangeSchemaKind::QueryResult,
+                RecordIdentity::QueryRow(_),
+                RecordData::QueryRow(_),
+            ) if record.semantics == UpdateSemantics::Replace
+                && matches!(
+                    (&record.metadata, &record.before),
+                    (
+                        UpdateMetadata::QueryUpdate { .. },
+                        Some(RecordData::QueryRow(_))
+                    ) | (
+                        UpdateMetadata::QueryAggregation { .. },
+                        None | Some(RecordData::QueryRow(_))
+                    )
+                ) =>
+            {
+                Ok(())
+            }
+            _ => Err(Self::schema_mismatch(schema, "updated", record.ordinal)),
+        }
+    }
+
+    fn validate_deleted(
+        schema: &ChangeSchema,
+        record: &DeletedRecord,
+    ) -> Result<(), ChangeContractError> {
+        match (schema.kind(), &record.identity, &record.before) {
+            (
+                ChangeSchemaKind::GraphChange,
+                identity,
+                Some(RecordData::Graph(
+                    graph @ (GraphRecord::Element(_) | GraphRecord::Metadata(_)),
+                )),
+            ) => Self::validate_graph_identity("deleted", record.ordinal, identity, graph),
+            (ChangeSchemaKind::GraphChange, RecordIdentity::GraphElement(_), None) => Ok(()),
+            (
+                ChangeSchemaKind::QueryResult,
+                RecordIdentity::QueryRow(_),
+                Some(RecordData::QueryRow(_)) | None,
+            ) => Ok(()),
+            _ => Err(Self::schema_mismatch(schema, "deleted", record.ordinal)),
+        }
+    }
+
+    pub(crate) const fn id(&self) -> ChangeSetId {
+        self.id
+    }
+
+    pub(crate) fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub(crate) fn added(&self) -> &[AddedRecord] {
+        &self.added
+    }
+
+    pub(crate) fn updated(&self) -> &[UpdatedRecord] {
+        &self.updated
+    }
+
+    pub(crate) fn deleted(&self) -> &[DeletedRecord] {
+        &self.deleted
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.updated.is_empty() && self.deleted.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TraceMetadata {
+    trace_id: Arc<str>,
+    span_id: Option<Arc<str>>,
+}
+
+impl TraceMetadata {
+    pub(crate) fn new(trace_id: impl Into<Arc<str>>, span_id: Option<Arc<str>>) -> Self {
+        Self {
+            trace_id: trace_id.into(),
+            span_id,
+        }
+    }
+
+    pub(crate) fn trace_id(&self) -> &str {
+        &self.trace_id
+    }
+
+    pub(crate) fn span_id(&self) -> Option<&str> {
+        self.span_id.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct SystemMetadataExtensions {
+    trace: Option<TraceMetadata>,
+    graph_epoch: Option<u64>,
+    config_epoch: Option<u64>,
+}
+
+impl SystemMetadataExtensions {
+    pub(crate) fn with_trace(mut self, trace: TraceMetadata) -> Self {
+        self.trace = Some(trace);
+        self
+    }
+
+    pub(crate) fn with_graph_epoch(mut self, graph_epoch: u64) -> Self {
+        self.graph_epoch = Some(graph_epoch);
+        self
+    }
+
+    pub(crate) fn with_config_epoch(mut self, config_epoch: u64) -> Self {
+        self.config_epoch = Some(config_epoch);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SystemMetadata {
+    source_id: Option<Arc<str>>,
+    query_id: Option<Arc<str>>,
+    sequence: Option<u64>,
+    source_position: Option<Bytes>,
+    timestamp: DateTime<Utc>,
+    profiling: Option<Arc<ProfilingMetadata>>,
+    trace: Option<TraceMetadata>,
+    graph_epoch: Option<u64>,
+    config_epoch: Option<u64>,
+}
+
+impl SystemMetadata {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        source_id: Option<Arc<str>>,
+        query_id: Option<Arc<str>>,
+        sequence: Option<u64>,
+        source_position: Option<Bytes>,
+        timestamp: DateTime<Utc>,
+        profiling: Option<ProfilingMetadata>,
+        extensions: SystemMetadataExtensions,
+    ) -> Self {
+        Self {
+            source_id,
+            query_id,
+            sequence,
+            source_position,
+            timestamp,
+            profiling: profiling.map(Arc::new),
+            trace: extensions.trace,
+            graph_epoch: extensions.graph_epoch,
+            config_epoch: extensions.config_epoch,
+        }
+    }
+
+    pub(crate) fn source_id(&self) -> Option<&str> {
+        self.source_id.as_deref()
+    }
+
+    pub(crate) fn query_id(&self) -> Option<&str> {
+        self.query_id.as_deref()
+    }
+
+    pub(crate) const fn sequence(&self) -> Option<u64> {
+        self.sequence
+    }
+
+    pub(crate) fn source_position(&self) -> Option<&Bytes> {
+        self.source_position.as_ref()
+    }
+
+    pub(crate) const fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    pub(crate) fn profiling(&self) -> Option<&ProfilingMetadata> {
+        self.profiling.as_deref()
+    }
+
+    pub(crate) fn trace(&self) -> Option<&TraceMetadata> {
+        self.trace.as_ref()
+    }
+
+    pub(crate) const fn graph_epoch(&self) -> Option<u64> {
+        self.graph_epoch
+    }
+
+    pub(crate) const fn config_epoch(&self) -> Option<u64> {
+        self.config_epoch
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ContextContributorKind {
+    Runtime,
+    Source,
+    Query,
+    Reaction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ContextContributor {
+    kind: ContextContributorKind,
+    component_id: Arc<str>,
+}
+
+impl ContextContributor {
+    pub(crate) fn new(kind: ContextContributorKind, component_id: impl Into<Arc<str>>) -> Self {
+        Self {
+            kind,
+            component_id: component_id.into(),
+        }
+    }
+
+    pub(crate) const fn kind(&self) -> ContextContributorKind {
+        self.kind
+    }
+
+    pub(crate) fn component_id(&self) -> &str {
+        &self.component_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum ContextValue {
+    Bool(bool),
+    Signed(i64),
+    Unsigned(u64),
+    String(Arc<str>),
+    Bytes(Arc<[u8]>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ContextContribution {
+    contributor: ContextContributor,
+    key: Arc<str>,
+    value: ContextValue,
+}
+
+impl ContextContribution {
+    pub(crate) fn new(
+        contributor: ContextContributor,
+        key: impl Into<Arc<str>>,
+        value: ContextValue,
+    ) -> Self {
+        Self {
+            contributor,
+            key: key.into(),
+            value,
+        }
+    }
+
+    pub(crate) fn contributor(&self) -> &ContextContributor {
+        &self.contributor
+    }
+
+    pub(crate) fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub(crate) fn value(&self) -> &ContextValue {
+        &self.value
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ProcessingContextRoot {
+    id: ContextRootId,
+}
+
+impl ProcessingContextRoot {
+    pub(crate) const fn id(&self) -> ContextRootId {
+        self.id
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ProcessingContextNode {
+    parent: Option<Arc<ProcessingContextNode>>,
+    contribution: ContextContribution,
+}
+
+impl ProcessingContextNode {
+    pub(crate) fn parent(&self) -> Option<&Arc<ProcessingContextNode>> {
+        self.parent.as_ref()
+    }
+
+    pub(crate) fn contribution(&self) -> &ContextContribution {
+        &self.contribution
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProcessingContext {
+    root: Arc<ProcessingContextRoot>,
+    head: Option<Arc<ProcessingContextNode>>,
+    len: usize,
+}
+
+impl ProcessingContext {
+    fn new(root_id: ContextRootId) -> Self {
+        Self {
+            root: Arc::new(ProcessingContextRoot { id: root_id }),
+            head: None,
+            len: 0,
+        }
+    }
+
+    fn append(&self, contribution: ContextContribution) -> Self {
+        Self {
+            root: self.root.clone(),
+            head: Some(Arc::new(ProcessingContextNode {
+                parent: self.head.clone(),
+                contribution,
+            })),
+            len: self.len + 1,
+        }
+    }
+
+    pub(crate) fn root(&self) -> &Arc<ProcessingContextRoot> {
+        &self.root
+    }
+
+    pub(crate) fn head(&self) -> Option<&Arc<ProcessingContextNode>> {
+        self.head.as_ref()
+    }
+
+    pub(crate) const fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ChangeEnvelope {
+    id: EnvelopeId,
+    change_set: ChangeSetRef,
+    context: ProcessingContext,
+    system: Arc<SystemMetadata>,
+    metadata: Arc<HashMap<String, serde_json::Value>>,
+}
+
+impl ChangeEnvelope {
+    pub(crate) fn new(
+        change_set: ChangeSetRef,
+        system: SystemMetadata,
+        metadata: HashMap<String, serde_json::Value>,
+    ) -> Self {
+        let context_root_id = context_root_id(change_set.id(), &system);
+        let context = ProcessingContext::new(context_root_id);
+        let id = envelope_id(change_set.id(), &system, &metadata, context_root_id);
+        Self {
+            id,
+            change_set,
+            context,
+            system: Arc::new(system),
+            metadata: Arc::new(metadata),
+        }
+    }
+
+    pub(crate) fn append_context(&self, contribution: ContextContribution) -> Self {
+        let context = self.context.append(contribution.clone());
+        let mut identity = StableIdBuilder::new("drasi.internal.change-envelope.context/v1");
+        identity.u64("parent-envelope", self.id.value());
+        identity.context_contribution(&contribution);
+
+        Self {
+            id: EnvelopeId::new(identity.finish()),
+            change_set: self.change_set.clone(),
+            context,
+            system: self.system.clone(),
+            metadata: self.metadata.clone(),
+        }
+    }
+
+    pub(crate) const fn id(&self) -> EnvelopeId {
+        self.id
+    }
+
+    pub(crate) fn change_set(&self) -> &ChangeSetRef {
+        &self.change_set
+    }
+
+    pub(crate) fn context(&self) -> &ProcessingContext {
+        &self.context
+    }
+
+    pub(crate) fn system(&self) -> &SystemMetadata {
+        &self.system
+    }
+
+    pub(crate) fn metadata(&self) -> &HashMap<String, serde_json::Value> {
+        &self.metadata
+    }
+}
+
+pub(super) struct StableIdBuilder {
+    state: u64,
+}
+
+impl StableIdBuilder {
+    pub(super) fn new(domain: &str) -> Self {
+        let mut builder = Self {
+            state: 0xcbf2_9ce4_8422_2325,
+        };
+        builder.bytes("domain", domain.as_bytes());
+        builder
+    }
+
+    fn update(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.state ^= u64::from(*byte);
+            self.state = self.state.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+
+    pub(super) fn bytes(&mut self, label: &str, value: &[u8]) {
+        self.update(&(label.len() as u64).to_le_bytes());
+        self.update(label.as_bytes());
+        self.update(&(value.len() as u64).to_le_bytes());
+        self.update(value);
+    }
+
+    pub(super) fn optional_bytes(&mut self, label: &str, value: Option<&[u8]>) {
+        match value {
+            Some(value) => {
+                self.bytes("option", &[1]);
+                self.bytes(label, value);
+            }
+            None => self.bytes("option", &[0]),
+        }
+    }
+
+    pub(super) fn string(&mut self, label: &str, value: &str) {
+        self.bytes(label, value.as_bytes());
+    }
+
+    pub(super) fn optional_string(&mut self, label: &str, value: Option<&str>) {
+        self.optional_bytes(label, value.map(str::as_bytes));
+    }
+
+    pub(super) fn u64(&mut self, label: &str, value: u64) {
+        self.bytes(label, &value.to_le_bytes());
+    }
+
+    pub(super) fn optional_u64(&mut self, label: &str, value: Option<u64>) {
+        match value {
+            Some(value) => {
+                self.bytes("option", &[1]);
+                self.u64(label, value);
+            }
+            None => self.bytes("option", &[0]),
+        }
+    }
+
+    fn i64(&mut self, label: &str, value: i64) {
+        self.bytes(label, &value.to_le_bytes());
+    }
+
+    fn bool(&mut self, label: &str, value: bool) {
+        self.bytes(label, &[u8::from(value)]);
+    }
+
+    fn system(&mut self, system: &SystemMetadata) {
+        self.optional_string("source-id", system.source_id());
+        self.optional_string("query-id", system.query_id());
+        self.optional_u64("sequence", system.sequence());
+        self.optional_bytes(
+            "source-position",
+            system.source_position().map(Bytes::as_ref),
+        );
+        self.i64("timestamp-seconds", system.timestamp().timestamp());
+        self.u64(
+            "timestamp-nanos",
+            u64::from(system.timestamp().timestamp_subsec_nanos()),
+        );
+        self.optional_u64("graph-epoch", system.graph_epoch());
+        self.optional_u64("config-epoch", system.config_epoch());
+        if let Some(trace) = system.trace() {
+            self.bytes("trace-present", &[1]);
+            self.string("trace-id", trace.trace_id());
+            self.optional_string("span-id", trace.span_id());
+        } else {
+            self.bytes("trace-present", &[0]);
+        }
+        if let Some(profiling) = system.profiling() {
+            self.bytes("profiling-present", &[1]);
+            for (label, value) in [
+                ("source-ns", profiling.source_ns),
+                ("reactivator-start-ns", profiling.reactivator_start_ns),
+                ("reactivator-end-ns", profiling.reactivator_end_ns),
+                ("source-receive-ns", profiling.source_receive_ns),
+                ("source-send-ns", profiling.source_send_ns),
+                ("query-receive-ns", profiling.query_receive_ns),
+                ("query-core-call-ns", profiling.query_core_call_ns),
+                ("query-core-return-ns", profiling.query_core_return_ns),
+                ("query-send-ns", profiling.query_send_ns),
+                ("reaction-receive-ns", profiling.reaction_receive_ns),
+                ("reaction-complete-ns", profiling.reaction_complete_ns),
+            ] {
+                self.optional_u64(label, value);
+            }
+        } else {
+            self.bytes("profiling-present", &[0]);
+        }
+    }
+
+    fn json(&mut self, value: &serde_json::Value) {
+        match value {
+            serde_json::Value::Null => self.bytes("json-kind", b"null"),
+            serde_json::Value::Bool(value) => {
+                self.bytes("json-kind", b"bool");
+                self.bool("json-bool", *value);
+            }
+            serde_json::Value::Number(value) => {
+                self.bytes("json-kind", b"number");
+                self.string("json-number", &value.to_string());
+            }
+            serde_json::Value::String(value) => {
+                self.bytes("json-kind", b"string");
+                self.string("json-string", value);
+            }
+            serde_json::Value::Array(values) => {
+                self.bytes("json-kind", b"array");
+                self.u64("json-array-len", values.len() as u64);
+                for value in values {
+                    self.json(value);
+                }
+            }
+            serde_json::Value::Object(values) => {
+                self.bytes("json-kind", b"object");
+                self.u64("json-object-len", values.len() as u64);
+                let mut entries: Vec<_> = values.iter().collect();
+                entries.sort_unstable_by_key(|(key, _)| *key);
+                for (key, value) in entries {
+                    self.string("json-key", key);
+                    self.json(value);
+                }
+            }
+        }
+    }
+
+    fn metadata(&mut self, metadata: &HashMap<String, serde_json::Value>) {
+        let mut entries: Vec<_> = metadata.iter().collect();
+        entries.sort_unstable_by_key(|(key, _)| *key);
+        self.u64("metadata-len", entries.len() as u64);
+        for (key, value) in entries {
+            self.string("metadata-key", key);
+            self.json(value);
+        }
+    }
+
+    fn context_contribution(&mut self, contribution: &ContextContribution) {
+        let kind = match contribution.contributor().kind() {
+            ContextContributorKind::Runtime => "runtime",
+            ContextContributorKind::Source => "source",
+            ContextContributorKind::Query => "query",
+            ContextContributorKind::Reaction => "reaction",
+        };
+        self.string("context-kind", kind);
+        self.string(
+            "context-component",
+            contribution.contributor().component_id(),
+        );
+        self.string("context-key", contribution.key());
+        match contribution.value() {
+            ContextValue::Bool(value) => {
+                self.string("context-value-kind", "bool");
+                self.bool("context-value", *value);
+            }
+            ContextValue::Signed(value) => {
+                self.string("context-value-kind", "signed");
+                self.i64("context-value", *value);
+            }
+            ContextValue::Unsigned(value) => {
+                self.string("context-value-kind", "unsigned");
+                self.u64("context-value", *value);
+            }
+            ContextValue::String(value) => {
+                self.string("context-value-kind", "string");
+                self.string("context-value", value);
+            }
+            ContextValue::Bytes(value) => {
+                self.string("context-value-kind", "bytes");
+                self.bytes("context-value", value);
+            }
+        }
+    }
+
+    pub(super) const fn finish(self) -> u64 {
+        self.state
+    }
+}
+
+fn context_root_id(change_set_id: ChangeSetId, system: &SystemMetadata) -> ContextRootId {
+    let mut identity = StableIdBuilder::new("drasi.internal.processing-context/v1");
+    identity.u64("change-set", change_set_id.value());
+    identity.system(system);
+    ContextRootId::new(identity.finish())
+}
+
+fn envelope_id(
+    change_set_id: ChangeSetId,
+    system: &SystemMetadata,
+    metadata: &HashMap<String, serde_json::Value>,
+    context_root_id: ContextRootId,
+) -> EnvelopeId {
+    let mut identity = StableIdBuilder::new("drasi.internal.change-envelope/v1");
+    identity.u64("change-set", change_set_id.value());
+    identity.u64("context-root", context_root_id.value());
+    identity.system(system);
+    identity.metadata(metadata);
+    EnvelopeId::new(identity.finish())
+}
+
+#[cfg(test)]
+mod tests;

--- a/lib/src/change/mod.rs
+++ b/lib/src/change/mod.rs
@@ -27,6 +27,7 @@ pub(crate) use adapters::{
 use std::{
     collections::{HashMap, HashSet},
     fmt,
+    hash::{Hash, Hasher},
     sync::{Arc, OnceLock},
 };
 
@@ -579,6 +580,14 @@ impl SystemMetadataExtensions {
         self.config_epoch = Some(config_epoch);
         self
     }
+
+    pub(crate) const fn graph_epoch(&self) -> Option<u64> {
+        self.graph_epoch
+    }
+
+    pub(crate) const fn config_epoch(&self) -> Option<u64> {
+        self.config_epoch
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -925,8 +934,14 @@ impl StableIdBuilder {
         self.bytes(label, &value.to_le_bytes());
     }
 
-    fn bool(&mut self, label: &str, value: bool) {
+    pub(super) fn bool(&mut self, label: &str, value: bool) {
         self.bytes(label, &[u8::from(value)]);
+    }
+
+    pub(super) fn typed_hash<T: Hash>(&mut self, label: &str, value: &T) {
+        let mut hasher = fnv::FnvHasher::default();
+        value.hash(&mut hasher);
+        self.u64(label, hasher.finish());
     }
 
     fn system(&mut self, system: &SystemMetadata) {

--- a/lib/src/change/mod.rs
+++ b/lib/src/change/mod.rs
@@ -18,16 +18,18 @@
 //! not connected to the live pipeline until the next migration layer.
 
 mod adapters;
+mod canonical;
 
 pub(crate) use adapters::{
     query_evaluation_to_envelope, query_result_from_envelope, source_event_from_envelope,
     source_event_to_envelope, ChangeAdapterError, QueryEnvelopeMetadata,
 };
+#[cfg(test)]
+pub(crate) use canonical::encode_query_variables;
 
 use std::{
     collections::{HashMap, HashSet},
     fmt,
-    hash::{Hash, Hasher},
     sync::{Arc, OnceLock},
 };
 
@@ -936,12 +938,6 @@ impl StableIdBuilder {
 
     pub(super) fn bool(&mut self, label: &str, value: bool) {
         self.bytes(label, &[u8::from(value)]);
-    }
-
-    pub(super) fn typed_hash<T: Hash>(&mut self, label: &str, value: &T) {
-        let mut hasher = fnv::FnvHasher::default();
-        value.hash(&mut hasher);
-        self.u64(label, hasher.finish());
     }
 
     fn system(&mut self, system: &SystemMetadata) {

--- a/lib/src/change/tests.rs
+++ b/lib/src/change/tests.rs
@@ -640,6 +640,71 @@ fn canonical_float_encoding_preserves_nan_payloads_and_semantics() {
 }
 
 #[test]
+fn canonical_element_float_encoding_matches_ordered_float_semantics() {
+    fn graph_float(value: f64) -> SourceEventWrapper {
+        let mut properties = ElementPropertyMap::new();
+        properties.insert("value", ElementValue::Float(OrderedFloat(value)));
+        wrapper(SourceChange::Insert {
+            element: element(properties, 1_000),
+        })
+    }
+
+    fn change(wrapper: &SourceEventWrapper) -> &SourceChange {
+        let SourceEvent::Change(change) = &wrapper.event else {
+            panic!("expected source change");
+        };
+        change
+    }
+
+    let first_nan = graph_float(f64::from_bits(0x7ff8_0000_0000_0001));
+    let second_nan = graph_float(f64::from_bits(0xfff8_0000_0000_0002));
+    assert_eq!(first_nan.event, second_nan.event);
+    assert_eq!(
+        encode_source_change(change(&first_nan)).unwrap(),
+        encode_source_change(change(&second_nan)).unwrap()
+    );
+    assert_eq!(
+        source_event_to_envelope(&first_nan, SystemMetadataExtensions::default())
+            .unwrap()
+            .change_set()
+            .id(),
+        source_event_to_envelope(&second_nan, SystemMetadataExtensions::default())
+            .unwrap()
+            .change_set()
+            .id()
+    );
+
+    let positive_zero = graph_float(0.0);
+    let negative_zero = graph_float(-0.0);
+    assert_eq!(
+        encode_source_change(change(&positive_zero)).unwrap(),
+        encode_source_change(change(&negative_zero)).unwrap()
+    );
+    assert_eq!(
+        source_event_to_envelope(&positive_zero, SystemMetadataExtensions::default())
+            .unwrap()
+            .change_set()
+            .id(),
+        source_event_to_envelope(&negative_zero, SystemMetadataExtensions::default())
+            .unwrap()
+            .change_set()
+            .id()
+    );
+
+    let positive_infinity = graph_float(f64::INFINITY);
+    let negative_infinity = graph_float(f64::NEG_INFINITY);
+    let positive_infinity_bytes = encode_source_change(change(&positive_infinity)).unwrap();
+    assert_eq!(
+        positive_infinity_bytes,
+        encode_source_change(change(&positive_infinity)).unwrap()
+    );
+    assert_ne!(
+        positive_infinity_bytes,
+        encode_source_change(change(&negative_infinity)).unwrap()
+    );
+}
+
+#[test]
 fn query_change_set_ids_include_available_epochs() {
     let contexts = [QueryPartEvaluationContext::Adding {
         after: variables(&[("name", VariableValue::String("Alice".to_string()))]),

--- a/lib/src/change/tests.rs
+++ b/lib/src/change/tests.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 use bytes::Bytes;
 use chrono::NaiveDate;
@@ -458,6 +461,99 @@ fn query_change_set_ids_include_typed_result_content() {
         typed_date.change_set().id(),
         legacy_equivalent_string.change_set().id(),
         "typed values that share a legacy JSON representation must remain distinct"
+    );
+}
+
+#[test]
+fn canonical_integer_encoding_distinguishes_sign_variants() {
+    let positive = variables(&[("value", VariableValue::Integer(u64::MAX.into()))]);
+    let negative = variables(&[("value", VariableValue::Integer((-1_i64).into()))]);
+
+    assert_ne!(
+        encode_query_variables(&positive).unwrap(),
+        encode_query_variables(&negative).unwrap()
+    );
+
+    let positive_envelope = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: positive,
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    let negative_envelope = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: negative,
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    assert_ne!(
+        positive_envelope.change_set().id(),
+        negative_envelope.change_set().id()
+    );
+}
+
+#[test]
+fn canonical_nested_values_ignore_map_insertion_order() {
+    let mut first_object = BTreeMap::new();
+    first_object.insert(
+        "z".to_string(),
+        VariableValue::List(vec![
+            VariableValue::Integer(1.into()),
+            VariableValue::Bool(true),
+        ]),
+    );
+    first_object.insert("a".to_string(), VariableValue::String("first".to_string()));
+
+    let mut second_object = BTreeMap::new();
+    second_object.insert("a".to_string(), VariableValue::String("first".to_string()));
+    second_object.insert(
+        "z".to_string(),
+        VariableValue::List(vec![
+            VariableValue::Integer(1.into()),
+            VariableValue::Bool(true),
+        ]),
+    );
+
+    let first = variables(&[
+        ("nested", VariableValue::Object(first_object)),
+        ("tail", VariableValue::Null),
+    ]);
+    let second = variables(&[
+        ("tail", VariableValue::Null),
+        ("nested", VariableValue::Object(second_object)),
+    ]);
+
+    assert_eq!(
+        encode_query_variables(&first).unwrap(),
+        encode_query_variables(&second).unwrap()
+    );
+}
+
+#[test]
+fn canonical_integer_bytes_are_fixed_width_and_versioned() {
+    let values = variables(&[
+        ("positive", VariableValue::Integer(u64::MAX.into())),
+        ("negative", VariableValue::Integer((-1_i64).into())),
+    ]);
+    let encoded = encode_query_variables(&values).unwrap();
+    let encoded_hex = encoded
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+
+    assert_eq!(
+        encoded_hex,
+        concat!(
+            "44524153492d5156010000000000000002",
+            "00000000000000086e6567617469766504ffffffffffffffff",
+            "0000000000000008706f73697469766503ffffffffffffffff",
+        )
     );
 }
 

--- a/lib/src/change/tests.rs
+++ b/lib/src/change/tests.rs
@@ -1,0 +1,414 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap, sync::Arc};
+
+use bytes::Bytes;
+use chrono::NaiveDate;
+use drasi_core::{
+    evaluation::{
+        context::{QueryPartEvaluationContext, QueryVariables},
+        variable_value::VariableValue,
+    },
+    interface::FutureElementRef,
+    models::{
+        Element, ElementMetadata, ElementPropertyMap, ElementReference, ElementValue, SourceChange,
+    },
+};
+use ordered_float::OrderedFloat;
+use serde_json::json;
+
+use crate::{
+    channels::{ResultDiff, SourceEvent, SourceEventWrapper},
+    profiling::ProfilingMetadata,
+};
+
+use super::*;
+
+fn element(properties: ElementPropertyMap, effective_from: u64) -> Element {
+    Element::Node {
+        metadata: ElementMetadata {
+            reference: ElementReference::new("source-a", "person-1"),
+            labels: vec!["Person".into()].into(),
+            effective_from,
+        },
+        properties,
+    }
+}
+
+fn wrapper(change: SourceChange) -> SourceEventWrapper {
+    let mut wrapper = SourceEventWrapper::with_sequence(
+        "source-a".to_string(),
+        SourceEvent::Change(change),
+        chrono::DateTime::from_timestamp_millis(1_700_000_000_123).unwrap(),
+        42,
+        Some(ProfilingMetadata {
+            source_ns: Some(10),
+            source_receive_ns: Some(20),
+            source_send_ns: Some(30),
+            ..Default::default()
+        }),
+    );
+    wrapper.set_source_position(Bytes::from_static(b"offset-42"));
+    wrapper
+}
+
+fn variables(entries: &[(&str, VariableValue)]) -> QueryVariables {
+    entries
+        .iter()
+        .map(|(key, value)| ((*key).into(), value.clone()))
+        .collect()
+}
+
+fn query_metadata(sequence: u64) -> QueryEnvelopeMetadata {
+    QueryEnvelopeMetadata::new(
+        "query-a",
+        Some(Arc::from("source-a")),
+        sequence,
+        chrono::DateTime::from_timestamp_millis(1_700_000_000_456).unwrap(),
+        HashMap::from([
+            ("source_id".to_string(), json!("source-a")),
+            ("processed_by".to_string(), json!("drasi-core")),
+        ]),
+        Some(ProfilingMetadata {
+            query_receive_ns: Some(40),
+            query_core_call_ns: Some(50),
+            query_core_return_ns: Some(60),
+            query_send_ns: Some(70),
+            ..Default::default()
+        }),
+    )
+}
+
+fn assert_source_wrapper_eq(actual: &SourceEventWrapper, expected: &SourceEventWrapper) {
+    assert_eq!(actual.source_id, expected.source_id);
+    assert_eq!(actual.event, expected.event);
+    assert_eq!(actual.timestamp, expected.timestamp);
+    assert_eq!(actual.profiling, expected.profiling);
+    assert_eq!(actual.sequence, expected.sequence);
+    assert_eq!(actual.source_position, expected.source_position);
+}
+
+#[test]
+fn schema_references_are_versioned_and_distinct() {
+    let graph = graph_change_schema();
+    let graph_again = graph_change_schema();
+    let query = query_result_schema();
+
+    assert!(Arc::ptr_eq(&graph, &graph_again));
+    assert_eq!(graph.id(), "drasi.internal.graph-change");
+    assert_eq!(graph.version().value(), 1);
+    assert_eq!(graph.fingerprint().value(), 0x7763_808c_f677_2102);
+    assert_eq!(query.id(), "drasi.internal.query-result");
+    assert_eq!(query.version().value(), 1);
+    assert_eq!(query.fingerprint().value(), 0x476f_7b05_8973_4c67);
+    assert_ne!(graph.fingerprint(), query.fingerprint());
+}
+
+#[test]
+fn append_only_inputs_use_only_added_records() {
+    let graph_input = wrapper(SourceChange::Insert {
+        element: element(ElementPropertyMap::from(json!({ "name": "Alice" })), 1_000),
+    });
+    let graph =
+        source_event_to_envelope(&graph_input, SystemMetadataExtensions::default()).unwrap();
+
+    assert_eq!(graph.change_set().added().len(), 1);
+    assert!(graph.change_set().updated().is_empty());
+    assert!(graph.change_set().deleted().is_empty());
+    assert!(Arc::ptr_eq(
+        graph.change_set().schema(),
+        &graph_change_schema()
+    ));
+
+    let query = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: variables(&[("name", VariableValue::String("Alice".to_string()))]),
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(query.change_set().added().len(), 1);
+    assert!(query.change_set().updated().is_empty());
+    assert!(query.change_set().deleted().is_empty());
+}
+
+#[test]
+fn graph_updates_and_deletes_roundtrip_with_explicit_semantics() {
+    let update_input = wrapper(SourceChange::Update {
+        element: element(ElementPropertyMap::from(json!({ "name": "Alicia" })), 2_000),
+    });
+    let update =
+        source_event_to_envelope(&update_input, SystemMetadataExtensions::default()).unwrap();
+    assert_eq!(update.change_set().updated().len(), 1);
+    assert_eq!(
+        update.change_set().updated()[0].semantics(),
+        UpdateSemantics::Patch
+    );
+    assert!(update.change_set().updated()[0].before().is_none());
+    assert_source_wrapper_eq(&source_event_from_envelope(&update).unwrap(), &update_input);
+
+    let metadata = ElementMetadata {
+        reference: ElementReference::new("source-a", "person-1"),
+        labels: vec!["Person".into()].into(),
+        effective_from: 3_000,
+    };
+    let delete_input = wrapper(SourceChange::Delete {
+        metadata: metadata.clone(),
+    });
+    let delete =
+        source_event_to_envelope(&delete_input, SystemMetadataExtensions::default()).unwrap();
+    assert_eq!(delete.change_set().deleted().len(), 1);
+    assert_eq!(
+        delete.change_set().deleted()[0].before(),
+        Some(&RecordData::Graph(GraphRecord::Metadata(Arc::new(
+            metadata
+        ))))
+    );
+    assert_source_wrapper_eq(&source_event_from_envelope(&delete).unwrap(), &delete_input);
+
+    let future_input = wrapper(SourceChange::Future {
+        future_ref: FutureElementRef {
+            element_ref: ElementReference::new("source-a", "person-1"),
+            original_time: 3_000,
+            due_time: 4_000,
+            group_signature: 55,
+        },
+    });
+    let future =
+        source_event_to_envelope(&future_input, SystemMetadataExtensions::default()).unwrap();
+    assert_eq!(
+        future.change_set().updated()[0].semantics(),
+        UpdateSemantics::Patch
+    );
+    assert!(matches!(
+        future.change_set().updated()[0].after(),
+        RecordData::Graph(GraphRecord::Future(_))
+    ));
+    assert_source_wrapper_eq(&source_event_from_envelope(&future).unwrap(), &future_input);
+}
+
+#[test]
+fn graph_and_query_values_remain_typed_inside_change_sets() {
+    let mut properties = ElementPropertyMap::new();
+    properties.insert("infinity", ElementValue::Float(OrderedFloat(f64::INFINITY)));
+    properties.insert(
+        "local_datetime",
+        ElementValue::LocalDateTime(
+            NaiveDate::from_ymd_opt(2026, 9, 8)
+                .unwrap()
+                .and_hms_opt(7, 8, 9)
+                .unwrap(),
+        ),
+    );
+    let graph_input = wrapper(SourceChange::Insert {
+        element: element(properties, 1_000),
+    });
+    let graph =
+        source_event_to_envelope(&graph_input, SystemMetadataExtensions::default()).unwrap();
+    assert_source_wrapper_eq(&source_event_from_envelope(&graph).unwrap(), &graph_input);
+
+    let typed_row = variables(&[
+        (
+            "date",
+            VariableValue::Date(NaiveDate::from_ymd_opt(2026, 9, 8).unwrap()),
+        ),
+        ("large", VariableValue::Integer(u64::MAX.into())),
+    ]);
+    let query = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: typed_row.clone(),
+            row_signature: 99,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    let RecordData::QueryRow(stored) = query.change_set().added()[0].after() else {
+        panic!("query rows must stay typed");
+    };
+    assert_eq!(stored.as_ref(), &typed_row);
+}
+
+#[test]
+fn query_updates_preserve_order_before_images_and_legacy_shape() {
+    let contexts = vec![
+        QueryPartEvaluationContext::Adding {
+            after: variables(&[("kind", VariableValue::String("added".to_string()))]),
+            row_signature: 11,
+        },
+        QueryPartEvaluationContext::Noop,
+        QueryPartEvaluationContext::Updating {
+            before: variables(&[("kind", VariableValue::String("before".to_string()))]),
+            after: variables(&[("kind", VariableValue::String("after".to_string()))]),
+            row_signature: 22,
+        },
+        QueryPartEvaluationContext::Removing {
+            before: variables(&[("kind", VariableValue::String("removed".to_string()))]),
+            row_signature: 33,
+        },
+        QueryPartEvaluationContext::Aggregation {
+            before: Some(variables(&[("total", VariableValue::Integer(1.into()))])),
+            after: variables(&[("total", VariableValue::Integer(2.into()))]),
+            grouping_keys: vec!["group".to_string()],
+            default_before: true,
+            default_after: false,
+            row_signature: 44,
+        },
+    ];
+    let envelope = query_evaluation_to_envelope(&contexts, query_metadata(7))
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(envelope.change_set().updated().len(), 2);
+    assert_eq!(
+        envelope.change_set().updated()[0].semantics(),
+        UpdateSemantics::Replace
+    );
+    assert!(envelope.change_set().updated()[0].before().is_some());
+    assert!(matches!(
+        envelope.change_set().updated()[1].metadata(),
+        UpdateMetadata::QueryAggregation {
+            grouping_keys,
+            default_before: true,
+            default_after: false,
+        } if grouping_keys.as_ref() == [Arc::<str>::from("group")]
+    ));
+
+    let result = query_result_from_envelope(&envelope).unwrap();
+    assert_eq!(result.query_id, "query-a");
+    assert_eq!(result.sequence, 7);
+    assert_eq!(
+        result.results,
+        vec![
+            ResultDiff::Add {
+                data: json!({ "kind": "added" }),
+                row_signature: 11,
+            },
+            ResultDiff::Update {
+                data: json!({ "kind": "after" }),
+                before: json!({ "kind": "before" }),
+                after: json!({ "kind": "after" }),
+                grouping_keys: None,
+                row_signature: 22,
+            },
+            ResultDiff::Delete {
+                data: json!({ "kind": "removed" }),
+                row_signature: 33,
+            },
+            ResultDiff::Aggregation {
+                before: Some(json!({ "total": 1 })),
+                after: json!({ "total": 2 }),
+                row_signature: 44,
+            },
+        ]
+    );
+    assert_eq!(result.metadata, *envelope.metadata());
+    assert_eq!(result.profiling, envelope.system().profiling().cloned());
+    assert_eq!(result.timestamp, envelope.system().timestamp());
+}
+
+#[test]
+fn envelopes_share_immutable_changes_and_append_context_persistently() {
+    let input = wrapper(SourceChange::Insert {
+        element: element(ElementPropertyMap::from(json!({ "name": "Alice" })), 1_000),
+    });
+    let envelope = source_event_to_envelope(
+        &input,
+        SystemMetadataExtensions::default()
+            .with_trace(TraceMetadata::new("trace-1", Some(Arc::from("span-1"))))
+            .with_graph_epoch(5)
+            .with_config_epoch(8),
+    )
+    .unwrap();
+    let first = envelope.append_context(ContextContribution::new(
+        ContextContributor::new(ContextContributorKind::Source, "source-a"),
+        "partition",
+        ContextValue::Unsigned(3),
+    ));
+    let second = first.append_context(ContextContribution::new(
+        ContextContributor::new(ContextContributorKind::Query, "query-a"),
+        "matched",
+        ContextValue::Bool(true),
+    ));
+
+    assert!(Arc::ptr_eq(envelope.change_set(), first.change_set()));
+    assert!(Arc::ptr_eq(first.change_set(), second.change_set()));
+    assert!(Arc::ptr_eq(
+        envelope.context().root(),
+        second.context().root()
+    ));
+    assert!(Arc::ptr_eq(
+        first.context().head().unwrap(),
+        second.context().head().unwrap().parent().unwrap()
+    ));
+    assert_eq!(envelope.context().len(), 0);
+    assert_eq!(first.context().len(), 1);
+    assert_eq!(second.context().len(), 2);
+    assert_ne!(envelope.id(), first.id());
+    assert_ne!(first.id(), second.id());
+    assert_eq!(envelope.system().graph_epoch(), Some(5));
+    assert_eq!(envelope.system().config_epoch(), Some(8));
+    assert_eq!(
+        envelope.system().trace().unwrap(),
+        &TraceMetadata::new("trace-1", Some(Arc::from("span-1")))
+    );
+}
+
+#[test]
+fn boundary_ids_are_deterministic_and_distinct() {
+    let input = wrapper(SourceChange::Insert {
+        element: element(ElementPropertyMap::from(json!({ "name": "Alice" })), 1_000),
+    });
+    let first = source_event_to_envelope(&input, SystemMetadataExtensions::default()).unwrap();
+    let second = source_event_to_envelope(&input, SystemMetadataExtensions::default()).unwrap();
+
+    assert_eq!(first.change_set().id(), second.change_set().id());
+    assert_eq!(first.id(), second.id());
+    assert_ne!(first.change_set().id().value(), first.id().value());
+    assert_source_wrapper_eq(&source_event_from_envelope(&first).unwrap(), &input);
+
+    let query_one = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: variables(&[("name", VariableValue::String("Alice".to_string()))]),
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    let query_two = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: variables(&[("name", VariableValue::String("Alice".to_string()))]),
+            row_signature: 11,
+        }],
+        query_metadata(2),
+    )
+    .unwrap()
+    .unwrap();
+    assert_ne!(query_one.change_set().id(), query_two.change_set().id());
+    assert_ne!(query_one.id(), query_two.id());
+}
+
+#[test]
+fn all_noop_query_results_do_not_create_an_envelope() {
+    assert!(
+        query_evaluation_to_envelope(&[QueryPartEvaluationContext::Noop], query_metadata(1))
+            .unwrap()
+            .is_none()
+    );
+}

--- a/lib/src/change/tests.rs
+++ b/lib/src/change/tests.rs
@@ -370,7 +370,7 @@ fn envelopes_share_immutable_changes_and_append_context_persistently() {
 }
 
 #[test]
-fn boundary_ids_are_deterministic_and_distinct() {
+fn boundary_ids_are_deterministic_for_identical_batches() {
     let input = wrapper(SourceChange::Insert {
         element: element(ElementPropertyMap::from(json!({ "name": "Alice" })), 1_000),
     });
@@ -384,7 +384,10 @@ fn boundary_ids_are_deterministic_and_distinct() {
 
     let query_one = query_evaluation_to_envelope(
         &[QueryPartEvaluationContext::Adding {
-            after: variables(&[("name", VariableValue::String("Alice".to_string()))]),
+            after: variables(&[
+                ("name", VariableValue::String("Alice".to_string())),
+                ("age", VariableValue::Integer(42.into())),
+            ]),
             row_signature: 11,
         }],
         query_metadata(1),
@@ -393,15 +396,110 @@ fn boundary_ids_are_deterministic_and_distinct() {
     .unwrap();
     let query_two = query_evaluation_to_envelope(
         &[QueryPartEvaluationContext::Adding {
-            after: variables(&[("name", VariableValue::String("Alice".to_string()))]),
+            after: variables(&[
+                ("age", VariableValue::Integer(42.into())),
+                ("name", VariableValue::String("Alice".to_string())),
+            ]),
             row_signature: 11,
         }],
-        query_metadata(2),
+        query_metadata(1),
     )
     .unwrap()
     .unwrap();
-    assert_ne!(query_one.change_set().id(), query_two.change_set().id());
-    assert_ne!(query_one.id(), query_two.id());
+    assert_eq!(query_one.change_set().id(), query_two.change_set().id());
+    assert_eq!(query_one.id(), query_two.id());
+}
+
+#[test]
+fn query_change_set_ids_include_typed_result_content() {
+    let alice = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: variables(&[("name", VariableValue::String("Alice".to_string()))]),
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    let bob = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: variables(&[("name", VariableValue::String("Bob".to_string()))]),
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_ne!(alice.change_set().id(), bob.change_set().id());
+
+    let typed_date = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: variables(&[(
+                "value",
+                VariableValue::Date(NaiveDate::from_ymd_opt(2026, 9, 8).unwrap()),
+            )]),
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    let legacy_equivalent_string = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: variables(&[("value", VariableValue::String("2026-09-08".to_string()))]),
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    assert_ne!(
+        typed_date.change_set().id(),
+        legacy_equivalent_string.change_set().id(),
+        "typed values that share a legacy JSON representation must remain distinct"
+    );
+}
+
+#[test]
+fn query_change_set_ids_include_available_epochs() {
+    let contexts = [QueryPartEvaluationContext::Adding {
+        after: variables(&[("name", VariableValue::String("Alice".to_string()))]),
+        row_signature: 11,
+    }];
+    let baseline = query_evaluation_to_envelope(
+        &contexts,
+        query_metadata(1).with_extensions(
+            SystemMetadataExtensions::default()
+                .with_graph_epoch(5)
+                .with_config_epoch(8),
+        ),
+    )
+    .unwrap()
+    .unwrap();
+    let graph_changed = query_evaluation_to_envelope(
+        &contexts,
+        query_metadata(1).with_extensions(
+            SystemMetadataExtensions::default()
+                .with_graph_epoch(6)
+                .with_config_epoch(8),
+        ),
+    )
+    .unwrap()
+    .unwrap();
+    let config_changed = query_evaluation_to_envelope(
+        &contexts,
+        query_metadata(1).with_extensions(
+            SystemMetadataExtensions::default()
+                .with_graph_epoch(5)
+                .with_config_epoch(9),
+        ),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_ne!(baseline.change_set().id(), graph_changed.change_set().id());
+    assert_ne!(baseline.change_set().id(), config_changed.change_set().id());
 }
 
 #[test]

--- a/lib/src/change/tests.rs
+++ b/lib/src/change/tests.rs
@@ -18,11 +18,14 @@ use std::{
 };
 
 use bytes::Bytes;
-use chrono::NaiveDate;
+use chrono::{FixedOffset, NaiveDate, NaiveTime, TimeZone};
 use drasi_core::{
     evaluation::{
         context::{QueryPartEvaluationContext, QueryVariables},
-        variable_value::{float::Float, VariableValue},
+        variable_value::{
+            float::Float, zoned_datetime::ZonedDateTime as VarZonedDateTime,
+            zoned_time::ZonedTime as VarZonedTime, VariableValue,
+        },
     },
     interface::FutureElementRef,
     models::{
@@ -701,6 +704,112 @@ fn canonical_element_float_encoding_matches_ordered_float_semantics() {
     assert_ne!(
         positive_infinity_bytes,
         encode_source_change(change(&negative_infinity)).unwrap()
+    );
+}
+
+#[test]
+fn canonical_fixed_datetimes_follow_temporal_equality() {
+    fn query_value_envelope(value: VariableValue) -> ChangeEnvelope {
+        query_evaluation_to_envelope(
+            &[QueryPartEvaluationContext::Adding {
+                after: variables(&[("value", value)]),
+                row_signature: 11,
+            }],
+            query_metadata(1),
+        )
+        .unwrap()
+        .unwrap()
+    }
+
+    fn source_change(wrapper: &SourceEventWrapper) -> &SourceChange {
+        let SourceEvent::Change(change) = &wrapper.event else {
+            panic!("expected source change");
+        };
+        change
+    }
+
+    fn graph_datetime(value: chrono::DateTime<FixedOffset>) -> SourceEventWrapper {
+        let mut properties = ElementPropertyMap::new();
+        properties.insert("value", ElementValue::ZonedDateTime(value));
+        wrapper(SourceChange::Insert {
+            element: element(properties, 1_000),
+        })
+    }
+
+    let utc = FixedOffset::east_opt(0)
+        .unwrap()
+        .with_ymd_and_hms(2020, 1, 1, 0, 0, 0)
+        .single()
+        .unwrap();
+    let plus_one = FixedOffset::east_opt(3_600)
+        .unwrap()
+        .with_ymd_and_hms(2020, 1, 1, 1, 0, 0)
+        .single()
+        .unwrap();
+    assert_eq!(utc, plus_one);
+
+    let utc_graph = graph_datetime(utc);
+    let plus_one_graph = graph_datetime(plus_one);
+    assert_eq!(
+        encode_source_change(source_change(&utc_graph)).unwrap(),
+        encode_source_change(source_change(&plus_one_graph)).unwrap()
+    );
+    assert_eq!(
+        source_event_to_envelope(&utc_graph, SystemMetadataExtensions::default())
+            .unwrap()
+            .change_set()
+            .id(),
+        source_event_to_envelope(&plus_one_graph, SystemMetadataExtensions::default())
+            .unwrap()
+            .change_set()
+            .id()
+    );
+
+    let utc_zoned =
+        VariableValue::ZonedDateTime(VarZonedDateTime::new(utc, Some("Etc/UTC".to_string())));
+    let plus_one_zoned =
+        VariableValue::ZonedDateTime(VarZonedDateTime::new(plus_one, Some("Etc/UTC".to_string())));
+    assert_eq!(utc_zoned, plus_one_zoned);
+    assert_eq!(
+        encode_query_variables(&variables(&[("value", utc_zoned.clone())])).unwrap(),
+        encode_query_variables(&variables(&[("value", plus_one_zoned.clone())])).unwrap()
+    );
+    assert_eq!(
+        query_value_envelope(utc_zoned).change_set().id(),
+        query_value_envelope(plus_one_zoned).change_set().id()
+    );
+
+    let utc_named =
+        VariableValue::ZonedDateTime(VarZonedDateTime::new(utc, Some("Etc/UTC".to_string())));
+    let differently_named =
+        VariableValue::ZonedDateTime(VarZonedDateTime::new(utc, Some("UTC".to_string())));
+    assert_ne!(utc_named, differently_named);
+    assert_ne!(
+        encode_query_variables(&variables(&[("value", utc_named.clone())])).unwrap(),
+        encode_query_variables(&variables(&[("value", differently_named.clone())])).unwrap()
+    );
+    assert_ne!(
+        query_value_envelope(utc_named).change_set().id(),
+        query_value_envelope(differently_named).change_set().id()
+    );
+
+    let local_time = NaiveTime::from_hms_nano_opt(12, 30, 45, 123_456_789).unwrap();
+    let utc_time = VariableValue::ZonedTime(VarZonedTime::new(
+        local_time,
+        FixedOffset::east_opt(0).unwrap(),
+    ));
+    let plus_one_time = VariableValue::ZonedTime(VarZonedTime::new(
+        local_time,
+        FixedOffset::east_opt(3_600).unwrap(),
+    ));
+    assert_ne!(utc_time, plus_one_time);
+    assert_ne!(
+        encode_query_variables(&variables(&[("value", utc_time.clone())])).unwrap(),
+        encode_query_variables(&variables(&[("value", plus_one_time.clone())])).unwrap()
+    );
+    assert_ne!(
+        query_value_envelope(utc_time).change_set().id(),
+        query_value_envelope(plus_one_time).change_set().id()
     );
 }
 

--- a/lib/src/change/tests.rs
+++ b/lib/src/change/tests.rs
@@ -22,7 +22,7 @@ use chrono::NaiveDate;
 use drasi_core::{
     evaluation::{
         context::{QueryPartEvaluationContext, QueryVariables},
-        variable_value::VariableValue,
+        variable_value::{float::Float, VariableValue},
     },
     interface::FutureElementRef,
     models::{
@@ -555,6 +555,88 @@ fn canonical_integer_bytes_are_fixed_width_and_versioned() {
             "0000000000000008706f73697469766503ffffffffffffffff",
         )
     );
+}
+
+#[test]
+fn canonical_float_encoding_preserves_nan_payloads_and_semantics() {
+    let first_nan_bits = 0x7ff8_0000_0000_0001;
+    let second_nan_bits = 0xfff8_0000_0000_0002;
+    let first_nan = variables(&[(
+        "value",
+        VariableValue::Float(Float::from(f64::from_bits(first_nan_bits))),
+    )]);
+    let second_nan = variables(&[(
+        "value",
+        VariableValue::Float(Float::from(f64::from_bits(second_nan_bits))),
+    )]);
+
+    let first_bytes = encode_query_variables(&first_nan).unwrap();
+    assert_eq!(first_bytes, encode_query_variables(&first_nan).unwrap());
+    assert!(first_bytes.ends_with(&first_nan_bits.to_be_bytes()));
+    assert!(encode_query_variables(&second_nan)
+        .unwrap()
+        .ends_with(&second_nan_bits.to_be_bytes()));
+    assert_ne!(first_bytes, encode_query_variables(&second_nan).unwrap());
+
+    let first_envelope = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: first_nan,
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    let second_envelope = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: second_nan,
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    assert_ne!(
+        first_envelope.change_set().id(),
+        second_envelope.change_set().id()
+    );
+
+    let positive_zero = variables(&[("value", VariableValue::Float(Float::from(0.0)))]);
+    let negative_zero = variables(&[("value", VariableValue::Float(Float::from(-0.0)))]);
+    assert_eq!(
+        encode_query_variables(&positive_zero).unwrap(),
+        encode_query_variables(&negative_zero).unwrap(),
+        "signed zero compares equal in Float and must have one canonical encoding"
+    );
+    let positive_zero_envelope = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: positive_zero,
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    let negative_zero_envelope = query_evaluation_to_envelope(
+        &[QueryPartEvaluationContext::Adding {
+            after: negative_zero,
+            row_signature: 11,
+        }],
+        query_metadata(1),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        positive_zero_envelope.change_set().id(),
+        negative_zero_envelope.change_set().id()
+    );
+
+    for value in [1.5, f64::INFINITY, f64::NEG_INFINITY] {
+        let variables = variables(&[("value", VariableValue::Float(Float::from(value)))]);
+        let encoded = encode_query_variables(&variables).unwrap();
+        assert_eq!(encoded, encode_query_variables(&variables).unwrap());
+        assert!(encoded.ends_with(&value.to_bits().to_be_bytes()));
+    }
 }
 
 #[test]

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -648,6 +648,19 @@ mod tests {
         let source_position = Bytes::from_static(b"offset-42");
         wrapper.set_source_position(source_position.clone());
 
+        let envelope = crate::change::source_event_to_envelope(
+            &wrapper,
+            crate::change::SystemMetadataExtensions::default(),
+        )
+        .unwrap();
+        let adapted = crate::change::source_event_from_envelope(&envelope).unwrap();
+        assert_eq!(adapted.source_id, wrapper.source_id);
+        assert_eq!(adapted.event, wrapper.event);
+        assert_eq!(adapted.timestamp, wrapper.timestamp);
+        assert_eq!(adapted.profiling, wrapper.profiling);
+        assert_eq!(adapted.sequence, wrapper.sequence);
+        assert_eq!(adapted.source_position, wrapper.source_position);
+
         let parts = wrapper.into_parts();
 
         assert_eq!(parts.source_id, "test-source");

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -62,6 +62,11 @@ pub mod recovery;
 // Internal Modules (crate-private, but visible to integration tests)
 // ============================================================================
 
+// Introduced ahead of pipeline wiring so the compatibility adapters can be reviewed
+// independently from the runtime behavior change.
+#[allow(dead_code)]
+pub(crate) mod change;
+
 // These modules are internal but need to be accessible to integration tests
 // that test platform-specific components
 #[cfg_attr(not(test), doc(hidden))]

--- a/lib/src/queries/manager/pipeline_characterization_tests.rs
+++ b/lib/src/queries/manager/pipeline_characterization_tests.rs
@@ -858,6 +858,27 @@ async fn evaluation_results_map_to_ordered_query_result_and_sequence() {
     assert_eq!(result.metadata["result_count"], json!(4));
     assert_eq!(result.profiling, Some(ProfilingMetadata::default()));
 
+    let envelope = crate::change::query_evaluation_to_envelope(
+        &contexts,
+        crate::change::QueryEnvelopeMetadata::new(
+            result.query_id.clone(),
+            Some(Arc::from("source-a")),
+            result.sequence,
+            result.timestamp,
+            result.metadata.clone(),
+            result.profiling.clone(),
+        ),
+    )
+    .unwrap()
+    .expect("non-Noop evaluation results should produce an envelope");
+    let adapted = crate::change::query_result_from_envelope(&envelope).unwrap();
+    assert_eq!(adapted.query_id, result.query_id);
+    assert_eq!(adapted.sequence, result.sequence);
+    assert_eq!(adapted.timestamp, result.timestamp);
+    assert_eq!(adapted.results, result.results);
+    assert_eq!(adapted.metadata, result.metadata);
+    assert_eq!(adapted.profiling, result.profiling);
+
     let state = output_state.read().await;
     assert_eq!(state.as_of_sequence(), 1);
     assert_eq!(state.outbox_len(), 1);


### PR DESCRIPTION
Stack A layer 2 of 7.

Depends on #864. Base: `agentofreality-characterize-query-pipeline`.

## Summary
- add crate-private immutable `ChangeSet` and `ChangeEnvelope` contracts with graph/query schemas, typed record identities, Patch/Replace semantics, optional before images, runtime metadata, and append-only processing context
- add currently-unused lossless adapters for `SourceEventWrapper`/`SourceChange` and query evaluation diffs/legacy `QueryResult`
- add focused codec, deterministic identity, immutable-sharing, and A1 fixture coverage

This layer makes no live routing, public API, plugin ABI, or persistence behavior changes. A3 will wire these adapters into the fixed pipeline.

## Tests
- `cargo test -p drasi-lib --lib change::tests`
- `cargo test -p drasi-lib --lib channels::events::tests::test_source_event_wrapper_into_parts`
- `cargo test -p drasi-lib --lib pipeline_characterization_tests`
- `cargo clippy -p drasi-lib --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`