### PR TITLE
refactor(lib): route fixed query path through change envelopes

### DIFF
--- a/core/src/models/element_value.rs
+++ b/core/src/models/element_value.rs
@@ -267,6 +267,21 @@ impl ElementPropertyMap {
     ) -> impl Iterator<Item = T> + '_ {
         self.values.iter().map(move |(k, v)| f(k, v))
     }
+
+    /// Iterate over properties in their canonical key order.
+    pub fn iter(&self) -> impl Iterator<Item = (&Arc<str>, &ElementValue)> {
+        self.values.iter()
+    }
+
+    /// Return the number of properties.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Return whether the property map is empty.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
 }
 
 impl Index<&str> for ElementPropertyMap {

--- a/lib/src/change/adapters.rs
+++ b/lib/src/change/adapters.rs
@@ -183,54 +183,7 @@ pub(crate) fn source_event_to_envelope(
 pub(crate) fn source_event_from_envelope(
     envelope: &ChangeEnvelope,
 ) -> Result<SourceEventWrapper, ChangeAdapterError> {
-    if envelope.change_set().schema().kind() != super::ChangeSchemaKind::GraphChange {
-        return Err(ChangeAdapterError::WrongSchema {
-            expected: "graph-change",
-        });
-    }
-
-    let change_set = envelope.change_set();
-    let change = match (
-        change_set.added().first(),
-        change_set.updated().first(),
-        change_set.deleted().first(),
-        change_set.added().len() + change_set.updated().len() + change_set.deleted().len(),
-    ) {
-        (Some(added), None, None, 1) => match added.after() {
-            RecordData::Graph(GraphRecord::Element(element)) => SourceChange::Insert {
-                element: element.as_ref().clone(),
-            },
-            _ => return Err(ChangeAdapterError::InvalidGraphEnvelope),
-        },
-        (None, Some(updated), None, 1) => match updated.after() {
-            RecordData::Graph(GraphRecord::Element(element))
-                if updated.semantics() == UpdateSemantics::Patch =>
-            {
-                SourceChange::Update {
-                    element: element.as_ref().clone(),
-                }
-            }
-            RecordData::Graph(GraphRecord::Future(future))
-                if updated.semantics() == UpdateSemantics::Patch =>
-            {
-                SourceChange::Future {
-                    future_ref: future.as_ref().clone(),
-                }
-            }
-            _ => return Err(ChangeAdapterError::InvalidGraphEnvelope),
-        },
-        (None, None, Some(deleted), 1) => match deleted.before() {
-            Some(RecordData::Graph(GraphRecord::Metadata(metadata))) => SourceChange::Delete {
-                metadata: metadata.as_ref().clone(),
-            },
-            Some(RecordData::Graph(GraphRecord::Element(element))) => SourceChange::Delete {
-                metadata: element.get_metadata().clone(),
-            },
-            _ => return Err(ChangeAdapterError::InvalidGraphEnvelope),
-        },
-        _ => return Err(ChangeAdapterError::InvalidGraphEnvelope),
-    };
-
+    let change = source_change_from_envelope(envelope)?;
     let system = envelope.system();
     let source_id = system
         .source_id()
@@ -244,6 +197,58 @@ pub(crate) fn source_event_from_envelope(
         sequence: system.sequence(),
         source_position: system.source_position().cloned(),
     })
+}
+
+pub(crate) fn source_change_from_envelope(
+    envelope: &ChangeEnvelope,
+) -> Result<SourceChange, ChangeAdapterError> {
+    if envelope.change_set().schema().kind() != super::ChangeSchemaKind::GraphChange {
+        return Err(ChangeAdapterError::WrongSchema {
+            expected: "graph-change",
+        });
+    }
+
+    let change_set = envelope.change_set();
+    match (
+        change_set.added().first(),
+        change_set.updated().first(),
+        change_set.deleted().first(),
+        change_set.added().len() + change_set.updated().len() + change_set.deleted().len(),
+    ) {
+        (Some(added), None, None, 1) => match added.after() {
+            RecordData::Graph(GraphRecord::Element(element)) => Ok(SourceChange::Insert {
+                element: element.as_ref().clone(),
+            }),
+            _ => Err(ChangeAdapterError::InvalidGraphEnvelope),
+        },
+        (None, Some(updated), None, 1) => match updated.after() {
+            RecordData::Graph(GraphRecord::Element(element))
+                if updated.semantics() == UpdateSemantics::Patch =>
+            {
+                Ok(SourceChange::Update {
+                    element: element.as_ref().clone(),
+                })
+            }
+            RecordData::Graph(GraphRecord::Future(future))
+                if updated.semantics() == UpdateSemantics::Patch =>
+            {
+                Ok(SourceChange::Future {
+                    future_ref: future.as_ref().clone(),
+                })
+            }
+            _ => Err(ChangeAdapterError::InvalidGraphEnvelope),
+        },
+        (None, None, Some(deleted), 1) => match deleted.before() {
+            Some(RecordData::Graph(GraphRecord::Metadata(metadata))) => Ok(SourceChange::Delete {
+                metadata: metadata.as_ref().clone(),
+            }),
+            Some(RecordData::Graph(GraphRecord::Element(element))) => Ok(SourceChange::Delete {
+                metadata: element.get_metadata().clone(),
+            }),
+            _ => Err(ChangeAdapterError::InvalidGraphEnvelope),
+        },
+        _ => Err(ChangeAdapterError::InvalidGraphEnvelope),
+    }
 }
 
 pub(crate) fn query_evaluation_to_envelope(

--- a/lib/src/change/adapters.rs
+++ b/lib/src/change/adapters.rs
@@ -14,6 +14,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use drasi_core::{
     evaluation::{
@@ -24,7 +25,7 @@ use drasi_core::{
 };
 
 use crate::{
-    channels::{QueryResult, ResultDiff, SourceEvent, SourceEventWrapper},
+    channels::{QueryResult, ResultDiff, SourceEvent, SourceEventParts, SourceEventWrapper},
     profiling::ProfilingMetadata,
 };
 
@@ -104,12 +105,61 @@ pub(crate) fn source_event_to_envelope(
         return Err(ChangeAdapterError::UnsupportedSourceControl);
     };
 
+    source_change_to_envelope(
+        Arc::from(wrapper.source_id.as_str()),
+        change.clone(),
+        wrapper.timestamp,
+        wrapper.profiling.clone(),
+        wrapper.sequence,
+        wrapper.source_position.clone(),
+        extensions,
+    )
+}
+
+pub(crate) fn source_event_parts_to_envelope(
+    parts: SourceEventParts,
+    extensions: SystemMetadataExtensions,
+) -> Result<ChangeEnvelope, ChangeAdapterError> {
+    let SourceEventParts {
+        source_id,
+        event,
+        timestamp,
+        profiling,
+        sequence,
+        source_position,
+    } = parts;
+    let SourceEvent::Change(change) = event else {
+        return Err(ChangeAdapterError::UnsupportedSourceControl);
+    };
+
+    source_change_to_envelope(
+        Arc::from(source_id),
+        change,
+        timestamp,
+        profiling,
+        sequence,
+        source_position,
+        extensions,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn source_change_to_envelope(
+    source_id: Arc<str>,
+    change: SourceChange,
+    timestamp: DateTime<Utc>,
+    profiling: Option<ProfilingMetadata>,
+    sequence: Option<u64>,
+    source_position: Option<Bytes>,
+    extensions: SystemMetadataExtensions,
+) -> Result<ChangeEnvelope, ChangeAdapterError> {
+    let encoded_change = encode_source_change(&change)?;
     let (added, updated, deleted) = match change {
         SourceChange::Insert { element } => (
             vec![AddedRecord::new(
                 0,
                 RecordIdentity::GraphElement(element.get_reference().clone()),
-                RecordData::Graph(GraphRecord::Element(Arc::new(element.clone()))),
+                RecordData::Graph(GraphRecord::Element(Arc::new(element))),
             )],
             vec![],
             vec![],
@@ -120,7 +170,7 @@ pub(crate) fn source_event_to_envelope(
                 0,
                 RecordIdentity::GraphElement(element.get_reference().clone()),
                 None,
-                RecordData::Graph(GraphRecord::Element(Arc::new(element.clone()))),
+                RecordData::Graph(GraphRecord::Element(Arc::new(element))),
                 UpdateSemantics::Patch,
                 UpdateMetadata::None,
             )],
@@ -132,9 +182,7 @@ pub(crate) fn source_event_to_envelope(
             vec![DeletedRecord::new(
                 0,
                 RecordIdentity::GraphElement(metadata.reference.clone()),
-                Some(RecordData::Graph(GraphRecord::Metadata(Arc::new(
-                    metadata.clone(),
-                )))),
+                Some(RecordData::Graph(GraphRecord::Metadata(Arc::new(metadata)))),
             )],
         ),
         SourceChange::Future { future_ref } => (
@@ -143,7 +191,7 @@ pub(crate) fn source_event_to_envelope(
                 0,
                 RecordIdentity::GraphElement(future_ref.element_ref.clone()),
                 None,
-                RecordData::Graph(GraphRecord::Future(Arc::new(future_ref.clone()))),
+                RecordData::Graph(GraphRecord::Future(Arc::new(future_ref))),
                 UpdateSemantics::Patch,
                 UpdateMetadata::None,
             )],
@@ -151,13 +199,12 @@ pub(crate) fn source_event_to_envelope(
         ),
     };
 
-    let encoded_change = encode_source_change(change)?;
     let mut identity = StableIdBuilder::new("drasi.internal.graph-change-set/v1");
-    identity.string("source-id", &wrapper.source_id);
-    identity.optional_u64("sequence", wrapper.sequence);
+    identity.string("source-id", &source_id);
+    identity.optional_u64("sequence", sequence);
     identity.optional_bytes(
         "source-position",
-        wrapper.source_position.as_ref().map(bytes::Bytes::as_ref),
+        source_position.as_ref().map(Bytes::as_ref),
     );
     identity.bytes("source-change", &encoded_change);
     let change_set = ChangeSet::try_new(
@@ -168,12 +215,12 @@ pub(crate) fn source_event_to_envelope(
         deleted,
     )?;
     let system = SystemMetadata::new(
-        Some(Arc::from(wrapper.source_id.as_str())),
+        Some(source_id),
         None,
-        wrapper.sequence,
-        wrapper.source_position.clone(),
-        wrapper.timestamp,
-        wrapper.profiling.clone(),
+        sequence,
+        source_position,
+        timestamp,
+        profiling,
         extensions,
     );
 
@@ -208,7 +255,91 @@ pub(crate) fn source_change_from_envelope(
         });
     }
 
-    let change_set = envelope.change_set();
+    source_change_from_change_set(envelope.change_set())
+}
+
+pub(crate) fn source_change_from_envelope_owned(
+    envelope: ChangeEnvelope,
+) -> Result<SourceChange, ChangeAdapterError> {
+    if envelope.change_set().schema().kind() != super::ChangeSchemaKind::GraphChange {
+        return Err(ChangeAdapterError::WrongSchema {
+            expected: "graph-change",
+        });
+    }
+
+    let change_set = envelope.into_change_set();
+    let change_set = match Arc::try_unwrap(change_set) {
+        Ok(change_set) => change_set,
+        Err(shared) => return source_change_from_change_set(&shared),
+    };
+
+    // Clone only an Arc-backed record handle, then drop the sole-owned set so
+    // the graph payload itself can be unwrapped without a deep clone.
+    match (
+        change_set.added().len(),
+        change_set.updated().len(),
+        change_set.deleted().len(),
+    ) {
+        (1, 0, 0) => {
+            let after = change_set.added()[0].after().clone();
+            drop(change_set);
+            match after {
+                RecordData::Graph(GraphRecord::Element(element)) => Ok(SourceChange::Insert {
+                    element: unwrap_or_clone(element),
+                }),
+                _ => Err(ChangeAdapterError::InvalidGraphEnvelope),
+            }
+        }
+        (0, 1, 0) => {
+            let updated = &change_set.updated()[0];
+            let semantics = updated.semantics();
+            let after = updated.after().clone();
+            drop(change_set);
+            match (after, semantics) {
+                (RecordData::Graph(GraphRecord::Element(element)), UpdateSemantics::Patch) => {
+                    Ok(SourceChange::Update {
+                        element: unwrap_or_clone(element),
+                    })
+                }
+                (RecordData::Graph(GraphRecord::Future(future)), UpdateSemantics::Patch) => {
+                    Ok(SourceChange::Future {
+                        future_ref: unwrap_or_clone(future),
+                    })
+                }
+                _ => Err(ChangeAdapterError::InvalidGraphEnvelope),
+            }
+        }
+        (0, 0, 1) => {
+            let before = change_set.deleted()[0].before().cloned();
+            drop(change_set);
+            match before {
+                Some(RecordData::Graph(GraphRecord::Metadata(metadata))) => {
+                    Ok(SourceChange::Delete {
+                        metadata: unwrap_or_clone(metadata),
+                    })
+                }
+                Some(RecordData::Graph(GraphRecord::Element(element))) => {
+                    Ok(SourceChange::Delete {
+                        metadata: element.get_metadata().clone(),
+                    })
+                }
+                _ => Err(ChangeAdapterError::InvalidGraphEnvelope),
+            }
+        }
+        _ => Err(ChangeAdapterError::InvalidGraphEnvelope),
+    }
+}
+
+fn unwrap_or_clone<T: Clone>(value: Arc<T>) -> T {
+    match Arc::try_unwrap(value) {
+        Ok(value) => value,
+        Err(shared) => shared.as_ref().clone(),
+    }
+}
+
+fn source_change_from_change_set(
+    change_set: &ChangeSet,
+) -> Result<SourceChange, ChangeAdapterError> {
     match (
         change_set.added().first(),
         change_set.updated().first(),

--- a/lib/src/change/canonical.rs
+++ b/lib/src/change/canonical.rs
@@ -330,13 +330,10 @@ impl CanonicalEncoder {
         &mut self,
         value: &ElementPropertyMap,
     ) -> Result<(), CanonicalEncodingError> {
-        let entries: Vec<_> = value
-            .map_iter(|key, value| (key.clone(), value.clone()))
-            .collect();
-        self.length(entries.len());
-        for (key, value) in entries {
-            self.string(&key);
-            self.element_value(&value)?;
+        self.length(value.len());
+        for (key, value) in value.iter() {
+            self.string(key);
+            self.element_value(value)?;
         }
         Ok(())
     }

--- a/lib/src/change/mod.rs
+++ b/lib/src/change/mod.rs
@@ -14,15 +14,16 @@
 
 //! Internal immutable change contracts.
 //!
-//! These types intentionally remain crate-private. The compatibility adapters are
-//! not connected to the live pipeline until the next migration layer.
+//! These types intentionally remain crate-private. The fixed query pipeline uses
+//! compatibility adapters at its ingress and egress boundaries.
 
 mod adapters;
 mod canonical;
 
 pub(crate) use adapters::{
-    query_evaluation_to_envelope, query_result_from_envelope, source_event_from_envelope,
-    source_event_to_envelope, ChangeAdapterError, QueryEnvelopeMetadata,
+    query_evaluation_to_envelope, query_result_from_envelope, source_change_from_envelope,
+    source_event_from_envelope, source_event_to_envelope, ChangeAdapterError,
+    QueryEnvelopeMetadata,
 };
 #[cfg(test)]
 pub(crate) use canonical::{encode_query_variables, encode_source_change};

--- a/lib/src/change/mod.rs
+++ b/lib/src/change/mod.rs
@@ -22,8 +22,8 @@ mod canonical;
 
 pub(crate) use adapters::{
     query_evaluation_to_envelope, query_result_from_envelope, source_change_from_envelope,
-    source_event_from_envelope, source_event_to_envelope, ChangeAdapterError,
-    QueryEnvelopeMetadata,
+    source_change_from_envelope_owned, source_event_from_envelope, source_event_parts_to_envelope,
+    source_event_to_envelope, ChangeAdapterError, QueryEnvelopeMetadata,
 };
 #[cfg(test)]
 pub(crate) use canonical::{encode_query_variables, encode_source_change};
@@ -634,6 +634,10 @@ impl SystemMetadata {
         self.source_id.as_deref()
     }
 
+    pub(crate) fn source_id_arc(&self) -> Option<&Arc<str>> {
+        self.source_id.as_ref()
+    }
+
     pub(crate) fn query_id(&self) -> Option<&str> {
         self.query_id.as_deref()
     }
@@ -859,6 +863,10 @@ impl ChangeEnvelope {
 
     pub(crate) fn change_set(&self) -> &ChangeSetRef {
         &self.change_set
+    }
+
+    pub(crate) fn into_change_set(self) -> ChangeSetRef {
+        self.change_set
     }
 
     pub(crate) fn context(&self) -> &ProcessingContext {

--- a/lib/src/change/tests.rs
+++ b/lib/src/change/tests.rs
@@ -154,6 +154,90 @@ fn append_only_inputs_use_only_added_records() {
 }
 
 #[test]
+fn owned_graph_envelope_path_moves_the_element_without_fallback_cloning() {
+    let input = Arc::new(wrapper(SourceChange::Insert {
+        element: element(
+            ElementPropertyMap::from(json!({
+                "payload": {
+                    "name": "Alice",
+                    "tags": ["one", "two", "three"],
+                }
+            })),
+            1_000,
+        ),
+    }));
+    let original_property_address = match &input.event {
+        SourceEvent::Change(SourceChange::Insert { element }) => {
+            std::ptr::from_ref(element.get_property("payload")).addr()
+        }
+        _ => unreachable!("test input is an insert"),
+    };
+
+    let parts = SourceEventWrapper::try_unwrap_arc(input)
+        .expect("the sole-owned source wrapper should move into parts");
+    let envelope =
+        source_event_parts_to_envelope(parts, SystemMetadataExtensions::default()).unwrap();
+    assert_eq!(Arc::strong_count(envelope.change_set()), 1);
+    let RecordData::Graph(GraphRecord::Element(stored)) = envelope.change_set().added()[0].after()
+    else {
+        panic!("owned insert should remain a typed element");
+    };
+    assert_eq!(Arc::strong_count(stored), 1);
+    assert_eq!(
+        std::ptr::from_ref(stored.get_property("payload")).addr(),
+        original_property_address,
+        "moving SourceEventParts into the envelope must retain the property allocation"
+    );
+
+    let recovered = source_change_from_envelope_owned(envelope).unwrap();
+    let SourceChange::Insert { element } = recovered else {
+        panic!("owned graph envelope should recover the insert");
+    };
+    assert_eq!(
+        std::ptr::from_ref(element.get_property("payload")).addr(),
+        original_property_address,
+        "the sole-owned envelope must unwrap its element instead of deep-cloning it"
+    );
+}
+
+#[test]
+fn owned_graph_envelope_path_roundtrips_every_change_variant() {
+    let metadata = ElementMetadata {
+        reference: ElementReference::new("source-a", "person-1"),
+        labels: vec!["Person".into()].into(),
+        effective_from: 3_000,
+    };
+    let changes = [
+        SourceChange::Update {
+            element: element(ElementPropertyMap::from(json!({ "name": "Alicia" })), 2_000),
+        },
+        SourceChange::Delete {
+            metadata: metadata.clone(),
+        },
+        SourceChange::Future {
+            future_ref: FutureElementRef {
+                element_ref: metadata.reference,
+                original_time: 3_000,
+                due_time: 4_000,
+                group_signature: 55,
+            },
+        },
+    ];
+
+    for expected in changes {
+        let envelope = source_event_parts_to_envelope(
+            wrapper(expected.clone()).into_parts(),
+            SystemMetadataExtensions::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            source_change_from_envelope_owned(envelope).unwrap(),
+            expected
+        );
+    }
+}
+
+#[test]
 fn graph_updates_and_deletes_roundtrip_with_explicit_semantics() {
     let update_input = wrapper(SourceChange::Update {
         element: element(ElementPropertyMap::from(json!({ "name": "Alicia" })), 2_000),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -62,9 +62,6 @@ pub mod recovery;
 // Internal Modules (crate-private, but visible to integration tests)
 // ============================================================================
 
-// Introduced ahead of pipeline wiring so the compatibility adapters can be reviewed
-// independently from the runtime behavior change.
-#[allow(dead_code)]
 pub(crate) mod change;
 
 // These modules are internal but need to be accessible to integration tests

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -268,8 +268,8 @@ enum BootstrapPhase {
 /// Dispatch query evaluation results to the current result set and all subscribed reactions.
 ///
 /// Shared between the regular event processing path and the future queue drain path.
-/// Uses `QueryOutputState` for O(1) result-set updates keyed by `row_signature`,
-/// increments the sequence counter, and pushes to the outbox ring buffer.
+/// Converts the core evaluation into a typed change envelope before exposing the
+/// legacy `QueryResult`, then updates `QueryOutputState` and the outbox.
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_query_results(
     results: &[QueryPartEvaluationContext],
@@ -283,96 +283,49 @@ async fn dispatch_query_results(
     outbox_capacity: usize,
     profiling: crate::profiling::ProfilingMetadata,
     output_metrics: &Arc<QueryOutputMetrics>,
-) {
-    // Convert Drasi results to our QueryResult format, filtering out Noops
-    let converted_results: Vec<ResultDiff> = results
+) -> Result<()> {
+    let result_count = results
         .iter()
-        .filter_map(|ctx| match ctx {
-            QueryPartEvaluationContext::Adding {
-                after,
-                row_signature,
-            } => Some(ResultDiff::Add {
-                data: convert_query_variables_to_json(after),
-                row_signature: *row_signature,
-            }),
-            QueryPartEvaluationContext::Removing {
-                before,
-                row_signature,
-            } => Some(ResultDiff::Delete {
-                data: convert_query_variables_to_json(before),
-                row_signature: *row_signature,
-            }),
-            QueryPartEvaluationContext::Updating {
-                before,
-                after,
-                row_signature,
-            } => {
-                let after_json = convert_query_variables_to_json(after);
-                Some(ResultDiff::Update {
-                    data: after_json.clone(),
-                    before: convert_query_variables_to_json(before),
-                    after: after_json,
-                    grouping_keys: None,
-                    row_signature: *row_signature,
-                })
-            }
-            // NOTE: When a group empties (last contributor removed), core emits
-            // Aggregation { default_after: true, .. } with identity values (count:0,
-            // sum:0, etc.) rather than Removing. Proper empty-group → Delete detection
-            // requires core-level `is_at_identity()` on each accumulator (see PR #409).
-            // Without that infrastructure, this conversion preserves current behavior:
-            // the row stays in the result set with zeroed-out values.
-            QueryPartEvaluationContext::Aggregation {
-                before,
-                after,
-                row_signature,
-                ..
-            } => Some(ResultDiff::Aggregation {
-                before: before.as_ref().map(convert_query_variables_to_json),
-                after: convert_query_variables_to_json(after),
-                row_signature: *row_signature,
-            }),
-            QueryPartEvaluationContext::Noop => None,
-        })
-        .collect();
+        .filter(|result| !matches!(result, QueryPartEvaluationContext::Noop))
+        .count();
 
-    // If all results were Noops, skip outbox/sequence advancement and dispatch
-    if converted_results.is_empty() {
-        return;
-    }
-
-    // Apply diffs to the output state, build QueryResult, increment sequence,
-    // push to outbox, and get back the Arc for zero-copy dispatch — all in one
-    // write-lock acquisition.
+    // Build the typed envelope and adapt it to the legacy output while holding the
+    // state lock so the envelope carries the exact sequence assigned to this result.
     let arc_result = {
         let tx_start = std::time::Instant::now();
         let mut state = output_state.write().await;
-        state.apply_diffs(&converted_results);
-
-        let result_count = converted_results.len();
-        let query_result = QueryResult::with_profiling(
-            query_id.to_string(),
-            0, // sequence assigned by advance_sequence_and_push
-            chrono::Utc::now(),
-            converted_results,
-            {
-                let mut meta = HashMap::new();
-                meta.insert(
-                    "source_id".to_string(),
-                    serde_json::Value::String(source_id.to_string()),
-                );
-                meta.insert(
-                    "processed_by".to_string(),
-                    serde_json::Value::String("drasi-core".to_string()),
-                );
-                meta.insert(
-                    "result_count".to_string(),
-                    serde_json::Value::Number(result_count.into()),
-                );
-                meta
-            },
-            profiling,
+        let next_sequence = state.as_of_sequence().saturating_add(1);
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "source_id".to_string(),
+            serde_json::Value::String(source_id.to_string()),
         );
+        metadata.insert(
+            "processed_by".to_string(),
+            serde_json::Value::String("drasi-core".to_string()),
+        );
+        metadata.insert(
+            "result_count".to_string(),
+            serde_json::Value::Number(result_count.into()),
+        );
+
+        let Some(envelope) = crate::change::query_evaluation_to_envelope(
+            results,
+            crate::change::QueryEnvelopeMetadata::new(
+                query_id,
+                Some(Arc::from(source_id)),
+                next_sequence,
+                chrono::Utc::now(),
+                metadata,
+                Some(profiling),
+            ),
+        )?
+        else {
+            return Ok(());
+        };
+        let query_result = crate::change::query_result_from_envelope(&envelope)?;
+        debug_assert_eq!(query_result.sequence, next_sequence);
+        state.apply_diffs(&query_result.results);
 
         let result = state.advance_sequence_and_push(query_result);
 
@@ -522,6 +475,8 @@ async fn dispatch_query_results(
             debug!("Failed to dispatch result for query '{query_id}': {e}");
         }
     }
+
+    Ok(())
 }
 
 pub struct DrasiQuery {
@@ -2183,8 +2138,48 @@ impl Query for DrasiQuery {
 
                         // Dequeue events from priority queue (blocks until available)
                         arc_event = priority_queue.dequeue() => {
-                            // Try to extract without cloning if we have sole ownership (zero-copy path).
-                            let parts =
+                            let parts = if matches!(&arc_event.event, SourceEvent::Change(_)) {
+                                let envelope = match crate::change::source_event_to_envelope(
+                                    arc_event.as_ref(),
+                                    crate::change::SystemMetadataExtensions::default(),
+                                ) {
+                                    Ok(envelope) => envelope,
+                                    Err(e) => {
+                                        error!(
+                                            "Query '{query_id}' failed to adapt source event to a change envelope: {e}"
+                                        );
+                                        continue;
+                                    }
+                                };
+                                let source_change =
+                                    match crate::change::source_change_from_envelope(&envelope) {
+                                        Ok(change) => change,
+                                        Err(e) => {
+                                            error!(
+                                                "Query '{query_id}' failed to read graph change envelope: {e}"
+                                            );
+                                            continue;
+                                        }
+                                    };
+                                let system = envelope.system();
+                                let Some(source_id) = system.source_id() else {
+                                    error!(
+                                        "Query '{query_id}' received a graph change envelope without a source ID"
+                                    );
+                                    continue;
+                                };
+
+                                crate::channels::events::SourceEventParts {
+                                    source_id: source_id.to_string(),
+                                    event: SourceEvent::Change(source_change),
+                                    timestamp: system.timestamp(),
+                                    profiling: system.profiling().cloned(),
+                                    sequence: system.sequence(),
+                                    source_position: system.source_position().cloned(),
+                                }
+                            } else {
+                                // Control events stay on the legacy path and retain their
+                                // priority-queue ordering.
                                 match SourceEventWrapper::try_unwrap_arc(arc_event) {
                                     Ok(parts) => parts,
                                     Err(arc) => {
@@ -2197,7 +2192,8 @@ impl Query for DrasiQuery {
                                             source_position: arc.source_position.clone(),
                                         }
                                     }
-                                };
+                                }
+                            };
                             let source_id = parts.source_id;
                             let event = parts.event;
                             let profiling_opt = parts.profiling;
@@ -2224,7 +2220,7 @@ impl Query for DrasiQuery {
                                             Ok(Some(due_result)) => {
                                                 if !due_result.results.is_empty() {
                                                     let profiling = crate::profiling::ProfilingMetadata::new();
-                                                    dispatch_query_results(
+                                                    if let Err(e) = dispatch_query_results(
                                                         &due_result.results,
                                                         &due_result.source_id,
                                                         &query_id,
@@ -2237,7 +2233,12 @@ impl Query for DrasiQuery {
                                                         profiling,
                                                         &output_metrics_for_processor,
                                                     )
-                                                    .await;
+                                                    .await
+                                                    {
+                                                        error!(
+                                                            "Query '{query_id}' failed to adapt due-future results: {e}"
+                                                        );
+                                                    }
                                                 }
                                             }
                                             Ok(None) => break,
@@ -2296,7 +2297,7 @@ impl Query for DrasiQuery {
 
                                             if !results.is_empty() {
                                                 profiling.query_send_ns = Some(crate::profiling::timestamp_ns());
-                                                dispatch_query_results(
+                                                if let Err(e) = dispatch_query_results(
                                                     &results,
                                                     &source_id,
                                                     &query_id,
@@ -2309,7 +2310,12 @@ impl Query for DrasiQuery {
                                                     profiling,
                                                     &output_metrics_for_processor,
                                                 )
-                                                .await;
+                                                .await
+                                                {
+                                                    error!(
+                                                        "Query '{query_id}' failed to adapt query results: {e}"
+                                                    );
+                                                }
                                             }
                                         }
                                         Err(e) => {

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -288,46 +288,51 @@ async fn dispatch_query_results(
         .iter()
         .filter(|result| !matches!(result, QueryPartEvaluationContext::Noop))
         .count();
+    if result_count == 0 {
+        return Ok(());
+    }
 
-    // Build the typed envelope and adapt it to the legacy output while holding the
-    // state lock so the envelope carries the exact sequence assigned to this result.
-    let arc_result = {
-        let tx_start = std::time::Instant::now();
-        let mut state = output_state.write().await;
-        let next_sequence = state.as_of_sequence().saturating_add(1);
-        let mut metadata = HashMap::new();
-        metadata.insert(
-            "source_id".to_string(),
-            serde_json::Value::String(source_id.to_string()),
-        );
-        metadata.insert(
-            "processed_by".to_string(),
-            serde_json::Value::String("drasi-core".to_string()),
-        );
-        metadata.insert(
-            "result_count".to_string(),
-            serde_json::Value::Number(result_count.into()),
-        );
+    let tx_start = std::time::Instant::now();
+    let query_identity = Arc::<str>::from(query_id);
+    let source_identity = Arc::<str>::from(source_id);
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "source_id".to_string(),
+        serde_json::Value::String(source_id.to_string()),
+    );
+    metadata.insert(
+        "processed_by".to_string(),
+        serde_json::Value::String("drasi-core".to_string()),
+    );
+    metadata.insert(
+        "result_count".to_string(),
+        serde_json::Value::Number(result_count.into()),
+    );
 
-        let Some(envelope) = crate::change::query_evaluation_to_envelope(
+    // Canonicalization and legacy JSON projection happen outside the write lock.
+    // If another writer advances the sequence before commit, rebuild against the
+    // new sequence and retry without changing state.
+    let arc_result = loop {
+        let expected_sequence = output_state.read().await.next_sequence();
+        let envelope = crate::change::query_evaluation_to_envelope(
             results,
             crate::change::QueryEnvelopeMetadata::new(
-                query_id,
-                Some(Arc::from(source_id)),
-                next_sequence,
+                query_identity.clone(),
+                Some(source_identity.clone()),
+                expected_sequence,
                 chrono::Utc::now(),
-                metadata,
-                Some(profiling),
+                metadata.clone(),
+                Some(profiling.clone()),
             ),
         )?
-        else {
-            return Ok(());
-        };
+        .ok_or_else(|| anyhow::anyhow!("non-Noop query evaluation produced no change envelope"))?;
         let query_result = crate::change::query_result_from_envelope(&envelope)?;
-        debug_assert_eq!(query_result.sequence, next_sequence);
-        state.apply_diffs(&query_result.results);
 
-        let result = state.advance_sequence_and_push(query_result);
+        let mut state = output_state.write().await;
+        let result = match state.try_apply_prepared_result(query_result) {
+            Some(result) => result,
+            None => continue,
+        };
 
         // Update query output metrics
         let duration_ns = u64::try_from(tx_start.elapsed().as_nanos()).unwrap_or(u64::MAX);
@@ -337,7 +342,7 @@ async fn dispatch_query_results(
         let earliest_seq = state.outbox_earliest_seq().unwrap_or(0);
         output_metrics.update_outbox(state.outbox_len(), earliest_seq, state.as_of_sequence());
 
-        result
+        break result;
     };
 
     // Persist to outbox and live results writers if available (best-effort).
@@ -2138,11 +2143,22 @@ impl Query for DrasiQuery {
 
                         // Dequeue events from priority queue (blocks until available)
                         arc_event = priority_queue.dequeue() => {
-                            let parts = if matches!(&arc_event.event, SourceEvent::Change(_)) {
-                                let envelope = match crate::change::source_event_to_envelope(
-                                    arc_event.as_ref(),
-                                    crate::change::SystemMetadataExtensions::default(),
-                                ) {
+                            let (source_id, event, profiling_opt, sequence, source_position) =
+                                if matches!(&arc_event.event, SourceEvent::Change(_)) {
+                                // Move sole-owned channel events through the envelope. Shared
+                                // broadcast events retain the existing single-clone fallback.
+                                let envelope_result =
+                                    match SourceEventWrapper::try_unwrap_arc(arc_event) {
+                                        Ok(parts) => crate::change::source_event_parts_to_envelope(
+                                            parts,
+                                            crate::change::SystemMetadataExtensions::default(),
+                                        ),
+                                        Err(shared) => crate::change::source_event_to_envelope(
+                                            shared.as_ref(),
+                                            crate::change::SystemMetadataExtensions::default(),
+                                        ),
+                                    };
+                                let envelope = match envelope_result {
                                     Ok(envelope) => envelope,
                                     Err(e) => {
                                         error!(
@@ -2151,36 +2167,41 @@ impl Query for DrasiQuery {
                                         continue;
                                     }
                                 };
-                                let source_change =
-                                    match crate::change::source_change_from_envelope(&envelope) {
-                                        Ok(change) => change,
-                                        Err(e) => {
-                                            error!(
-                                                "Query '{query_id}' failed to read graph change envelope: {e}"
-                                            );
-                                            continue;
-                                        }
+                                let (source_id, profiling, sequence, source_position) = {
+                                    let system = envelope.system();
+                                    let Some(source_id) = system.source_id_arc().cloned() else {
+                                        error!(
+                                            "Query '{query_id}' received a graph change envelope without a source ID"
+                                        );
+                                        continue;
                                     };
-                                let system = envelope.system();
-                                let Some(source_id) = system.source_id() else {
-                                    error!(
-                                        "Query '{query_id}' received a graph change envelope without a source ID"
-                                    );
-                                    continue;
+                                    (
+                                        source_id,
+                                        system.profiling().cloned(),
+                                        system.sequence(),
+                                        system.source_position().cloned(),
+                                    )
                                 };
-
-                                crate::channels::events::SourceEventParts {
-                                    source_id: source_id.to_string(),
-                                    event: SourceEvent::Change(source_change),
-                                    timestamp: system.timestamp(),
-                                    profiling: system.profiling().cloned(),
-                                    sequence: system.sequence(),
-                                    source_position: system.source_position().cloned(),
-                                }
+                                let source_change = match crate::change::source_change_from_envelope_owned(envelope) {
+                                    Ok(change) => change,
+                                    Err(e) => {
+                                        error!(
+                                            "Query '{query_id}' failed to read graph change envelope: {e}"
+                                        );
+                                        continue;
+                                    }
+                                };
+                                (
+                                    source_id,
+                                    SourceEvent::Change(source_change),
+                                    profiling,
+                                    sequence,
+                                    source_position,
+                                )
                             } else {
                                 // Control events stay on the legacy path and retain their
                                 // priority-queue ordering.
-                                match SourceEventWrapper::try_unwrap_arc(arc_event) {
+                                let parts = match SourceEventWrapper::try_unwrap_arc(arc_event) {
                                     Ok(parts) => parts,
                                     Err(arc) => {
                                         crate::channels::events::SourceEventParts {
@@ -2192,22 +2213,24 @@ impl Query for DrasiQuery {
                                             source_position: arc.source_position.clone(),
                                         }
                                     }
-                                }
+                                };
+                                (
+                                    Arc::<str>::from(parts.source_id),
+                                    parts.event,
+                                    parts.profiling,
+                                    parts.sequence,
+                                    parts.source_position,
+                                )
                             };
-                            let source_id = parts.source_id;
-                            let event = parts.event;
-                            let profiling_opt = parts.profiling;
-                            let sequence = parts.sequence;
-                            let source_position = parts.source_position;
 
                             debug!("Query '{query_id}' processing event from source '{source_id}'");
 
                             // Dedup: skip events already processed for this source
-                            if dedup.should_skip(&source_id, sequence) {
+                            if dedup.should_skip(source_id.as_ref(), sequence) {
                                 debug!(
                                     "Query '{query_id}' skipping duplicate event from '{source_id}' (seq={seq}, checkpoint={cp})",
                                     seq = sequence.unwrap_or(0),
-                                    cp = dedup.checkpoint_for(&source_id).unwrap_or(0)
+                                    cp = dedup.checkpoint_for(source_id.as_ref()).unwrap_or(0)
                                 );
                                 continue;
                             }
@@ -2272,7 +2295,7 @@ impl Query for DrasiQuery {
                                                     _ => None,
                                                 };
                                                 cp_store
-                                                    .stage_checkpoint(&cp_source_id, seq, pos_ref)
+                                                    .stage_checkpoint(cp_source_id.as_ref(), seq, pos_ref)
                                                     .await?;
                                             }
                                             Ok(())
@@ -2288,9 +2311,9 @@ impl Query for DrasiQuery {
 
                                             // Advance dedup and notify source on successful commit
                                             if let Some(seq) = sequence {
-                                                dedup.advance(&source_id, seq);
+                                                dedup.advance(source_id.as_ref(), seq);
 
-                                                if let Some(handle) = position_handles_for_processor.get(&source_id) {
+                                                if let Some(handle) = position_handles_for_processor.get(source_id.as_ref()) {
                                                     handle.store(seq, std::sync::atomic::Ordering::Release);
                                                 }
                                             }
@@ -2299,7 +2322,7 @@ impl Query for DrasiQuery {
                                                 profiling.query_send_ns = Some(crate::profiling::timestamp_ns());
                                                 if let Err(e) = dispatch_query_results(
                                                     &results,
-                                                    &source_id,
+                                                    source_id.as_ref(),
                                                     &query_id,
                                                     &output_state,
                                                     &base_dispatchers,

--- a/lib/src/queries/manager/pipeline_characterization_tests.rs
+++ b/lib/src/queries/manager/pipeline_characterization_tests.rs
@@ -496,11 +496,12 @@ impl CharacterizationSource {
         }
     }
 
-    async fn inject(
+    async fn inject_with_profiling(
         &self,
         change: SourceChange,
         sequence: u64,
         source_position: Bytes,
+        profiling: ProfilingMetadata,
     ) -> anyhow::Result<()> {
         let timestamp =
             chrono::DateTime::from_timestamp_millis(change.get_realtime() as i64).unwrap();
@@ -509,7 +510,7 @@ impl CharacterizationSource {
             SourceEvent::Change(change),
             timestamp,
             sequence,
-            Some(ProfilingMetadata::default()),
+            Some(profiling),
         );
         event.set_source_position(source_position);
         self.base.dispatch_event(event).await
@@ -696,6 +697,22 @@ impl PipelineHarness {
     }
 
     async fn inject(&self, change: SourceChange, sequence: u64, source_position: Bytes) {
+        self.inject_with_profiling(
+            change,
+            sequence,
+            source_position,
+            ProfilingMetadata::default(),
+        )
+        .await;
+    }
+
+    async fn inject_with_profiling(
+        &self,
+        change: SourceChange,
+        sequence: u64,
+        source_position: Bytes,
+        profiling: ProfilingMetadata,
+    ) {
         let source = self
             .source_manager
             .get_source_instance(SOURCE_ID)
@@ -705,7 +722,7 @@ impl PipelineHarness {
             .as_any()
             .downcast_ref::<CharacterizationSource>()
             .unwrap()
-            .inject(change, sequence, source_position)
+            .inject_with_profiling(change, sequence, source_position, profiling)
             .await
             .unwrap();
     }
@@ -754,6 +771,53 @@ fn variables(entries: &[(&str, VariableValue)]) -> QueryVariables {
     entries
         .iter()
         .map(|(key, value)| ((*key).into(), value.clone()))
+        .collect()
+}
+
+fn legacy_result_diffs(results: &[QueryPartEvaluationContext]) -> Vec<ResultDiff> {
+    results
+        .iter()
+        .filter_map(|context| match context {
+            QueryPartEvaluationContext::Adding {
+                after,
+                row_signature,
+            } => Some(ResultDiff::Add {
+                data: convert_query_variables_to_json(after),
+                row_signature: *row_signature,
+            }),
+            QueryPartEvaluationContext::Updating {
+                before,
+                after,
+                row_signature,
+            } => {
+                let after = convert_query_variables_to_json(after);
+                Some(ResultDiff::Update {
+                    data: after.clone(),
+                    before: convert_query_variables_to_json(before),
+                    after,
+                    grouping_keys: None,
+                    row_signature: *row_signature,
+                })
+            }
+            QueryPartEvaluationContext::Removing {
+                before,
+                row_signature,
+            } => Some(ResultDiff::Delete {
+                data: convert_query_variables_to_json(before),
+                row_signature: *row_signature,
+            }),
+            QueryPartEvaluationContext::Aggregation {
+                before,
+                after,
+                row_signature,
+                ..
+            } => Some(ResultDiff::Aggregation {
+                before: before.as_ref().map(convert_query_variables_to_json),
+                after: convert_query_variables_to_json(after),
+                row_signature: *row_signature,
+            }),
+            QueryPartEvaluationContext::Noop => None,
+        })
         .collect()
 }
 
@@ -823,7 +887,8 @@ async fn evaluation_results_map_to_ordered_query_result_and_sequence() {
         ProfilingMetadata::default(),
         &output_metrics,
     )
-    .await;
+    .await
+    .unwrap();
 
     let result = next_result(&mut result_rx).await;
     assert_eq!(result.query_id, "query-a");
@@ -921,7 +986,8 @@ async fn evaluation_results_map_to_ordered_query_result_and_sequence() {
         ProfilingMetadata::default(),
         &output_metrics,
     )
-    .await;
+    .await
+    .unwrap();
 
     let second = next_result(&mut result_rx).await;
     assert_eq!(second.sequence, 2);
@@ -936,6 +1002,116 @@ async fn evaluation_results_map_to_ordered_query_result_and_sequence() {
             .collect::<Vec<_>>(),
         vec![1, 2]
     );
+}
+
+#[tokio::test]
+async fn live_source_change_envelope_path_preserves_legacy_result_metadata() {
+    let backend = Arc::new(CharacterizationBackend::new(false));
+    let mut harness = PipelineHarness::new(backend.clone()).await;
+    let (query, mut result_rx) = harness.start_query(backend.trace.clone()).await;
+    let subscription = harness.next_subscription().await;
+    assert_eq!(subscription.resume_sequence, None);
+    assert_eq!(subscription.resume_from, None);
+    backend.trace.clear();
+
+    let source_position = Bytes::from_static(b"envelope-position-7");
+    let source_profiling = ProfilingMetadata {
+        source_ns: Some(10),
+        reactivator_start_ns: Some(20),
+        reactivator_end_ns: Some(30),
+        source_receive_ns: Some(40),
+        source_send_ns: Some(50),
+        ..Default::default()
+    };
+    harness
+        .inject_with_profiling(
+            person_insert("person-envelope", "Envelope", 1_000),
+            7,
+            source_position.clone(),
+            source_profiling.clone(),
+        )
+        .await;
+
+    let delivered = next_result(&mut result_rx).await;
+    assert_eq!(delivered.query_id, QUERY_ID);
+    assert_eq!(delivered.sequence, 1);
+    assert_eq!(delivered.results.len(), 1);
+    assert!(matches!(
+        &delivered.results[0],
+        ResultDiff::Add { data, .. } if data == &json!({ "name": "Envelope" })
+    ));
+    assert_eq!(
+        delivered.metadata,
+        HashMap::from([
+            ("source_id".to_string(), json!(SOURCE_ID)),
+            ("processed_by".to_string(), json!("drasi-core")),
+            ("result_count".to_string(), json!(1)),
+        ])
+    );
+
+    let delivered_profiling = delivered
+        .profiling
+        .as_ref()
+        .expect("live results retain source profiling");
+    assert_eq!(delivered_profiling.source_ns, source_profiling.source_ns);
+    assert_eq!(
+        delivered_profiling.reactivator_start_ns,
+        source_profiling.reactivator_start_ns
+    );
+    assert_eq!(
+        delivered_profiling.reactivator_end_ns,
+        source_profiling.reactivator_end_ns
+    );
+    assert_eq!(
+        delivered_profiling.source_receive_ns,
+        source_profiling.source_receive_ns
+    );
+    assert_eq!(
+        delivered_profiling.source_send_ns,
+        source_profiling.source_send_ns
+    );
+    assert!(delivered_profiling.query_receive_ns.is_some());
+    assert!(delivered_profiling.query_core_call_ns.is_some());
+    assert!(delivered_profiling.query_core_return_ns.is_some());
+    assert!(delivered_profiling.query_send_ns.is_some());
+
+    assert_eq!(
+        backend.trace.snapshot(),
+        vec![
+            TraceEvent::SessionBegin,
+            TraceEvent::CheckpointStaged {
+                source_id: SOURCE_ID.to_string(),
+                sequence: 7,
+                source_position: Some(source_position),
+            },
+            TraceEvent::SessionCommit,
+            TraceEvent::OutboxAppendAttempt {
+                query_id: QUERY_ID.to_string(),
+                sequence: 1,
+            },
+            TraceEvent::LiveResultsApplyAttempt {
+                query_id: QUERY_ID.to_string(),
+                mutation_count: 1,
+            },
+            TraceEvent::ResultSequenceWritten {
+                query_id: QUERY_ID.to_string(),
+                sequence: 1,
+            },
+            TraceEvent::ReactionDispatch { sequence: 1 },
+        ]
+    );
+    assert_eq!(
+        backend.output_store.read_from(QUERY_ID, 0).await.unwrap()[0].1,
+        rmp_serde::to_vec(delivered.as_ref()).unwrap()
+    );
+
+    query.stop().await.unwrap();
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .unwrap();
+    drop(harness.graph);
 }
 
 #[tokio::test]
@@ -1191,6 +1367,13 @@ async fn due_future_output_is_dispatched_after_core_commit() {
     let live_results_writer: Option<Arc<dyn LiveResultsWriter>> = Some(output_store);
     let checkpoint_writer: Option<Arc<dyn CheckpointStore>> = Some(checkpoint_store);
 
+    let profiling = ProfilingMetadata {
+        source_ns: Some(101),
+        source_receive_ns: Some(202),
+        source_send_ns: Some(303),
+        ..Default::default()
+    };
+    let expected_results = legacy_result_diffs(&due.results);
     dispatch_query_results(
         &due.results,
         &due.source_id,
@@ -1201,12 +1384,24 @@ async fn due_future_output_is_dispatched_after_core_commit() {
         &live_results_writer,
         &checkpoint_writer,
         16,
-        ProfilingMetadata::default(),
+        profiling.clone(),
         &output_metrics,
     )
-    .await;
+    .await
+    .unwrap();
     let dispatched = next_result(&mut result_rx).await;
-    assert_eq!(dispatched.metadata["source_id"], json!("future-source"));
+    assert_eq!(dispatched.query_id, "future-query");
+    assert_eq!(dispatched.sequence, 1);
+    assert_eq!(dispatched.results, expected_results);
+    assert_eq!(
+        dispatched.metadata,
+        HashMap::from([
+            ("source_id".to_string(), json!("future-source")),
+            ("processed_by".to_string(), json!("drasi-core")),
+            ("result_count".to_string(), json!(dispatched.results.len()),),
+        ])
+    );
+    assert_eq!(dispatched.profiling, Some(profiling));
     assert_eq!(
         trace.snapshot(),
         vec![

--- a/lib/src/queries/manager/pipeline_characterization_tests.rs
+++ b/lib/src/queries/manager/pipeline_characterization_tests.rs
@@ -1002,6 +1002,31 @@ async fn evaluation_results_map_to_ordered_query_result_and_sequence() {
             .collect::<Vec<_>>(),
         vec![1, 2]
     );
+
+    dispatch_query_results(
+        &[QueryPartEvaluationContext::Noop],
+        "source-c",
+        "query-a",
+        &output_state,
+        &dispatchers,
+        &outbox_writer,
+        &live_results_writer,
+        &checkpoint_writer,
+        16,
+        ProfilingMetadata::default(),
+        &output_metrics,
+    )
+    .await
+    .unwrap();
+
+    let state = output_state.read().await;
+    assert_eq!(state.as_of_sequence(), 2);
+    assert_eq!(state.outbox_len(), 2);
+    drop(state);
+    assert!(matches!(
+        result_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
 }
 
 #[tokio::test]

--- a/lib/src/queries/output_state.rs
+++ b/lib/src/queries/output_state.rs
@@ -51,8 +51,7 @@ pub const DEFAULT_OUTBOX_CAPACITY: usize = 1000;
 /// acquire a read lock and clone the `im::HashMap` in O(1) via structural sharing.
 ///
 /// All fields are private to enforce invariants (sequence monotonicity, ring buffer
-/// bounds). Use accessor methods for read access and `apply_diffs` /
-/// `advance_sequence_and_push` for mutations.
+/// bounds). Use accessor methods for read access and the mutation helpers below.
 #[derive(Debug, Clone)]
 pub struct QueryOutputState {
     /// Live result set, keyed by `row_signature` for O(1) updates.
@@ -142,6 +141,31 @@ impl QueryOutputState {
         self.outbox.push_back(arc_result.clone());
 
         arc_result
+    }
+
+    /// Return the sequence that the next emitted result will receive.
+    pub(crate) const fn next_sequence(&self) -> u64 {
+        self.as_of_sequence.saturating_add(1)
+    }
+
+    /// Apply a result prepared for the current next sequence.
+    ///
+    /// Returns `None` when another writer advanced the state while the result was
+    /// being prepared, allowing the caller to rebuild it with a fresh sequence
+    /// without mutating state or creating a gap.
+    pub(crate) fn try_apply_prepared_result(
+        &mut self,
+        result: QueryResult,
+    ) -> Option<Arc<QueryResult>> {
+        let expected_sequence = self.next_sequence();
+        if result.sequence != expected_sequence {
+            return None;
+        }
+
+        self.apply_diffs(&result.results);
+        let result = self.advance_sequence_and_push(result);
+        debug_assert_eq!(result.sequence, expected_sequence);
+        Some(result)
     }
 
     /// Return the live result set as a `Vec` for backward compatibility with `get_current_results`.
@@ -630,6 +654,74 @@ mod tests {
         let arc = state.advance_sequence_and_push(result);
         assert_eq!(arc.sequence, 2);
         assert_eq!(state.outbox.len(), 2);
+    }
+
+    #[test]
+    fn test_prepared_result_retries_after_sequence_changes() {
+        let mut state = QueryOutputState::new(3);
+        let mut stale = make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"name": "stale"}),
+                row_signature: 1,
+            }],
+        );
+        stale.sequence = state.next_sequence();
+
+        let mut winner = make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"name": "winner"}),
+                row_signature: 2,
+            }],
+        );
+        winner.sequence = state.next_sequence();
+        state.try_apply_prepared_result(winner).unwrap();
+
+        assert!(state.try_apply_prepared_result(stale).is_none());
+        assert_eq!(state.as_of_sequence(), 1);
+        assert_eq!(state.results_len(), 1);
+        assert_eq!(state.get_result(&1), None);
+        assert_eq!(
+            state.get_result(&2),
+            Some(&serde_json::json!({"name": "winner"}))
+        );
+
+        let mut retried = make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"name": "stale"}),
+                row_signature: 1,
+            }],
+        );
+        retried.sequence = state.next_sequence();
+        let retried = state.try_apply_prepared_result(retried).unwrap();
+        assert_eq!(retried.sequence, 2);
+        assert_eq!(state.as_of_sequence(), 2);
+        assert_eq!(
+            state.get_result(&1),
+            Some(&serde_json::json!({"name": "stale"}))
+        );
+    }
+
+    #[test]
+    fn test_prepared_result_preserves_saturating_sequence_behavior() {
+        let mut state = QueryOutputState::new(3);
+        state.as_of_sequence = u64::MAX;
+
+        let mut result = make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"name": "max"}),
+                row_signature: 1,
+            }],
+        );
+        result.sequence = state.next_sequence();
+
+        let applied = state.try_apply_prepared_result(result).unwrap();
+        assert_eq!(applied.sequence, u64::MAX);
+        assert_eq!(state.as_of_sequence(), u64::MAX);
+        assert_eq!(state.outbox.back().unwrap().sequence, u64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
Stack A layer 3 of 7.

Depends on #865 (and #864 transitively).

Routes the fixed live Source -> Continuous Query -> Reaction path through A2's crate-private `ChangeEnvelope` adapters at source/query ingress and query-result egress. External Source, QueryResult, Reaction, plugin, persistence, ComponentGraph, and Drasi Server behavior remain intentionally unchanged, including the current durable-output gap.

A4 will extract the static Query Composite Host.