### PR TITLE
feat(core): add result-aware pre-commit hooks

### DIFF
--- a/components/indexes/garnet/src/checkpoint.rs
+++ b/components/indexes/garnet/src/checkpoint.rs
@@ -24,15 +24,16 @@
 //! - `ss:{<query_id>}:sources` → JSON array of source IDs with checkpoints
 //! - `ss:{<query_id>}:config_hash` → decimal u64 hash
 //!
-//! `stage_checkpoint` writes into the active `GarnetSessionState` write buffer
-//! so it commits atomically with index updates.
+//! `stage_checkpoint` and `write_result_sequence` use the active
+//! `GarnetSessionState` write buffer so they commit atomically with index
+//! updates. Result-sequence writes remain standalone outside a session.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use drasi_core::interface::{CheckpointStore, IndexError, SourceCheckpoint};
+use drasi_core::interface::{CheckpointStore, IndexError, SourceCheckpoint, TransactionDomain};
 use redis::{aio::MultiplexedConnection, AsyncCommands};
 
 use crate::session_state::{BufferReadResult, GarnetSessionState};
@@ -83,6 +84,10 @@ impl GarnetCheckpointStore {
 
 #[async_trait]
 impl CheckpointStore for GarnetCheckpointStore {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.session_state.transaction_domain())
+    }
+
     fn is_persistent(&self) -> bool {
         true
     }
@@ -297,6 +302,15 @@ impl CheckpointStore for GarnetCheckpointStore {
         sequence: u64,
     ) -> Result<(), IndexError> {
         let key = self.result_sequence_key();
+
+        {
+            let mut guard = self.session_state.lock()?;
+            if let Some(buffer) = guard.as_mut() {
+                buffer.string_set(key, sequence.to_string().into_bytes());
+                return Ok(());
+            }
+        }
+
         let mut con = self.connection.clone();
         con.set::<&str, String, ()>(&key, sequence.to_string())
             .await
@@ -306,10 +320,30 @@ impl CheckpointStore for GarnetCheckpointStore {
 
     async fn read_result_sequence(&self, _query_id: &str) -> Result<Option<u64>, IndexError> {
         let key = self.result_sequence_key();
-        let mut con = self.connection.clone();
-        match con.get::<String, Option<u64>>(key).await {
-            Ok(v) => Ok(v),
-            Err(e) => Err(IndexError::other(e)),
+
+        let buffered = {
+            let guard = self.session_state.lock()?;
+            match guard.as_ref() {
+                Some(buffer) => buffer.string_get(&key),
+                None => BufferReadResult::NotInBuffer,
+            }
+        };
+
+        match buffered {
+            BufferReadResult::Found(bytes) => {
+                let sequence = String::from_utf8(bytes)
+                    .map_err(IndexError::other)?
+                    .parse()
+                    .map_err(IndexError::other)?;
+                Ok(Some(sequence))
+            }
+            BufferReadResult::KeyDeleted => Ok(None),
+            BufferReadResult::NotInBuffer => {
+                let mut con = self.connection.clone();
+                con.get::<String, Option<u64>>(key)
+                    .await
+                    .map_err(IndexError::other)
+            }
         }
     }
 }

--- a/components/indexes/garnet/src/session_state.rs
+++ b/components/indexes/garnet/src/session_state.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use drasi_core::interface::{IndexError, SessionControl};
+use drasi_core::interface::{IndexError, SessionControl, TransactionDomain};
 use redis::{aio::MultiplexedConnection, Pipeline, ToRedisArgs};
 
 /// Result of checking the write buffer for a key/field.
@@ -476,6 +476,7 @@ impl SessionInner {
 pub struct GarnetSessionState {
     connection: MultiplexedConnection,
     inner: Mutex<SessionInner>,
+    transaction_domain: TransactionDomain,
 }
 
 impl GarnetSessionState {
@@ -486,7 +487,12 @@ impl GarnetSessionState {
                 buffer: None,
                 depth: 0,
             }),
+            transaction_domain: TransactionDomain::new(),
         }
+    }
+
+    pub(crate) fn transaction_domain(&self) -> TransactionDomain {
+        self.transaction_domain.clone()
     }
 
     /// Begin a new session-scoped transaction, or nest into an existing one.
@@ -645,8 +651,8 @@ impl GarnetSessionControl {
 
 #[async_trait]
 impl SessionControl for GarnetSessionControl {
-    fn supports_atomic_sessions(&self) -> bool {
-        true
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.state.transaction_domain())
     }
 
     async fn begin(&self) -> Result<(), IndexError> {

--- a/components/indexes/garnet/src/session_state.rs
+++ b/components/indexes/garnet/src/session_state.rs
@@ -645,6 +645,10 @@ impl GarnetSessionControl {
 
 #[async_trait]
 impl SessionControl for GarnetSessionControl {
+    fn supports_atomic_sessions(&self) -> bool {
+        true
+    }
+
     async fn begin(&self) -> Result<(), IndexError> {
         self.state.begin()
     }

--- a/components/indexes/garnet/tests/outbox_live_results_tests.rs
+++ b/components/indexes/garnet/tests/outbox_live_results_tests.rs
@@ -19,8 +19,8 @@
 //! Requires a running Redis instance. Uses testcontainers via `shared_tests::redis_helpers`.
 //! Tests are marked `#[ignore]` for CI environments without Docker.
 
-use drasi_core::interface::{LiveResultsWriter, OutboxWriter, RowMutation};
-use drasi_index_garnet::{GarnetLiveResultsWriter, GarnetOutboxWriter};
+use drasi_core::interface::{IndexBackendPlugin, LiveResultsWriter, OutboxWriter, RowMutation};
+use drasi_index_garnet::{GarnetIndexProvider, GarnetLiveResultsWriter, GarnetOutboxWriter};
 use shared_tests::redis_helpers::{setup_redis, RedisGuard};
 use tokio::sync::OnceCell;
 use uuid::Uuid;
@@ -44,6 +44,69 @@ async fn get_connection() -> redis::aio::MultiplexedConnection {
 /// Generate a unique query ID to avoid test interference.
 fn unique_query_id() -> String {
     format!("test-{}", Uuid::new_v4())
+}
+
+#[tokio::test]
+#[ignore]
+async fn garnet_bundle_does_not_advertise_full_atomic_result_persistence() {
+    let redis = shared_redis().await;
+    let provider = GarnetIndexProvider::new(redis.url(), None, true);
+    let query_id = unique_query_id();
+    let created = provider
+        .create_indexes(&query_id)
+        .await
+        .expect("create Garnet indexes");
+
+    let core_domain = created
+        .set
+        .session_control
+        .transaction_domain()
+        .expect("Garnet core indexes have an atomic session domain");
+    assert_eq!(
+        created
+            .checkpoint_store
+            .as_ref()
+            .and_then(|store| store.transaction_domain()),
+        Some(core_domain)
+    );
+    assert!(created
+        .outbox_writer
+        .as_ref()
+        .and_then(|writer| writer.transaction_domain())
+        .is_none());
+    assert!(created
+        .live_results_writer
+        .as_ref()
+        .and_then(|writer| writer.transaction_domain())
+        .is_none());
+    assert!(created.atomic_result_transaction().is_none());
+
+    let checkpoint_store = created
+        .checkpoint_store
+        .as_ref()
+        .expect("Garnet checkpoint store");
+    created
+        .set
+        .session_control
+        .begin()
+        .await
+        .expect("begin result-sequence rollback session");
+    checkpoint_store
+        .write_result_sequence(&query_id, 1)
+        .await
+        .expect("stage result sequence");
+    created
+        .set
+        .session_control
+        .rollback()
+        .expect("rollback result sequence");
+    assert_eq!(
+        checkpoint_store
+            .read_result_sequence(&query_id)
+            .await
+            .expect("read rolled-back result sequence"),
+        None
+    );
 }
 
 // ─── OutboxWriter Tests ──────────────────────────────────────────────────────

--- a/components/indexes/rocksdb/Cargo.toml
+++ b/components/indexes/rocksdb/Cargo.toml
@@ -57,6 +57,7 @@ anyhow = { version = "1.0", optional = true }
 plugin-descriptor = ["dep:drasi-plugin-sdk", "dep:utoipa", "dep:anyhow"]
 
 [dev-dependencies]
+drasi-query-cypher.workspace = true
 shared-tests = { path = "../../../shared-tests" }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 serial_test = "3"

--- a/components/indexes/rocksdb/src/checkpoint.rs
+++ b/components/indexes/rocksdb/src/checkpoint.rs
@@ -22,9 +22,9 @@
 //! - `source_position:{source_id}` → raw opaque bytes
 //! - `config_hash` → 8-byte big-endian `u64`
 //!
-//! `stage_checkpoint` writes into the active session transaction so it commits
-//! atomically with index updates. All other methods (reads, config hash,
-//! clear) operate directly on the DB without requiring an active session.
+//! `stage_checkpoint` and `write_result_sequence` write into an active session
+//! transaction so they commit atomically with index updates. Outside a session,
+//! result-sequence writes retain their standalone behavior.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use crate::IndexDb;
 use async_trait::async_trait;
 use bytes::Bytes;
-use drasi_core::interface::{CheckpointStore, IndexError, SourceCheckpoint};
+use drasi_core::interface::{CheckpointStore, IndexError, SourceCheckpoint, TransactionDomain};
 use rocksdb::ColumnFamilyDescriptor;
 use tokio::task;
 
@@ -139,6 +139,10 @@ fn read_all_checkpoints_impl(
 
 #[async_trait]
 impl CheckpointStore for RocksDbCheckpointStore {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.session_state.transaction_domain())
+    }
+
     fn is_persistent(&self) -> bool {
         true
     }
@@ -355,14 +359,23 @@ impl CheckpointStore for RocksDbCheckpointStore {
 
     async fn write_result_sequence(&self, query_id: &str, sequence: u64) -> Result<(), IndexError> {
         let db = self.db.clone();
+        let session_state = self.session_state.clone();
+        let active_session_state = session_state.is_active()?;
         let key = format!("{RESULT_SEQUENCE_PREFIX}{query_id}");
 
         let task = task::spawn_blocking(move || {
             let cf = db
                 .cf_handle(STREAM_STATE_CF)
                 .expect("stream_state cf not found");
-            db.put_cf(&cf, &key, sequence.to_be_bytes())
-                .map_err(IndexError::other)
+            if active_session_state {
+                session_state.with_txn(|txn| {
+                    txn.put_cf(&cf, &key, sequence.to_be_bytes())
+                        .map_err(IndexError::other)
+                })
+            } else {
+                db.put_cf(&cf, &key, sequence.to_be_bytes())
+                    .map_err(IndexError::other)
+            }
         });
 
         match task.await {
@@ -373,13 +386,17 @@ impl CheckpointStore for RocksDbCheckpointStore {
 
     async fn read_result_sequence(&self, query_id: &str) -> Result<Option<u64>, IndexError> {
         let db = self.db.clone();
+        let session_state = self.session_state.clone();
         let key = format!("{RESULT_SEQUENCE_PREFIX}{query_id}");
 
         let task = task::spawn_blocking(move || {
             let cf = db
                 .cf_handle(STREAM_STATE_CF)
                 .expect("stream_state cf not found");
-            let data = db.get_cf(&cf, &key).map_err(IndexError::other)?;
+            let data = session_state.with_txn_or_db(
+                |txn| txn.get_cf(&cf, &key).map_err(IndexError::other),
+                |db| db.get_cf(&cf, &key).map_err(IndexError::other),
+            )?;
             match data {
                 Some(v) => {
                     let bytes: [u8; 8] = v

--- a/components/indexes/rocksdb/src/live_results.rs
+++ b/components/indexes/rocksdb/src/live_results.rs
@@ -17,14 +17,15 @@
 //! Uses a dedicated `live_results` column family with keys formatted as:
 //! `{query_id}\x00{row_signature_u64_be}` (8-byte big-endian suffix).
 //!
-//! Writes are standalone (not part of the session transaction) since live results
-//! persistence happens after the index transaction commits.
+//! Provider-created writers share session state with the core indexes, so live
+//! mutations join an active transaction. Writers created directly retain
+//! standalone behavior.
 
 use std::sync::Arc;
 
-use crate::IndexDb;
+use crate::{IndexDb, RocksDbSessionState};
 use async_trait::async_trait;
-use drasi_core::interface::{IndexError, LiveResultsWriter, RowMutation};
+use drasi_core::interface::{IndexError, LiveResultsWriter, RowMutation, TransactionDomain};
 use rocksdb::{ColumnFamilyDescriptor, IteratorMode, WriteBatchWithTransaction};
 use tokio::task;
 
@@ -72,22 +73,48 @@ fn make_prefix(query_id: &str) -> Vec<u8> {
 /// Uses WriteBatch for atomic multi-row mutations.
 pub struct RocksDbLiveResultsWriter {
     db: Arc<IndexDb>,
+    session_state: Option<Arc<RocksDbSessionState>>,
 }
 
 impl RocksDbLiveResultsWriter {
+    /// Create a standalone writer whose mutations commit immediately.
     pub fn new(db: Arc<IndexDb>) -> Self {
-        Self { db }
+        Self {
+            db,
+            session_state: None,
+        }
+    }
+
+    /// Create a writer that joins active transactions in `session_state`.
+    pub fn new_with_session_state(
+        db: Arc<IndexDb>,
+        session_state: Arc<RocksDbSessionState>,
+    ) -> Self {
+        Self {
+            db,
+            session_state: Some(session_state),
+        }
     }
 }
 
 #[async_trait]
 impl LiveResultsWriter for RocksDbLiveResultsWriter {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        self.session_state
+            .as_ref()
+            .map(|state| state.transaction_domain())
+    }
+
     async fn apply_mutations(
         &self,
         query_id: &str,
         mutations: &[RowMutation<'_>],
     ) -> Result<(), IndexError> {
         let db = self.db.clone();
+        let active_session_state = match &self.session_state {
+            Some(state) if state.is_active()? => Some(state.clone()),
+            _ => None,
+        };
         // Collect owned mutation data for the blocking task
         let owned_mutations: Vec<(Vec<u8>, Option<Vec<u8>>)> = mutations
             .iter()
@@ -103,14 +130,29 @@ impl LiveResultsWriter for RocksDbLiveResultsWriter {
                 .cf_handle(LIVE_RESULTS_CF)
                 .expect("live_results cf not found");
 
-            let mut batch = WriteBatchWithTransaction::<true>::default();
-            for (key, data) in &owned_mutations {
-                match data {
-                    Some(value) => batch.put_cf(&cf, key, value),
-                    None => batch.delete_cf(&cf, key),
+            match active_session_state {
+                Some(state) => state.with_txn(|txn| {
+                    for (key, data) in &owned_mutations {
+                        match data {
+                            Some(value) => {
+                                txn.put_cf(&cf, key, value).map_err(IndexError::other)?
+                            }
+                            None => txn.delete_cf(&cf, key).map_err(IndexError::other)?,
+                        }
+                    }
+                    Ok(())
+                }),
+                None => {
+                    let mut batch = WriteBatchWithTransaction::<true>::default();
+                    for (key, data) in &owned_mutations {
+                        match data {
+                            Some(value) => batch.put_cf(&cf, key, value),
+                            None => batch.delete_cf(&cf, key),
+                        }
+                    }
+                    db.write(batch).map_err(IndexError::other)
                 }
             }
-            db.write(batch).map_err(IndexError::other)
         })
         .await
         .map_err(IndexError::other)?

--- a/components/indexes/rocksdb/src/outbox.rs
+++ b/components/indexes/rocksdb/src/outbox.rs
@@ -17,14 +17,15 @@
 //! Uses a dedicated `outbox` column family with keys formatted as:
 //! `{query_id}:{sequence_u64_be}` (8-byte big-endian suffix for ordered iteration).
 //!
-//! Writes are standalone (not part of the session transaction) since outbox
-//! persistence happens after the index transaction commits.
+//! Provider-created writers share session state with the core indexes, so
+//! append and capacity trimming join an active transaction. Writers created
+//! directly retain standalone behavior.
 
 use std::sync::Arc;
 
-use crate::IndexDb;
+use crate::{IndexDb, RocksDbSessionState};
 use async_trait::async_trait;
-use drasi_core::interface::{IndexError, OutboxWriter};
+use drasi_core::interface::{IndexError, OutboxWriter, TransactionDomain};
 use rocksdb::{ColumnFamilyDescriptor, IteratorMode};
 use tokio::task;
 
@@ -66,30 +67,77 @@ fn make_prefix(query_id: &str) -> Vec<u8> {
     prefix
 }
 
+fn collect_prefixed_keys<I, K, V>(iter: I, prefix: &[u8]) -> Result<Vec<Vec<u8>>, IndexError>
+where
+    I: IntoIterator<Item = Result<(K, V), rocksdb::Error>>,
+    K: AsRef<[u8]>,
+{
+    let mut keys = Vec::new();
+    for item in iter {
+        let (key, _) = item.map_err(IndexError::other)?;
+        if !key.as_ref().starts_with(prefix) {
+            break;
+        }
+        keys.push(key.as_ref().to_vec());
+    }
+    Ok(keys)
+}
+
 /// RocksDB-backed outbox writer.
 ///
 /// Stores serialized query results in a column family with ordered keys
 /// for efficient range reads and trimming.
 pub struct RocksDbOutboxWriter {
     db: Arc<IndexDb>,
+    session_state: Option<Arc<RocksDbSessionState>>,
 }
 
 impl RocksDbOutboxWriter {
+    /// Create a standalone writer whose mutations commit immediately.
     pub fn new(db: Arc<IndexDb>) -> Self {
-        Self { db }
+        Self {
+            db,
+            session_state: None,
+        }
+    }
+
+    /// Create a writer that joins active transactions in `session_state`.
+    pub fn new_with_session_state(
+        db: Arc<IndexDb>,
+        session_state: Arc<RocksDbSessionState>,
+    ) -> Self {
+        Self {
+            db,
+            session_state: Some(session_state),
+        }
     }
 }
 
 #[async_trait]
 impl OutboxWriter for RocksDbOutboxWriter {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        self.session_state
+            .as_ref()
+            .map(|state| state.transaction_domain())
+    }
+
     async fn append(&self, query_id: &str, sequence: u64, data: &[u8]) -> Result<(), IndexError> {
         let db = self.db.clone();
+        let active_session_state = match &self.session_state {
+            Some(state) if state.is_active()? => Some(state.clone()),
+            _ => None,
+        };
         let key = make_key(query_id, sequence);
         let data = data.to_vec();
 
         task::spawn_blocking(move || {
             let cf = db.cf_handle(OUTBOX_CF).expect("outbox cf not found");
-            db.put_cf(&cf, &key, &data).map_err(IndexError::other)
+            match active_session_state {
+                Some(state) => {
+                    state.with_txn(|txn| txn.put_cf(&cf, &key, &data).map_err(IndexError::other))
+                }
+                None => db.put_cf(&cf, &key, &data).map_err(IndexError::other),
+            }
         })
         .await
         .map_err(IndexError::other)?
@@ -196,39 +244,45 @@ impl OutboxWriter for RocksDbOutboxWriter {
 
     async fn trim_to_capacity(&self, query_id: &str, capacity: usize) -> Result<usize, IndexError> {
         let db = self.db.clone();
+        let active_session_state = match &self.session_state {
+            Some(state) if state.is_active()? => Some(state.clone()),
+            _ => None,
+        };
         let prefix = make_prefix(query_id);
 
         task::spawn_blocking(move || {
             let cf = db.cf_handle(OUTBOX_CF).expect("outbox cf not found");
 
-            // First, count total entries
-            let iter = db.iterator_cf(
-                &cf,
-                IteratorMode::From(&prefix, rocksdb::Direction::Forward),
-            );
-            let mut keys: Vec<Vec<u8>> = Vec::new();
-            for item in iter {
-                match item {
-                    Ok((key, _)) => {
-                        if !key.starts_with(&prefix) {
-                            break;
-                        }
-                        keys.push(key.to_vec());
+            match active_session_state {
+                Some(state) => state.with_txn(|txn| {
+                    let keys = collect_prefixed_keys(
+                        txn.iterator_cf(
+                            &cf,
+                            IteratorMode::From(&prefix, rocksdb::Direction::Forward),
+                        ),
+                        &prefix,
+                    )?;
+                    let to_remove = keys.len().saturating_sub(capacity);
+                    for key in keys.iter().take(to_remove) {
+                        txn.delete_cf(&cf, key).map_err(IndexError::other)?;
                     }
-                    Err(e) => return Err(IndexError::other(e)),
+                    Ok(to_remove)
+                }),
+                None => {
+                    let keys = collect_prefixed_keys(
+                        db.iterator_cf(
+                            &cf,
+                            IteratorMode::From(&prefix, rocksdb::Direction::Forward),
+                        ),
+                        &prefix,
+                    )?;
+                    let to_remove = keys.len().saturating_sub(capacity);
+                    for key in keys.iter().take(to_remove) {
+                        db.delete_cf(&cf, key).map_err(IndexError::other)?;
+                    }
+                    Ok(to_remove)
                 }
             }
-
-            let total = keys.len();
-            if total <= capacity {
-                return Ok(0);
-            }
-
-            let to_remove = total - capacity;
-            for key in keys.iter().take(to_remove) {
-                db.delete_cf(&cf, key).map_err(IndexError::other)?;
-            }
-            Ok(to_remove)
         })
         .await
         .map_err(IndexError::other)?

--- a/components/indexes/rocksdb/src/plugin.rs
+++ b/components/indexes/rocksdb/src/plugin.rs
@@ -251,9 +251,18 @@ impl IndexBackendPlugin for RocksDbIndexProvider {
             session_state.clone(),
             options,
         ));
-        let checkpoint_store = Arc::new(RocksDbCheckpointStore::new(db.clone(), session_state));
-        let outbox_writer = Arc::new(RocksDbOutboxWriter::new(db.clone()));
-        let live_results_writer = Arc::new(RocksDbLiveResultsWriter::new(db));
+        let checkpoint_store = Arc::new(RocksDbCheckpointStore::new(
+            db.clone(),
+            session_state.clone(),
+        ));
+        let outbox_writer = Arc::new(RocksDbOutboxWriter::new_with_session_state(
+            db.clone(),
+            session_state.clone(),
+        ));
+        let live_results_writer = Arc::new(RocksDbLiveResultsWriter::new_with_session_state(
+            db,
+            session_state,
+        ));
 
         Ok(CreatedIndexes {
             set: IndexSet {

--- a/components/indexes/rocksdb/src/session_state.rs
+++ b/components/indexes/rocksdb/src/session_state.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::IndexDb;
 use async_trait::async_trait;
-use drasi_core::interface::{IndexError, SessionControl};
+use drasi_core::interface::{IndexError, SessionControl, TransactionDomain};
 use rocksdb::Transaction;
 
 /// Groups the active transaction and nesting depth under a single mutex.
@@ -60,11 +60,13 @@ struct SessionInner {
 ///    any clone of the Arc exists.
 /// 2. The `Drop` impl on `RocksDbSessionState` clears the transaction before struct fields
 ///    are dropped, ensuring the transaction is released before the Arc can be decremented.
-/// 3. All holders of `Arc<RocksDbSessionState>` (the three index structs + `RocksDbSessionControl`)
-///    are grouped in `IndexSet` and dropped together.
+/// 3. Indexes, checkpoint/output writers, and `RocksDbSessionControl` hold the
+///    state through `Arc`; whichever clone is dropped last runs the same ordered
+///    cleanup before releasing the database.
 pub struct RocksDbSessionState {
     db: Arc<IndexDb>,
     inner: Mutex<SessionInner>,
+    transaction_domain: TransactionDomain,
 }
 
 impl RocksDbSessionState {
@@ -75,7 +77,16 @@ impl RocksDbSessionState {
                 txn: None,
                 depth: 0,
             }),
+            transaction_domain: TransactionDomain::new(),
         }
+    }
+
+    pub(crate) fn transaction_domain(&self) -> TransactionDomain {
+        self.transaction_domain.clone()
+    }
+
+    pub(crate) fn is_active(&self) -> Result<bool, IndexError> {
+        Ok(self.lock()?.depth > 0)
     }
 
     /// Begin a new session-scoped transaction, or nest into an existing one.
@@ -260,8 +271,8 @@ impl RocksDbSessionControl {
 
 #[async_trait]
 impl SessionControl for RocksDbSessionControl {
-    fn supports_atomic_sessions(&self) -> bool {
-        true
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.state.transaction_domain())
     }
 
     async fn begin(&self) -> Result<(), IndexError> {

--- a/components/indexes/rocksdb/src/session_state.rs
+++ b/components/indexes/rocksdb/src/session_state.rs
@@ -260,6 +260,10 @@ impl RocksDbSessionControl {
 
 #[async_trait]
 impl SessionControl for RocksDbSessionControl {
+    fn supports_atomic_sessions(&self) -> bool {
+        true
+    }
+
     async fn begin(&self) -> Result<(), IndexError> {
         let state = self.state.clone();
         tokio::task::spawn_blocking(move || state.begin())

--- a/components/indexes/rocksdb/tests/outbox_live_results_tests.rs
+++ b/components/indexes/rocksdb/tests/outbox_live_results_tests.rs
@@ -41,6 +41,7 @@ async fn test_outbox_append_and_read() {
     let tmp = TempDir::new().unwrap();
     let db = open_db(tmp.path().to_str().unwrap(), "q1");
     let writer = RocksDbOutboxWriter::new(db);
+    assert!(writer.transaction_domain().is_none());
 
     writer.append("q1", 1, b"hello").await.unwrap();
     writer.append("q1", 2, b"world").await.unwrap();
@@ -172,6 +173,7 @@ async fn test_live_results_apply_upserts() {
     let tmp = TempDir::new().unwrap();
     let db = open_db(tmp.path().to_str().unwrap(), "q1");
     let writer = RocksDbLiveResultsWriter::new(db);
+    assert!(writer.transaction_domain().is_none());
 
     let mutations = vec![
         RowMutation {

--- a/components/indexes/rocksdb/tests/result_hook_tests.rs
+++ b/components/indexes/rocksdb/tests/result_hook_tests.rs
@@ -31,7 +31,7 @@ use drasi_core::{
         CheckpointStore, ElementIndex, FutureQueue, IndexBackendPlugin, IndexError, SessionControl,
     },
     models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
-    query::{ContinuousQuery, QueryBuilder, ResultHookFuture},
+    query::{ContinuousQuery, QueryBuilder},
 };
 use drasi_index_rocksdb::RocksDbIndexProvider;
 use drasi_query_cypher::CypherParser;
@@ -146,18 +146,17 @@ async fn source_result_hook_commits_or_rolls_back_core_and_staged_writes_togethe
         functions,
     )
     .await;
+    assert!(fixture.query.supports_atomic_result_hooks());
 
     let checkpoint_store = fixture.checkpoint_store.clone();
     let committed = fixture
         .query
         .process_source_change_with_result_hook(
             person_change("alice", "Alice", 1_000),
-            move |results| -> ResultHookFuture<'_> {
-                Box::pin(async move {
-                    checkpoint_store.stage_checkpoint("people", 1, None).await?;
-                    assert_count_transition(results, 0, 1);
-                    Ok(())
-                })
+            move |results| async move {
+                checkpoint_store.stage_checkpoint("people", 1, None).await?;
+                assert_count_transition(&results, 0, 1);
+                Ok(())
             },
         )
         .await
@@ -179,12 +178,10 @@ async fn source_result_hook_commits_or_rolls_back_core_and_staged_writes_togethe
         .query
         .process_source_change_with_result_hook(
             person_change("bob", "Bob", 2_000),
-            move |results| -> ResultHookFuture<'_> {
-                Box::pin(async move {
-                    checkpoint_store.stage_checkpoint("people", 2, None).await?;
-                    assert_count_transition(results, 1, 2);
-                    Err(IndexError::CorruptedData)
-                })
+            move |results| async move {
+                checkpoint_store.stage_checkpoint("people", 2, None).await?;
+                assert_count_transition(&results, 1, 2);
+                Err(IndexError::CorruptedData)
             },
         )
         .await;
@@ -238,6 +235,7 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
         Arc::new(FunctionRegistry::new()),
     )
     .await;
+    assert!(fixture.query.supports_atomic_result_hooks());
 
     let initial = fixture
         .query
@@ -259,18 +257,16 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
     let checkpoint_store = fixture.checkpoint_store.clone();
     let failed = fixture
         .query
-        .process_due_futures_with_result_hook(move |due_result| -> ResultHookFuture<'_> {
-            Box::pin(async move {
-                checkpoint_store
-                    .stage_checkpoint("future-output", 1, None)
-                    .await?;
-                assert_eq!(due_result.source_id.as_ref(), "people");
-                hook_signature.store(
-                    assert_added_name(&due_result.results, "Alice"),
-                    Ordering::Relaxed,
-                );
-                Err(IndexError::CorruptedData)
-            })
+        .process_due_futures_with_result_hook(move |due_result| async move {
+            checkpoint_store
+                .stage_checkpoint("future-output", 1, None)
+                .await?;
+            assert_eq!(due_result.source_id.as_ref(), "people");
+            hook_signature.store(
+                assert_added_name(&due_result.results, "Alice"),
+                Ordering::Relaxed,
+            );
+            Err(IndexError::CorruptedData)
         })
         .await;
     assert!(matches!(
@@ -301,18 +297,16 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
     let checkpoint_store = fixture.checkpoint_store.clone();
     let replayed = fixture
         .query
-        .process_due_futures_with_result_hook(move |due_result| -> ResultHookFuture<'_> {
-            Box::pin(async move {
-                checkpoint_store
-                    .stage_checkpoint("future-output", 2, None)
-                    .await?;
-                hook_pointer.store(due_result.results.as_ptr() as usize, Ordering::Relaxed);
-                assert_eq!(
-                    assert_added_name(&due_result.results, "Alice"),
-                    failed_signature.load(Ordering::Relaxed)
-                );
-                Ok(())
-            })
+        .process_due_futures_with_result_hook(move |due_result| async move {
+            checkpoint_store
+                .stage_checkpoint("future-output", 2, None)
+                .await?;
+            hook_pointer.store(due_result.results.as_ptr() as usize, Ordering::Relaxed);
+            assert_eq!(
+                assert_added_name(&due_result.results, "Alice"),
+                failed_signature.load(Ordering::Relaxed)
+            );
+            Ok(())
         })
         .await
         .expect("replayed future should commit")
@@ -320,7 +314,7 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
     assert_eq!(
         observed_pointer.load(Ordering::Relaxed),
         replayed.results.as_ptr() as usize,
-        "the hook must borrow the returned due-future result allocation"
+        "the hook and caller must share the due-future result allocation"
     );
     assert_eq!(
         fixture
@@ -345,9 +339,9 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
     let hook_called = no_due_hook_called.clone();
     let no_due = fixture
         .query
-        .process_due_futures_with_result_hook(move |_| -> ResultHookFuture<'_> {
+        .process_due_futures_with_result_hook(move |_| async move {
             hook_called.store(true, Ordering::Relaxed);
-            Box::pin(async { Ok(()) })
+            Ok(())
         })
         .await
         .expect("empty queue should succeed");

--- a/components/indexes/rocksdb/tests/result_hook_tests.rs
+++ b/components/indexes/rocksdb/tests/result_hook_tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    future,
     path::Path,
     sync::{
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
@@ -20,6 +21,7 @@ use std::{
     },
 };
 
+use async_trait::async_trait;
 use drasi_core::{
     evaluation::{
         context::{QueryPartEvaluationContext, QueryVariables},
@@ -28,7 +30,9 @@ use drasi_core::{
         EvaluationError,
     },
     interface::{
-        CheckpointStore, ElementIndex, FutureQueue, IndexBackendPlugin, IndexError, SessionControl,
+        AtomicResultTransaction, CheckpointStore, ElementIndex, FutureQueue, IndexBackendPlugin,
+        IndexError, LiveResultsWriter, OutboxWriter, RowMutation, SessionControl,
+        TransactionDomain,
     },
     models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
     query::{ContinuousQuery, QueryBuilder},
@@ -38,8 +42,12 @@ use drasi_query_cypher::CypherParser;
 use serde_json::json;
 
 struct QueryFixture {
-    query: ContinuousQuery,
+    query_id: String,
+    query: Arc<ContinuousQuery>,
+    transaction: AtomicResultTransaction,
     checkpoint_store: Arc<dyn CheckpointStore>,
+    outbox_writer: Arc<dyn OutboxWriter>,
+    live_results_writer: Arc<dyn LiveResultsWriter>,
     element_index: Arc<dyn ElementIndex>,
     future_queue: Arc<dyn FutureQueue>,
     session_control: Arc<dyn SessionControl>,
@@ -51,33 +59,170 @@ async fn build_query(
     query: &str,
     functions: Arc<FunctionRegistry>,
 ) -> QueryFixture {
+    build_query_internal(path, query_id, query, functions, false).await
+}
+
+async fn build_query_with_failing_commit(
+    path: &Path,
+    query_id: &str,
+    query: &str,
+    functions: Arc<FunctionRegistry>,
+) -> QueryFixture {
+    build_query_internal(path, query_id, query, functions, true).await
+}
+
+async fn build_query_internal(
+    path: &Path,
+    query_id: &str,
+    query: &str,
+    functions: Arc<FunctionRegistry>,
+    fail_commit: bool,
+) -> QueryFixture {
     let provider = RocksDbIndexProvider::new(path, true, false);
     let created = provider
         .create_indexes(query_id)
         .await
         .expect("create RocksDB indexes");
+    let transaction_domain = created
+        .set
+        .session_control
+        .transaction_domain()
+        .expect("RocksDB core session domain");
+    let transaction = created
+        .atomic_result_transaction()
+        .expect("RocksDB bundle should share one transaction domain");
     let checkpoint_store = created
         .checkpoint_store
+        .clone()
         .expect("RocksDB provides a checkpoint store");
+    let outbox_writer = created
+        .outbox_writer
+        .clone()
+        .expect("RocksDB provides an outbox writer");
+    let live_results_writer = created
+        .live_results_writer
+        .clone()
+        .expect("RocksDB provides a live-results writer");
     let indexes = created.set;
+    let session_control: Arc<dyn SessionControl> = if fail_commit {
+        Arc::new(FailingCommitSessionControl {
+            inner: indexes.session_control.clone(),
+            transaction_domain: transaction_domain.clone(),
+        })
+    } else {
+        indexes.session_control.clone()
+    };
     let parser = Arc::new(CypherParser::new(functions.clone()));
-    let continuous_query = QueryBuilder::new(query, parser)
-        .with_function_registry(functions)
-        .with_element_index(indexes.element_index.clone())
-        .with_archive_index(indexes.archive_index)
-        .with_result_index(indexes.result_index)
-        .with_future_queue(indexes.future_queue.clone())
-        .with_session_control(indexes.session_control.clone())
-        .build()
-        .await;
+    let continuous_query = Arc::new(
+        QueryBuilder::new(query, parser)
+            .with_function_registry(functions)
+            .with_element_index(indexes.element_index.clone())
+            .with_archive_index(indexes.archive_index)
+            .with_result_index(indexes.result_index)
+            .with_future_queue(indexes.future_queue.clone())
+            .with_session_control(session_control.clone())
+            .build()
+            .await,
+    );
 
     QueryFixture {
+        query_id: query_id.to_string(),
         query: continuous_query,
+        transaction,
         checkpoint_store,
+        outbox_writer,
+        live_results_writer,
         element_index: indexes.element_index,
         future_queue: indexes.future_queue,
-        session_control: indexes.session_control,
+        session_control,
     }
+}
+
+struct FailingCommitSessionControl {
+    inner: Arc<dyn SessionControl>,
+    transaction_domain: TransactionDomain,
+}
+
+#[async_trait]
+impl SessionControl for FailingCommitSessionControl {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.transaction_domain.clone())
+    }
+
+    async fn begin(&self) -> Result<(), IndexError> {
+        self.inner.begin().await
+    }
+
+    async fn commit(&self) -> Result<(), IndexError> {
+        Err(IndexError::CorruptedData)
+    }
+
+    fn rollback(&self) -> Result<(), IndexError> {
+        self.inner.rollback()
+    }
+}
+
+async fn stage_all_persistent_output(
+    checkpoint_store: &dyn CheckpointStore,
+    outbox_writer: &dyn OutboxWriter,
+    live_results_writer: &dyn LiveResultsWriter,
+    query_id: &str,
+    sequence: u64,
+    row_signature: u64,
+    outbox_capacity: usize,
+) -> Result<(), IndexError> {
+    let outbox_data = format!("result-{sequence}").into_bytes();
+    let live_result_data = format!("row-{sequence}").into_bytes();
+    checkpoint_store
+        .stage_checkpoint("people", sequence, None)
+        .await?;
+    outbox_writer
+        .append(query_id, sequence, &outbox_data)
+        .await?;
+    outbox_writer
+        .trim_to_capacity(query_id, outbox_capacity)
+        .await?;
+    live_results_writer
+        .apply_mutations(
+            query_id,
+            &[RowMutation {
+                row_signature,
+                data: Some(&live_result_data),
+            }],
+        )
+        .await?;
+    checkpoint_store
+        .write_result_sequence(query_id, sequence)
+        .await
+}
+
+async fn assert_no_persistent_output(fixture: &QueryFixture) {
+    assert!(fixture
+        .checkpoint_store
+        .read_checkpoint("people")
+        .await
+        .expect("read checkpoint")
+        .is_none());
+    assert!(fixture
+        .outbox_writer
+        .read_from(&fixture.query_id, 0)
+        .await
+        .expect("read outbox")
+        .is_empty());
+    assert!(fixture
+        .live_results_writer
+        .read_snapshot(&fixture.query_id)
+        .await
+        .expect("read live results")
+        .is_empty());
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(&fixture.query_id)
+            .await
+            .expect("read result sequence"),
+        None
+    );
 }
 
 fn person_change(id: &str, name: &str, effective_from: u64) -> SourceChange {
@@ -135,6 +280,78 @@ fn assert_added_name(results: &[QueryPartEvaluationContext], expected: &str) -> 
 }
 
 #[tokio::test]
+async fn provider_writers_preserve_outside_session_behavior() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let fixture = build_query(
+        temp_dir.path(),
+        "outside-session-writers",
+        "MATCH (n:Person) RETURN n.name AS name",
+        Arc::new(FunctionRegistry::new()),
+    )
+    .await;
+
+    fixture
+        .outbox_writer
+        .append(&fixture.query_id, 1, b"first")
+        .await
+        .expect("outside-session outbox append");
+    fixture
+        .outbox_writer
+        .append(&fixture.query_id, 2, b"second")
+        .await
+        .expect("outside-session outbox append");
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .trim_to_capacity(&fixture.query_id, 1)
+            .await
+            .expect("outside-session outbox trim"),
+        1
+    );
+    fixture
+        .live_results_writer
+        .apply_mutations(
+            &fixture.query_id,
+            &[RowMutation {
+                row_signature: 42,
+                data: Some(b"live"),
+            }],
+        )
+        .await
+        .expect("outside-session live-result mutation");
+    fixture
+        .checkpoint_store
+        .write_result_sequence(&fixture.query_id, 2)
+        .await
+        .expect("outside-session result-sequence write");
+
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .read_from(&fixture.query_id, 0)
+            .await
+            .expect("read outside-session outbox"),
+        vec![(2, b"second".to_vec())]
+    );
+    assert_eq!(
+        fixture
+            .live_results_writer
+            .read_snapshot(&fixture.query_id)
+            .await
+            .expect("read outside-session live results"),
+        vec![(42, b"live".to_vec())]
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(&fixture.query_id)
+            .await
+            .expect("read outside-session result sequence"),
+        Some(2)
+    );
+}
+
+#[tokio::test]
 async fn source_result_hook_commits_or_rolls_back_core_and_staged_writes_together() {
     let temp_dir = tempfile::TempDir::new().expect("create temp directory");
     let functions = Arc::new(FunctionRegistry::new());
@@ -146,17 +363,78 @@ async fn source_result_hook_commits_or_rolls_back_core_and_staged_writes_togethe
         functions,
     )
     .await;
-    assert!(fixture.query.supports_atomic_result_hooks());
+
+    let mismatched_fixture = build_query(
+        temp_dir.path(),
+        "mismatched-source-domain",
+        "MATCH (n:Person) RETURN n.name AS name",
+        Arc::new(FunctionRegistry::new()),
+    )
+    .await;
+    let mismatched_hook_called = Arc::new(AtomicBool::new(false));
+    let hook_called = mismatched_hook_called.clone();
+    let rejected = fixture
+        .query
+        .process_source_change_with_result_hook(
+            person_change("alice", "Alice", 1_000),
+            &mismatched_fixture.transaction,
+            move |_| async move {
+                hook_called.store(true, Ordering::Relaxed);
+                Ok(())
+            },
+        )
+        .await;
+    assert!(matches!(
+        rejected,
+        Err(EvaluationError::IndexError(
+            IndexError::TransactionDomainMismatch
+        ))
+    ));
+    assert!(!mismatched_hook_called.load(Ordering::Relaxed));
+
+    fixture
+        .session_control
+        .begin()
+        .await
+        .expect("begin mismatch verification session");
+    let alice = fixture
+        .element_index
+        .get_element(&ElementReference::new("people", "alice"))
+        .await
+        .expect("read rejected element");
+    fixture
+        .session_control
+        .rollback()
+        .expect("end mismatch verification session");
+    assert!(alice.is_none(), "domain rejection must precede core writes");
+
+    fixture
+        .outbox_writer
+        .append(&fixture.query_id, 1, b"legacy-outbox")
+        .await
+        .expect("outside-session append should commit directly");
 
     let checkpoint_store = fixture.checkpoint_store.clone();
+    let outbox_writer = fixture.outbox_writer.clone();
+    let live_results_writer = fixture.live_results_writer.clone();
+    let query_id = fixture.query_id.clone();
     let committed = fixture
         .query
         .process_source_change_with_result_hook(
             person_change("alice", "Alice", 1_000),
+            &fixture.transaction,
             move |results| async move {
-                checkpoint_store.stage_checkpoint("people", 1, None).await?;
                 assert_count_transition(&results, 0, 1);
-                Ok(())
+                stage_all_persistent_output(
+                    checkpoint_store.as_ref(),
+                    outbox_writer.as_ref(),
+                    live_results_writer.as_ref(),
+                    &query_id,
+                    2,
+                    results[0].row_signature(),
+                    1,
+                )
+                .await
             },
         )
         .await
@@ -170,17 +448,55 @@ async fn source_result_hook_commits_or_rolls_back_core_and_staged_writes_togethe
             .expect("read checkpoint")
             .expect("checkpoint should commit")
             .sequence,
-        1
+        2
+    );
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .read_from(&fixture.query_id, 0)
+            .await
+            .expect("read committed outbox"),
+        vec![(2, b"result-2".to_vec())],
+        "transactional trim should retain only the latest entry"
+    );
+    assert_eq!(
+        fixture
+            .live_results_writer
+            .read_snapshot(&fixture.query_id)
+            .await
+            .expect("read committed live results"),
+        vec![(committed[0].row_signature(), b"row-2".to_vec())]
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(&fixture.query_id)
+            .await
+            .expect("read committed result sequence"),
+        Some(2)
     );
 
     let checkpoint_store = fixture.checkpoint_store.clone();
+    let outbox_writer = fixture.outbox_writer.clone();
+    let live_results_writer = fixture.live_results_writer.clone();
+    let query_id = fixture.query_id.clone();
     let failed = fixture
         .query
         .process_source_change_with_result_hook(
             person_change("bob", "Bob", 2_000),
+            &fixture.transaction,
             move |results| async move {
-                checkpoint_store.stage_checkpoint("people", 2, None).await?;
                 assert_count_transition(&results, 1, 2);
+                stage_all_persistent_output(
+                    checkpoint_store.as_ref(),
+                    outbox_writer.as_ref(),
+                    live_results_writer.as_ref(),
+                    &query_id,
+                    3,
+                    results[0].row_signature(),
+                    1,
+                )
+                .await?;
                 Err(IndexError::CorruptedData)
             },
         )
@@ -197,8 +513,32 @@ async fn source_result_hook_commits_or_rolls_back_core_and_staged_writes_togethe
             .expect("read checkpoint")
             .expect("previous checkpoint should remain")
             .sequence,
-        1,
+        2,
         "the staged checkpoint must roll back"
+    );
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .read_from(&fixture.query_id, 0)
+            .await
+            .expect("read rolled-back outbox"),
+        vec![(2, b"result-2".to_vec())]
+    );
+    assert_eq!(
+        fixture
+            .live_results_writer
+            .read_snapshot(&fixture.query_id)
+            .await
+            .expect("read rolled-back live results"),
+        vec![(committed[0].row_signature(), b"row-2".to_vec())]
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(&fixture.query_id)
+            .await
+            .expect("read rolled-back result sequence"),
+        Some(2)
     );
 
     fixture
@@ -226,6 +566,129 @@ async fn source_result_hook_commits_or_rolls_back_core_and_staged_writes_togethe
 }
 
 #[tokio::test]
+async fn cancelled_hook_rolls_back_all_persistent_output_and_core_state() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let fixture = build_query(
+        temp_dir.path(),
+        "cancelled-result-hook",
+        "MATCH (n:Person) RETURN n.name AS name",
+        Arc::new(FunctionRegistry::new()),
+    )
+    .await;
+    let query = fixture.query.clone();
+    let transaction = fixture.transaction.clone();
+    let checkpoint_store = fixture.checkpoint_store.clone();
+    let outbox_writer = fixture.outbox_writer.clone();
+    let live_results_writer = fixture.live_results_writer.clone();
+    let query_id = fixture.query_id.clone();
+    let (staged_tx, staged_rx) = tokio::sync::oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        query
+            .process_source_change_with_result_hook(
+                person_change("cancelled", "Cancelled", 1_000),
+                &transaction,
+                move |results| async move {
+                    stage_all_persistent_output(
+                        checkpoint_store.as_ref(),
+                        outbox_writer.as_ref(),
+                        live_results_writer.as_ref(),
+                        &query_id,
+                        1,
+                        results[0].row_signature(),
+                        16,
+                    )
+                    .await?;
+                    let _ = staged_tx.send(());
+                    future::pending::<Result<(), IndexError>>().await
+                },
+            )
+            .await
+    });
+
+    staged_rx.await.expect("hook should stage every resource");
+    task.abort();
+    assert!(task
+        .await
+        .expect_err("task should be cancelled")
+        .is_cancelled());
+
+    assert_no_persistent_output(&fixture).await;
+    fixture
+        .session_control
+        .begin()
+        .await
+        .expect("begin cancellation verification session");
+    let element = fixture
+        .element_index
+        .get_element(&ElementReference::new("people", "cancelled"))
+        .await
+        .expect("read cancelled element");
+    fixture
+        .session_control
+        .rollback()
+        .expect("end cancellation verification session");
+    assert!(element.is_none());
+}
+
+#[tokio::test]
+async fn commit_failure_rolls_back_all_persistent_output_and_core_state() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let fixture = build_query_with_failing_commit(
+        temp_dir.path(),
+        "failed-commit-result-hook",
+        "MATCH (n:Person) RETURN n.name AS name",
+        Arc::new(FunctionRegistry::new()),
+    )
+    .await;
+    let checkpoint_store = fixture.checkpoint_store.clone();
+    let outbox_writer = fixture.outbox_writer.clone();
+    let live_results_writer = fixture.live_results_writer.clone();
+    let query_id = fixture.query_id.clone();
+
+    let result = fixture
+        .query
+        .process_source_change_with_result_hook(
+            person_change("failed-commit", "Failed", 1_000),
+            &fixture.transaction,
+            move |results| async move {
+                stage_all_persistent_output(
+                    checkpoint_store.as_ref(),
+                    outbox_writer.as_ref(),
+                    live_results_writer.as_ref(),
+                    &query_id,
+                    1,
+                    results[0].row_signature(),
+                    16,
+                )
+                .await
+            },
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(EvaluationError::IndexError(IndexError::CorruptedData))
+    ));
+
+    assert_no_persistent_output(&fixture).await;
+    fixture
+        .session_control
+        .begin()
+        .await
+        .expect("begin commit-failure verification session");
+    let element = fixture
+        .element_index
+        .get_element(&ElementReference::new("people", "failed-commit"))
+        .await
+        .expect("read failed-commit element");
+    fixture
+        .session_control
+        .rollback()
+        .expect("end commit-failure verification session");
+    assert!(element.is_none());
+}
+
+#[tokio::test]
 async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
     let temp_dir = tempfile::TempDir::new().expect("create temp directory");
     let fixture = build_query(
@@ -235,7 +698,6 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
         Arc::new(FunctionRegistry::new()),
     )
     .await;
-    assert!(fixture.query.supports_atomic_result_hooks());
 
     let initial = fixture
         .query
@@ -252,20 +714,63 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
         Some(2_000)
     );
 
+    let mismatched_fixture = build_query(
+        temp_dir.path(),
+        "mismatched-future-domain",
+        "MATCH (n:Person) RETURN n.name AS name",
+        Arc::new(FunctionRegistry::new()),
+    )
+    .await;
+    let mismatched_hook_called = Arc::new(AtomicBool::new(false));
+    let hook_called = mismatched_hook_called.clone();
+    let mismatched = fixture
+        .query
+        .process_due_futures_with_result_hook(
+            &mismatched_fixture.transaction,
+            move |_| async move {
+                hook_called.store(true, Ordering::Relaxed);
+                Ok(())
+            },
+        )
+        .await;
+    assert!(matches!(
+        mismatched,
+        Err(EvaluationError::IndexError(
+            IndexError::TransactionDomainMismatch
+        ))
+    ));
+    assert!(!mismatched_hook_called.load(Ordering::Relaxed));
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek future after domain rejection"),
+        Some(2_000)
+    );
+
     let failed_signature = Arc::new(AtomicU64::new(0));
     let hook_signature = failed_signature.clone();
     let checkpoint_store = fixture.checkpoint_store.clone();
+    let outbox_writer = fixture.outbox_writer.clone();
+    let live_results_writer = fixture.live_results_writer.clone();
+    let query_id = fixture.query_id.clone();
     let failed = fixture
         .query
-        .process_due_futures_with_result_hook(move |due_result| async move {
-            checkpoint_store
-                .stage_checkpoint("future-output", 1, None)
-                .await?;
+        .process_due_futures_with_result_hook(&fixture.transaction, move |due_result| async move {
             assert_eq!(due_result.source_id.as_ref(), "people");
-            hook_signature.store(
-                assert_added_name(&due_result.results, "Alice"),
-                Ordering::Relaxed,
-            );
+            let row_signature = assert_added_name(&due_result.results, "Alice");
+            hook_signature.store(row_signature, Ordering::Relaxed);
+            stage_all_persistent_output(
+                checkpoint_store.as_ref(),
+                outbox_writer.as_ref(),
+                live_results_writer.as_ref(),
+                &query_id,
+                1,
+                row_signature,
+                16,
+            )
+            .await?;
             Err(IndexError::CorruptedData)
         })
         .await;
@@ -276,11 +781,31 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
     assert!(
         fixture
             .checkpoint_store
-            .read_checkpoint("future-output")
+            .read_checkpoint("people")
             .await
             .expect("read checkpoint")
             .is_none(),
         "the staged future output write must roll back"
+    );
+    assert!(fixture
+        .outbox_writer
+        .read_from(&fixture.query_id, 0)
+        .await
+        .expect("read rolled-back future outbox")
+        .is_empty());
+    assert!(fixture
+        .live_results_writer
+        .read_snapshot(&fixture.query_id)
+        .await
+        .expect("read rolled-back future live results")
+        .is_empty());
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(&fixture.query_id)
+            .await
+            .expect("read rolled-back future result sequence"),
+        None
     );
     assert_eq!(
         fixture
@@ -295,18 +820,25 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
     let observed_pointer = Arc::new(AtomicUsize::new(0));
     let hook_pointer = observed_pointer.clone();
     let checkpoint_store = fixture.checkpoint_store.clone();
+    let outbox_writer = fixture.outbox_writer.clone();
+    let live_results_writer = fixture.live_results_writer.clone();
+    let query_id = fixture.query_id.clone();
     let replayed = fixture
         .query
-        .process_due_futures_with_result_hook(move |due_result| async move {
-            checkpoint_store
-                .stage_checkpoint("future-output", 2, None)
-                .await?;
+        .process_due_futures_with_result_hook(&fixture.transaction, move |due_result| async move {
             hook_pointer.store(due_result.results.as_ptr() as usize, Ordering::Relaxed);
-            assert_eq!(
-                assert_added_name(&due_result.results, "Alice"),
-                failed_signature.load(Ordering::Relaxed)
-            );
-            Ok(())
+            let row_signature = assert_added_name(&due_result.results, "Alice");
+            assert_eq!(row_signature, failed_signature.load(Ordering::Relaxed));
+            stage_all_persistent_output(
+                checkpoint_store.as_ref(),
+                outbox_writer.as_ref(),
+                live_results_writer.as_ref(),
+                &query_id,
+                2,
+                row_signature,
+                16,
+            )
+            .await
         })
         .await
         .expect("replayed future should commit")
@@ -319,12 +851,36 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
     assert_eq!(
         fixture
             .checkpoint_store
-            .read_checkpoint("future-output")
+            .read_checkpoint("people")
             .await
             .expect("read checkpoint")
             .expect("future output checkpoint should commit")
             .sequence,
         2
+    );
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .read_from(&fixture.query_id, 0)
+            .await
+            .expect("read committed future outbox"),
+        vec![(2, b"result-2".to_vec())]
+    );
+    assert_eq!(
+        fixture
+            .live_results_writer
+            .read_snapshot(&fixture.query_id)
+            .await
+            .expect("read committed future live results"),
+        vec![(replayed.results[0].row_signature(), b"row-2".to_vec())]
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(&fixture.query_id)
+            .await
+            .expect("read committed future result sequence"),
+        Some(2)
     );
     assert_eq!(
         fixture
@@ -339,7 +895,7 @@ async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
     let hook_called = no_due_hook_called.clone();
     let no_due = fixture
         .query
-        .process_due_futures_with_result_hook(move |_| async move {
+        .process_due_futures_with_result_hook(&fixture.transaction, move |_| async move {
             hook_called.store(true, Ordering::Relaxed);
             Ok(())
         })

--- a/components/indexes/rocksdb/tests/result_hook_tests.rs
+++ b/components/indexes/rocksdb/tests/result_hook_tests.rs
@@ -1,0 +1,359 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    path::Path,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use drasi_core::{
+    evaluation::{
+        context::{QueryPartEvaluationContext, QueryVariables},
+        functions::{aggregation::RegisterAggregationFunctions, FunctionRegistry},
+        variable_value::VariableValue,
+        EvaluationError,
+    },
+    interface::{
+        CheckpointStore, ElementIndex, FutureQueue, IndexBackendPlugin, IndexError, SessionControl,
+    },
+    models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
+    query::{ContinuousQuery, QueryBuilder, ResultHookFuture},
+};
+use drasi_index_rocksdb::RocksDbIndexProvider;
+use drasi_query_cypher::CypherParser;
+use serde_json::json;
+
+struct QueryFixture {
+    query: ContinuousQuery,
+    checkpoint_store: Arc<dyn CheckpointStore>,
+    element_index: Arc<dyn ElementIndex>,
+    future_queue: Arc<dyn FutureQueue>,
+    session_control: Arc<dyn SessionControl>,
+}
+
+async fn build_query(
+    path: &Path,
+    query_id: &str,
+    query: &str,
+    functions: Arc<FunctionRegistry>,
+) -> QueryFixture {
+    let provider = RocksDbIndexProvider::new(path, true, false);
+    let created = provider
+        .create_indexes(query_id)
+        .await
+        .expect("create RocksDB indexes");
+    let checkpoint_store = created
+        .checkpoint_store
+        .expect("RocksDB provides a checkpoint store");
+    let indexes = created.set;
+    let parser = Arc::new(CypherParser::new(functions.clone()));
+    let continuous_query = QueryBuilder::new(query, parser)
+        .with_function_registry(functions)
+        .with_element_index(indexes.element_index.clone())
+        .with_archive_index(indexes.archive_index)
+        .with_result_index(indexes.result_index)
+        .with_future_queue(indexes.future_queue.clone())
+        .with_session_control(indexes.session_control.clone())
+        .build()
+        .await;
+
+    QueryFixture {
+        query: continuous_query,
+        checkpoint_store,
+        element_index: indexes.element_index,
+        future_queue: indexes.future_queue,
+        session_control: indexes.session_control,
+    }
+}
+
+fn person_change(id: &str, name: &str, effective_from: u64) -> SourceChange {
+    SourceChange::Insert {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("people", id),
+                labels: Arc::new([Arc::from("Person")]),
+                effective_from,
+            },
+            properties: ElementPropertyMap::from(json!({ "name": name })),
+        },
+    }
+}
+
+fn value<'a>(variables: &'a QueryVariables, key: &str) -> &'a VariableValue {
+    variables
+        .get(key)
+        .unwrap_or_else(|| panic!("missing result variable {key}"))
+}
+
+fn assert_count_transition(
+    results: &[QueryPartEvaluationContext],
+    expected_before: i64,
+    expected_after: i64,
+) {
+    let [QueryPartEvaluationContext::Aggregation {
+        before: Some(before),
+        after,
+        ..
+    }] = results
+    else {
+        panic!("expected one aggregation result, got {results:?}");
+    };
+    assert_eq!(
+        value(before, "total"),
+        &VariableValue::Integer(expected_before.into())
+    );
+    assert_eq!(
+        value(after, "total"),
+        &VariableValue::Integer(expected_after.into())
+    );
+}
+
+fn assert_added_name(results: &[QueryPartEvaluationContext], expected: &str) -> u64 {
+    let [QueryPartEvaluationContext::Adding {
+        after,
+        row_signature,
+    }] = results
+    else {
+        panic!("expected one adding result, got {results:?}");
+    };
+    assert_eq!(value(after, "name"), &VariableValue::from(expected));
+    *row_signature
+}
+
+#[tokio::test]
+async fn source_result_hook_commits_or_rolls_back_core_and_staged_writes_together() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let functions = Arc::new(FunctionRegistry::new());
+    functions.register_aggregation_functions();
+    let fixture = build_query(
+        temp_dir.path(),
+        "source-result-hook",
+        "MATCH (n:Person) RETURN count(n) AS total",
+        functions,
+    )
+    .await;
+
+    let checkpoint_store = fixture.checkpoint_store.clone();
+    let committed = fixture
+        .query
+        .process_source_change_with_result_hook(
+            person_change("alice", "Alice", 1_000),
+            move |results| -> ResultHookFuture<'_> {
+                Box::pin(async move {
+                    checkpoint_store.stage_checkpoint("people", 1, None).await?;
+                    assert_count_transition(results, 0, 1);
+                    Ok(())
+                })
+            },
+        )
+        .await
+        .expect("successful hook should commit");
+    assert_count_transition(&committed, 0, 1);
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint("people")
+            .await
+            .expect("read checkpoint")
+            .expect("checkpoint should commit")
+            .sequence,
+        1
+    );
+
+    let checkpoint_store = fixture.checkpoint_store.clone();
+    let failed = fixture
+        .query
+        .process_source_change_with_result_hook(
+            person_change("bob", "Bob", 2_000),
+            move |results| -> ResultHookFuture<'_> {
+                Box::pin(async move {
+                    checkpoint_store.stage_checkpoint("people", 2, None).await?;
+                    assert_count_transition(results, 1, 2);
+                    Err(IndexError::CorruptedData)
+                })
+            },
+        )
+        .await;
+    assert!(matches!(
+        failed,
+        Err(EvaluationError::IndexError(IndexError::CorruptedData))
+    ));
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint("people")
+            .await
+            .expect("read checkpoint")
+            .expect("previous checkpoint should remain")
+            .sequence,
+        1,
+        "the staged checkpoint must roll back"
+    );
+
+    fixture
+        .session_control
+        .begin()
+        .await
+        .expect("begin verification session");
+    let bob = fixture
+        .element_index
+        .get_element(&ElementReference::new("people", "bob"))
+        .await
+        .expect("read rolled-back element");
+    fixture
+        .session_control
+        .rollback()
+        .expect("end verification session");
+    assert!(bob.is_none(), "the core element write must roll back");
+
+    let after_rollback = fixture
+        .query
+        .process_source_change(person_change("carol", "Carol", 3_000))
+        .await
+        .expect("processing should continue after rollback");
+    assert_count_transition(&after_rollback, 1, 2);
+}
+
+#[tokio::test]
+async fn due_future_result_hook_observes_replays_and_skips_empty_queue() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let fixture = build_query(
+        temp_dir.path(),
+        "future-result-hook",
+        "MATCH (n:Person) WHERE drasi.trueLater(true, 2000) RETURN n.name AS name",
+        Arc::new(FunctionRegistry::new()),
+    )
+    .await;
+
+    let initial = fixture
+        .query
+        .process_source_change(person_change("alice", "Alice", 1_000))
+        .await
+        .expect("initial evaluation should succeed");
+    assert!(initial.is_empty());
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek future"),
+        Some(2_000)
+    );
+
+    let failed_signature = Arc::new(AtomicU64::new(0));
+    let hook_signature = failed_signature.clone();
+    let checkpoint_store = fixture.checkpoint_store.clone();
+    let failed = fixture
+        .query
+        .process_due_futures_with_result_hook(move |due_result| -> ResultHookFuture<'_> {
+            Box::pin(async move {
+                checkpoint_store
+                    .stage_checkpoint("future-output", 1, None)
+                    .await?;
+                assert_eq!(due_result.source_id.as_ref(), "people");
+                hook_signature.store(
+                    assert_added_name(&due_result.results, "Alice"),
+                    Ordering::Relaxed,
+                );
+                Err(IndexError::CorruptedData)
+            })
+        })
+        .await;
+    assert!(matches!(
+        failed,
+        Err(EvaluationError::IndexError(IndexError::CorruptedData))
+    ));
+    assert!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint("future-output")
+            .await
+            .expect("read checkpoint")
+            .is_none(),
+        "the staged future output write must roll back"
+    );
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek replayable future"),
+        Some(2_000),
+        "a hook failure must retain the popped future"
+    );
+
+    let observed_pointer = Arc::new(AtomicUsize::new(0));
+    let hook_pointer = observed_pointer.clone();
+    let checkpoint_store = fixture.checkpoint_store.clone();
+    let replayed = fixture
+        .query
+        .process_due_futures_with_result_hook(move |due_result| -> ResultHookFuture<'_> {
+            Box::pin(async move {
+                checkpoint_store
+                    .stage_checkpoint("future-output", 2, None)
+                    .await?;
+                hook_pointer.store(due_result.results.as_ptr() as usize, Ordering::Relaxed);
+                assert_eq!(
+                    assert_added_name(&due_result.results, "Alice"),
+                    failed_signature.load(Ordering::Relaxed)
+                );
+                Ok(())
+            })
+        })
+        .await
+        .expect("replayed future should commit")
+        .expect("the future should be replayed");
+    assert_eq!(
+        observed_pointer.load(Ordering::Relaxed),
+        replayed.results.as_ptr() as usize,
+        "the hook must borrow the returned due-future result allocation"
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint("future-output")
+            .await
+            .expect("read checkpoint")
+            .expect("future output checkpoint should commit")
+            .sequence,
+        2
+    );
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek drained queue"),
+        None
+    );
+
+    let no_due_hook_called = Arc::new(AtomicBool::new(false));
+    let hook_called = no_due_hook_called.clone();
+    let no_due = fixture
+        .query
+        .process_due_futures_with_result_hook(move |_| -> ResultHookFuture<'_> {
+            hook_called.store(true, Ordering::Relaxed);
+            Box::pin(async { Ok(()) })
+        })
+        .await
+        .expect("empty queue should succeed");
+    assert!(no_due.is_none());
+    assert!(
+        !no_due_hook_called.load(Ordering::Relaxed),
+        "the hook must not run when no future is due"
+    );
+}

--- a/core/src/interface/checkpoint_store.rs
+++ b/core/src/interface/checkpoint_store.rs
@@ -18,11 +18,11 @@
 //! position bytes (for native stream resumption), and config hashing.
 //!
 //! Implementations are paired with an [`IndexBackendPlugin`](super::IndexBackendPlugin)
-//! and share the same session state. [`CheckpointStore::stage_checkpoint`] writes
-//! into the currently-active session transaction (opened by
-//! [`SessionControl::begin`](super::SessionControl)) and is committed by the
-//! session's outer commit alongside the index updates. All other methods operate
-//! outside a session transaction and commit independently.
+//! and may share the same session state. [`CheckpointStore::stage_checkpoint`]
+//! and [`CheckpointStore::write_result_sequence`] participate in that active
+//! transaction when [`CheckpointStore::transaction_domain`] matches the
+//! [`SessionControl`](super::SessionControl). Other methods operate outside a
+//! session transaction and commit independently.
 //!
 //! This trait lives in core (not lib) so that index plugins can implement it
 //! without taking a reverse dependency on `drasi-lib`.
@@ -32,7 +32,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use super::IndexError;
+use super::{IndexError, TransactionDomain};
 
 /// Per-source checkpoint data.
 ///
@@ -64,8 +64,9 @@ impl SourceCheckpoint {
 ///   `SessionControl::begin` and `SessionControl::commit` for persistent backends.
 ///   The write is staged into the active session transaction and persisted by the
 ///   outer commit. For volatile (in-memory) backends, it applies immediately.
-/// - All other methods operate independently of the session transaction and
-///   commit on their own.
+/// - [`write_result_sequence`](Self::write_result_sequence) joins an active
+///   matching transaction when supported and otherwise commits on its own.
+/// - Other methods operate independently of the session transaction.
 ///
 /// # Source positions
 ///
@@ -74,6 +75,13 @@ impl SourceCheckpoint {
 /// query reads each source's position and passes it via `resume_from`.
 #[async_trait]
 pub trait CheckpointStore: Send + Sync {
+    /// Transaction domain used by staged checkpoints and result sequences.
+    ///
+    /// Returns `None` when these writes cannot join a query's active session.
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        None
+    }
+
     /// Whether this store persists checkpoints across process restarts.
     ///
     /// The orchestration layer uses this to decide whether to propagate
@@ -131,12 +139,12 @@ pub trait CheckpointStore: Send + Sync {
 
     /// Write the last persisted result sequence for a query.
     ///
-    /// Called after outbox and live-results writes succeed, outside any session
-    /// transaction. Records the highest sequence that was durably persisted so
-    /// that recovery can detect outbox gaps (compare with the index's committed
-    /// sequence from `stage_checkpoint`).
+    /// Records the highest sequence that was durably persisted so recovery can
+    /// detect outbox gaps (compare with the index's committed sequence from
+    /// `stage_checkpoint`).
     ///
-    /// Standalone commit — does not require an active session.
+    /// Transaction-domain implementations stage this write when a matching
+    /// session is active and preserve standalone behavior otherwise.
     ///
     /// Default: no-op (volatile backends that don't track result sequences).
     async fn write_result_sequence(

--- a/core/src/interface/index_backend.rs
+++ b/core/src/interface/index_backend.rs
@@ -31,8 +31,8 @@ use std::fmt;
 use std::sync::Arc;
 
 use super::{
-    CheckpointStore, ElementArchiveIndex, ElementIndex, FutureQueue, IndexError, LiveResultsWriter,
-    OutboxWriter, ResultIndex, SessionControl,
+    AtomicResultTransaction, CheckpointStore, ElementArchiveIndex, ElementIndex, FutureQueue,
+    IndexError, LiveResultsWriter, OutboxWriter, ResultIndex, SessionControl,
 };
 
 /// Set of indexes for a query.
@@ -72,14 +72,12 @@ impl fmt::Debug for IndexSet {
 /// that shares the same underlying session state. Persistent backends return
 /// `Some(store)`; volatile (in-memory) backends return `None`.
 ///
-/// The store's `stage_checkpoint` calls land in the same database transaction
-/// as index updates because both are derived from the same `SessionControl` /
-/// session state instance — that is why the plugin returns them together
-/// rather than via two separate calls.
+/// Call [`Self::atomic_result_transaction`] to verify that every
+/// persistent result resource joins the same transaction as the core indexes.
 pub struct CreatedIndexes {
     /// The set of indexes for the query.
     pub set: IndexSet,
-    /// Atomic checkpoint store paired with the set's session state.
+    /// Checkpoint store paired with the index set.
     /// `None` for volatile backends (no persistent storage to checkpoint into).
     pub checkpoint_store: Option<Arc<dyn CheckpointStore>>,
     /// Outbox writer for persisting query results for reaction replay.
@@ -88,6 +86,44 @@ pub struct CreatedIndexes {
     /// Live results writer for persisting the current result snapshot.
     /// `None` for volatile backends or when live result persistence is not needed.
     pub live_results_writer: Option<Arc<dyn LiveResultsWriter>>,
+}
+
+impl CreatedIndexes {
+    /// Return a validated capability only when every persistent result resource
+    /// can participate in the index session transaction.
+    ///
+    /// This covers core indexes through [`SessionControl`], source checkpoints
+    /// and persisted result sequences through [`CheckpointStore`], outbox
+    /// append/trim through [`OutboxWriter`], and live-result mutations through
+    /// [`LiveResultsWriter`].
+    pub fn atomic_result_transaction(&self) -> Option<AtomicResultTransaction> {
+        validate_atomic_result_domains(
+            self.set.session_control.transaction_domain(),
+            self.checkpoint_store
+                .as_ref()
+                .and_then(|store| store.transaction_domain()),
+            self.outbox_writer
+                .as_ref()
+                .and_then(|writer| writer.transaction_domain()),
+            self.live_results_writer
+                .as_ref()
+                .and_then(|writer| writer.transaction_domain()),
+        )
+    }
+}
+
+fn validate_atomic_result_domains(
+    session_domain: Option<super::TransactionDomain>,
+    checkpoint_domain: Option<super::TransactionDomain>,
+    outbox_domain: Option<super::TransactionDomain>,
+    live_results_domain: Option<super::TransactionDomain>,
+) -> Option<AtomicResultTransaction> {
+    let domain = session_domain?;
+    if checkpoint_domain? == domain && outbox_domain? == domain && live_results_domain? == domain {
+        Some(AtomicResultTransaction::new(domain))
+    } else {
+        None
+    }
 }
 
 impl fmt::Debug for CreatedIndexes {
@@ -150,7 +186,10 @@ pub trait IndexBackendPlugin: Send + Sync {
     /// Persistent backends additionally return a [`CheckpointStore`] that
     /// shares the same session state as the returned `SessionControl`, so
     /// `stage_checkpoint` writes land in the same database transaction as
-    /// index updates. Volatile backends return `checkpoint_store: None`.
+    /// index updates. Other persistent writers advertise participation through
+    /// [`TransactionDomain`](super::TransactionDomain); callers validate the complete bundle with
+    /// [`CreatedIndexes::atomic_result_transaction`]. Volatile backends
+    /// return `checkpoint_store: None`.
     async fn create_indexes(&self, query_id: &str) -> Result<CreatedIndexes, IndexError>;
 
     /// Returns true if this backend is volatile (data lost on restart).
@@ -158,4 +197,40 @@ pub trait IndexBackendPlugin: Send + Sync {
     /// Volatile backends (like in-memory) require re-bootstrapping after restart,
     /// while persistent backends (like RocksDB) retain data.
     fn is_volatile(&self) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_atomic_result_domains;
+    use crate::interface::TransactionDomain;
+
+    #[test]
+    fn atomic_result_transaction_requires_every_resource_in_one_domain() {
+        let domain = TransactionDomain::new();
+        let other = TransactionDomain::new();
+
+        assert!(validate_atomic_result_domains(
+            Some(domain.clone()),
+            Some(domain.clone()),
+            Some(domain.clone()),
+            Some(domain.clone()),
+        )
+        .is_some());
+
+        assert!(validate_atomic_result_domains(
+            Some(domain.clone()),
+            Some(domain.clone()),
+            None,
+            Some(domain.clone()),
+        )
+        .is_none());
+
+        assert!(validate_atomic_result_domains(
+            Some(domain.clone()),
+            Some(domain.clone()),
+            Some(other),
+            Some(domain),
+        )
+        .is_none());
+    }
 }

--- a/core/src/interface/live_results_writer.rs
+++ b/core/src/interface/live_results_writer.rs
@@ -28,7 +28,7 @@
 
 use async_trait::async_trait;
 
-use super::IndexError;
+use super::{IndexError, TransactionDomain};
 
 /// A single row mutation: upsert if data is `Some`, delete if `None`.
 #[derive(Debug, Clone)]
@@ -45,13 +45,22 @@ pub struct RowMutation<'a> {
 /// The `lib` layer handles serialization/deserialization of row data.
 #[async_trait]
 pub trait LiveResultsWriter: Send + Sync {
+    /// Transaction domain used by live-result mutations.
+    ///
+    /// Returns `None` when mutations cannot join a query's active session.
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        None
+    }
+
     /// Apply a batch of row mutations atomically.
     ///
     /// - `data = Some(bytes)`: Upsert the row (insert or replace).
     /// - `data = None`: Delete the row if it exists.
     ///
     /// Implementations should apply all mutations in a single batch/transaction
-    /// when possible for efficiency.
+    /// when possible for efficiency. Domain-aware implementations stage the
+    /// batch in an active matching session and retain standalone behavior
+    /// outside a session.
     async fn apply_mutations(
         &self,
         query_id: &str,

--- a/core/src/interface/mod.rs
+++ b/core/src/interface/mod.rs
@@ -22,6 +22,7 @@ mod query_clock;
 mod result_index;
 mod session_control;
 mod source_middleware;
+mod transaction_domain;
 
 use std::error::Error;
 use std::fmt::Display;
@@ -59,6 +60,7 @@ pub use source_middleware::MiddlewareSetupError;
 pub use source_middleware::SourceMiddleware;
 pub use source_middleware::SourceMiddlewareFactory;
 use thiserror::Error;
+pub use transaction_domain::{AtomicResultTransaction, TransactionDomain};
 
 use crate::evaluation::EvaluationError;
 
@@ -68,6 +70,8 @@ pub enum IndexError {
     NotSupported,
     /// A result-aware hook requires a session that can atomically roll back index writes.
     AtomicSessionNotSupported,
+    /// A result-aware hook was prepared for a different transaction domain.
+    TransactionDomainMismatch,
     /// A temporal read was attempted on an index whose archive is not enabled.
     ArchiveNotEnabled,
     CorruptedData,
@@ -82,6 +86,7 @@ impl PartialEq for IndexError {
             (IndexError::IOError, IndexError::IOError) => true,
             (IndexError::NotSupported, IndexError::NotSupported) => true,
             (IndexError::AtomicSessionNotSupported, IndexError::AtomicSessionNotSupported) => true,
+            (IndexError::TransactionDomainMismatch, IndexError::TransactionDomainMismatch) => true,
             (IndexError::ArchiveNotEnabled, IndexError::ArchiveNotEnabled) => true,
             (IndexError::CorruptedData, IndexError::CorruptedData) => true,
             (IndexError::ConnectionFailed(a), IndexError::ConnectionFailed(b)) => {
@@ -104,6 +109,12 @@ impl Display for IndexError {
         match self {
             IndexError::AtomicSessionNotSupported => {
                 write!(f, "result-aware hooks require atomic session support")
+            }
+            IndexError::TransactionDomainMismatch => {
+                write!(
+                    f,
+                    "result-aware hook transaction domain does not match the query"
+                )
             }
             IndexError::ArchiveNotEnabled => write!(
                 f,

--- a/core/src/interface/mod.rs
+++ b/core/src/interface/mod.rs
@@ -66,6 +66,8 @@ use crate::evaluation::EvaluationError;
 pub enum IndexError {
     IOError,
     NotSupported,
+    /// A result-aware hook requires a session that can atomically roll back index writes.
+    AtomicSessionNotSupported,
     /// A temporal read was attempted on an index whose archive is not enabled.
     ArchiveNotEnabled,
     CorruptedData,
@@ -79,6 +81,7 @@ impl PartialEq for IndexError {
         match (self, other) {
             (IndexError::IOError, IndexError::IOError) => true,
             (IndexError::NotSupported, IndexError::NotSupported) => true,
+            (IndexError::AtomicSessionNotSupported, IndexError::AtomicSessionNotSupported) => true,
             (IndexError::ArchiveNotEnabled, IndexError::ArchiveNotEnabled) => true,
             (IndexError::CorruptedData, IndexError::CorruptedData) => true,
             (IndexError::ConnectionFailed(a), IndexError::ConnectionFailed(b)) => {
@@ -99,6 +102,9 @@ impl PartialEq for IndexError {
 impl Display for IndexError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            IndexError::AtomicSessionNotSupported => {
+                write!(f, "result-aware hooks require atomic session support")
+            }
             IndexError::ArchiveNotEnabled => write!(
                 f,
                 "archive index not enabled for this query; set enable_archive to use past()"

--- a/core/src/interface/outbox_writer.rs
+++ b/core/src/interface/outbox_writer.rs
@@ -30,7 +30,7 @@
 
 use async_trait::async_trait;
 
-use super::IndexError;
+use super::{IndexError, TransactionDomain};
 
 /// Persistent outbox storage for query result replay.
 ///
@@ -38,9 +38,18 @@ use super::IndexError;
 /// The `lib` layer handles serialization/deserialization.
 #[async_trait]
 pub trait OutboxWriter: Send + Sync {
+    /// Transaction domain used by append and capacity-trim mutations.
+    ///
+    /// Returns `None` when these writes cannot join a query's active session.
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        None
+    }
+
     /// Append a serialized query result entry.
     ///
     /// If the outbox already contains an entry at this sequence, it is overwritten.
+    /// Domain-aware implementations stage the mutation in an active matching
+    /// session and retain standalone behavior outside a session.
     async fn append(&self, query_id: &str, sequence: u64, data: &[u8]) -> Result<(), IndexError>;
 
     /// Read all entries with sequence strictly greater than `after_sequence`.
@@ -67,5 +76,6 @@ pub trait OutboxWriter: Send + Sync {
     ///
     /// Returns the number of entries removed. If the outbox has ≤ `capacity`
     /// entries, this is a no-op returning 0.
+    /// Domain-aware implementations stage removals in the active session.
     async fn trim_to_capacity(&self, query_id: &str, capacity: usize) -> Result<usize, IndexError>;
 }

--- a/core/src/interface/session_control.rs
+++ b/core/src/interface/session_control.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use super::IndexError;
+use super::{IndexError, TransactionDomain};
 
 /// Backend-implemented lifecycle control for session-scoped transactions.
 ///
@@ -25,14 +25,13 @@ use super::IndexError;
 /// Session state lives inside backend implementations, shared via `Arc`.
 #[async_trait]
 pub trait SessionControl: Send + Sync {
-    /// Whether this control provides an atomic transaction for result-aware hooks.
+    /// Identity of the atomic transaction domain managed by this control.
     ///
-    /// Implementations should return `true` only when rollback discards every
-    /// core index mutation made between `begin` and `commit`. Writes staged by a
-    /// hook are part of that transaction only when they use a backend resource
-    /// created with the same shared session state.
-    fn supports_atomic_sessions(&self) -> bool {
-        false
+    /// Implementations return `Some` only when rollback discards every core
+    /// index mutation made between `begin` and `commit`. Stageable writers join
+    /// the transaction by returning the same domain identity.
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        None
     }
 
     /// Begin a new session-scoped transaction.

--- a/core/src/interface/session_control.rs
+++ b/core/src/interface/session_control.rs
@@ -25,6 +25,16 @@ use super::IndexError;
 /// Session state lives inside backend implementations, shared via `Arc`.
 #[async_trait]
 pub trait SessionControl: Send + Sync {
+    /// Whether this control provides an atomic transaction for result-aware hooks.
+    ///
+    /// Implementations should return `true` only when rollback discards every
+    /// core index mutation made between `begin` and `commit`. Writes staged by a
+    /// hook are part of that transaction only when they use a backend resource
+    /// created with the same shared session state.
+    fn supports_atomic_sessions(&self) -> bool {
+        false
+    }
+
     /// Begin a new session-scoped transaction.
     async fn begin(&self) -> Result<(), IndexError>;
 

--- a/core/src/interface/transaction_domain.rs
+++ b/core/src/interface/transaction_domain.rs
@@ -1,0 +1,89 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{fmt, sync::Arc};
+
+/// Opaque identity for resources that participate in one transaction domain.
+///
+/// Backend providers create one domain and share clones with their session
+/// control and every writer whose staged mutations join that session. Equality
+/// compares identity, not backend type or configuration.
+#[derive(Clone)]
+pub struct TransactionDomain(Arc<()>);
+
+impl TransactionDomain {
+    /// Create a new identity distinct from every existing transaction domain.
+    pub fn new() -> Self {
+        Self(Arc::new(()))
+    }
+}
+
+impl Default for TransactionDomain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for TransactionDomain {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for TransactionDomain {}
+
+impl fmt::Debug for TransactionDomain {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TransactionDomain(<opaque>)")
+    }
+}
+
+/// Validated capability for staging complete persistent query output atomically.
+///
+/// Values are created only after a [`CreatedIndexes`](super::CreatedIndexes)
+/// bundle proves that its session, checkpoint/result-sequence store, outbox, and
+/// live-results writer share one [`TransactionDomain`].
+#[derive(Clone, Debug)]
+pub struct AtomicResultTransaction {
+    transaction_domain: TransactionDomain,
+}
+
+impl AtomicResultTransaction {
+    pub(crate) fn new(transaction_domain: TransactionDomain) -> Self {
+        Self { transaction_domain }
+    }
+
+    pub(crate) fn matches(&self, transaction_domain: &TransactionDomain) -> bool {
+        self.transaction_domain == *transaction_domain
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AtomicResultTransaction, TransactionDomain};
+
+    #[test]
+    fn equality_tracks_shared_identity() {
+        let first = TransactionDomain::new();
+        let shared = first.clone();
+        let second = TransactionDomain::new();
+
+        assert_eq!(first, shared);
+        assert_ne!(first, second);
+
+        let transaction = AtomicResultTransaction::new(first.clone());
+        assert!(transaction.matches(&first));
+        assert!(!transaction.matches(&second));
+    }
+}

--- a/core/src/query/continuous_query.rs
+++ b/core/src/query/continuous_query.rs
@@ -36,8 +36,8 @@ use crate::{
         QueryPartEvaluator,
     },
     interface::{
-        ElementIndex, FutureQueue, FutureQueueConsumer, IndexError, MiddlewareError, QueryClock,
-        SessionControl, SessionGuard,
+        AtomicResultTransaction, ElementIndex, FutureQueue, FutureQueueConsumer, IndexError,
+        MiddlewareError, QueryClock, SessionControl, SessionGuard, TransactionDomain,
     },
     middleware::SourceMiddlewarePipelineCollection,
     models::{Element, SourceChange},
@@ -101,12 +101,9 @@ impl ContinuousQuery {
         }
     }
 
-    /// Whether the configured session can safely run result-aware hooks.
-    ///
-    /// A hook-staged write is atomic with core index mutations only when it uses
-    /// a backend resource that shares this query's session state.
-    pub fn supports_atomic_result_hooks(&self) -> bool {
-        self.session_control.supports_atomic_sessions()
+    /// Transaction domain used by this query's core index session.
+    pub(crate) fn transaction_domain(&self) -> Option<TransactionDomain> {
+        self.session_control.transaction_domain()
     }
 
     #[tracing::instrument(skip_all, err, level = "debug")]
@@ -161,22 +158,27 @@ impl ContinuousQuery {
     /// produced by middleware and evaluation. Cloning the `Arc` does not clone
     /// its result values, and an ordinary async closure may borrow caller state.
     ///
-    /// This method requires an atomic session and rejects unsupported backends
-    /// before middleware or evaluation begins. The hook runs after index updates
-    /// but before commit, while the change lock remains held. If it fails, its
-    /// [`IndexError`] is returned as an [`EvaluationError`] and the transaction
-    /// rolls back.
+    /// This method requires a validated atomic transaction and rejects an
+    /// unsupported backend or mismatched capability before middleware/evaluation
+    /// begins. The hook runs after index updates but before commit, while the
+    /// change lock remains held. If it fails, its [`IndexError`] is returned as
+    /// an [`EvaluationError`] and the transaction rolls back.
+    ///
+    /// Callers staging all persistent query output should use
+    /// [`CreatedIndexes::atomic_result_transaction`](crate::interface::CreatedIndexes::atomic_result_transaction)
+    /// so every participant is validated before this method is called.
     #[tracing::instrument(skip_all, err, level = "debug")]
     pub async fn process_source_change_with_result_hook<F, Fut>(
         &self,
         change: SourceChange,
+        transaction: &AtomicResultTransaction,
         pre_commit_hook: F,
     ) -> Result<Arc<[QueryPartEvaluationContext]>, EvaluationError>
     where
         F: FnOnce(Arc<[QueryPartEvaluationContext]>) -> Fut + Send,
         Fut: Future<Output = Result<(), IndexError>> + Send,
     {
-        self.require_atomic_result_hooks()?;
+        self.require_atomic_result_transaction(transaction)?;
         let _lock = self.change_lock.lock().await;
         let guard = SessionGuard::begin(self.session_control.clone()).await?;
 
@@ -224,21 +226,26 @@ impl ContinuousQuery {
     /// The hook receives an immutable [`Arc`] containing the exact
     /// [`DueFutureResult`] and may borrow caller state in its async operation.
     ///
-    /// This method requires an atomic session and rejects unsupported backends
-    /// before popping the queue. The hook runs before commit and is called only
-    /// when a future was popped; an empty queue commits the session and returns
-    /// `Ok(None)` without calling it. Hook failure rolls back the future pop and
-    /// all evaluation writes.
+    /// This method requires a validated atomic transaction and rejects an
+    /// unsupported backend or mismatched capability before popping the queue. The hook runs
+    /// before commit and is called only when a future was popped; an empty queue
+    /// commits the session and returns `Ok(None)` without calling it. Hook
+    /// failure rolls back the future pop and all evaluation writes.
+    ///
+    /// Callers staging all persistent query output should use
+    /// [`CreatedIndexes::atomic_result_transaction`](crate::interface::CreatedIndexes::atomic_result_transaction)
+    /// to obtain the required domain.
     #[tracing::instrument(skip_all, err, level = "debug")]
     pub async fn process_due_futures_with_result_hook<F, Fut>(
         &self,
+        transaction: &AtomicResultTransaction,
         pre_commit_hook: F,
     ) -> Result<Option<Arc<DueFutureResult>>, EvaluationError>
     where
         F: FnOnce(Arc<DueFutureResult>) -> Fut + Send,
         Fut: Future<Output = Result<(), IndexError>> + Send,
     {
-        self.require_atomic_result_hooks()?;
+        self.require_atomic_result_transaction(transaction)?;
         let _lock = self.change_lock.lock().await;
         let guard = SessionGuard::begin(self.session_control.clone()).await?;
 
@@ -262,11 +269,14 @@ impl ContinuousQuery {
         Ok(Some(result))
     }
 
-    fn require_atomic_result_hooks(&self) -> Result<(), EvaluationError> {
-        if self.supports_atomic_result_hooks() {
-            Ok(())
-        } else {
-            Err(IndexError::AtomicSessionNotSupported.into())
+    fn require_atomic_result_transaction(
+        &self,
+        transaction: &AtomicResultTransaction,
+    ) -> Result<(), EvaluationError> {
+        match self.transaction_domain() {
+            Some(actual_domain) if transaction.matches(&actual_domain) => Ok(()),
+            Some(_) => Err(IndexError::TransactionDomainMismatch.into()),
+            None => Err(IndexError::AtomicSessionNotSupported.into()),
         }
     }
 

--- a/core/src/query/continuous_query.rs
+++ b/core/src/query/continuous_query.rs
@@ -17,6 +17,7 @@ use std::{
     fmt::Debug,
     future::Future,
     hash::{Hash, Hasher},
+    pin::Pin,
     sync::Arc,
     time::Duration,
 };
@@ -56,6 +57,12 @@ pub struct DueFutureResult {
     /// The source_id from the popped future's element_ref.
     pub source_id: Arc<str>,
 }
+
+/// Boxed future returned by a result-aware pre-commit hook.
+///
+/// The future may borrow the core-computed result for the duration of the hook,
+/// avoiding a deep clone before related writes are staged.
+pub type ResultHookFuture<'a> = Pin<Box<dyn Future<Output = Result<(), IndexError>> + Send + 'a>>;
 
 pub struct ContinuousQuery {
     expression_evaluator: Arc<ExpressionEvaluator>,
@@ -143,6 +150,32 @@ impl ContinuousQuery {
         Ok(result)
     }
 
+    /// Process a source change with a result-aware pre-commit hook.
+    ///
+    /// The hook borrows the exact result produced by middleware and evaluation.
+    /// It runs after index updates but before the session commits, while the
+    /// change lock remains held. If the hook fails, its [`IndexError`] is
+    /// returned as an [`EvaluationError`] and the session is rolled back.
+    #[tracing::instrument(skip_all, err, level = "debug")]
+    pub async fn process_source_change_with_result_hook<F>(
+        &self,
+        change: SourceChange,
+        pre_commit_hook: F,
+    ) -> Result<Vec<QueryPartEvaluationContext>, EvaluationError>
+    where
+        F: for<'a> FnOnce(&'a [QueryPartEvaluationContext]) -> ResultHookFuture<'a> + Send,
+    {
+        let _lock = self.change_lock.lock().await;
+        let guard = SessionGuard::begin(self.session_control.clone()).await?;
+
+        let changes = self.execute_source_middleware(change).await?;
+        let result = self.process_changes_inner(changes).await?;
+
+        pre_commit_hook(&result).await?;
+        guard.commit().await?;
+        Ok(result)
+    }
+
     /// Atomically pop a due future from the queue and process it within a single session.
     ///
     /// Returns `Ok(None)` when the queue is empty (stale peek).
@@ -170,6 +203,43 @@ impl ContinuousQuery {
         let results = self.process_changes_inner(changes).await?;
         guard.commit().await?;
         Ok(Some(DueFutureResult { results, source_id }))
+    }
+
+    /// Atomically process a due future with a result-aware pre-commit hook.
+    ///
+    /// The hook borrows the exact [`DueFutureResult`] after evaluation and runs
+    /// before the session commits. It is called only when a future was popped;
+    /// an empty queue commits the session and returns `Ok(None)` without calling
+    /// the hook. Hook failure rolls back the future pop and all evaluation writes.
+    #[tracing::instrument(skip_all, err, level = "debug")]
+    pub async fn process_due_futures_with_result_hook<F>(
+        &self,
+        pre_commit_hook: F,
+    ) -> Result<Option<DueFutureResult>, EvaluationError>
+    where
+        F: for<'a> FnOnce(&'a DueFutureResult) -> ResultHookFuture<'a> + Send,
+    {
+        let _lock = self.change_lock.lock().await;
+        let guard = SessionGuard::begin(self.session_control.clone()).await?;
+
+        let future_ref = match self.future_queue.pop().await {
+            Ok(Some(fr)) => fr,
+            Ok(None) => {
+                guard.commit().await?;
+                return Ok(None);
+            }
+            Err(e) => return Err(EvaluationError::from(e)),
+        };
+
+        let source_id = future_ref.element_ref.source_id.clone();
+        let change = SourceChange::Future { future_ref };
+        let changes = self.execute_source_middleware(change).await?;
+        let results = self.process_changes_inner(changes).await?;
+        let result = DueFutureResult { results, source_id };
+
+        pre_commit_hook(&result).await?;
+        guard.commit().await?;
+        Ok(Some(result))
     }
 
     /// Expose the ContinuousQuery's future queue for external polling.

--- a/core/src/query/continuous_query.rs
+++ b/core/src/query/continuous_query.rs
@@ -17,7 +17,6 @@ use std::{
     fmt::Debug,
     future::Future,
     hash::{Hash, Hasher},
-    pin::Pin,
     sync::Arc,
     time::Duration,
 };
@@ -57,12 +56,6 @@ pub struct DueFutureResult {
     /// The source_id from the popped future's element_ref.
     pub source_id: Arc<str>,
 }
-
-/// Boxed future returned by a result-aware pre-commit hook.
-///
-/// The future may borrow the core-computed result for the duration of the hook,
-/// avoiding a deep clone before related writes are staged.
-pub type ResultHookFuture<'a> = Pin<Box<dyn Future<Output = Result<(), IndexError>> + Send + 'a>>;
 
 pub struct ContinuousQuery {
     expression_evaluator: Arc<ExpressionEvaluator>,
@@ -108,6 +101,14 @@ impl ContinuousQuery {
         }
     }
 
+    /// Whether the configured session can safely run result-aware hooks.
+    ///
+    /// A hook-staged write is atomic with core index mutations only when it uses
+    /// a backend resource that shares this query's session state.
+    pub fn supports_atomic_result_hooks(&self) -> bool {
+        self.session_control.supports_atomic_sessions()
+    }
+
     #[tracing::instrument(skip_all, err, level = "debug")]
     pub async fn process_source_change(
         &self,
@@ -126,9 +127,13 @@ impl ContinuousQuery {
     /// Process a source change with a pre-commit hook that runs inside the session.
     ///
     /// The hook executes after index updates but before the session commits,
-    /// allowing callers to stage additional writes (e.g. checkpoint data) into
-    /// the same atomic transaction. The change_lock is held for the entire
-    /// duration, preserving serialization.
+    /// allowing callers to stage additional writes (e.g. checkpoint data). The
+    /// change lock is held for the entire duration, preserving serialization.
+    ///
+    /// This legacy API does not require an atomic [`SessionControl`]. Hook and
+    /// index rollback is therefore backend-dependent; use
+    /// [`Self::process_source_change_with_result_hook`] when atomic rollback is
+    /// required.
     #[tracing::instrument(skip_all, err, level = "debug")]
     pub async fn process_source_change_with_hook<F, Fut>(
         &self,
@@ -152,37 +157,46 @@ impl ContinuousQuery {
 
     /// Process a source change with a result-aware pre-commit hook.
     ///
-    /// The hook borrows the exact result produced by middleware and evaluation.
-    /// It runs after index updates but before the session commits, while the
-    /// change lock remains held. If the hook fails, its [`IndexError`] is
-    /// returned as an [`EvaluationError`] and the session is rolled back.
+    /// The hook receives an immutable [`Arc`] containing the exact typed result
+    /// produced by middleware and evaluation. Cloning the `Arc` does not clone
+    /// its result values, and an ordinary async closure may borrow caller state.
+    ///
+    /// This method requires an atomic session and rejects unsupported backends
+    /// before middleware or evaluation begins. The hook runs after index updates
+    /// but before commit, while the change lock remains held. If it fails, its
+    /// [`IndexError`] is returned as an [`EvaluationError`] and the transaction
+    /// rolls back.
     #[tracing::instrument(skip_all, err, level = "debug")]
-    pub async fn process_source_change_with_result_hook<F>(
+    pub async fn process_source_change_with_result_hook<F, Fut>(
         &self,
         change: SourceChange,
         pre_commit_hook: F,
-    ) -> Result<Vec<QueryPartEvaluationContext>, EvaluationError>
+    ) -> Result<Arc<[QueryPartEvaluationContext]>, EvaluationError>
     where
-        F: for<'a> FnOnce(&'a [QueryPartEvaluationContext]) -> ResultHookFuture<'a> + Send,
+        F: FnOnce(Arc<[QueryPartEvaluationContext]>) -> Fut + Send,
+        Fut: Future<Output = Result<(), IndexError>> + Send,
     {
+        self.require_atomic_result_hooks()?;
         let _lock = self.change_lock.lock().await;
         let guard = SessionGuard::begin(self.session_control.clone()).await?;
 
         let changes = self.execute_source_middleware(change).await?;
-        let result = self.process_changes_inner(changes).await?;
+        let result: Arc<[QueryPartEvaluationContext]> =
+            self.process_changes_inner(changes).await?.into();
 
-        pre_commit_hook(&result).await?;
+        pre_commit_hook(result.clone()).await?;
         guard.commit().await?;
         Ok(result)
     }
 
-    /// Atomically pop a due future from the queue and process it within a single session.
+    /// Pop a due future from the queue and process it within a single session.
     ///
     /// Returns `Ok(None)` when the queue is empty (stale peek).
     /// Returns `Ok(Some(DueFutureResult))` with results and the original source_id.
     ///
-    /// Pop happens inside the session → atomic with all downstream index writes.
-    /// If a crash occurs before commit, the pop rolls back and the item stays in the queue.
+    /// With an atomic [`SessionControl`], the pop and downstream index writes
+    /// commit or roll back together. The legacy API does not reject non-atomic
+    /// sessions.
     #[tracing::instrument(skip_all, err, level = "debug")]
     pub async fn process_due_futures(&self) -> Result<Option<DueFutureResult>, EvaluationError> {
         let _lock = self.change_lock.lock().await;
@@ -207,18 +221,24 @@ impl ContinuousQuery {
 
     /// Atomically process a due future with a result-aware pre-commit hook.
     ///
-    /// The hook borrows the exact [`DueFutureResult`] after evaluation and runs
-    /// before the session commits. It is called only when a future was popped;
-    /// an empty queue commits the session and returns `Ok(None)` without calling
-    /// the hook. Hook failure rolls back the future pop and all evaluation writes.
+    /// The hook receives an immutable [`Arc`] containing the exact
+    /// [`DueFutureResult`] and may borrow caller state in its async operation.
+    ///
+    /// This method requires an atomic session and rejects unsupported backends
+    /// before popping the queue. The hook runs before commit and is called only
+    /// when a future was popped; an empty queue commits the session and returns
+    /// `Ok(None)` without calling it. Hook failure rolls back the future pop and
+    /// all evaluation writes.
     #[tracing::instrument(skip_all, err, level = "debug")]
-    pub async fn process_due_futures_with_result_hook<F>(
+    pub async fn process_due_futures_with_result_hook<F, Fut>(
         &self,
         pre_commit_hook: F,
-    ) -> Result<Option<DueFutureResult>, EvaluationError>
+    ) -> Result<Option<Arc<DueFutureResult>>, EvaluationError>
     where
-        F: for<'a> FnOnce(&'a DueFutureResult) -> ResultHookFuture<'a> + Send,
+        F: FnOnce(Arc<DueFutureResult>) -> Fut + Send,
+        Fut: Future<Output = Result<(), IndexError>> + Send,
     {
+        self.require_atomic_result_hooks()?;
         let _lock = self.change_lock.lock().await;
         let guard = SessionGuard::begin(self.session_control.clone()).await?;
 
@@ -235,11 +255,19 @@ impl ContinuousQuery {
         let change = SourceChange::Future { future_ref };
         let changes = self.execute_source_middleware(change).await?;
         let results = self.process_changes_inner(changes).await?;
-        let result = DueFutureResult { results, source_id };
+        let result = Arc::new(DueFutureResult { results, source_id });
 
-        pre_commit_hook(&result).await?;
+        pre_commit_hook(result.clone()).await?;
         guard.commit().await?;
         Ok(Some(result))
+    }
+
+    fn require_atomic_result_hooks(&self) -> Result<(), EvaluationError> {
+        if self.supports_atomic_result_hooks() {
+            Ok(())
+        } else {
+            Err(IndexError::AtomicSessionNotSupported.into())
+        }
     }
 
     /// Expose the ContinuousQuery's future queue for external polling.

--- a/core/src/query/mod.rs
+++ b/core/src/query/mod.rs
@@ -18,7 +18,7 @@ mod continuous_query;
 mod query_builder;
 
 pub use auto_future_queue_consumer::AutoFutureQueueConsumer;
-pub use continuous_query::{ContinuousQuery, DueFutureResult, ResultHookFuture};
+pub use continuous_query::{ContinuousQuery, DueFutureResult};
 pub use query_builder::QueryBuilder;
 
 #[cfg(test)]

--- a/core/src/query/mod.rs
+++ b/core/src/query/mod.rs
@@ -18,7 +18,7 @@ mod continuous_query;
 mod query_builder;
 
 pub use auto_future_queue_consumer::AutoFutureQueueConsumer;
-pub use continuous_query::{ContinuousQuery, DueFutureResult};
+pub use continuous_query::{ContinuousQuery, DueFutureResult, ResultHookFuture};
 pub use query_builder::QueryBuilder;
 
 #[cfg(test)]

--- a/core/src/query/tests/mod.rs
+++ b/core/src/query/tests/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod result_hook_tests;
 mod row_signature_tests;
 
 use std::sync::Arc;

--- a/core/src/query/tests/result_hook_tests.rs
+++ b/core/src/query/tests/result_hook_tests.rs
@@ -38,8 +38,9 @@ use crate::{
         in_memory_element_index::InMemoryElementIndex, in_memory_future_queue::InMemoryFutureQueue,
     },
     interface::{
-        ElementIndex, FutureQueue, IndexError, MiddlewareError, MiddlewareSetupError,
-        SessionControl, SourceMiddleware, SourceMiddlewareFactory,
+        AtomicResultTransaction, ElementIndex, FutureQueue, IndexError, MiddlewareError,
+        MiddlewareSetupError, SessionControl, SourceMiddleware, SourceMiddlewareFactory,
+        TransactionDomain,
     },
     middleware::MiddlewareTypeRegistry,
     models::{
@@ -49,12 +50,15 @@ use crate::{
     query::{ContinuousQuery, QueryBuilder},
 };
 
-struct AtomicTestSessionControl;
+#[derive(Default)]
+struct AtomicTestSessionControl {
+    transaction_domain: TransactionDomain,
+}
 
 #[async_trait]
 impl SessionControl for AtomicTestSessionControl {
-    fn supports_atomic_sessions(&self) -> bool {
-        true
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.transaction_domain.clone())
     }
 
     async fn begin(&self) -> Result<(), IndexError> {
@@ -74,7 +78,7 @@ async fn build_query(query: &str, functions: Arc<FunctionRegistry>) -> Continuou
     let parser = Arc::new(CypherParser::new(functions.clone()));
     QueryBuilder::new(query, parser)
         .with_function_registry(functions)
-        .with_session_control(Arc::new(AtomicTestSessionControl))
+        .with_session_control(Arc::new(AtomicTestSessionControl::default()))
         .build()
         .await
 }
@@ -112,12 +116,15 @@ async fn result_hook_shares_exact_add_update_delete_and_aggregation_results() {
         Arc::new(FunctionRegistry::new()),
     )
     .await;
+    let transaction =
+        AtomicResultTransaction::new(query.transaction_domain().expect("atomic test domain"));
 
     let observed_pointer = Arc::new(AtomicUsize::new(0));
     let hook_pointer = observed_pointer.clone();
     let added = query
         .process_source_change_with_result_hook(
             person_change("person-1", "Alice", 1_000, false),
+            &transaction,
             move |results| async move {
                 tokio::task::yield_now().await;
                 hook_pointer.store(results.as_ptr() as usize, Ordering::Relaxed);
@@ -139,6 +146,7 @@ async fn result_hook_shares_exact_add_update_delete_and_aggregation_results() {
     let updated = query
         .process_source_change_with_result_hook(
             person_change("person-1", "Alicia", 2_000, true),
+            &transaction,
             |results| async move {
                 tokio::task::yield_now().await;
                 let [QueryPartEvaluationContext::Updating { before, after, .. }] = results.as_ref()
@@ -166,6 +174,7 @@ async fn result_hook_shares_exact_add_update_delete_and_aggregation_results() {
                     effective_from: 3_000,
                 },
             },
+            &transaction,
             |results| async move {
                 tokio::task::yield_now().await;
                 let [QueryPartEvaluationContext::Removing { before, .. }] = results.as_ref() else {
@@ -185,9 +194,15 @@ async fn result_hook_shares_exact_add_update_delete_and_aggregation_results() {
     let functions = Arc::new(FunctionRegistry::new());
     functions.register_aggregation_functions();
     let aggregate_query = build_query("MATCH (n:Person) RETURN count(n) AS total", functions).await;
+    let aggregate_transaction = AtomicResultTransaction::new(
+        aggregate_query
+            .transaction_domain()
+            .expect("atomic aggregate test domain"),
+    );
     let aggregated = aggregate_query
         .process_source_change_with_result_hook(
             person_change("person-2", "Grace", 4_000, false),
+            &aggregate_transaction,
             |results| async move {
                 tokio::task::yield_now().await;
                 let [QueryPartEvaluationContext::Aggregation {
@@ -223,6 +238,7 @@ async fn result_hook_shares_exact_add_update_delete_and_aggregation_results() {
 #[derive(Default)]
 struct RecordingSessionControl {
     calls: Mutex<Vec<&'static str>>,
+    transaction_domain: TransactionDomain,
 }
 
 impl RecordingSessionControl {
@@ -233,8 +249,8 @@ impl RecordingSessionControl {
 
 #[async_trait]
 impl SessionControl for RecordingSessionControl {
-    fn supports_atomic_sessions(&self) -> bool {
-        true
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.transaction_domain.clone())
     }
 
     async fn begin(&self) -> Result<(), IndexError> {
@@ -290,12 +306,15 @@ async fn result_hook_is_not_called_when_evaluation_fails() {
         .with_session_control(session_control.clone())
         .build()
         .await;
+    let transaction =
+        AtomicResultTransaction::new(query.transaction_domain().expect("recording test domain"));
     let hook_called = Arc::new(AtomicBool::new(false));
     let hook_called_inside = hook_called.clone();
 
     let result = query
         .process_source_change_with_result_hook(
             person_change("person-1", "Alice", 1_000, false),
+            &transaction,
             move |_| async move {
                 hook_called_inside.store(true, Ordering::Relaxed);
                 Ok(())
@@ -357,11 +376,17 @@ async fn result_hook_preserves_empty_and_middleware_fan_out_results() {
         Arc::new(FunctionRegistry::new()),
     )
     .await;
+    let no_result_transaction = AtomicResultTransaction::new(
+        no_result_query
+            .transaction_domain()
+            .expect("atomic no-result test domain"),
+    );
     let empty_hook_called = Arc::new(AtomicBool::new(false));
     let empty_hook_called_inside = empty_hook_called.clone();
     let empty = no_result_query
         .process_source_change_with_result_hook(
             person_change("person-1", "Alice", 1_000, false),
+            &no_result_transaction,
             move |results| async move {
                 tokio::task::yield_now().await;
                 assert!(results.is_empty());
@@ -387,13 +412,19 @@ async fn result_hook_preserves_empty_and_middleware_fan_out_results() {
             serde_json::Map::new(),
         )))
         .with_source_pipeline("people", &["fan-out".to_string()])
-        .with_session_control(Arc::new(AtomicTestSessionControl))
+        .with_session_control(Arc::new(AtomicTestSessionControl::default()))
         .build()
         .await;
+    let transaction = AtomicResultTransaction::new(
+        query
+            .transaction_domain()
+            .expect("atomic fan-out test domain"),
+    );
 
     let results = query
         .process_source_change_with_result_hook(
             person_change("ignored", "ignored", 2_000, false),
+            &transaction,
             |results| async move {
                 tokio::task::yield_now().await;
                 let names = results
@@ -426,10 +457,11 @@ impl BorrowingHost {
     async fn run(
         &self,
         query: &ContinuousQuery,
+        transaction: &AtomicResultTransaction,
         change: SourceChange,
     ) -> Result<Arc<[QueryPartEvaluationContext]>, EvaluationError> {
         query
-            .process_source_change_with_result_hook(change, |results| async move {
+            .process_source_change_with_result_hook(change, transaction, |results| async move {
                 tokio::task::yield_now().await;
                 let [QueryPartEvaluationContext::Adding { after, .. }] = results.as_ref() else {
                     panic!("expected one adding result, got {results:?}");
@@ -456,9 +488,18 @@ async fn result_hook_can_borrow_host_state_across_await() {
         expected_name: "Ada".to_string(),
         hook_called: AtomicBool::new(false),
     };
+    let transaction = AtomicResultTransaction::new(
+        query
+            .transaction_domain()
+            .expect("borrowing host requires an atomic domain"),
+    );
 
     let results = host
-        .run(&query, person_change("person-1", "Ada", 1_000, false))
+        .run(
+            &query,
+            &transaction,
+            person_change("person-1", "Ada", 1_000, false),
+        )
         .await
         .expect("borrowed host hook should compile and run");
 
@@ -477,13 +518,14 @@ async fn result_hooks_reject_non_atomic_sessions_before_mutation_or_pop() {
         .with_archive_index(element_index.clone())
         .build()
         .await;
-    assert!(!query.supports_atomic_result_hooks());
+    assert!(query.transaction_domain().is_none());
 
     let source_hook_called = Arc::new(AtomicBool::new(false));
     let called = source_hook_called.clone();
     let source_result = query
         .process_source_change_with_result_hook(
             person_change("person-1", "Alice", 1_000, false),
+            &AtomicResultTransaction::new(TransactionDomain::new()),
             move |_| async move {
                 called.store(true, Ordering::Relaxed);
                 Ok(())
@@ -533,10 +575,13 @@ async fn result_hooks_reject_non_atomic_sessions_before_mutation_or_pop() {
     let future_hook_called = Arc::new(AtomicBool::new(false));
     let called = future_hook_called.clone();
     let due_result = future_query
-        .process_due_futures_with_result_hook(move |_| async move {
-            called.store(true, Ordering::Relaxed);
-            Ok(())
-        })
+        .process_due_futures_with_result_hook(
+            &AtomicResultTransaction::new(TransactionDomain::new()),
+            move |_| async move {
+                called.store(true, Ordering::Relaxed);
+                Ok(())
+            },
+        )
         .await;
     assert!(matches!(
         due_result,

--- a/core/src/query/tests/result_hook_tests.rs
+++ b/core/src/query/tests/result_hook_tests.rs
@@ -32,24 +32,49 @@ use crate::{
             aggregation::RegisterAggregationFunctions, Function, FunctionRegistry, ScalarFunction,
         },
         variable_value::VariableValue,
-        ExpressionEvaluationContext, FunctionError, FunctionEvaluationError,
+        EvaluationError, ExpressionEvaluationContext, FunctionError, FunctionEvaluationError,
+    },
+    in_memory_index::{
+        in_memory_element_index::InMemoryElementIndex, in_memory_future_queue::InMemoryFutureQueue,
     },
     interface::{
-        ElementIndex, IndexError, MiddlewareError, MiddlewareSetupError, SessionControl,
-        SourceMiddleware, SourceMiddlewareFactory,
+        ElementIndex, FutureQueue, IndexError, MiddlewareError, MiddlewareSetupError,
+        SessionControl, SourceMiddleware, SourceMiddlewareFactory,
     },
     middleware::MiddlewareTypeRegistry,
     models::{
         Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange,
         SourceMiddlewareConfig,
     },
-    query::{ContinuousQuery, QueryBuilder, ResultHookFuture},
+    query::{ContinuousQuery, QueryBuilder},
 };
+
+struct AtomicTestSessionControl;
+
+#[async_trait]
+impl SessionControl for AtomicTestSessionControl {
+    fn supports_atomic_sessions(&self) -> bool {
+        true
+    }
+
+    async fn begin(&self) -> Result<(), IndexError> {
+        Ok(())
+    }
+
+    async fn commit(&self) -> Result<(), IndexError> {
+        Ok(())
+    }
+
+    fn rollback(&self) -> Result<(), IndexError> {
+        Ok(())
+    }
+}
 
 async fn build_query(query: &str, functions: Arc<FunctionRegistry>) -> ContinuousQuery {
     let parser = Arc::new(CypherParser::new(functions.clone()));
     QueryBuilder::new(query, parser)
         .with_function_registry(functions)
+        .with_session_control(Arc::new(AtomicTestSessionControl))
         .build()
         .await
 }
@@ -81,7 +106,7 @@ fn value<'a>(variables: &'a QueryVariables, key: &str) -> &'a VariableValue {
 }
 
 #[tokio::test]
-async fn result_hook_borrows_exact_add_update_delete_and_aggregation_results() {
+async fn result_hook_shares_exact_add_update_delete_and_aggregation_results() {
     let query = build_query(
         "MATCH (n:Person) RETURN n.name AS name",
         Arc::new(FunctionRegistry::new()),
@@ -93,16 +118,14 @@ async fn result_hook_borrows_exact_add_update_delete_and_aggregation_results() {
     let added = query
         .process_source_change_with_result_hook(
             person_change("person-1", "Alice", 1_000, false),
-            move |results| -> ResultHookFuture<'_> {
-                Box::pin(async move {
-                    tokio::task::yield_now().await;
-                    hook_pointer.store(results.as_ptr() as usize, Ordering::Relaxed);
-                    let [QueryPartEvaluationContext::Adding { after, .. }] = results else {
-                        panic!("expected one adding result, got {results:?}");
-                    };
-                    assert_eq!(value(after, "name"), &VariableValue::from("Alice"));
-                    Ok(())
-                })
+            move |results| async move {
+                tokio::task::yield_now().await;
+                hook_pointer.store(results.as_ptr() as usize, Ordering::Relaxed);
+                let [QueryPartEvaluationContext::Adding { after, .. }] = results.as_ref() else {
+                    panic!("expected one adding result, got {results:?}");
+                };
+                assert_eq!(value(after, "name"), &VariableValue::from("Alice"));
+                Ok(())
             },
         )
         .await
@@ -110,29 +133,27 @@ async fn result_hook_borrows_exact_add_update_delete_and_aggregation_results() {
     assert_eq!(
         observed_pointer.load(Ordering::Relaxed),
         added.as_ptr() as usize,
-        "the hook must borrow the returned result allocation"
+        "the hook and caller must share the result allocation"
     );
 
     let updated = query
         .process_source_change_with_result_hook(
             person_change("person-1", "Alicia", 2_000, true),
-            |results| -> ResultHookFuture<'_> {
-                Box::pin(async move {
-                    tokio::task::yield_now().await;
-                    let [QueryPartEvaluationContext::Updating { before, after, .. }] = results
-                    else {
-                        panic!("expected one updating result, got {results:?}");
-                    };
-                    assert_eq!(value(before, "name"), &VariableValue::from("Alice"));
-                    assert_eq!(value(after, "name"), &VariableValue::from("Alicia"));
-                    Ok(())
-                })
+            |results| async move {
+                tokio::task::yield_now().await;
+                let [QueryPartEvaluationContext::Updating { before, after, .. }] = results.as_ref()
+                else {
+                    panic!("expected one updating result, got {results:?}");
+                };
+                assert_eq!(value(before, "name"), &VariableValue::from("Alice"));
+                assert_eq!(value(after, "name"), &VariableValue::from("Alicia"));
+                Ok(())
             },
         )
         .await
         .expect("update should succeed");
     assert!(matches!(
-        updated.as_slice(),
+        updated.as_ref(),
         [QueryPartEvaluationContext::Updating { .. }]
     ));
 
@@ -145,21 +166,19 @@ async fn result_hook_borrows_exact_add_update_delete_and_aggregation_results() {
                     effective_from: 3_000,
                 },
             },
-            |results| -> ResultHookFuture<'_> {
-                Box::pin(async move {
-                    tokio::task::yield_now().await;
-                    let [QueryPartEvaluationContext::Removing { before, .. }] = results else {
-                        panic!("expected one removing result, got {results:?}");
-                    };
-                    assert_eq!(value(before, "name"), &VariableValue::from("Alicia"));
-                    Ok(())
-                })
+            |results| async move {
+                tokio::task::yield_now().await;
+                let [QueryPartEvaluationContext::Removing { before, .. }] = results.as_ref() else {
+                    panic!("expected one removing result, got {results:?}");
+                };
+                assert_eq!(value(before, "name"), &VariableValue::from("Alicia"));
+                Ok(())
             },
         )
         .await
         .expect("delete should succeed");
     assert!(matches!(
-        removed.as_slice(),
+        removed.as_ref(),
         [QueryPartEvaluationContext::Removing { .. }]
     ));
 
@@ -169,36 +188,34 @@ async fn result_hook_borrows_exact_add_update_delete_and_aggregation_results() {
     let aggregated = aggregate_query
         .process_source_change_with_result_hook(
             person_change("person-2", "Grace", 4_000, false),
-            |results| -> ResultHookFuture<'_> {
-                Box::pin(async move {
-                    tokio::task::yield_now().await;
-                    let [QueryPartEvaluationContext::Aggregation {
-                        before,
-                        after,
-                        grouping_keys,
-                        default_before,
-                        default_after,
-                        ..
-                    }] = results
-                    else {
-                        panic!("expected one aggregation result, got {results:?}");
-                    };
-                    assert_eq!(
-                        value(before.as_ref().expect("default count result"), "total"),
-                        &VariableValue::Integer(0.into())
-                    );
-                    assert!(grouping_keys.is_empty());
-                    assert!(*default_before);
-                    assert!(!default_after);
-                    assert_eq!(value(after, "total"), &VariableValue::Integer(1.into()));
-                    Ok(())
-                })
+            |results| async move {
+                tokio::task::yield_now().await;
+                let [QueryPartEvaluationContext::Aggregation {
+                    before,
+                    after,
+                    grouping_keys,
+                    default_before,
+                    default_after,
+                    ..
+                }] = results.as_ref()
+                else {
+                    panic!("expected one aggregation result, got {results:?}");
+                };
+                assert_eq!(
+                    value(before.as_ref().expect("default count result"), "total"),
+                    &VariableValue::Integer(0.into())
+                );
+                assert!(grouping_keys.is_empty());
+                assert!(*default_before);
+                assert!(!default_after);
+                assert_eq!(value(after, "total"), &VariableValue::Integer(1.into()));
+                Ok(())
             },
         )
         .await
         .expect("aggregation should succeed");
     assert!(matches!(
-        aggregated.as_slice(),
+        aggregated.as_ref(),
         [QueryPartEvaluationContext::Aggregation { .. }]
     ));
 }
@@ -216,6 +233,10 @@ impl RecordingSessionControl {
 
 #[async_trait]
 impl SessionControl for RecordingSessionControl {
+    fn supports_atomic_sessions(&self) -> bool {
+        true
+    }
+
     async fn begin(&self) -> Result<(), IndexError> {
         self.calls
             .lock()
@@ -275,9 +296,9 @@ async fn result_hook_is_not_called_when_evaluation_fails() {
     let result = query
         .process_source_change_with_result_hook(
             person_change("person-1", "Alice", 1_000, false),
-            move |_| -> ResultHookFuture<'_> {
+            move |_| async move {
                 hook_called_inside.store(true, Ordering::Relaxed);
-                Box::pin(async { Ok(()) })
+                Ok(())
             },
         )
         .await;
@@ -341,13 +362,11 @@ async fn result_hook_preserves_empty_and_middleware_fan_out_results() {
     let empty = no_result_query
         .process_source_change_with_result_hook(
             person_change("person-1", "Alice", 1_000, false),
-            move |results| -> ResultHookFuture<'_> {
-                Box::pin(async move {
-                    tokio::task::yield_now().await;
-                    assert!(results.is_empty());
-                    empty_hook_called_inside.store(true, Ordering::Relaxed);
-                    Ok(())
-                })
+            move |results| async move {
+                tokio::task::yield_now().await;
+                assert!(results.is_empty());
+                empty_hook_called_inside.store(true, Ordering::Relaxed);
+                Ok(())
             },
         )
         .await
@@ -368,33 +387,170 @@ async fn result_hook_preserves_empty_and_middleware_fan_out_results() {
             serde_json::Map::new(),
         )))
         .with_source_pipeline("people", &["fan-out".to_string()])
+        .with_session_control(Arc::new(AtomicTestSessionControl))
         .build()
         .await;
 
     let results = query
         .process_source_change_with_result_hook(
             person_change("ignored", "ignored", 2_000, false),
-            |results| -> ResultHookFuture<'_> {
-                Box::pin(async move {
-                    tokio::task::yield_now().await;
-                    let names = results
-                        .iter()
-                        .map(|result| match result {
-                            QueryPartEvaluationContext::Adding { after, .. } => {
-                                value(after, "name").to_string()
-                            }
-                            other => panic!("expected adding result, got {other:?}"),
-                        })
-                        .collect::<BTreeSet<_>>();
-                    assert_eq!(
-                        names,
-                        BTreeSet::from(["first".to_string(), "second".to_string()])
-                    );
-                    Ok(())
-                })
+            |results| async move {
+                tokio::task::yield_now().await;
+                let names = results
+                    .iter()
+                    .map(|result| match result {
+                        QueryPartEvaluationContext::Adding { after, .. } => {
+                            value(after, "name").to_string()
+                        }
+                        other => panic!("expected adding result, got {other:?}"),
+                    })
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(
+                    names,
+                    BTreeSet::from(["first".to_string(), "second".to_string()])
+                );
+                Ok(())
             },
         )
         .await
         .expect("fan-out evaluation should succeed");
     assert_eq!(results.len(), 2);
+}
+
+struct BorrowingHost {
+    expected_name: String,
+    hook_called: AtomicBool,
+}
+
+impl BorrowingHost {
+    async fn run(
+        &self,
+        query: &ContinuousQuery,
+        change: SourceChange,
+    ) -> Result<Arc<[QueryPartEvaluationContext]>, EvaluationError> {
+        query
+            .process_source_change_with_result_hook(change, |results| async move {
+                tokio::task::yield_now().await;
+                let [QueryPartEvaluationContext::Adding { after, .. }] = results.as_ref() else {
+                    panic!("expected one adding result, got {results:?}");
+                };
+                assert_eq!(
+                    value(after, "name"),
+                    &VariableValue::from(self.expected_name.as_str())
+                );
+                self.hook_called.store(true, Ordering::Relaxed);
+                Ok(())
+            })
+            .await
+    }
+}
+
+#[tokio::test]
+async fn result_hook_can_borrow_host_state_across_await() {
+    let query = build_query(
+        "MATCH (n:Person) RETURN n.name AS name",
+        Arc::new(FunctionRegistry::new()),
+    )
+    .await;
+    let host = BorrowingHost {
+        expected_name: "Ada".to_string(),
+        hook_called: AtomicBool::new(false),
+    };
+
+    let results = host
+        .run(&query, person_change("person-1", "Ada", 1_000, false))
+        .await
+        .expect("borrowed host hook should compile and run");
+
+    assert_eq!(results.len(), 1);
+    assert!(host.hook_called.load(Ordering::Relaxed));
+}
+
+#[tokio::test]
+async fn result_hooks_reject_non_atomic_sessions_before_mutation_or_pop() {
+    let functions = Arc::new(FunctionRegistry::new());
+    let parser = Arc::new(CypherParser::new(functions.clone()));
+    let element_index = Arc::new(InMemoryElementIndex::new());
+    let query = QueryBuilder::new("MATCH (n:Person) RETURN n.name AS name", parser)
+        .with_function_registry(functions)
+        .with_element_index(element_index.clone())
+        .with_archive_index(element_index.clone())
+        .build()
+        .await;
+    assert!(!query.supports_atomic_result_hooks());
+
+    let source_hook_called = Arc::new(AtomicBool::new(false));
+    let called = source_hook_called.clone();
+    let source_result = query
+        .process_source_change_with_result_hook(
+            person_change("person-1", "Alice", 1_000, false),
+            move |_| async move {
+                called.store(true, Ordering::Relaxed);
+                Ok(())
+            },
+        )
+        .await;
+    assert!(matches!(
+        source_result,
+        Err(EvaluationError::IndexError(
+            IndexError::AtomicSessionNotSupported
+        ))
+    ));
+    assert!(!source_hook_called.load(Ordering::Relaxed));
+    assert!(
+        element_index
+            .get_element(&ElementReference::new("people", "person-1"))
+            .await
+            .expect("read in-memory element")
+            .is_none(),
+        "rejection must happen before core mutation"
+    );
+
+    let functions = Arc::new(FunctionRegistry::new());
+    let parser = Arc::new(CypherParser::new(functions.clone()));
+    let element_index = Arc::new(InMemoryElementIndex::new());
+    let future_queue = Arc::new(InMemoryFutureQueue::new());
+    let future_query = QueryBuilder::new(
+        "MATCH (n:Person) WHERE drasi.trueLater(true, 2000) RETURN n.name AS name",
+        parser,
+    )
+    .with_function_registry(functions)
+    .with_element_index(element_index.clone())
+    .with_archive_index(element_index)
+    .with_future_queue(future_queue.clone())
+    .build()
+    .await;
+    let initial = future_query
+        .process_source_change(person_change("future-person", "Grace", 1_000, false))
+        .await
+        .expect("legacy processing should queue a future");
+    assert!(initial.is_empty());
+    assert_eq!(
+        future_queue.peek_due_time().await.expect("peek future"),
+        Some(2_000)
+    );
+
+    let future_hook_called = Arc::new(AtomicBool::new(false));
+    let called = future_hook_called.clone();
+    let due_result = future_query
+        .process_due_futures_with_result_hook(move |_| async move {
+            called.store(true, Ordering::Relaxed);
+            Ok(())
+        })
+        .await;
+    assert!(matches!(
+        due_result,
+        Err(EvaluationError::IndexError(
+            IndexError::AtomicSessionNotSupported
+        ))
+    ));
+    assert!(!future_hook_called.load(Ordering::Relaxed));
+    assert_eq!(
+        future_queue
+            .peek_due_time()
+            .await
+            .expect("peek retained future"),
+        Some(2_000),
+        "rejection must happen before the future pop"
+    );
 }

--- a/core/src/query/tests/result_hook_tests.rs
+++ b/core/src/query/tests/result_hook_tests.rs
@@ -1,0 +1,400 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::BTreeSet,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use async_trait::async_trait;
+use drasi_query_ast::ast;
+use drasi_query_cypher::CypherParser;
+use serde_json::json;
+
+use crate::{
+    evaluation::{
+        context::{QueryPartEvaluationContext, QueryVariables},
+        functions::{
+            aggregation::RegisterAggregationFunctions, Function, FunctionRegistry, ScalarFunction,
+        },
+        variable_value::VariableValue,
+        ExpressionEvaluationContext, FunctionError, FunctionEvaluationError,
+    },
+    interface::{
+        ElementIndex, IndexError, MiddlewareError, MiddlewareSetupError, SessionControl,
+        SourceMiddleware, SourceMiddlewareFactory,
+    },
+    middleware::MiddlewareTypeRegistry,
+    models::{
+        Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange,
+        SourceMiddlewareConfig,
+    },
+    query::{ContinuousQuery, QueryBuilder, ResultHookFuture},
+};
+
+async fn build_query(query: &str, functions: Arc<FunctionRegistry>) -> ContinuousQuery {
+    let parser = Arc::new(CypherParser::new(functions.clone()));
+    QueryBuilder::new(query, parser)
+        .with_function_registry(functions)
+        .build()
+        .await
+}
+
+fn person_change(id: &str, name: &str, effective_from: u64, update: bool) -> SourceChange {
+    let element = Element::Node {
+        metadata: ElementMetadata {
+            reference: ElementReference::new("people", id),
+            labels: Arc::new([Arc::from("Person")]),
+            effective_from,
+        },
+        properties: ElementPropertyMap::from(json!({
+            "name": name,
+            "age": 30,
+        })),
+    };
+
+    if update {
+        SourceChange::Update { element }
+    } else {
+        SourceChange::Insert { element }
+    }
+}
+
+fn value<'a>(variables: &'a QueryVariables, key: &str) -> &'a VariableValue {
+    variables
+        .get(key)
+        .unwrap_or_else(|| panic!("missing result variable {key}"))
+}
+
+#[tokio::test]
+async fn result_hook_borrows_exact_add_update_delete_and_aggregation_results() {
+    let query = build_query(
+        "MATCH (n:Person) RETURN n.name AS name",
+        Arc::new(FunctionRegistry::new()),
+    )
+    .await;
+
+    let observed_pointer = Arc::new(AtomicUsize::new(0));
+    let hook_pointer = observed_pointer.clone();
+    let added = query
+        .process_source_change_with_result_hook(
+            person_change("person-1", "Alice", 1_000, false),
+            move |results| -> ResultHookFuture<'_> {
+                Box::pin(async move {
+                    tokio::task::yield_now().await;
+                    hook_pointer.store(results.as_ptr() as usize, Ordering::Relaxed);
+                    let [QueryPartEvaluationContext::Adding { after, .. }] = results else {
+                        panic!("expected one adding result, got {results:?}");
+                    };
+                    assert_eq!(value(after, "name"), &VariableValue::from("Alice"));
+                    Ok(())
+                })
+            },
+        )
+        .await
+        .expect("add should succeed");
+    assert_eq!(
+        observed_pointer.load(Ordering::Relaxed),
+        added.as_ptr() as usize,
+        "the hook must borrow the returned result allocation"
+    );
+
+    let updated = query
+        .process_source_change_with_result_hook(
+            person_change("person-1", "Alicia", 2_000, true),
+            |results| -> ResultHookFuture<'_> {
+                Box::pin(async move {
+                    tokio::task::yield_now().await;
+                    let [QueryPartEvaluationContext::Updating { before, after, .. }] = results
+                    else {
+                        panic!("expected one updating result, got {results:?}");
+                    };
+                    assert_eq!(value(before, "name"), &VariableValue::from("Alice"));
+                    assert_eq!(value(after, "name"), &VariableValue::from("Alicia"));
+                    Ok(())
+                })
+            },
+        )
+        .await
+        .expect("update should succeed");
+    assert!(matches!(
+        updated.as_slice(),
+        [QueryPartEvaluationContext::Updating { .. }]
+    ));
+
+    let removed = query
+        .process_source_change_with_result_hook(
+            SourceChange::Delete {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new("people", "person-1"),
+                    labels: Arc::new([Arc::from("Person")]),
+                    effective_from: 3_000,
+                },
+            },
+            |results| -> ResultHookFuture<'_> {
+                Box::pin(async move {
+                    tokio::task::yield_now().await;
+                    let [QueryPartEvaluationContext::Removing { before, .. }] = results else {
+                        panic!("expected one removing result, got {results:?}");
+                    };
+                    assert_eq!(value(before, "name"), &VariableValue::from("Alicia"));
+                    Ok(())
+                })
+            },
+        )
+        .await
+        .expect("delete should succeed");
+    assert!(matches!(
+        removed.as_slice(),
+        [QueryPartEvaluationContext::Removing { .. }]
+    ));
+
+    let functions = Arc::new(FunctionRegistry::new());
+    functions.register_aggregation_functions();
+    let aggregate_query = build_query("MATCH (n:Person) RETURN count(n) AS total", functions).await;
+    let aggregated = aggregate_query
+        .process_source_change_with_result_hook(
+            person_change("person-2", "Grace", 4_000, false),
+            |results| -> ResultHookFuture<'_> {
+                Box::pin(async move {
+                    tokio::task::yield_now().await;
+                    let [QueryPartEvaluationContext::Aggregation {
+                        before,
+                        after,
+                        grouping_keys,
+                        default_before,
+                        default_after,
+                        ..
+                    }] = results
+                    else {
+                        panic!("expected one aggregation result, got {results:?}");
+                    };
+                    assert_eq!(
+                        value(before.as_ref().expect("default count result"), "total"),
+                        &VariableValue::Integer(0.into())
+                    );
+                    assert!(grouping_keys.is_empty());
+                    assert!(*default_before);
+                    assert!(!default_after);
+                    assert_eq!(value(after, "total"), &VariableValue::Integer(1.into()));
+                    Ok(())
+                })
+            },
+        )
+        .await
+        .expect("aggregation should succeed");
+    assert!(matches!(
+        aggregated.as_slice(),
+        [QueryPartEvaluationContext::Aggregation { .. }]
+    ));
+}
+
+#[derive(Default)]
+struct RecordingSessionControl {
+    calls: Mutex<Vec<&'static str>>,
+}
+
+impl RecordingSessionControl {
+    fn calls(&self) -> Vec<&'static str> {
+        self.calls.lock().expect("calls lock poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl SessionControl for RecordingSessionControl {
+    async fn begin(&self) -> Result<(), IndexError> {
+        self.calls
+            .lock()
+            .expect("calls lock poisoned")
+            .push("begin");
+        Ok(())
+    }
+
+    async fn commit(&self) -> Result<(), IndexError> {
+        self.calls
+            .lock()
+            .expect("calls lock poisoned")
+            .push("commit");
+        Ok(())
+    }
+
+    fn rollback(&self) -> Result<(), IndexError> {
+        self.calls
+            .lock()
+            .expect("calls lock poisoned")
+            .push("rollback");
+        Ok(())
+    }
+}
+
+struct FailingScalar;
+
+#[async_trait]
+impl ScalarFunction for FailingScalar {
+    async fn call(
+        &self,
+        _context: &ExpressionEvaluationContext,
+        expression: &ast::FunctionExpression,
+        _args: Vec<VariableValue>,
+    ) -> Result<VariableValue, FunctionError> {
+        Err(FunctionError {
+            function_name: expression.name.to_string(),
+            error: FunctionEvaluationError::InvalidArgumentCount,
+        })
+    }
+}
+
+#[tokio::test]
+async fn result_hook_is_not_called_when_evaluation_fails() {
+    let functions = Arc::new(FunctionRegistry::new());
+    functions.register_function("fail", Function::Scalar(Arc::new(FailingScalar)));
+    let parser = Arc::new(CypherParser::new(functions.clone()));
+    let session_control = Arc::new(RecordingSessionControl::default());
+    let query = QueryBuilder::new("MATCH (n:Person) RETURN fail() AS value", parser)
+        .with_function_registry(functions)
+        .with_session_control(session_control.clone())
+        .build()
+        .await;
+    let hook_called = Arc::new(AtomicBool::new(false));
+    let hook_called_inside = hook_called.clone();
+
+    let result = query
+        .process_source_change_with_result_hook(
+            person_change("person-1", "Alice", 1_000, false),
+            move |_| -> ResultHookFuture<'_> {
+                hook_called_inside.store(true, Ordering::Relaxed);
+                Box::pin(async { Ok(()) })
+            },
+        )
+        .await;
+
+    assert!(result.is_err());
+    assert!(!hook_called.load(Ordering::Relaxed));
+    assert_eq!(session_control.calls(), vec!["begin", "rollback"]);
+}
+
+struct FanOutMiddleware;
+
+#[async_trait]
+impl SourceMiddleware for FanOutMiddleware {
+    async fn process(
+        &self,
+        source_change: SourceChange,
+        _element_index: &dyn ElementIndex,
+    ) -> Result<Vec<SourceChange>, MiddlewareError> {
+        let source_id = source_change.get_reference().source_id.clone();
+        let effective_from = source_change.get_transaction_time();
+        Ok(["first", "second"]
+            .into_iter()
+            .map(|name| SourceChange::Insert {
+                element: Element::Node {
+                    metadata: ElementMetadata {
+                        reference: ElementReference::new(source_id.as_ref(), name),
+                        labels: Arc::new([Arc::from("Person")]),
+                        effective_from,
+                    },
+                    properties: ElementPropertyMap::from(json!({ "name": name })),
+                },
+            })
+            .collect())
+    }
+}
+
+struct FanOutFactory;
+
+impl SourceMiddlewareFactory for FanOutFactory {
+    fn name(&self) -> String {
+        "fan-out".to_string()
+    }
+
+    fn create(
+        &self,
+        _config: &SourceMiddlewareConfig,
+    ) -> Result<Arc<dyn SourceMiddleware>, MiddlewareSetupError> {
+        Ok(Arc::new(FanOutMiddleware))
+    }
+}
+
+#[tokio::test]
+async fn result_hook_preserves_empty_and_middleware_fan_out_results() {
+    let no_result_query = build_query(
+        "MATCH (n:Person) WHERE n.age > 100 RETURN n.name AS name",
+        Arc::new(FunctionRegistry::new()),
+    )
+    .await;
+    let empty_hook_called = Arc::new(AtomicBool::new(false));
+    let empty_hook_called_inside = empty_hook_called.clone();
+    let empty = no_result_query
+        .process_source_change_with_result_hook(
+            person_change("person-1", "Alice", 1_000, false),
+            move |results| -> ResultHookFuture<'_> {
+                Box::pin(async move {
+                    tokio::task::yield_now().await;
+                    assert!(results.is_empty());
+                    empty_hook_called_inside.store(true, Ordering::Relaxed);
+                    Ok(())
+                })
+            },
+        )
+        .await
+        .expect("no-result evaluation should succeed");
+    assert!(empty.is_empty());
+    assert!(empty_hook_called.load(Ordering::Relaxed));
+
+    let functions = Arc::new(FunctionRegistry::new());
+    let parser = Arc::new(CypherParser::new(functions.clone()));
+    let mut registry = MiddlewareTypeRegistry::new();
+    registry.register(Arc::new(FanOutFactory));
+    let query = QueryBuilder::new("MATCH (n:Person) RETURN n.name AS name", parser)
+        .with_function_registry(functions)
+        .with_middleware_registry(Arc::new(registry))
+        .with_source_middleware(Arc::new(SourceMiddlewareConfig::new(
+            "fan-out",
+            "fan-out",
+            serde_json::Map::new(),
+        )))
+        .with_source_pipeline("people", &["fan-out".to_string()])
+        .build()
+        .await;
+
+    let results = query
+        .process_source_change_with_result_hook(
+            person_change("ignored", "ignored", 2_000, false),
+            |results| -> ResultHookFuture<'_> {
+                Box::pin(async move {
+                    tokio::task::yield_now().await;
+                    let names = results
+                        .iter()
+                        .map(|result| match result {
+                            QueryPartEvaluationContext::Adding { after, .. } => {
+                                value(after, "name").to_string()
+                            }
+                            other => panic!("expected adding result, got {other:?}"),
+                        })
+                        .collect::<BTreeSet<_>>();
+                    assert_eq!(
+                        names,
+                        BTreeSet::from(["first".to_string(), "second".to_string()])
+                    );
+                    Ok(())
+                })
+            },
+        )
+        .await
+        .expect("fan-out evaluation should succeed");
+    assert_eq!(results.len(), 2);
+}


### PR DESCRIPTION
Stack A layer 5 of 7

Depends on #868.

Adds result-aware pre-commit hooks for live source changes and due-future evaluation. Hooks receive immutable Arc-owned core results, so ordinary async closures can borrow non-static caller state while staging related writes without recomputation, JSON conversion, or deep-cloning result values.

Atomic result persistence is enforced through an opaque `AtomicResultTransaction` capability. `CreatedIndexes::atomic_result_transaction()` mints it only when the core session, checkpoint/result-sequence store, outbox append/trim writer, and live-results writer all advertise the same transaction-domain identity. The hooks reject unsupported or cross-bundle capabilities before evaluation or future pop.

RocksDB provider resources share one session domain: checkpoint, outbox append/trim, live mutations, result sequence, and core element/result/future state commit or roll back together. Direct/outside-session writer behavior remains unchanged. Garnet does not advertise full atomic result persistence because its outbox/live writers remain nonparticipating, allowing A6 to retain the legacy weaker path safely.

The legacy APIs remain source-compatible and behavior-neutral. A6 will use the validated capability for atomic live/future output staging.