### PR TITLE
fix(lib): atomically stage query outputs

### DIFF
--- a/components/indexes/rocksdb/src/checkpoint.rs
+++ b/components/indexes/rocksdb/src/checkpoint.rs
@@ -386,17 +386,16 @@ impl CheckpointStore for RocksDbCheckpointStore {
 
     async fn read_result_sequence(&self, query_id: &str) -> Result<Option<u64>, IndexError> {
         let db = self.db.clone();
-        let session_state = self.session_state.clone();
         let key = format!("{RESULT_SEQUENCE_PREFIX}{query_id}");
 
         let task = task::spawn_blocking(move || {
             let cf = db
                 .cf_handle(STREAM_STATE_CF)
                 .expect("stream_state cf not found");
-            let data = session_state.with_txn_or_db(
-                |txn| txn.get_cf(&cf, &key).map_err(IndexError::other),
-                |db| db.get_cf(&cf, &key).map_err(IndexError::other),
-            )?;
+            // Recovery and snapshot readers must never observe a sequence staged
+            // by an in-flight transaction while live rows are still committed at
+            // the previous sequence.
+            let data = db.get_cf(&cf, &key).map_err(IndexError::other)?;
             match data {
                 Some(v) => {
                     let bytes: [u8; 8] = v

--- a/lib/src/component_graph/graph.rs
+++ b/lib/src/component_graph/graph.rs
@@ -1224,7 +1224,7 @@ pub(super) fn is_valid_relationship(
 ///   ↓
 /// Reconfiguring ──→ Stopped | Starting | Error
 ///
-/// Error ──→ Starting (retry) | Stopped (reset)
+/// Error ──→ Starting (retry) | Stopping (cleanup) | Stopped (reset)
 ///
 /// Note: Added and Removed are set by the graph on add/remove_component()
 /// and are NOT valid targets for validate_and_transition().
@@ -1248,6 +1248,7 @@ pub(super) fn is_valid_transition(from: &ComponentStatus, to: &ComponentStatus) 
             | (Stopping, Error)
             // Error recovery
             | (Error, Starting) // retry
+            | (Error, Stopping) // operator cleanup
             | (Error, Stopped) // reset
             // Reconfiguration (from any stable state)
             | (Added, Reconfiguring)
@@ -1283,9 +1284,6 @@ fn describe_invalid_transition(id: &str, from: &ComponentStatus, to: &ComponentS
             format!("Cannot stop component '{id}': it is already stopped")
         }
         (Stopping, Stopping) => format!("Component '{id}' is already stopping"),
-        (Error, Stopping) => {
-            format!("Cannot stop component '{id}': it is in error state")
-        }
         // Trying to reconfigure during a transition
         (Starting, Reconfiguring) => {
             format!("Cannot reconfigure component '{id}' while it is starting")

--- a/lib/src/component_graph/tests.rs
+++ b/lib/src/component_graph/tests.rs
@@ -885,7 +885,7 @@ fn test_validate_and_transition_nonexistent_component() {
 }
 
 #[test]
-fn test_validate_and_transition_cannot_stop_error_state() {
+fn test_validate_and_transition_stops_error_state_for_cleanup() {
     let mut graph = create_test_graph();
     graph.add_component(source_node("s1")).unwrap();
     graph
@@ -896,11 +896,10 @@ fn test_validate_and_transition_cannot_stop_error_state() {
         .unwrap();
 
     let result = graph.validate_and_transition("s1", ComponentStatus::Stopping, None);
-    assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.contains("error state"),
-        "Expected 'error state' in: {err_msg}"
+    assert!(result.is_ok());
+    assert_eq!(
+        graph.get_component("s1").unwrap().status,
+        ComponentStatus::Stopping
     );
 }
 

--- a/lib/src/lifecycle.rs
+++ b/lib/src/lifecycle.rs
@@ -199,7 +199,7 @@ impl LifecycleManager {
             };
             if !matches!(
                 live_status,
-                ComponentStatus::Running | ComponentStatus::Starting
+                ComponentStatus::Running | ComponentStatus::Starting | ComponentStatus::Error
             ) {
                 continue;
             }
@@ -329,6 +329,40 @@ mod tests {
 
         let status = core.get_source_status("stop-src").await.unwrap();
         assert_eq!(status, ComponentStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn stop_all_components_cleans_up_error_components() {
+        let source = TestMockSource::with_auto_start("error-src".to_string(), true).unwrap();
+        let core = build_with_sources(vec![source]).await;
+        let mut event_rx = core.component_graph.read().await.subscribe();
+        core.start().await.unwrap();
+        wait_for_component_status(
+            &mut event_rx,
+            "error-src",
+            ComponentStatus::Running,
+            Duration::from_secs(5),
+        )
+        .await;
+        core.component_graph
+            .write()
+            .await
+            .validate_and_transition("error-src", ComponentStatus::Error, None)
+            .unwrap();
+
+        core.stop().await.unwrap();
+
+        wait_for_component_status(
+            &mut event_rx,
+            "error-src",
+            ComponentStatus::Stopped,
+            Duration::from_secs(5),
+        )
+        .await;
+        assert_eq!(
+            core.get_source_status("error-src").await.unwrap(),
+            ComponentStatus::Stopped
+        );
     }
 
     #[tokio::test]

--- a/lib/src/managers/lifecycle_helpers.rs
+++ b/lib/src/managers/lifecycle_helpers.rs
@@ -150,9 +150,8 @@ pub async fn start_component<R: ComponentRuntime>(
             id,
             ComponentStatus::Starting,
             Some(format!("Starting {component_type}")),
-        )?;
-    }
-
+        )?
+    };
     if let Err(e) = runtime.start().await {
         // Revert graph status so the component isn't stuck at Starting
         let mut g = graph.write().await;
@@ -185,9 +184,8 @@ pub async fn stop_component<R: ComponentRuntime>(
             id,
             ComponentStatus::Stopping,
             Some(format!("Stopping {component_type}")),
-        )?;
-    }
-
+        )?
+    };
     if let Err(e) = runtime.stop().await {
         // Revert graph status so the component isn't stuck at Stopping
         let mut g = graph.write().await;
@@ -259,7 +257,10 @@ where
             ));
         }
 
-        if matches!(status, ComponentStatus::Running | ComponentStatus::Starting) {
+        if matches!(
+            status,
+            ComponentStatus::Running | ComponentStatus::Starting | ComponentStatus::Error
+        ) {
             g.validate_and_transition(
                 id,
                 ComponentStatus::Stopping,
@@ -484,7 +485,7 @@ where
 
 /// Stop all active components of a given kind (best-effort).
 ///
-/// Components in Running or Starting state are stopped via the provided `stop_fn`.
+/// Components in Running, Starting, or Error state are stopped via the provided `stop_fn`.
 /// Errors are logged but do not prevent stopping other components.
 pub async fn stop_all_components<F, Fut>(
     graph: &Arc<RwLock<ComponentGraph>>,
@@ -511,7 +512,9 @@ where
                 .map(|n| {
                     matches!(
                         n.status,
-                        ComponentStatus::Running | ComponentStatus::Starting
+                        ComponentStatus::Running
+                            | ComponentStatus::Starting
+                            | ComponentStatus::Error
                     )
                 })
                 .unwrap_or(false)

--- a/lib/src/queries/atomic_lifecycle_tests.rs
+++ b/lib/src/queries/atomic_lifecycle_tests.rs
@@ -1,0 +1,823 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use drasi_core::{
+    interface::{IndexBackendPlugin, IndexError},
+    middleware::MiddlewareTypeRegistry,
+    models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
+};
+use drasi_index_rocksdb::RocksDbIndexProvider;
+use serde_json::json;
+use tokio::sync::{oneshot, Mutex, Notify, RwLock};
+
+use super::{
+    manager::{DrasiQuery, Query, QueryManager},
+    query_composite_host::{QueryIngressFence, QueryProcessingObserver},
+};
+use crate::{
+    channels::{
+        ChangeReceiver, ComponentStatus, DispatchMode, QueryResult, SourceEvent,
+        SourceEventWrapper, SubscriptionResponse,
+    },
+    component_graph::ComponentGraph,
+    config::{QueryConfig, QueryLanguage, SourceSubscriptionConfig},
+    indexes::{IndexFactory, StorageBackendRef},
+    managers::get_or_init_global_registry,
+    sources::{Source, SourceBase, SourceBaseParams, SourceManager},
+};
+
+const SOURCE_ID: &str = "atomic-lifecycle-source";
+const BLOCKING_SOURCE_ID: &str = "atomic-blocking-source";
+const BACKEND_NAME: &str = "atomic-lifecycle-rocks";
+
+struct BoundedLifecycleSource {
+    base: SourceBase,
+    removed_position_handles: Arc<AtomicUsize>,
+}
+
+impl Clone for BoundedLifecycleSource {
+    fn clone(&self) -> Self {
+        Self {
+            base: self.base.clone_shared(),
+            removed_position_handles: self.removed_position_handles.clone(),
+        }
+    }
+}
+
+impl BoundedLifecycleSource {
+    fn new() -> Self {
+        Self {
+            base: SourceBase::new(
+                SourceBaseParams::new(SOURCE_ID)
+                    .with_dispatch_mode(DispatchMode::Channel)
+                    .with_dispatch_buffer_capacity(1)
+                    .with_auto_start(false),
+            )
+            .expect("create bounded lifecycle source"),
+            removed_position_handles: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    async fn inject(&self, sequence: u64, name: &str) -> Result<()> {
+        let change = SourceChange::Insert {
+            element: Element::Node {
+                metadata: ElementMetadata {
+                    reference: ElementReference::new(SOURCE_ID, &format!("person-{sequence}")),
+                    labels: vec![Arc::from("Person")].into(),
+                    effective_from: sequence.saturating_mul(1_000),
+                },
+                properties: ElementPropertyMap::from(json!({ "name": name })),
+            },
+        };
+        let timestamp = chrono::DateTime::from_timestamp_millis(change.get_realtime() as i64)
+            .expect("valid lifecycle event timestamp");
+        let mut event = SourceEventWrapper::with_sequence(
+            SOURCE_ID.to_string(),
+            SourceEvent::Change(change),
+            timestamp,
+            sequence,
+            None,
+        );
+        event.set_source_position(Bytes::from(format!("position-{sequence}")));
+        self.base.dispatch_event(event).await
+    }
+
+    fn removed_position_handles(&self) -> usize {
+        self.removed_position_handles.load(Ordering::Acquire)
+    }
+}
+
+#[async_trait]
+impl Source for BoundedLifecycleSource {
+    fn id(&self) -> &str {
+        SOURCE_ID
+    }
+
+    fn type_name(&self) -> &str {
+        "atomic-lifecycle"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+
+    fn dispatch_mode(&self) -> DispatchMode {
+        DispatchMode::Channel
+    }
+
+    fn auto_start(&self) -> bool {
+        false
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.base
+            .set_status(ComponentStatus::Running, Some("Running".to_string()))
+            .await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base.stop_common().await
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.status_handle().get_status().await
+    }
+
+    async fn subscribe(
+        &self,
+        settings: crate::config::SourceSubscriptionSettings,
+    ) -> Result<SubscriptionResponse> {
+        self.base
+            .subscribe_with_bootstrap(&settings, self.type_name())
+            .await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn initialize(&self, context: crate::context::SourceRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn remove_position_handle(&self, query_id: &str) {
+        self.removed_position_handles.fetch_add(1, Ordering::AcqRel);
+        self.base.remove_position_handle(query_id).await;
+    }
+}
+
+struct BlockingSubscribeSource {
+    base: SourceBase,
+    entered_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    release: Arc<Notify>,
+}
+
+impl Clone for BlockingSubscribeSource {
+    fn clone(&self) -> Self {
+        Self {
+            base: self.base.clone_shared(),
+            entered_tx: self.entered_tx.clone(),
+            release: self.release.clone(),
+        }
+    }
+}
+
+impl BlockingSubscribeSource {
+    fn new() -> (Self, oneshot::Receiver<()>) {
+        let (entered_tx, entered_rx) = oneshot::channel();
+        (
+            Self {
+                base: SourceBase::new(
+                    SourceBaseParams::new(BLOCKING_SOURCE_ID)
+                        .with_dispatch_mode(DispatchMode::Channel)
+                        .with_dispatch_buffer_capacity(1)
+                        .with_auto_start(false),
+                )
+                .expect("create blocking lifecycle source"),
+                entered_tx: Arc::new(Mutex::new(Some(entered_tx))),
+                release: Arc::new(Notify::new()),
+            },
+            entered_rx,
+        )
+    }
+}
+
+#[async_trait]
+impl Source for BlockingSubscribeSource {
+    fn id(&self) -> &str {
+        BLOCKING_SOURCE_ID
+    }
+
+    fn type_name(&self) -> &str {
+        "atomic-blocking"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+
+    fn dispatch_mode(&self) -> DispatchMode {
+        DispatchMode::Channel
+    }
+
+    fn auto_start(&self) -> bool {
+        false
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.base
+            .set_status(ComponentStatus::Running, Some("Running".to_string()))
+            .await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base.stop_common().await
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.status_handle().get_status().await
+    }
+
+    async fn subscribe(
+        &self,
+        settings: crate::config::SourceSubscriptionSettings,
+    ) -> Result<SubscriptionResponse> {
+        if let Some(entered_tx) = self.entered_tx.lock().await.take() {
+            let _ = entered_tx.send(());
+        }
+        self.release.notified().await;
+        self.base
+            .subscribe_with_bootstrap(&settings, self.type_name())
+            .await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    async fn initialize(&self, context: crate::context::SourceRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn remove_position_handle(&self, query_id: &str) {
+        self.base.remove_position_handle(query_id).await;
+    }
+}
+
+struct FailBeforeCommit;
+
+#[async_trait]
+impl QueryProcessingObserver for FailBeforeCommit {
+    async fn after_output_staged(&self) -> std::result::Result<(), IndexError> {
+        Err(IndexError::CorruptedData)
+    }
+}
+
+struct FailAfterCommit;
+
+#[async_trait]
+impl QueryProcessingObserver for FailAfterCommit {
+    async fn after_commit_before_publish(&self) -> Result<()> {
+        Err(anyhow::anyhow!(
+            "injected manager failure after commit before publication"
+        ))
+    }
+}
+
+struct LifecycleHarness {
+    manager: Arc<QueryManager>,
+    source_manager: Arc<SourceManager>,
+    graph: Arc<RwLock<ComponentGraph>>,
+    source: BoundedLifecycleSource,
+}
+
+impl LifecycleHarness {
+    async fn new(path: &std::path::Path) -> Self {
+        let log_registry = get_or_init_global_registry();
+        let (graph, mut update_rx) = ComponentGraph::new("atomic-lifecycle");
+        let update_tx = graph.update_sender();
+        let graph = Arc::new(RwLock::new(graph));
+        let update_graph = graph.clone();
+        tokio::spawn(async move {
+            while let Some(update) = update_rx.recv().await {
+                update_graph.write().await.apply_update(update);
+            }
+        });
+
+        let source_manager = Arc::new(SourceManager::new(
+            "atomic-lifecycle",
+            log_registry.clone(),
+            graph.clone(),
+            update_tx.clone(),
+        ));
+        let provider: Arc<dyn IndexBackendPlugin> =
+            Arc::new(RocksDbIndexProvider::new(path, true, false));
+        let index_factory = Arc::new(IndexFactory::new(
+            vec![],
+            HashMap::from([(BACKEND_NAME.to_string(), provider)]),
+        ));
+        let manager = Arc::new(QueryManager::new(
+            "atomic-lifecycle",
+            source_manager.clone(),
+            index_factory,
+            Arc::new(MiddlewareTypeRegistry::new()),
+            log_registry,
+            graph.clone(),
+            update_tx,
+            None,
+        ));
+        let source = BoundedLifecycleSource::new();
+
+        graph
+            .write()
+            .await
+            .register_source(SOURCE_ID, HashMap::new())
+            .expect("register lifecycle source");
+        source_manager
+            .provision_source(source.clone())
+            .await
+            .expect("provision lifecycle source");
+        source_manager
+            .start_source(SOURCE_ID.to_string())
+            .await
+            .expect("start lifecycle source");
+
+        Self {
+            manager,
+            source_manager,
+            graph,
+            source,
+        }
+    }
+
+    async fn add_query(&self, query_id: &str) -> Arc<dyn Query> {
+        self.add_query_config(query_config(query_id)).await
+    }
+
+    async fn add_query_config(&self, config: QueryConfig) -> Arc<dyn Query> {
+        let query_id = config.id.clone();
+        let source_ids: Vec<String> = config
+            .sources
+            .iter()
+            .map(|source| source.source_id.clone())
+            .collect();
+        self.graph
+            .write()
+            .await
+            .register_query(&query_id, HashMap::new(), &source_ids)
+            .expect("register lifecycle query");
+        self.manager
+            .provision_query(config)
+            .await
+            .expect("provision lifecycle query");
+        self.manager
+            .get_query_instance(&query_id)
+            .await
+            .expect("get lifecycle query")
+    }
+
+    async fn start_query(&self, query_id: &str) {
+        self.manager
+            .start_query(query_id.to_string())
+            .await
+            .expect("start lifecycle query");
+        wait_for_status(&self.manager, query_id, ComponentStatus::Running).await;
+    }
+}
+
+fn query_config(query_id: &str) -> QueryConfig {
+    query_config_with_sources(query_id, &[SOURCE_ID])
+}
+
+fn query_config_with_sources(query_id: &str, source_ids: &[&str]) -> QueryConfig {
+    QueryConfig {
+        id: query_id.to_string(),
+        query: "MATCH (n:Person) RETURN n.name AS name".to_string(),
+        query_language: QueryLanguage::Cypher,
+        middleware: vec![],
+        sources: source_ids
+            .iter()
+            .map(|source_id| SourceSubscriptionConfig {
+                source_id: (*source_id).to_string(),
+                nodes: vec![],
+                relations: vec![],
+                pipeline: vec![],
+            })
+            .collect(),
+        auto_start: false,
+        joins: None,
+        enable_bootstrap: false,
+        bootstrap_buffer_size: 8,
+        priority_queue_capacity: Some(1),
+        dispatch_buffer_capacity: Some(8),
+        dispatch_mode: Some(DispatchMode::Channel),
+        storage_backend: Some(StorageBackendRef::Named(BACKEND_NAME.to_string())),
+        recovery_policy: None,
+        outbox_capacity: 8,
+        bootstrap_timeout_secs: 2,
+    }
+}
+
+fn concrete_query(query: &Arc<dyn Query>) -> &DrasiQuery {
+    query
+        .as_any()
+        .downcast_ref::<DrasiQuery>()
+        .expect("DrasiQuery runtime")
+}
+
+async fn wait_for_status(manager: &QueryManager, query_id: &str, expected: ComponentStatus) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if manager
+                .get_query_status(query_id.to_string())
+                .await
+                .expect("read query status")
+                == expected
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("query status transition timed out");
+}
+
+async fn receive_result(receiver: &mut Box<dyn ChangeReceiver<QueryResult>>) -> Arc<QueryResult> {
+    tokio::time::timeout(Duration::from_secs(5), receiver.recv())
+        .await
+        .expect("query result timed out")
+        .expect("query result channel closed")
+}
+
+#[tokio::test]
+async fn atomic_fence_unblocks_shared_source_and_error_stop_allows_replay() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let harness = LifecycleHarness::new(temp_dir.path()).await;
+    let failed = harness.add_query("atomic-failed").await;
+    let healthy = harness.add_query("atomic-healthy").await;
+    concrete_query(&failed)
+        .set_processing_observer(Some(Arc::new(FailBeforeCommit)))
+        .await;
+    let mut failed_results = failed
+        .subscribe("failed-test".to_string())
+        .await
+        .expect("subscribe failed query output")
+        .receiver;
+    let mut healthy_results = healthy
+        .subscribe("healthy-test".to_string())
+        .await
+        .expect("subscribe healthy query output")
+        .receiver;
+
+    harness.start_query("atomic-failed").await;
+    harness.start_query("atomic-healthy").await;
+    harness
+        .source
+        .inject(1, "first")
+        .await
+        .expect("inject failing event");
+    wait_for_status(&harness.manager, "atomic-failed", ComponentStatus::Error).await;
+    let healthy_first = receive_result(&mut healthy_results).await;
+    assert_eq!(healthy_first.sequence, 1);
+    assert_eq!(failed.subscription_count().await, 0);
+    assert!(!concrete_query(&failed).publication_recovery_required());
+
+    for sequence in 2..=6 {
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            harness
+                .source
+                .inject(sequence, &format!("healthy-{sequence}")),
+        )
+        .await
+        .expect("failed query must not backpressure the shared source")
+        .expect("inject event after atomic fence");
+        let healthy_result = receive_result(&mut healthy_results).await;
+        assert_eq!(healthy_result.sequence, sequence);
+    }
+
+    harness
+        .manager
+        .stop_query("atomic-failed".to_string())
+        .await
+        .expect("public stop from Error");
+    wait_for_status(&harness.manager, "atomic-failed", ComponentStatus::Stopped).await;
+    assert_eq!(failed.subscription_count().await, 0);
+    assert!(harness.source.removed_position_handles() >= 1);
+
+    concrete_query(&failed).set_processing_observer(None).await;
+    let restarted_subscription = failed
+        .subscribe("failed-restart-test".to_string())
+        .await
+        .expect("subscribe restarted failed query")
+        .receiver;
+    failed_results = restarted_subscription;
+    harness.start_query("atomic-failed").await;
+    assert_eq!(failed.subscription_count().await, 2);
+
+    harness
+        .source
+        .inject(1, "replayed")
+        .await
+        .expect("replay pre-commit failure");
+    let replayed = receive_result(&mut failed_results).await;
+    assert_eq!(replayed.sequence, 1);
+    assert_eq!(replayed.results.len(), 1);
+
+    harness
+        .manager
+        .stop_query("atomic-failed".to_string())
+        .await
+        .expect("stop restarted failed query");
+    harness
+        .manager
+        .stop_query("atomic-healthy".to_string())
+        .await
+        .expect("stop healthy query");
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn start_reaps_existing_forwarders_before_installing_replacements() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let harness = LifecycleHarness::new(temp_dir.path()).await;
+    let query = harness.add_query("atomic-restart").await;
+    let mut results = query
+        .subscribe("restart-test".to_string())
+        .await
+        .expect("subscribe restart query")
+        .receiver;
+    harness.start_query("atomic-restart").await;
+    assert_eq!(query.subscription_count().await, 2);
+    query
+        .start()
+        .await
+        .expect("same-state runtime start should be idempotent");
+    assert_eq!(
+        query.subscription_count().await,
+        2,
+        "same-state start must not replace active forwarders"
+    );
+
+    concrete_query(&query)
+        .set_local_status_for_test(ComponentStatus::Error)
+        .await;
+    wait_for_status(&harness.manager, "atomic-restart", ComponentStatus::Error).await;
+    harness
+        .manager
+        .start_query("atomic-restart".to_string())
+        .await
+        .expect("retry query from Error");
+    wait_for_status(&harness.manager, "atomic-restart", ComponentStatus::Running).await;
+    assert_eq!(
+        query.subscription_count().await,
+        2,
+        "start must reap the old source/future forwarders before replacement"
+    );
+    assert!(harness.source.removed_position_handles() >= 1);
+
+    harness
+        .source
+        .inject(1, "after-restart")
+        .await
+        .expect("inject after restart");
+    assert_eq!(receive_result(&mut results).await.sequence, 1);
+
+    harness
+        .manager
+        .stop_query("atomic-restart".to_string())
+        .await
+        .expect("stop restart query");
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn post_commit_fence_rejects_restart_without_reusing_durable_sequence() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let harness = LifecycleHarness::new(temp_dir.path()).await;
+    let query = harness.add_query("atomic-post-commit").await;
+    concrete_query(&query)
+        .set_processing_observer(Some(Arc::new(FailAfterCommit)))
+        .await;
+    harness.start_query("atomic-post-commit").await;
+
+    harness
+        .source
+        .inject(1, "committed")
+        .await
+        .expect("inject post-commit failure");
+    wait_for_status(
+        &harness.manager,
+        "atomic-post-commit",
+        ComponentStatus::Error,
+    )
+    .await;
+    let concrete = concrete_query(&query);
+    assert!(concrete.publication_recovery_required());
+    assert_eq!(concrete.output_sequence_for_test().await, 0);
+    assert_eq!(query.subscription_count().await, 0);
+    let outbox = concrete
+        .get_outbox_writer()
+        .await
+        .expect("atomic outbox writer");
+    let durable = outbox
+        .read_from("atomic-post-commit", 0)
+        .await
+        .expect("read committed outbox");
+    assert_eq!(durable.len(), 1);
+    assert_eq!(durable[0].0, 1);
+    let reconfigure = harness
+        .manager
+        .update_query(
+            "atomic-post-commit".to_string(),
+            query_config("atomic-post-commit"),
+        )
+        .await
+        .expect_err("reconfiguration must preserve the recovery fence");
+    assert!(
+        reconfigure.to_string().contains("A7 output reconciliation"),
+        "unexpected reconfiguration error: {reconfigure:#}"
+    );
+
+    harness
+        .manager
+        .stop_query("atomic-post-commit".to_string())
+        .await
+        .expect("stop post-commit query from Error");
+    wait_for_status(
+        &harness.manager,
+        "atomic-post-commit",
+        ComponentStatus::Stopped,
+    )
+    .await;
+
+    let restart = harness
+        .manager
+        .start_query("atomic-post-commit".to_string())
+        .await
+        .expect_err("unsafe in-process restart must be rejected");
+    assert!(
+        restart.to_string().contains("A7 output reconciliation"),
+        "unexpected restart error: {restart:#}"
+    );
+    wait_for_status(
+        &harness.manager,
+        "atomic-post-commit",
+        ComponentStatus::Error,
+    )
+    .await;
+    assert_eq!(query.subscription_count().await, 0);
+    assert_eq!(concrete.output_sequence_for_test().await, 0);
+    assert_eq!(
+        outbox
+            .read_from("atomic-post-commit", 0)
+            .await
+            .expect("reread committed outbox")
+            .into_iter()
+            .map(|(sequence, _)| sequence)
+            .collect::<Vec<_>>(),
+        vec![1],
+        "rejected restart must not reuse or overwrite the durable sequence"
+    );
+
+    let first_stop = harness.manager.stop_query("atomic-post-commit".to_string());
+    let second_stop = harness.manager.stop_query("atomic-post-commit".to_string());
+    let (first_stop, second_stop) = tokio::join!(first_stop, second_stop);
+    first_stop.expect("first repeated stop");
+    second_stop.expect("second repeated stop");
+    wait_for_status(
+        &harness.manager,
+        "atomic-post-commit",
+        ComponentStatus::Stopped,
+    )
+    .await;
+    assert_eq!(query.subscription_count().await, 0);
+
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn public_stop_cancels_blocked_start_and_aborts_pending_forwarders() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let harness = LifecycleHarness::new(temp_dir.path()).await;
+    let (blocking_source, subscribe_entered) = BlockingSubscribeSource::new();
+    harness
+        .graph
+        .write()
+        .await
+        .register_source(BLOCKING_SOURCE_ID, HashMap::new())
+        .expect("register blocking source");
+    harness
+        .source_manager
+        .provision_source(blocking_source.clone())
+        .await
+        .expect("provision blocking source");
+    harness
+        .source_manager
+        .start_source(BLOCKING_SOURCE_ID.to_string())
+        .await
+        .expect("start blocking source");
+
+    let query = harness
+        .add_query_config(query_config_with_sources(
+            "atomic-cancelled-start",
+            &[SOURCE_ID, BLOCKING_SOURCE_ID],
+        ))
+        .await;
+    let manager = harness.manager.clone();
+    let start_task = tokio::spawn(async move {
+        manager
+            .start_query("atomic-cancelled-start".to_string())
+            .await
+    });
+    subscribe_entered
+        .await
+        .expect("second source subscription should block");
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        harness
+            .manager
+            .stop_query("atomic-cancelled-start".to_string()),
+    )
+    .await
+    .expect("public stop must cancel a blocked subscription")
+    .expect("stop query during blocked start");
+    assert!(start_task
+        .await
+        .expect("start task should complete after cancellation")
+        .expect_err("cancelled start should return an error")
+        .to_string()
+        .contains("cancelled by stop"));
+    wait_for_status(
+        &harness.manager,
+        "atomic-cancelled-start",
+        ComponentStatus::Stopped,
+    )
+    .await;
+    assert_eq!(
+        query.subscription_count().await,
+        0,
+        "partially built forwarders must never be installed"
+    );
+    assert!(
+        harness.source.removed_position_handles() >= 1,
+        "public stop must release position state from partial subscriptions"
+    );
+
+    for sequence in 1..=4 {
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            harness.source.inject(sequence, "after-cancelled-start"),
+        )
+        .await
+        .expect("cancelled startup forwarder must release its bounded receiver")
+        .expect("dispatch after cancelled start");
+    }
+
+    harness
+        .source_manager
+        .stop_source(BLOCKING_SOURCE_ID.to_string())
+        .await
+        .expect("stop blocking source");
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn ingress_fence_close_is_idempotent_under_race() {
+    let queue = super::PriorityQueue::new(1);
+    let fence = QueryIngressFence::new(queue.clone());
+    let first = tokio::spawn(async {
+        std::future::pending::<()>().await;
+    });
+    let second = tokio::spawn(async {
+        std::future::pending::<()>().await;
+    });
+    fence.install(vec![first, second]).await;
+    assert_eq!(fence.task_count().await, 2);
+
+    let ((), ()) = tokio::join!(fence.close(), fence.close());
+    assert_eq!(fence.task_count().await, 0);
+    assert!(queue.is_empty().await);
+}

--- a/lib/src/queries/base.rs
+++ b/lib/src/queries/base.rs
@@ -72,6 +72,22 @@ pub struct QueryBase {
     pub shutdown_tx: Arc<RwLock<Option<tokio::sync::oneshot::Sender<()>>>>,
 }
 
+struct AbortTaskOnDrop(Option<tokio::task::JoinHandle<()>>);
+
+impl AbortTaskOnDrop {
+    fn take(&mut self) -> tokio::task::JoinHandle<()> {
+        self.0.take().expect("pending query task handle")
+    }
+}
+
+impl Drop for AbortTaskOnDrop {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.0 {
+            handle.abort();
+        }
+    }
+}
+
 impl QueryBase {
     /// Create a new QueryBase with the given configuration
     pub fn new(config: QueryConfig) -> Result<Self> {
@@ -217,13 +233,23 @@ impl QueryBase {
     /// Handle common stop functionality.
     pub async fn stop_common(&self) -> Result<()> {
         info!("Stopping query '{}'", self.config.id);
+        self.reap_task().await;
 
-        // Send shutdown signal if we have one
+        self.set_status(
+            ComponentStatus::Stopped,
+            Some(format!("Query '{}' stopped", self.config.id)),
+        )
+        .await;
+        info!("Query '{}' stopped", self.config.id);
+        Ok(())
+    }
+
+    /// Stop and fully reap the current processor task without changing status.
+    pub(super) async fn reap_task(&self) {
         if let Some(tx) = self.shutdown_tx.write().await.take() {
             let _ = tx.send(());
         }
 
-        // Wait for task to complete
         if let Some(mut handle) = self.task_handle.write().await.take() {
             match tokio::time::timeout(std::time::Duration::from_secs(5), &mut handle).await {
                 Ok(Ok(())) => {
@@ -238,22 +264,18 @@ impl QueryBase {
                         self.config.id
                     );
                     handle.abort();
+                    let _ = handle.await;
                 }
             }
         }
-
-        self.set_status(
-            ComponentStatus::Stopped,
-            Some(format!("Query '{}' stopped", self.config.id)),
-        )
-        .await;
-        info!("Query '{}' stopped", self.config.id);
-        Ok(())
     }
 
     /// Set the task handle
     pub async fn set_task_handle(&self, handle: tokio::task::JoinHandle<()>) {
-        *self.task_handle.write().await = Some(handle);
+        let mut pending = AbortTaskOnDrop(Some(handle));
+        let mut installed = self.task_handle.write().await;
+        debug_assert!(installed.is_none(), "query processor handle was not reaped");
+        *installed = Some(pending.take());
     }
 
     /// Set the shutdown sender

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -17,8 +17,9 @@ use async_trait::async_trait;
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
-use tokio::sync::{Notify, RwLock};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use tokio::sync::{oneshot, Mutex, Notify, RwLock};
 
 // Import drasi-core components
 use drasi_core::{
@@ -52,8 +53,8 @@ use crate::queries::output_state::{
 #[cfg(test)]
 use crate::queries::query_composite_host::dispatch_query_results;
 use crate::queries::query_composite_host::{
-    QueryCompositeHost, QueryHostRuntime, QueryLiveDependencies, QueryOutputDependencies,
-    QueryProcessingMode,
+    AtomicPublicationRecovery, QueryCompositeHost, QueryHostRuntime, QueryIngressFence,
+    QueryLiveDependencies, QueryOutputDependencies, QueryProcessingMode, QueryProcessingObserver,
 };
 use crate::queries::PriorityQueue;
 use crate::queries::QueryBase;
@@ -271,6 +272,66 @@ enum BootstrapPhase {
     Completed,
 }
 
+#[derive(Default)]
+struct PendingBootstrapAborts {
+    handles: Vec<tokio::task::AbortHandle>,
+}
+
+impl PendingBootstrapAborts {
+    fn push(&mut self, handle: tokio::task::AbortHandle) {
+        self.handles.push(handle);
+    }
+
+    fn into_handles(mut self) -> Vec<tokio::task::AbortHandle> {
+        std::mem::take(&mut self.handles)
+    }
+}
+
+impl Drop for PendingBootstrapAborts {
+    fn drop(&mut self) {
+        for handle in &self.handles {
+            handle.abort();
+        }
+    }
+}
+
+struct StartupCancellationRegistration {
+    slot: Arc<StdMutex<Option<oneshot::Sender<()>>>>,
+}
+
+impl StartupCancellationRegistration {
+    fn install(slot: Arc<StdMutex<Option<oneshot::Sender<()>>>>) -> (Self, oneshot::Receiver<()>) {
+        let (sender, receiver) = oneshot::channel();
+        let mut current = slot
+            .lock()
+            .expect("query startup cancellation lock poisoned");
+        debug_assert!(
+            current.is_none(),
+            "query startup cancellation was not cleared"
+        );
+        *current = Some(sender);
+        drop(current);
+        (Self { slot }, receiver)
+    }
+}
+
+impl Drop for StartupCancellationRegistration {
+    fn drop(&mut self) {
+        self.slot
+            .lock()
+            .expect("query startup cancellation lock poisoned")
+            .take();
+    }
+}
+
+struct StopRequestReset(Arc<AtomicBool>);
+
+impl Drop for StopRequestReset {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
 pub struct DrasiQuery {
     // DrasiLib instance ID for log routing isolation
     instance_id: String,
@@ -283,8 +344,16 @@ pub struct DrasiQuery {
     priority_queue: PriorityQueue,
     // Reference to SourceManager for direct subscription
     source_manager: Arc<SourceManager>,
-    // Track subscription tasks for cleanup
-    subscription_tasks: Arc<RwLock<Vec<tokio::task::JoinHandle<()>>>>,
+    // Own every source/future forwarder that can enqueue into the query.
+    ingress_fence: QueryIngressFence,
+    // Serialize start/stop so task handles cannot be replaced during cleanup.
+    lifecycle_lock: Arc<Mutex<()>>,
+    // Lets stop cancel a source subscription before waiting for lifecycle serialization.
+    startup_cancel: Arc<StdMutex<Option<oneshot::Sender<()>>>>,
+    // Level-triggered stop intent closes the gap before startup registers its sender.
+    stop_requested: Arc<AtomicBool>,
+    // Blocks unsafe in-process restart after committed output missed in-memory apply.
+    publication_recovery: AtomicPublicationRecovery,
     // Abort handles for bootstrap + supervisor tasks (for cleanup on stop)
     bootstrap_abort_handles: Arc<RwLock<Vec<tokio::task::AbortHandle>>>,
     // Track bootstrap state per source
@@ -309,6 +378,8 @@ pub struct DrasiQuery {
     subscribed_source_ids: Arc<RwLock<Vec<String>>>,
     // Per-query output metrics (outbox, sequence, snapshot health)
     output_metrics: Arc<QueryOutputMetrics>,
+    #[cfg(test)]
+    processing_observer: Arc<RwLock<Option<Arc<dyn QueryProcessingObserver>>>>,
 }
 
 impl DrasiQuery {
@@ -323,6 +394,7 @@ impl DrasiQuery {
         // Create priority queue with configured capacity (fallback to 10000 if not set)
         let priority_capacity = config.priority_queue_capacity.unwrap_or(10000);
         let priority_queue = PriorityQueue::new(priority_capacity);
+        let ingress_fence = QueryIngressFence::new(priority_queue.clone());
         let outbox_capacity = config.outbox_capacity;
         let bootstrap_timeout = std::time::Duration::from_secs(config.bootstrap_timeout_secs);
         let config_hash = crate::queries::compute_config_hash(&config);
@@ -343,7 +415,11 @@ impl DrasiQuery {
             config_hash,
             priority_queue,
             source_manager,
-            subscription_tasks: Arc::new(RwLock::new(Vec::new())),
+            ingress_fence,
+            lifecycle_lock: Arc::new(Mutex::new(())),
+            startup_cancel: Arc::new(StdMutex::new(None)),
+            stop_requested: Arc::new(AtomicBool::new(false)),
+            publication_recovery: AtomicPublicationRecovery::default(),
             bootstrap_abort_handles: Arc::new(RwLock::new(Vec::new())),
             bootstrap_state: Arc::new(RwLock::new(HashMap::new())),
             index_factory,
@@ -356,6 +432,8 @@ impl DrasiQuery {
             resolved_recovery_policy,
             subscribed_source_ids: Arc::new(RwLock::new(Vec::new())),
             output_metrics: Arc::new(QueryOutputMetrics::new()),
+            #[cfg(test)]
+            processing_observer: Arc::new(RwLock::new(None)),
         })
     }
 
@@ -365,6 +443,57 @@ impl DrasiQuery {
     /// pattern as Source and Reaction initialization.
     pub async fn initialize(&self, context: crate::context::QueryRuntimeContext) {
         self.base.initialize(context).await;
+    }
+
+    async fn abort_bootstrap_tasks(&self) {
+        let bootstrap_aborts: Vec<_> = {
+            let mut handles = self.bootstrap_abort_handles.write().await;
+            handles.drain(..).collect()
+        };
+        for handle in bootstrap_aborts {
+            handle.abort();
+        }
+    }
+
+    async fn stop_future_queue_source(&self) {
+        if let Some(source) = self.future_queue_source.write().await.take() {
+            source.stop().await;
+        }
+    }
+
+    async fn release_position_handles(&self) {
+        let source_ids = {
+            let mut source_ids = self.subscribed_source_ids.write().await;
+            std::mem::take(&mut *source_ids)
+        };
+        for source_id in source_ids {
+            if let Some(source) = self.source_manager.get_source_instance(&source_id).await {
+                source.remove_position_handle(&self.base.config.id).await;
+                debug!(
+                    "Query '{}' released position handle for source '{}'",
+                    self.base.config.id, source_id
+                );
+            }
+        }
+    }
+
+    async fn reap_previous_runtime(&self) {
+        self.ingress_fence.close().await;
+        self.abort_bootstrap_tasks().await;
+        self.stop_future_queue_source().await;
+        self.base.reap_task().await;
+        self.release_position_handles().await;
+    }
+
+    fn cancel_startup(&self) {
+        if let Some(cancel) = self
+            .startup_cancel
+            .lock()
+            .expect("query startup cancellation lock poisoned")
+            .take()
+        {
+            let _ = cancel.send(());
+        }
     }
 
     pub async fn get_current_results(&self) -> Vec<serde_json::Value> {
@@ -419,13 +548,38 @@ impl DrasiQuery {
 impl DrasiQuery {
     /// Count active subscription forwarder tasks (testing helper)
     pub async fn subscription_task_count(&self) -> usize {
-        self.subscription_tasks.read().await.len()
+        self.ingress_fence.task_count().await
     }
 
     /// Access the checkpoint store (for internal/test use only).
     #[doc(hidden)]
     pub async fn get_checkpoint_store(&self) -> Option<Arc<dyn CheckpointStore>> {
         self.checkpoint_store.read().await.clone()
+    }
+
+    pub(super) async fn set_processing_observer(
+        &self,
+        observer: Option<Arc<dyn QueryProcessingObserver>>,
+    ) {
+        *self.processing_observer.write().await = observer;
+    }
+
+    pub(crate) fn publication_recovery_required(&self) -> bool {
+        self.publication_recovery.is_required()
+    }
+
+    pub(crate) async fn get_outbox_writer(&self) -> Option<Arc<dyn OutboxWriter>> {
+        self.outbox_writer.read().await.clone()
+    }
+
+    pub(super) async fn set_local_status_for_test(&self, status: ComponentStatus) {
+        self.base
+            .set_status(status, Some("test transition".to_string()))
+            .await;
+    }
+
+    pub(super) async fn output_sequence_for_test(&self) -> u64 {
+        self.output_state.read().await.as_of_sequence()
     }
 }
 
@@ -489,10 +643,24 @@ async fn clear_persistent_indexes(
     Ok(())
 }
 
-#[async_trait]
-impl Query for DrasiQuery {
-    async fn start(&self) -> Result<()> {
+impl DrasiQuery {
+    async fn start_inner(&self) -> Result<()> {
         log_component_start("Query", &self.base.config.id);
+
+        self.reap_previous_runtime().await;
+        if self.publication_recovery.is_required() {
+            let message = format!(
+                "Query '{}' cannot restart in process because atomic output committed before \
+                 in-memory publication; A7 output reconciliation is required to preserve the \
+                 durable result sequence",
+                self.base.config.id
+            );
+            error!("{message}");
+            self.base
+                .set_status(ComponentStatus::Error, Some(message.clone()))
+                .await;
+            return Err(anyhow::anyhow!(message));
+        }
 
         self.bootstrap_state.write().await.clear();
 
@@ -954,8 +1122,6 @@ impl Query for DrasiQuery {
                 tokio::sync::oneshot::Receiver<anyhow::Result<crate::bootstrap::BootstrapResult>>,
             >,
         )> = Vec::new();
-        let mut subscription_tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
-
         // Build list of sources to subscribe to
         let mut sources_to_subscribe: Vec<(String, Arc<dyn Source>, SourceSubscriptionSettings)> =
             Vec::new();
@@ -977,10 +1143,7 @@ impl Query for DrasiQuery {
                         self.base.config.id, source_id
                     );
                     // Cleanup already-spawned tasks before returning error
-                    for handle in subscription_tasks.drain(..) {
-                        handle.abort();
-                        let _ = handle.await;
-                    }
+                    self.ingress_fence.close().await;
                     self.base
                         .set_status(
                             ComponentStatus::Error,
@@ -1027,6 +1190,13 @@ impl Query for DrasiQuery {
             }
         }
 
+        // Register every intended source before the first cancellable subscribe.
+        // Stop/restart cleanup can then remove partial-start position/replay state.
+        *self.subscribed_source_ids.write().await = sources_to_subscribe
+            .iter()
+            .map(|(id, _, _)| id.clone())
+            .collect();
+
         let mut position_handles: std::collections::HashMap<
             String,
             Arc<std::sync::atomic::AtomicU64>,
@@ -1052,7 +1222,7 @@ impl Query for DrasiQuery {
                 }
                 // Reset per-loop accumulators
                 bootstrap_channels.clear();
-                subscription_tasks.clear();
+                self.ingress_fence.close().await;
                 position_handles.clear();
                 self.bootstrap_state.write().await.clear();
                 checkpoint_sequences_per_source.clear();
@@ -1074,10 +1244,7 @@ impl Query for DrasiQuery {
                                             );
                                             error!("{msg}");
                                             // Cleanup already-spawned tasks
-                                            for handle in subscription_tasks.drain(..) {
-                                                handle.abort();
-                                                let _ = handle.await;
-                                            }
+                                            self.ingress_fence.close().await;
                                             // Release position handles for already-subscribed sources
                                             for (sid, _, _) in &sources_to_subscribe {
                                                 if let Some(src) = self
@@ -1106,10 +1273,7 @@ impl Query for DrasiQuery {
                                                     self.base.config.id, source_id
                                                 );
                                                 error!("{msg}");
-                                                for handle in subscription_tasks.drain(..) {
-                                                    handle.abort();
-                                                    let _ = handle.await;
-                                                }
+                                                self.ingress_fence.close().await;
                                                 // Release position handles for already-subscribed sources
                                                 for (sid, _, _) in &sources_to_subscribe {
                                                     if let Some(src) = self
@@ -1137,10 +1301,7 @@ impl Query for DrasiQuery {
                                             );
 
                                             // Abort already-spawned subscription tasks from this loop iteration
-                                            for handle in subscription_tasks.drain(..) {
-                                                handle.abort();
-                                                let _ = handle.await;
-                                            }
+                                            self.ingress_fence.close().await;
 
                                             // Drain queued events so stale pre-reset events don't
                                             // get processed after re-bootstrap.
@@ -1278,10 +1439,7 @@ impl Query for DrasiQuery {
                             self.base.config.id, source_id, e
                         );
                         // Cleanup already-spawned tasks before returning error
-                        for handle in subscription_tasks.drain(..) {
-                            handle.abort();
-                            let _ = handle.await;
-                        }
+                        self.ingress_fence.close().await;
                         // Release position handles for already-subscribed sources
                         for (sid, _, _) in &sources_to_subscribe {
                             if let Some(src) = self.source_manager.get_source_instance(sid).await {
@@ -1393,19 +1551,12 @@ impl Query for DrasiQuery {
                     .instrument(span),
                 );
 
-                subscription_tasks.push(task);
+                self.ingress_fence.push(task).await;
             }
 
             // All sources subscribed successfully — break out of the retry loop
             break;
         }
-
-        // Store subscription tasks and record subscribed source IDs for cleanup in stop()
-        *self.subscription_tasks.write().await = subscription_tasks;
-        *self.subscribed_source_ids.write().await = sources_to_subscribe
-            .iter()
-            .map(|(id, _, _)| id.clone())
-            .collect();
 
         // Wrap continuous_query in Arc for sharing across tasks
         let continuous_query = Arc::new(continuous_query);
@@ -1457,7 +1608,7 @@ impl Query for DrasiQuery {
             let bootstrap_output_state = self.output_state.clone();
 
             let mut bootstrap_handles = Vec::new();
-            let mut abort_handles = Vec::new();
+            let mut abort_handles = PendingBootstrapAborts::default();
 
             for (source_id, mut bootstrap_rx, bootstrap_result_rx) in bootstrap_channels {
                 // Mark source bootstrap as in progress
@@ -1800,7 +1951,7 @@ impl Query for DrasiQuery {
             }
 
             // Store abort handles for cleanup on stop()
-            *self.bootstrap_abort_handles.write().await = abort_handles;
+            *self.bootstrap_abort_handles.write().await = abort_handles.into_handles();
         } else {
             info!(
                 "Query '{}' no bootstrap channels, skipping bootstrap",
@@ -1819,8 +1970,25 @@ impl Query for DrasiQuery {
                     fq_priority_queue.enqueue_wait(event).await;
                 }
             });
-            self.subscription_tasks.write().await.push(fq_forwarder);
+            self.ingress_fence.push(fq_forwarder).await;
         }
+
+        let output_dependencies = QueryOutputDependencies::new(
+            self.base.config.id.clone(),
+            self.output_state.clone(),
+            self.base.dispatchers.clone(),
+            self.outbox_writer.read().await.clone(),
+            self.live_results_writer.read().await.clone(),
+            Some(checkpoint_store.clone()),
+            self.output_state.read().await.outbox_capacity(),
+            self.output_metrics.clone(),
+        )
+        .with_publication_recovery(self.publication_recovery.clone());
+        #[cfg(test)]
+        let output_dependencies = match self.processing_observer.read().await.clone() {
+            Some(observer) => output_dependencies.with_observer(observer),
+            None => output_dependencies,
+        };
 
         let host = QueryCompositeHost::new(
             QueryHostRuntime::new(
@@ -1830,6 +1998,7 @@ impl Query for DrasiQuery {
                 bootstrap_gate,
                 self.base.status_handle(),
                 future_queue_source,
+                self.ingress_fence.clone(),
             ),
             processing_mode,
             QueryLiveDependencies::new(
@@ -1838,23 +2007,74 @@ impl Query for DrasiQuery {
                 checkpoint_sequences_per_source,
                 position_handles,
             ),
-            QueryOutputDependencies::new(
-                self.base.config.id.clone(),
-                self.output_state.clone(),
-                self.base.dispatchers.clone(),
-                self.outbox_writer.read().await.clone(),
-                self.live_results_writer.read().await.clone(),
-                Some(checkpoint_store),
-                self.output_state.read().await.outbox_capacity(),
-                self.output_metrics.clone(),
-            ),
+            output_dependencies,
         );
         host.start(&self.base).await;
 
         Ok(())
     }
+}
+
+#[async_trait]
+impl Query for DrasiQuery {
+    async fn start(&self) -> Result<()> {
+        let _lifecycle = self.lifecycle_lock.lock().await;
+        if self.stop_requested.load(Ordering::Acquire) {
+            return Err(anyhow::anyhow!(
+                "Query '{}' startup was cancelled by stop",
+                self.base.config.id
+            ));
+        }
+        let current_status = self.base.status_handle().get_status().await;
+        let processor_installed = self.base.task_handle.read().await.is_some();
+        if processor_installed
+            && matches!(
+                current_status,
+                ComponentStatus::Starting | ComponentStatus::Running
+            )
+        {
+            debug!(
+                "Query '{}' start is already in progress or complete",
+                self.base.config.id
+            );
+            return Ok(());
+        }
+        if current_status == ComponentStatus::Stopping {
+            return Err(anyhow::anyhow!(
+                "Query '{}' cannot start while cleanup is in progress",
+                self.base.config.id
+            ));
+        }
+        let (_startup_registration, mut startup_cancel) =
+            StartupCancellationRegistration::install(self.startup_cancel.clone());
+        if self.stop_requested.load(Ordering::Acquire) {
+            return Err(anyhow::anyhow!(
+                "Query '{}' startup was cancelled by stop",
+                self.base.config.id
+            ));
+        }
+
+        tokio::select! {
+            biased;
+            _ = &mut startup_cancel => {
+                // The losing startup future has been dropped, so all locally
+                // pending task guards have fired. Reap anything already
+                // transferred to shared ownership before releasing the lock.
+                self.reap_previous_runtime().await;
+                Err(anyhow::anyhow!(
+                    "Query '{}' startup was cancelled by stop",
+                    self.base.config.id
+                ))
+            }
+            result = self.start_inner() => result,
+        }
+    }
 
     async fn stop(&self) -> Result<()> {
+        self.stop_requested.store(true, Ordering::Release);
+        let _stop_request = StopRequestReset(self.stop_requested.clone());
+        self.cancel_startup();
+        let _lifecycle = self.lifecycle_lock.lock().await;
         log_component_stop("Query", &self.base.config.id);
 
         // Set Stopping on the local status handle. The manager has already validated
@@ -1866,58 +2086,27 @@ impl Query for DrasiQuery {
         debug_assert!(
             matches!(
                 self.base.status_handle().get_status().await,
-                ComponentStatus::Running | ComponentStatus::Starting | ComponentStatus::Stopping
+                ComponentStatus::Running
+                    | ComponentStatus::Starting
+                    | ComponentStatus::Stopping
+                    | ComponentStatus::Error
+                    | ComponentStatus::Stopped
             ),
             "DrasiQuery::stop() called but local handle is not in expected pre-stop state"
         );
-        self.base
-            .set_status(
-                ComponentStatus::Stopping,
-                Some("Stopping query".to_string()),
-            )
-            .await;
-
-        // Abort bootstrap tasks and supervisor
-        let bootstrap_aborts: Vec<_> = {
-            let mut handles = self.bootstrap_abort_handles.write().await;
-            handles.drain(..).collect()
-        };
-        for handle in bootstrap_aborts {
-            handle.abort();
+        if self.base.status_handle().get_status().await != ComponentStatus::Stopped {
+            self.base
+                .set_status(
+                    ComponentStatus::Stopping,
+                    Some("Stopping query".to_string()),
+                )
+                .await;
         }
 
-        // Drain and abort source subscription forwarders so they don't leak across restarts
-        let subscription_handles: Vec<_> = {
-            let mut tasks = self.subscription_tasks.write().await;
-            tasks.drain(..).collect()
-        };
-
-        for handle in subscription_handles {
-            handle.abort();
-            let _ = handle.await;
-        }
-
-        // Stop the FutureQueueSource polling task
-        if let Some(fq) = self.future_queue_source.write().await.take() {
-            fq.stop().await;
-        }
-
-        // Release position handles so sources can advance their min-watermark.
-        // Each subscribed source may hold a position handle for this query.
-        {
-            let source_ids = self.subscribed_source_ids.read().await;
-            for source_id in source_ids.iter() {
-                if let Some(source) = self.source_manager.get_source_instance(source_id).await {
-                    source.remove_position_handle(&self.base.config.id).await;
-                    debug!(
-                        "Query '{}' released position handle for source '{}'",
-                        self.base.config.id, source_id
-                    );
-                }
-            }
-        }
-        // Clear tracked source IDs
-        self.subscribed_source_ids.write().await.clear();
+        self.ingress_fence.close().await;
+        self.abort_bootstrap_tasks().await;
+        self.stop_future_queue_source().await;
+        self.release_position_handles().await;
 
         // Finish shutting down the host-owned processor task through QueryBase.
         QueryCompositeHost::stop(&self.base).await?;
@@ -1945,7 +2134,7 @@ impl Query for DrasiQuery {
     }
 
     async fn subscription_count(&self) -> usize {
-        self.subscription_tasks.read().await.len()
+        self.ingress_fence.task_count().await
     }
 
     async fn subscribe(&self, reaction_id: String) -> Result<QuerySubscriptionResponse> {
@@ -2333,6 +2522,8 @@ impl QueryManager {
                     id
                 ));
             }
+            let recovery_query = old_query.clone();
+            let recovery_id = id.clone();
 
             crate::managers::lifecycle_helpers::reconfigure_component::<Arc<dyn Query>, _, _, _>(
                 &self.graph,
@@ -2340,7 +2531,20 @@ impl QueryManager {
                 "query",
                 &old_query,
                 || async {},
-                || self.provision_query(new_config),
+                || async move {
+                    if recovery_query
+                        .as_any()
+                        .downcast_ref::<DrasiQuery>()
+                        .is_some_and(|query| query.publication_recovery.is_required())
+                    {
+                        return Err(anyhow::anyhow!(
+                            "Query '{recovery_id}' cannot be reconfigured because atomic output \
+                             committed before in-memory publication; A7 output reconciliation is \
+                             required first"
+                        ));
+                    }
+                    self.provision_query(new_config).await
+                },
                 || self.start_query(id.clone()),
             )
             .await
@@ -2558,7 +2762,7 @@ impl QueryManager {
         .await
     }
 
-    /// Stop all currently running or starting queries.
+    /// Stop all currently running, starting, or errored queries.
     ///
     /// # Errors
     /// Returns an error listing any queries that failed to stop.
@@ -2582,7 +2786,9 @@ impl QueryManager {
                     .map(|n| {
                         matches!(
                             n.status,
-                            ComponentStatus::Running | ComponentStatus::Starting
+                            ComponentStatus::Running
+                                | ComponentStatus::Starting
+                                | ComponentStatus::Error
                         )
                     })
                     .unwrap_or(false)

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -53,6 +53,7 @@ use crate::queries::output_state::{
 use crate::queries::query_composite_host::dispatch_query_results;
 use crate::queries::query_composite_host::{
     QueryCompositeHost, QueryHostRuntime, QueryLiveDependencies, QueryOutputDependencies,
+    QueryProcessingMode,
 };
 use crate::queries::PriorityQueue;
 use crate::queries::QueryBase;
@@ -586,6 +587,7 @@ impl Query for DrasiQuery {
         let result_index: Option<Arc<dyn drasi_core::interface::ResultIndex>>;
         let future_queue: Option<Arc<dyn drasi_core::interface::FutureQueue>>;
         let session_control: Option<Arc<dyn drasi_core::interface::SessionControl>>;
+        let processing_mode: QueryProcessingMode;
 
         if let Some(backend_ref) = self
             .base
@@ -612,6 +614,12 @@ impl Query for DrasiQuery {
                 .build(backend_ref, &self.base.config.id)
                 .await
                 .context("Failed to build indexes")?;
+            processing_mode = QueryProcessingMode::from_created_indexes(&created);
+            debug!(
+                "Query '{}' selected {} result processing",
+                self.base.config.id,
+                processing_mode.diagnostic_name()
+            );
 
             // Use backend-provided checkpoint store, or create in-memory fallback
             checkpoint_store = match created.checkpoint_store {
@@ -652,6 +660,7 @@ impl Query for DrasiQuery {
             result_index = None;
             future_queue = None;
             session_control = None;
+            processing_mode = QueryProcessingMode::legacy();
         };
 
         // Persist the checkpoint_store for future stop/start cycles
@@ -1822,6 +1831,7 @@ impl Query for DrasiQuery {
                 self.base.status_handle(),
                 future_queue_source,
             ),
+            processing_mode,
             QueryLiveDependencies::new(
                 continuous_query,
                 checkpoint_store.clone(),

--- a/lib/src/queries/manager/pipeline_characterization_tests.rs
+++ b/lib/src/queries/manager/pipeline_characterization_tests.rs
@@ -14,10 +14,10 @@
 
 //! Characterization tests for the fixed Source -> Continuous Query -> Reaction pipeline.
 //!
-//! These tests intentionally pin the current transaction and output boundaries. In
-//! particular, they document the known durability gap where source progress commits
-//! before query output is persisted. A later stack layer will intentionally invert
-//! that behavior by staging output inside the core transaction.
+//! These tests intentionally pin the legacy transaction and output boundaries. Their
+//! non-domain backend remains in legacy mode and documents the weaker durability gap
+//! where source progress commits before query output is persisted. Fully capable
+//! bundles use the atomic `QueryCompositeHost` path instead.
 
 use std::{
     collections::{BTreeMap, HashMap},

--- a/lib/src/queries/mod.rs
+++ b/lib/src/queries/mod.rs
@@ -34,6 +34,9 @@ mod checkpoint_tests;
 #[cfg(test)]
 mod e2e_checkpoint_tests;
 
+#[cfg(test)]
+mod atomic_lifecycle_tests;
+
 pub use base::QueryBase;
 pub use config_hash::compute_config_hash;
 pub use label_extractor::*;

--- a/lib/src/queries/output_state.rs
+++ b/lib/src/queries/output_state.rs
@@ -68,6 +68,13 @@ pub struct QueryOutputState {
     outbox_capacity: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("prepared query result sequence {prepared} does not match expected sequence {expected}")]
+pub(crate) struct PreparedSequenceMismatch {
+    pub(crate) expected: u64,
+    pub(crate) prepared: u64,
+}
+
 impl QueryOutputState {
     /// Maximum allowed outbox capacity to prevent memory exhaustion from misconfiguration.
     const MAX_OUTBOX_CAPACITY: usize = 1_000_000;
@@ -166,6 +173,29 @@ impl QueryOutputState {
         let result = self.advance_sequence_and_push(result);
         debug_assert_eq!(result.sequence, expected_sequence);
         Some(result)
+    }
+
+    /// Apply a result prepared by the query host's sole output writer.
+    ///
+    /// Atomic processing has already committed the prepared sequence durably, so a
+    /// stale sequence is a recoverable fatal invariant violation rather than a
+    /// reason to rebuild the result under a different sequence.
+    pub(crate) fn apply_committed_result(
+        &mut self,
+        result: QueryResult,
+    ) -> Result<Arc<QueryResult>, PreparedSequenceMismatch> {
+        let expected = self.next_sequence();
+        if result.sequence != expected {
+            return Err(PreparedSequenceMismatch {
+                expected,
+                prepared: result.sequence,
+            });
+        }
+
+        self.apply_diffs(&result.results);
+        let result = self.advance_sequence_and_push(result);
+        debug_assert_eq!(result.sequence, expected);
+        Ok(result)
     }
 
     /// Return the live result set as a `Vec` for backward compatibility with `get_current_results`.
@@ -719,6 +749,26 @@ mod tests {
         result.sequence = state.next_sequence();
 
         let applied = state.try_apply_prepared_result(result).unwrap();
+        assert_eq!(applied.sequence, u64::MAX);
+        assert_eq!(state.as_of_sequence(), u64::MAX);
+        assert_eq!(state.outbox.back().unwrap().sequence, u64::MAX);
+    }
+
+    #[test]
+    fn test_committed_result_preserves_saturating_sequence_behavior() {
+        let mut state = QueryOutputState::new(3);
+        state.as_of_sequence = u64::MAX;
+
+        let mut result = make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"name": "max"}),
+                row_signature: 1,
+            }],
+        );
+        result.sequence = state.next_sequence();
+
+        let applied = state.apply_committed_result(result).unwrap();
         assert_eq!(applied.sequence, u64::MAX);
         assert_eq!(state.as_of_sequence(), u64::MAX);
         assert_eq!(state.outbox.back().unwrap().sequence, u64::MAX);

--- a/lib/src/queries/query_composite_host.rs
+++ b/lib/src/queries/query_composite_host.rs
@@ -22,15 +22,20 @@ use std::{
     collections::HashMap,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc,
+        Arc, Mutex,
     },
+    time::{Instant, SystemTime},
 };
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
 use bytes::Bytes;
 use drasi_core::{
     evaluation::context::QueryPartEvaluationContext,
-    interface::{CheckpointStore, LiveResultsWriter, OutboxWriter},
+    interface::{
+        AtomicResultTransaction, CheckpointStore, CreatedIndexes, IndexError, LiveResultsWriter,
+        OutboxWriter, RowMutation,
+    },
     models::SourceChange,
     query::ContinuousQuery,
 };
@@ -104,7 +109,79 @@ impl QueryLiveDependencies {
     }
 }
 
-/// Dependencies for preparing, persisting, and publishing legacy query output.
+/// Explicit processing capability for the fixed query host.
+///
+/// `Atomic` owns the validated token and the exact writer instances used to
+/// mint it. Missing or mismatched bundles remain `Legacy`; the host never
+/// infers atomicity from an individual writer.
+#[derive(Clone)]
+pub(super) enum QueryProcessingMode {
+    Atomic(AtomicQueryResources),
+    Legacy,
+}
+
+#[derive(Clone)]
+pub(super) struct AtomicQueryResources {
+    transaction: AtomicResultTransaction,
+    checkpoint_store: Arc<dyn CheckpointStore>,
+    outbox_writer: Arc<dyn OutboxWriter>,
+    live_results_writer: Arc<dyn LiveResultsWriter>,
+}
+
+impl QueryProcessingMode {
+    pub(super) const fn legacy() -> Self {
+        Self::Legacy
+    }
+
+    /// Capture the bundle-level capability before `CreatedIndexes` is distributed.
+    pub(super) fn from_created_indexes(created: &CreatedIndexes) -> Self {
+        let Some(transaction) = created.atomic_result_transaction() else {
+            return Self::Legacy;
+        };
+
+        let (Some(checkpoint_store), Some(outbox_writer), Some(live_results_writer)) = (
+            created.checkpoint_store.as_ref(),
+            created.outbox_writer.as_ref(),
+            created.live_results_writer.as_ref(),
+        ) else {
+            error!(
+                "Atomic result capability was issued without every persistent output writer; \
+                 falling back to legacy processing"
+            );
+            return Self::Legacy;
+        };
+
+        Self::Atomic(AtomicQueryResources {
+            transaction,
+            checkpoint_store: checkpoint_store.clone(),
+            outbox_writer: outbox_writer.clone(),
+            live_results_writer: live_results_writer.clone(),
+        })
+    }
+
+    pub(super) const fn diagnostic_name(&self) -> &'static str {
+        match self {
+            Self::Atomic(_) => "atomic",
+            Self::Legacy => "legacy",
+        }
+    }
+}
+
+/// Deterministic crate-private seam for transaction-boundary tests.
+#[async_trait]
+pub(super) trait QueryProcessingObserver: Send + Sync {
+    async fn after_output_staged(&self) -> std::result::Result<(), IndexError> {
+        Ok(())
+    }
+
+    async fn after_commit_before_publish(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn after_source_acknowledged(&self) {}
+}
+
+/// Dependencies for preparing and publishing query output.
 pub(super) struct QueryOutputDependencies {
     query_id: String,
     output_state: Arc<RwLock<QueryOutputState>>,
@@ -114,6 +191,7 @@ pub(super) struct QueryOutputDependencies {
     checkpoint_store: Option<Arc<dyn CheckpointStore>>,
     outbox_capacity: usize,
     output_metrics: Arc<QueryOutputMetrics>,
+    observer: Option<Arc<dyn QueryProcessingObserver>>,
 }
 
 impl QueryOutputDependencies {
@@ -137,7 +215,14 @@ impl QueryOutputDependencies {
             checkpoint_store,
             outbox_capacity,
             output_metrics,
+            observer: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_observer(mut self, observer: Arc<dyn QueryProcessingObserver>) -> Self {
+        self.observer = Some(observer);
+        self
     }
 }
 
@@ -155,6 +240,7 @@ pub(super) struct QueryCompositeHost {
 impl QueryCompositeHost {
     pub(super) fn new(
         runtime: QueryHostRuntime,
+        mode: QueryProcessingMode,
         live: QueryLiveDependencies,
         output: QueryOutputDependencies,
     ) -> Self {
@@ -167,10 +253,12 @@ impl QueryCompositeHost {
                 continuous_query: continuous_query.clone(),
                 checkpoint_store: live.checkpoint_store,
                 output: output.clone(),
+                mode: mode.clone(),
             },
             future_processing: FutureProcessingStage {
                 continuous_query,
                 output,
+                mode,
             },
             source_acknowledgement: SourceAcknowledgement::new(
                 live.checkpoint_sequences,
@@ -289,7 +377,23 @@ impl QueryCompositeHost {
                 }
 
                 arc_event = self.runtime.priority_queue.dequeue() => {
-                    self.process_event(arc_event).await;
+                    if let Err(e) = self.process_event(arc_event).await {
+                        let detail = format!("{e:#}");
+                        error!(
+                            "Query '{}' fenced after recoverable atomic processing failure: {detail}",
+                            self.runtime.query_id
+                        );
+                        self.runtime
+                            .status_handle
+                            .set_status(
+                                ComponentStatus::Error,
+                                Some(format!(
+                                    "Atomic query processing failed; restart can recover durable work: {detail}"
+                                )),
+                            )
+                            .await;
+                        break;
+                    }
                 }
             }
         }
@@ -298,9 +402,9 @@ impl QueryCompositeHost {
         info!("Query '{}' processing task exited", self.runtime.query_id);
     }
 
-    async fn process_event(&mut self, arc_event: Arc<SourceEventWrapper>) {
+    async fn process_event(&mut self, arc_event: Arc<SourceEventWrapper>) -> Result<()> {
         let Some(input) = LiveInput::from_wrapper(arc_event, &self.runtime.query_id) else {
-            return;
+            return Ok(());
         };
 
         debug!(
@@ -322,12 +426,12 @@ impl QueryCompositeHost {
                     .checkpoint_for(input.source_id.as_ref())
                     .unwrap_or(0)
             );
-            return;
+            return Ok(());
         }
 
         match input.event {
             SourceEvent::Control(SourceControl::FuturesDue) => {
-                self.future_processing.drain_due().await;
+                self.future_processing.drain_due().await?;
             }
             SourceEvent::Change(source_change) => {
                 self.live_input
@@ -341,7 +445,7 @@ impl QueryCompositeHost {
                         },
                         &mut self.source_acknowledgement,
                     )
-                    .await;
+                    .await?;
             }
             SourceEvent::Control(_) => {
                 debug!(
@@ -350,6 +454,8 @@ impl QueryCompositeHost {
                 );
             }
         }
+
+        Ok(())
     }
 }
 
@@ -452,10 +558,31 @@ struct LiveInputStage {
     continuous_query: Arc<ContinuousQuery>,
     checkpoint_store: Arc<dyn CheckpointStore>,
     output: Arc<OutputPublicationStage>,
+    mode: QueryProcessingMode,
 }
 
 impl LiveInputStage {
-    async fn process(&self, input: LiveChangeContext, acknowledgement: &mut SourceAcknowledgement) {
+    async fn process(
+        &self,
+        input: LiveChangeContext,
+        acknowledgement: &mut SourceAcknowledgement,
+    ) -> Result<()> {
+        match &self.mode {
+            QueryProcessingMode::Atomic(resources) => {
+                self.process_atomic(input, acknowledgement, resources).await
+            }
+            QueryProcessingMode::Legacy => {
+                self.process_legacy(input, acknowledgement).await;
+                Ok(())
+            }
+        }
+    }
+
+    async fn process_legacy(
+        &self,
+        input: LiveChangeContext,
+        acknowledgement: &mut SourceAcknowledgement,
+    ) {
         let mut profiling = match input.profiling {
             Some(profiling) => profiling,
             None => ProfilingMetadata::new(),
@@ -463,8 +590,8 @@ impl LiveInputStage {
         profiling.query_receive_ns = Some(crate::profiling::timestamp_ns());
         profiling.query_core_call_ns = Some(crate::profiling::timestamp_ns());
 
-        // The checkpoint hook intentionally remains pre-commit. A later layer changes
-        // transaction/output ordering; this host only gives the existing hook an owner.
+        // Legacy mode intentionally retains the A1 ordering. Atomic mode stages
+        // checkpoint and output together in its result-aware hook.
         let checkpoint_store = self.checkpoint_store.clone();
         let checkpoint_source_id = input.source_id.clone();
         let checkpoint_position = input.source_position.clone();
@@ -519,6 +646,121 @@ impl LiveInputStage {
             }
         }
     }
+
+    async fn process_atomic(
+        &self,
+        input: LiveChangeContext,
+        acknowledgement: &mut SourceAcknowledgement,
+        resources: &AtomicQueryResources,
+    ) -> Result<()> {
+        let mut profiling = match input.profiling {
+            Some(profiling) => profiling,
+            None => ProfilingMetadata::new(),
+        };
+        profiling.query_receive_ns = Some(crate::profiling::timestamp_ns());
+        profiling.query_core_call_ns = Some(crate::profiling::timestamp_ns());
+
+        let prepared_slot: Arc<Mutex<Option<PreparedQueryOutput>>> = Arc::new(Mutex::new(None));
+        let hook_slot = prepared_slot.clone();
+        let output = self.output.clone();
+        let staging_resources = resources.clone();
+        let checkpoint_source_id = input.source_id.clone();
+        let output_source_id = input.source_id.clone();
+        let checkpoint_position = input.source_position.clone();
+        let sequence = input.sequence;
+
+        let committed_results = self
+            .continuous_query
+            .process_source_change_with_result_hook(
+                input.source_change,
+                &resources.transaction,
+                move |results| async move {
+                    profiling.query_core_return_ns = Some(crate::profiling::timestamp_ns());
+
+                    if let Some(sequence) = sequence {
+                        staging_resources
+                            .checkpoint_store
+                            .stage_checkpoint(
+                                checkpoint_source_id.as_ref(),
+                                sequence,
+                                valid_checkpoint_position(checkpoint_position.as_ref()),
+                            )
+                            .await?;
+                    }
+
+                    if has_query_output(&results) {
+                        // In atomic mode this timestamp marks durable output staging,
+                        // not post-commit dispatch. One materialized QueryResult is
+                        // persisted and later dispatched unchanged.
+                        profiling.query_send_ns = Some(crate::profiling::timestamp_ns());
+                        let prepared = output
+                            .prepare_atomic(&results, output_source_id.as_ref(), profiling)
+                            .await
+                            .map_err(index_error)?;
+                        output.stage_atomic(&staging_resources, &prepared).await?;
+                        let mut slot = hook_slot.lock().map_err(|_| {
+                            IndexError::other(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                "prepared query output slot was poisoned",
+                            ))
+                        })?;
+                        *slot = Some(prepared);
+                    }
+
+                    output.observe_output_staged().await
+                },
+            )
+            .await
+            .context("atomic source transaction failed before commit")?;
+
+        self.output
+            .observe_commit_before_publish()
+            .await
+            .context("atomic source transaction committed before publication was interrupted")?;
+
+        let prepared = prepared_slot
+            .lock()
+            .map_err(|_| anyhow::anyhow!("prepared query output slot was poisoned"))?
+            .take();
+        anyhow::ensure!(
+            has_query_output(&committed_results) == prepared.is_some(),
+            "committed source output did not match the prepared output slot"
+        );
+
+        let committed_result = match prepared {
+            Some(prepared) => Some(self.output.apply_committed(prepared).await.context(
+                "durable source output committed but in-memory publication invariant failed",
+            )?),
+            None => None,
+        };
+
+        acknowledgement.advance(input.source_id.as_ref(), input.sequence);
+        self.output.observe_source_acknowledged();
+        if let Some(result) = committed_result {
+            self.output.dispatch(result).await;
+        }
+
+        Ok(())
+    }
+}
+
+fn valid_checkpoint_position(position: Option<&Bytes>) -> Option<&Bytes> {
+    position.filter(|position| {
+        position.len() <= crate::sources::base::SourceBase::MAX_SOURCE_POSITION_BYTES
+    })
+}
+
+fn has_query_output(results: &[QueryPartEvaluationContext]) -> bool {
+    results
+        .iter()
+        .any(|result| !matches!(result, QueryPartEvaluationContext::Noop))
+}
+
+fn index_error(error: anyhow::Error) -> IndexError {
+    IndexError::other(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        error.to_string(),
+    ))
 }
 
 struct SourceAcknowledgement {
@@ -560,10 +802,21 @@ impl SourceAcknowledgement {
 struct FutureProcessingStage {
     continuous_query: Arc<ContinuousQuery>,
     output: Arc<OutputPublicationStage>,
+    mode: QueryProcessingMode,
 }
 
 impl FutureProcessingStage {
-    async fn drain_due(&self) {
+    async fn drain_due(&self) -> Result<()> {
+        match &self.mode {
+            QueryProcessingMode::Atomic(resources) => self.drain_due_atomic(resources).await,
+            QueryProcessingMode::Legacy => {
+                self.drain_due_legacy().await;
+                Ok(())
+            }
+        }
+    }
+
+    async fn drain_due_legacy(&self) {
         loop {
             match self.continuous_query.process_due_futures().await {
                 Ok(Some(due_result)) => {
@@ -592,6 +845,101 @@ impl FutureProcessingStage {
             }
         }
     }
+
+    async fn drain_due_atomic(&self, resources: &AtomicQueryResources) -> Result<()> {
+        loop {
+            let next_due_time = self
+                .continuous_query
+                .future_queue()
+                .peek_due_time()
+                .await
+                .context("failed to inspect the next atomic due future")?;
+            let Some(next_due_time) = next_due_time else {
+                break;
+            };
+            if next_due_time > current_time_millis() {
+                break;
+            }
+
+            let prepared_slot: Arc<Mutex<Option<PreparedQueryOutput>>> = Arc::new(Mutex::new(None));
+            let hook_slot = prepared_slot.clone();
+            let output = self.output.clone();
+            let staging_resources = resources.clone();
+            let mut profiling = ProfilingMetadata::new();
+            profiling.query_core_call_ns = Some(crate::profiling::timestamp_ns());
+
+            let due_result = self
+                .continuous_query
+                .process_due_futures_with_result_hook(
+                    &resources.transaction,
+                    move |due_result| async move {
+                        profiling.query_core_return_ns = Some(crate::profiling::timestamp_ns());
+
+                        if has_query_output(&due_result.results) {
+                            profiling.query_send_ns = Some(crate::profiling::timestamp_ns());
+                            let prepared = output
+                                .prepare_atomic(
+                                    &due_result.results,
+                                    &due_result.source_id,
+                                    profiling,
+                                )
+                                .await
+                                .map_err(index_error)?;
+                            output.stage_atomic(&staging_resources, &prepared).await?;
+                            let mut slot = hook_slot.lock().map_err(|_| {
+                                IndexError::other(std::io::Error::new(
+                                    std::io::ErrorKind::Other,
+                                    "prepared due-future output slot was poisoned",
+                                ))
+                            })?;
+                            *slot = Some(prepared);
+                        }
+
+                        output.observe_output_staged().await
+                    },
+                )
+                .await
+                .context("atomic due-future transaction failed before commit")?;
+
+            let Some(due_result) = due_result else {
+                break;
+            };
+
+            self.output.observe_commit_before_publish().await.context(
+                "atomic due-future transaction committed before publication was interrupted",
+            )?;
+
+            let prepared = prepared_slot
+                .lock()
+                .map_err(|_| anyhow::anyhow!("prepared due-future output slot was poisoned"))?
+                .take();
+            anyhow::ensure!(
+                has_query_output(&due_result.results) == prepared.is_some(),
+                "committed due-future output did not match the prepared output slot"
+            );
+
+            if let Some(prepared) = prepared {
+                let result = self
+                        .output
+                        .apply_committed(prepared)
+                        .await
+                        .context(
+                            "durable due-future output committed but in-memory publication invariant failed",
+                        )?;
+                self.output.dispatch(result).await;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn current_time_millis() -> u64 {
+    let elapsed = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    u64::try_from(elapsed).unwrap_or(u64::MAX)
 }
 
 #[derive(Clone)]
@@ -604,6 +952,7 @@ struct OutputPublicationStage {
     checkpoint_store: Option<Arc<dyn CheckpointStore>>,
     outbox_capacity: usize,
     output_metrics: Arc<QueryOutputMetrics>,
+    observer: Option<Arc<dyn QueryProcessingObserver>>,
 }
 
 impl OutputPublicationStage {
@@ -617,6 +966,7 @@ impl OutputPublicationStage {
             checkpoint_store: dependencies.checkpoint_store,
             outbox_capacity: dependencies.outbox_capacity,
             output_metrics: dependencies.output_metrics,
+            observer: dependencies.observer,
         }
     }
 
@@ -641,6 +991,236 @@ impl OutputPublicationStage {
         )
         .await
     }
+
+    async fn prepare_atomic(
+        &self,
+        results: &[QueryPartEvaluationContext],
+        source_id: &str,
+        profiling: ProfilingMetadata,
+    ) -> Result<PreparedQueryOutput> {
+        // A7 will hydrate this state from durable output during startup. A6
+        // intentionally preserves the existing in-memory sequence origin.
+        let expected_sequence = self.output_state.read().await.next_sequence();
+        let mut prepared = PreparedQueryOutput::from_evaluation(
+            results,
+            source_id,
+            &self.query_id,
+            expected_sequence,
+            profiling,
+            Instant::now(),
+        )?
+        .ok_or_else(|| anyhow::anyhow!("non-Noop query evaluation produced no change envelope"))?;
+        prepared.materialize_atomic()?;
+        Ok(prepared)
+    }
+
+    async fn stage_atomic(
+        &self,
+        resources: &AtomicQueryResources,
+        prepared: &PreparedQueryOutput,
+    ) -> std::result::Result<(), IndexError> {
+        let outbox_data = prepared
+            .outbox_data
+            .as_deref()
+            .ok_or(IndexError::CorruptedData)?;
+        let live_result_data = prepared
+            .live_result_data
+            .as_ref()
+            .ok_or(IndexError::CorruptedData)?;
+
+        resources
+            .outbox_writer
+            .append(&self.query_id, prepared.result.sequence, outbox_data)
+            .await?;
+        resources
+            .outbox_writer
+            .trim_to_capacity(&self.query_id, self.outbox_capacity)
+            .await?;
+
+        let row_mutations: Vec<RowMutation<'_>> = live_result_data
+            .iter()
+            .map(|(signature, data)| RowMutation {
+                row_signature: *signature,
+                data: data.as_deref(),
+            })
+            .collect();
+        if !row_mutations.is_empty() {
+            resources
+                .live_results_writer
+                .apply_mutations(&self.query_id, &row_mutations)
+                .await?;
+        }
+
+        resources
+            .checkpoint_store
+            .write_result_sequence(&self.query_id, prepared.result.sequence)
+            .await
+    }
+
+    async fn observe_output_staged(&self) -> std::result::Result<(), IndexError> {
+        match &self.observer {
+            Some(observer) => observer.after_output_staged().await,
+            None => Ok(()),
+        }
+    }
+
+    async fn observe_commit_before_publish(&self) -> Result<()> {
+        match &self.observer {
+            Some(observer) => observer.after_commit_before_publish().await,
+            None => Ok(()),
+        }
+    }
+
+    fn observe_source_acknowledged(&self) {
+        if let Some(observer) = &self.observer {
+            observer.after_source_acknowledged();
+        }
+    }
+
+    async fn apply_committed(&self, prepared: PreparedQueryOutput) -> Result<Arc<QueryResult>> {
+        let PreparedQueryOutput {
+            result, started_at, ..
+        } = prepared;
+        let mut state = self.output_state.write().await;
+        let result = state.apply_committed_result(result)?;
+
+        let duration_ns = u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        self.output_metrics
+            .record_transaction_duration_ns(duration_ns);
+        self.output_metrics.record_seq_advance();
+        self.output_metrics
+            .record_live_results_count(state.results_len());
+        let earliest_seq = state.outbox_earliest_seq().unwrap_or(0);
+        self.output_metrics
+            .update_outbox(state.outbox_len(), earliest_seq, state.as_of_sequence());
+
+        Ok(result)
+    }
+
+    async fn dispatch(&self, result: Arc<QueryResult>) {
+        debug!(
+            "Query '{}' sending {} results to reactions (seq={})",
+            self.query_id,
+            result.results.len(),
+            result.sequence
+        );
+
+        let dispatchers = self.dispatchers.read().await;
+        for dispatcher in dispatchers.iter() {
+            if let Err(e) = dispatcher.dispatch_change(result.clone()).await {
+                debug!(
+                    "Failed to dispatch result for query '{}': {e}",
+                    self.query_id
+                );
+            }
+        }
+    }
+}
+
+struct PreparedQueryOutput {
+    result: QueryResult,
+    started_at: Instant,
+    outbox_data: Option<Vec<u8>>,
+    live_result_data: Option<Vec<(u64, Option<Vec<u8>>)>>,
+}
+
+impl PreparedQueryOutput {
+    fn from_evaluation(
+        results: &[QueryPartEvaluationContext],
+        source_id: &str,
+        query_id: &str,
+        sequence: u64,
+        profiling: ProfilingMetadata,
+        started_at: Instant,
+    ) -> Result<Option<Self>> {
+        let result_count = results
+            .iter()
+            .filter(|result| !matches!(result, QueryPartEvaluationContext::Noop))
+            .count();
+        if result_count == 0 {
+            return Ok(None);
+        }
+
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "source_id".to_string(),
+            serde_json::Value::String(source_id.to_string()),
+        );
+        metadata.insert(
+            "processed_by".to_string(),
+            serde_json::Value::String("drasi-core".to_string()),
+        );
+        metadata.insert(
+            "result_count".to_string(),
+            serde_json::Value::Number(result_count.into()),
+        );
+        let envelope = crate::change::query_evaluation_to_envelope(
+            results,
+            crate::change::QueryEnvelopeMetadata::new(
+                Arc::<str>::from(query_id),
+                Some(Arc::<str>::from(source_id)),
+                sequence,
+                chrono::Utc::now(),
+                metadata,
+                Some(profiling),
+            ),
+        )?
+        .ok_or_else(|| anyhow::anyhow!("non-Noop query evaluation produced no change envelope"))?;
+
+        Ok(Some(Self {
+            result: crate::change::query_result_from_envelope(&envelope)?,
+            started_at,
+            outbox_data: None,
+            live_result_data: None,
+        }))
+    }
+
+    fn materialize_atomic(&mut self) -> Result<()> {
+        self.outbox_data = Some(
+            rmp_serde::to_vec(&self.result)
+                .context("failed to serialize prepared query result for the atomic outbox")?,
+        );
+
+        let mut live_result_data = Vec::with_capacity(self.result.results.len());
+        for diff in &self.result.results {
+            match diff {
+                ResultDiff::Add {
+                    data,
+                    row_signature,
+                } => live_result_data.push((
+                    *row_signature,
+                    Some(rmp_serde::to_vec(data).with_context(|| {
+                        format!(
+                            "failed to serialize prepared Add row (sig={row_signature}) for atomic live results"
+                        )
+                    })?),
+                )),
+                ResultDiff::Update {
+                    after,
+                    row_signature,
+                    ..
+                }
+                | ResultDiff::Aggregation {
+                    after,
+                    row_signature,
+                    ..
+                } => live_result_data.push((
+                    *row_signature,
+                    Some(rmp_serde::to_vec(after).with_context(|| {
+                        format!(
+                            "failed to serialize prepared row (sig={row_signature}) for atomic live results"
+                        )
+                    })?),
+                )),
+                ResultDiff::Delete { row_signature, .. } => {
+                    live_result_data.push((*row_signature, None));
+                }
+                ResultDiff::Noop => {}
+            }
+        }
+        self.live_result_data = Some(live_result_data);
+        Ok(())
+    }
 }
 
 /// Prepare, persist, and dispatch a legacy `QueryResult`.
@@ -660,46 +1240,22 @@ pub(super) async fn dispatch_query_results(
     profiling: ProfilingMetadata,
     output_metrics: &Arc<QueryOutputMetrics>,
 ) -> Result<()> {
-    let result_count = results
-        .iter()
-        .filter(|result| !matches!(result, QueryPartEvaluationContext::Noop))
-        .count();
-    if result_count == 0 {
-        return Ok(());
-    }
-
-    let tx_start = std::time::Instant::now();
-    let query_identity = Arc::<str>::from(query_id);
-    let source_identity = Arc::<str>::from(source_id);
-    let mut metadata = HashMap::new();
-    metadata.insert(
-        "source_id".to_string(),
-        serde_json::Value::String(source_id.to_string()),
-    );
-    metadata.insert(
-        "processed_by".to_string(),
-        serde_json::Value::String("drasi-core".to_string()),
-    );
-    metadata.insert(
-        "result_count".to_string(),
-        serde_json::Value::Number(result_count.into()),
-    );
+    let tx_start = Instant::now();
 
     let arc_result = loop {
         let expected_sequence = output_state.read().await.next_sequence();
-        let envelope = crate::change::query_evaluation_to_envelope(
+        let Some(prepared) = PreparedQueryOutput::from_evaluation(
             results,
-            crate::change::QueryEnvelopeMetadata::new(
-                query_identity.clone(),
-                Some(source_identity.clone()),
-                expected_sequence,
-                chrono::Utc::now(),
-                metadata.clone(),
-                Some(profiling.clone()),
-            ),
+            source_id,
+            query_id,
+            expected_sequence,
+            profiling.clone(),
+            tx_start,
         )?
-        .ok_or_else(|| anyhow::anyhow!("non-Noop query evaluation produced no change envelope"))?;
-        let query_result = crate::change::query_result_from_envelope(&envelope)?;
+        else {
+            return Ok(());
+        };
+        let query_result = prepared.result;
 
         let mut state = output_state.write().await;
         let result = match state.try_apply_prepared_result(query_result) {
@@ -965,6 +1521,7 @@ mod tests {
                 base.status_handle(),
                 future_queue_source.clone(),
             ),
+            QueryProcessingMode::legacy(),
             QueryLiveDependencies::new(
                 continuous_query,
                 checkpoint_store.clone(),
@@ -1446,3 +2003,6 @@ mod tests {
         assert!(fixture.base.shutdown_tx.read().await.is_none());
     }
 }
+
+#[cfg(test)]
+mod atomic_tests;

--- a/lib/src/queries/query_composite_host.rs
+++ b/lib/src/queries/query_composite_host.rs
@@ -21,7 +21,7 @@
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
     },
     time::{Instant, SystemTime},
@@ -40,7 +40,10 @@ use drasi_core::{
     query::ContinuousQuery,
 };
 use log::{debug, error, info, warn};
-use tokio::sync::{oneshot, Notify, RwLock};
+use tokio::{
+    sync::{oneshot, Mutex as AsyncMutex, Notify, RwLock},
+    task::JoinHandle,
+};
 use tracing::Instrument;
 
 use super::{PriorityQueue, QueryBase, QueryOutputState, SequenceDedup};
@@ -55,6 +58,151 @@ use crate::{
     sources::FutureQueueSource,
 };
 
+/// Shared owner for every task that can enqueue into one query's priority queue.
+///
+/// Fatal atomic processing, normal stop, and restart preparation all use this
+/// single serialized cleanup path. The processor task itself is intentionally
+/// not stored here, so it can fence ingress without aborting itself.
+#[derive(Clone)]
+pub(super) struct QueryIngressFence {
+    subscription_tasks: Arc<RwLock<Vec<JoinHandle<()>>>>,
+    priority_queue: PriorityQueue,
+    cleanup_lock: Arc<AsyncMutex<()>>,
+}
+
+struct AbortTasksOnDrop {
+    tasks: Vec<JoinHandle<()>>,
+}
+
+impl AbortTasksOnDrop {
+    fn new(tasks: Vec<JoinHandle<()>>) -> Self {
+        Self { tasks }
+    }
+
+    fn take(&mut self) -> Vec<JoinHandle<()>> {
+        std::mem::take(&mut self.tasks)
+    }
+}
+
+impl Drop for AbortTasksOnDrop {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+impl QueryIngressFence {
+    pub(super) fn new(priority_queue: PriorityQueue) -> Self {
+        Self {
+            subscription_tasks: Arc::new(RwLock::new(Vec::new())),
+            priority_queue,
+            cleanup_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
+
+    pub(super) async fn install(&self, tasks: Vec<JoinHandle<()>>) {
+        let mut pending = AbortTasksOnDrop::new(tasks);
+        let _cleanup = self.cleanup_lock.lock().await;
+        let mut old_tasks = AbortTasksOnDrop::new({
+            let mut installed = self.subscription_tasks.write().await;
+            let old_tasks = installed.drain(..).collect();
+            *installed = pending.take();
+            old_tasks
+        });
+        Self::abort_and_reap(old_tasks.take()).await;
+    }
+
+    pub(super) async fn push(&self, task: JoinHandle<()>) {
+        let mut pending = AbortTasksOnDrop::new(vec![task]);
+        let _cleanup = self.cleanup_lock.lock().await;
+        self.subscription_tasks
+            .write()
+            .await
+            .push(pending.take().pop().expect("pending query ingress task"));
+    }
+
+    pub(super) async fn close(&self) {
+        let _cleanup = self.cleanup_lock.lock().await;
+        let tasks = {
+            let mut installed = self.subscription_tasks.write().await;
+            installed.drain(..).collect()
+        };
+        Self::abort_and_reap(tasks).await;
+
+        let drained = self.priority_queue.drain().await.len();
+        if drained > 0 {
+            debug!("Discarded {drained} queued events while fencing query ingress");
+        }
+    }
+
+    async fn abort_and_reap(tasks: Vec<JoinHandle<()>>) {
+        for task in &tasks {
+            task.abort();
+        }
+        for task in tasks {
+            let _ = task.await;
+        }
+    }
+
+    pub(super) async fn task_count(&self) -> usize {
+        self.subscription_tasks.read().await.len()
+    }
+}
+
+/// In-process fence for an output that committed durably but was not applied
+/// to the host's in-memory output state.
+#[derive(Clone, Default)]
+pub(super) struct AtomicPublicationRecovery {
+    required: Arc<AtomicBool>,
+}
+
+impl AtomicPublicationRecovery {
+    pub(super) fn is_required(&self) -> bool {
+        self.required.load(Ordering::Acquire)
+    }
+
+    fn require(&self) {
+        self.required.store(true, Ordering::Release);
+    }
+
+    fn reconcile_in_memory(&self) {
+        self.required.store(false, Ordering::Release);
+    }
+}
+
+struct CommittedPublicationGuard {
+    recovery: AtomicPublicationRecovery,
+    armed: bool,
+}
+
+impl CommittedPublicationGuard {
+    fn new(recovery: AtomicPublicationRecovery, has_output: bool) -> Self {
+        if has_output {
+            recovery.require();
+        }
+        Self {
+            recovery,
+            armed: has_output,
+        }
+    }
+
+    fn complete(mut self) {
+        if self.armed {
+            self.recovery.reconcile_in_memory();
+            self.armed = false;
+        }
+    }
+}
+
+impl Drop for CommittedPublicationGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.recovery.require();
+        }
+    }
+}
+
 /// Dependencies that define the lifecycle and ingress boundary of the fixed query host.
 pub(super) struct QueryHostRuntime {
     instance_id: String,
@@ -63,6 +211,7 @@ pub(super) struct QueryHostRuntime {
     bootstrap_gate: Arc<Notify>,
     status_handle: ComponentStatusHandle,
     future_queue_source: Arc<FutureQueueSource>,
+    ingress_fence: QueryIngressFence,
 }
 
 impl QueryHostRuntime {
@@ -73,6 +222,7 @@ impl QueryHostRuntime {
         bootstrap_gate: Arc<Notify>,
         status_handle: ComponentStatusHandle,
         future_queue_source: Arc<FutureQueueSource>,
+        ingress_fence: QueryIngressFence,
     ) -> Self {
         Self {
             instance_id,
@@ -81,6 +231,7 @@ impl QueryHostRuntime {
             bootstrap_gate,
             status_handle,
             future_queue_source,
+            ingress_fence,
         }
     }
 }
@@ -192,6 +343,7 @@ pub(super) struct QueryOutputDependencies {
     outbox_capacity: usize,
     output_metrics: Arc<QueryOutputMetrics>,
     observer: Option<Arc<dyn QueryProcessingObserver>>,
+    publication_recovery: AtomicPublicationRecovery,
 }
 
 impl QueryOutputDependencies {
@@ -216,7 +368,16 @@ impl QueryOutputDependencies {
             outbox_capacity,
             output_metrics,
             observer: None,
+            publication_recovery: AtomicPublicationRecovery::default(),
         }
+    }
+
+    pub(super) fn with_publication_recovery(
+        mut self,
+        publication_recovery: AtomicPublicationRecovery,
+    ) -> Self {
+        self.publication_recovery = publication_recovery;
+        self
     }
 
     #[cfg(test)]
@@ -235,6 +396,7 @@ pub(super) struct QueryCompositeHost {
     live_input: LiveInputStage,
     future_processing: FutureProcessingStage,
     source_acknowledgement: SourceAcknowledgement,
+    publication_recovery: AtomicPublicationRecovery,
 }
 
 impl QueryCompositeHost {
@@ -244,6 +406,7 @@ impl QueryCompositeHost {
         live: QueryLiveDependencies,
         output: QueryOutputDependencies,
     ) -> Self {
+        let publication_recovery = output.publication_recovery.clone();
         let output = Arc::new(OutputPublicationStage::new(output));
         let continuous_query = live.continuous_query;
 
@@ -264,6 +427,7 @@ impl QueryCompositeHost {
                 live.checkpoint_sequences,
                 live.position_handles,
             ),
+            publication_recovery,
         }
     }
 
@@ -340,6 +504,8 @@ impl QueryCompositeHost {
                 "Query '{}' failed to start FutureQueueSource: {e}",
                 self.runtime.query_id
             );
+            self.runtime.ingress_fence.close().await;
+            self.runtime.future_queue_source.stop().await;
             self.runtime
                 .status_handle
                 .set_status(
@@ -379,17 +545,28 @@ impl QueryCompositeHost {
                 arc_event = self.runtime.priority_queue.dequeue() => {
                     if let Err(e) = self.process_event(arc_event).await {
                         let detail = format!("{e:#}");
+                        self.runtime.ingress_fence.close().await;
+                        let status_detail = if self.publication_recovery.is_required() {
+                            format!(
+                                "Atomic output committed before in-memory publication; \
+                                 ingress is fenced and in-process restart requires A7 \
+                                 output reconciliation: {detail}"
+                            )
+                        } else {
+                            format!(
+                                "Atomic query processing failed before publication; \
+                                 ingress is fenced and a clean stop/start can replay it: {detail}"
+                            )
+                        };
                         error!(
-                            "Query '{}' fenced after recoverable atomic processing failure: {detail}",
+                            "Query '{}' {status_detail}",
                             self.runtime.query_id
                         );
                         self.runtime
                             .status_handle
                             .set_status(
                                 ComponentStatus::Error,
-                                Some(format!(
-                                    "Atomic query processing failed; restart can recover durable work: {detail}"
-                                )),
+                                Some(status_detail),
                             )
                             .await;
                         break;
@@ -398,6 +575,7 @@ impl QueryCompositeHost {
             }
         }
 
+        self.runtime.ingress_fence.close().await;
         self.runtime.future_queue_source.stop().await;
         info!("Query '{}' processing task exited", self.runtime.query_id);
     }
@@ -669,7 +847,7 @@ impl LiveInputStage {
         let checkpoint_position = input.source_position.clone();
         let sequence = input.sequence;
 
-        let committed_results = self
+        let transaction_result = self
             .continuous_query
             .process_source_change_with_result_hook(
                 input.source_change,
@@ -707,12 +885,30 @@ impl LiveInputStage {
                         *slot = Some(prepared);
                     }
 
-                    output.observe_output_staged().await
+                    output.observe_output_staged().await?;
+                    if has_query_output(&results) {
+                        // Arm before the cancellable backend commit begins.
+                        output.arm_publication_recovery();
+                    }
+                    Ok(())
                 },
             )
-            .await
-            .context("atomic source transaction failed before commit")?;
+            .await;
+        let committed_results = match transaction_result {
+            Ok(results) => results,
+            Err(error) => {
+                // A returned error means SessionGuard completed rollback. An abort
+                // during commit never reaches here and leaves the fence armed.
+                self.output.clear_publication_recovery();
+                return Err(error).context("atomic source transaction failed before commit");
+            }
+        };
 
+        // Keep this synchronous with the completed commit: cancellation must
+        // never observe durable output before the recovery fence is armed.
+        let publication_guard = self
+            .output
+            .committed_publication_guard(has_query_output(&committed_results));
         self.output
             .observe_commit_before_publish()
             .await
@@ -733,6 +929,8 @@ impl LiveInputStage {
             )?),
             None => None,
         };
+        // `apply_committed` is the only await between arming and clearing.
+        publication_guard.complete();
 
         acknowledgement.advance(input.source_id.as_ref(), input.sequence);
         self.output.observe_source_acknowledged();
@@ -868,7 +1066,7 @@ impl FutureProcessingStage {
             let mut profiling = ProfilingMetadata::new();
             profiling.query_core_call_ns = Some(crate::profiling::timestamp_ns());
 
-            let due_result = self
+            let transaction_result = self
                 .continuous_query
                 .process_due_futures_with_result_hook(
                     &resources.transaction,
@@ -895,16 +1093,35 @@ impl FutureProcessingStage {
                             *slot = Some(prepared);
                         }
 
-                        output.observe_output_staged().await
+                        output.observe_output_staged().await?;
+                        if has_query_output(&due_result.results) {
+                            // Arm before the cancellable backend commit begins.
+                            output.arm_publication_recovery();
+                        }
+                        Ok(())
                     },
                 )
-                .await
-                .context("atomic due-future transaction failed before commit")?;
+                .await;
+            let due_result = match transaction_result {
+                Ok(result) => result,
+                Err(error) => {
+                    // A returned error means SessionGuard completed rollback. An
+                    // abort during commit leaves this recovery fence armed.
+                    self.output.clear_publication_recovery();
+                    return Err(error)
+                        .context("atomic due-future transaction failed before commit");
+                }
+            };
 
             let Some(due_result) = due_result else {
                 break;
             };
 
+            // Keep this synchronous with the completed commit: cancellation must
+            // never observe durable output before the recovery fence is armed.
+            let publication_guard = self
+                .output
+                .committed_publication_guard(has_query_output(&due_result.results));
             self.output.observe_commit_before_publish().await.context(
                 "atomic due-future transaction committed before publication was interrupted",
             )?;
@@ -926,7 +1143,11 @@ impl FutureProcessingStage {
                         .context(
                             "durable due-future output committed but in-memory publication invariant failed",
                         )?;
+                // `apply_committed` is the only await between arming and clearing.
+                publication_guard.complete();
                 self.output.dispatch(result).await;
+            } else {
+                publication_guard.complete();
             }
         }
 
@@ -953,6 +1174,7 @@ struct OutputPublicationStage {
     outbox_capacity: usize,
     output_metrics: Arc<QueryOutputMetrics>,
     observer: Option<Arc<dyn QueryProcessingObserver>>,
+    publication_recovery: AtomicPublicationRecovery,
 }
 
 impl OutputPublicationStage {
@@ -967,6 +1189,7 @@ impl OutputPublicationStage {
             outbox_capacity: dependencies.outbox_capacity,
             output_metrics: dependencies.output_metrics,
             observer: dependencies.observer,
+            publication_recovery: dependencies.publication_recovery,
         }
     }
 
@@ -1069,6 +1292,18 @@ impl OutputPublicationStage {
             Some(observer) => observer.after_commit_before_publish().await,
             None => Ok(()),
         }
+    }
+
+    fn committed_publication_guard(&self, has_output: bool) -> CommittedPublicationGuard {
+        CommittedPublicationGuard::new(self.publication_recovery.clone(), has_output)
+    }
+
+    fn arm_publication_recovery(&self) {
+        self.publication_recovery.require();
+    }
+
+    fn clear_publication_recovery(&self) {
+        self.publication_recovery.reconcile_in_memory();
     }
 
     fn observe_source_acknowledged(&self) {
@@ -1520,6 +1755,7 @@ mod tests {
                 bootstrap_gate.clone(),
                 base.status_handle(),
                 future_queue_source.clone(),
+                QueryIngressFence::new(priority_queue.clone()),
             ),
             QueryProcessingMode::legacy(),
             QueryLiveDependencies::new(

--- a/lib/src/queries/query_composite_host/atomic_tests.rs
+++ b/lib/src/queries/query_composite_host/atomic_tests.rs
@@ -65,10 +65,11 @@ impl QueryConfiguration for AtomicTestQueryConfig {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 enum BackendFault {
     None,
     Commit,
+    CommitThenBlock(Arc<CommitBlock>),
     OutboxStage,
     LiveResultsStage,
 }
@@ -90,6 +91,57 @@ impl SessionControl for FailingCommitSessionControl {
 
     async fn commit(&self) -> std::result::Result<(), IndexError> {
         Err(IndexError::CorruptedData)
+    }
+
+    fn rollback(&self) -> std::result::Result<(), IndexError> {
+        self.inner.rollback()
+    }
+}
+
+struct CommitBlock {
+    committed_tx: Mutex<Option<oneshot::Sender<()>>>,
+    commits_before_block: AtomicUsize,
+}
+
+struct CommitThenBlockSessionControl {
+    inner: Arc<dyn SessionControl>,
+    transaction_domain: TransactionDomain,
+    block: Arc<CommitBlock>,
+}
+
+#[async_trait]
+impl SessionControl for CommitThenBlockSessionControl {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.transaction_domain.clone())
+    }
+
+    async fn begin(&self) -> std::result::Result<(), IndexError> {
+        self.inner.begin().await
+    }
+
+    async fn commit(&self) -> std::result::Result<(), IndexError> {
+        if self
+            .block
+            .commits_before_block
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return self.inner.commit().await;
+        }
+
+        self.inner.commit().await?;
+        if let Some(committed_tx) = self
+            .block
+            .committed_tx
+            .lock()
+            .expect("commit-block signal lock poisoned")
+            .take()
+        {
+            let _ = committed_tx.send(());
+        }
+        std::future::pending().await
     }
 
     fn rollback(&self) -> std::result::Result<(), IndexError> {
@@ -219,6 +271,7 @@ struct AtomicHostFixture {
     session_control: Arc<dyn SessionControl>,
     continuous_query: Arc<ContinuousQuery>,
     position_handle: Arc<AtomicU64>,
+    publication_recovery: AtomicPublicationRecovery,
 }
 
 async fn build_host(
@@ -244,6 +297,17 @@ async fn build_host(
             created.set.session_control = Arc::new(FailingCommitSessionControl {
                 inner,
                 transaction_domain,
+            });
+        }
+        BackendFault::CommitThenBlock(block) => {
+            let inner = created.set.session_control.clone();
+            let transaction_domain = inner
+                .transaction_domain()
+                .expect("RocksDB session transaction domain");
+            created.set.session_control = Arc::new(CommitThenBlockSessionControl {
+                inner,
+                transaction_domain,
+                block,
             });
         }
         BackendFault::OutboxStage => {
@@ -344,6 +408,8 @@ async fn build_host(
     ));
     let position_handle = Arc::new(AtomicU64::new(u64::MAX));
     let position_handles = HashMap::from([(SOURCE_ID.to_string(), position_handle.clone())]);
+    let ingress_fence = QueryIngressFence::new(priority_queue.clone());
+    let publication_recovery = AtomicPublicationRecovery::default();
 
     let output_dependencies = QueryOutputDependencies::new(
         QUERY_ID.to_string(),
@@ -354,7 +420,8 @@ async fn build_host(
         Some(checkpoint_store.clone()),
         16,
         Arc::new(QueryOutputMetrics::new()),
-    );
+    )
+    .with_publication_recovery(publication_recovery.clone());
     let output_dependencies = match observer {
         Some(observer) => output_dependencies.with_observer(observer),
         None => output_dependencies,
@@ -368,6 +435,7 @@ async fn build_host(
             bootstrap_gate.clone(),
             base.status_handle(),
             future_queue_source.clone(),
+            ingress_fence,
         ),
         mode,
         QueryLiveDependencies::new(
@@ -397,6 +465,7 @@ async fn build_host(
             session_control,
             continuous_query,
             position_handle,
+            publication_recovery,
         },
     )
 }
@@ -597,6 +666,32 @@ impl QueryProcessingObserver for FailAfterCommitObserver {
     }
 }
 
+struct BlockAfterCommitObserver {
+    committed_tx: Mutex<Option<oneshot::Sender<()>>>,
+    release_rx: AsyncMutex<Option<oneshot::Receiver<()>>>,
+}
+
+#[async_trait]
+impl QueryProcessingObserver for BlockAfterCommitObserver {
+    async fn after_commit_before_publish(&self) -> anyhow::Result<()> {
+        if let Some(committed_tx) = self
+            .committed_tx
+            .lock()
+            .expect("commit signal lock poisoned")
+            .take()
+        {
+            let _ = committed_tx.send(());
+        }
+        self.release_rx
+            .lock()
+            .await
+            .take()
+            .expect("commit release receiver already consumed")
+            .await
+            .map_err(|_| anyhow::anyhow!("commit release signal dropped"))
+    }
+}
+
 struct StaleSequenceAfterCommitObserver {
     output_state: Mutex<Option<Arc<RwLock<QueryOutputState>>>>,
 }
@@ -743,6 +838,7 @@ async fn rocksdb_atomic_source_commits_every_resource_before_ack_and_dispatch() 
     assert_eq!(fixture.position_handle.load(Ordering::Acquire), 1);
     assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 1);
     assert!(element_exists(&fixture, "person-success").await);
+    assert!(!fixture.publication_recovery.is_required());
 
     stop_host(&fixture).await;
 }
@@ -800,6 +896,10 @@ async fn rocksdb_atomic_source_fault_matrix_rolls_back_and_fences() {
             fixture.dispatch_count.load(Ordering::Acquire),
             0,
             "{name}: result was dispatched"
+        );
+        assert!(
+            !fixture.publication_recovery.is_required(),
+            "{name}: pre-commit failure incorrectly requires output reconciliation"
         );
         assert!(
             !element_exists(&fixture, &format!("person-{name}")).await,
@@ -884,6 +984,190 @@ async fn cancellation_during_atomic_hook_rolls_back_without_ack_or_dispatch() {
 }
 
 #[tokio::test]
+async fn cancellation_after_commit_marks_output_recovery_required() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (committed_tx, committed_rx) = oneshot::channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    let observer = Arc::new(BlockAfterCommitObserver {
+        committed_tx: Mutex::new(Some(committed_tx)),
+        release_rx: AsyncMutex::new(Some(release_rx)),
+    });
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        Some(observer),
+    )
+    .await;
+    start_host(host, &fixture).await;
+
+    enqueue_source_change(
+        &fixture,
+        "person-post-commit-cancelled",
+        "Committed",
+        10,
+        Bytes::from_static(b"post-commit-cancelled-position"),
+    )
+    .await;
+    committed_rx
+        .await
+        .expect("observer should report committed output");
+    assert!(fixture.publication_recovery.is_required());
+
+    let task = fixture
+        .base
+        .task_handle
+        .write()
+        .await
+        .take()
+        .expect("host task handle");
+    task.abort();
+    assert!(task
+        .await
+        .expect_err("aborted host task should not complete")
+        .is_cancelled());
+
+    assert!(fixture.publication_recovery.is_required());
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fixture.position_handle.load(Ordering::Acquire), u64::MAX);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read committed result sequence"),
+        Some(1)
+    );
+    fixture.future_queue_source.stop().await;
+}
+
+#[tokio::test]
+async fn cancellation_while_source_commit_returns_late_keeps_recovery_fence_armed() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (committed_tx, committed_rx) = oneshot::channel();
+    let commit_block = Arc::new(CommitBlock {
+        committed_tx: Mutex::new(Some(committed_tx)),
+        commits_before_block: AtomicUsize::new(0),
+    });
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::CommitThenBlock(commit_block),
+        false,
+        None,
+    )
+    .await;
+    start_host(host, &fixture).await;
+    enqueue_source_change(
+        &fixture,
+        "person-commit-cancelled",
+        "Committed",
+        12,
+        Bytes::from_static(b"commit-cancelled-position"),
+    )
+    .await;
+    committed_rx.await.expect("source commit should complete");
+    assert!(fixture.publication_recovery.is_required());
+
+    let task = fixture
+        .base
+        .task_handle
+        .write()
+        .await
+        .take()
+        .expect("host task handle");
+    task.abort();
+    assert!(task
+        .await
+        .expect_err("aborted host task should not complete")
+        .is_cancelled());
+
+    assert!(fixture.publication_recovery.is_required());
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fixture.position_handle.load(Ordering::Acquire), u64::MAX);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read committed result sequence"),
+        Some(1)
+    );
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .read_from(QUERY_ID, 0)
+            .await
+            .expect("read committed outbox")
+            .len(),
+        1
+    );
+    fixture.future_queue_source.stop().await;
+}
+
+#[tokio::test]
+async fn cancellation_while_future_commit_returns_late_keeps_recovery_fence_armed() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (committed_tx, committed_rx) = oneshot::channel();
+    let commit_block = Arc::new(CommitBlock {
+        committed_tx: Mutex::new(Some(committed_tx)),
+        commits_before_block: AtomicUsize::new(1),
+    });
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) WHERE drasi.trueLater(true, 2000) RETURN n.name AS name",
+        BackendFault::CommitThenBlock(commit_block),
+        false,
+        None,
+    )
+    .await;
+    seed_due_future(&fixture).await;
+    start_host(host, &fixture).await;
+    enqueue_futures_due(&fixture).await;
+    committed_rx
+        .await
+        .expect("due-future commit should complete");
+    assert!(fixture.publication_recovery.is_required());
+
+    let task = fixture
+        .base
+        .task_handle
+        .write()
+        .await
+        .take()
+        .expect("host task handle");
+    task.abort();
+    assert!(task
+        .await
+        .expect_err("aborted host task should not complete")
+        .is_cancelled());
+
+    assert!(fixture.publication_recovery.is_required());
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek committed future"),
+        None
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read future result sequence"),
+        Some(1)
+    );
+    fixture.future_queue_source.stop().await;
+}
+
+#[tokio::test]
 async fn failure_after_commit_leaves_authoritative_output_without_publication() {
     let temp_dir = tempfile::TempDir::new().expect("create temp directory");
     let (host, fixture) = build_host(
@@ -945,6 +1229,7 @@ async fn failure_after_commit_leaves_authoritative_output_without_publication() 
     assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
     assert_eq!(fixture.position_handle.load(Ordering::Acquire), u64::MAX);
     assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+    assert!(fixture.publication_recovery.is_required());
 
     stop_host(&fixture).await;
 }
@@ -990,6 +1275,7 @@ async fn stale_prepared_sequence_after_commit_is_fatal_and_not_acknowledged() {
     assert_eq!(fixture.position_handle.load(Ordering::Acquire), u64::MAX);
     assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
     assert_eq!(fixture.output_state.read().await.as_of_sequence(), 1);
+    assert!(fixture.publication_recovery.is_required());
 
     stop_host(&fixture).await;
 }
@@ -1207,6 +1493,55 @@ async fn due_future_stage_failure_retains_future_and_publishes_nothing() {
     assert_no_durable_output(&fixture).await;
     assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
     assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn due_future_post_commit_failure_requires_output_reconciliation() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) WHERE drasi.trueLater(true, 2000) RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        Some(Arc::new(FailAfterCommitObserver)),
+    )
+    .await;
+    seed_due_future(&fixture).await;
+    start_host(host, &fixture).await;
+    enqueue_futures_due(&fixture).await;
+    wait_for_status(&fixture.base, ComponentStatus::Error).await;
+
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek committed future"),
+        None,
+        "the future pop committed before publication failed"
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read future result sequence"),
+        Some(1)
+    );
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .read_from(QUERY_ID, 0)
+            .await
+            .expect("read future outbox")
+            .len(),
+        1
+    );
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+    assert!(fixture.publication_recovery.is_required());
 
     stop_host(&fixture).await;
 }

--- a/lib/src/queries/query_composite_host/atomic_tests.rs
+++ b/lib/src/queries/query_composite_host/atomic_tests.rs
@@ -1,0 +1,1338 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use drasi_core::{
+    evaluation::{
+        context::{QueryPartEvaluationContext, QueryVariables},
+        functions::FunctionRegistry,
+        variable_value::VariableValue,
+    },
+    interface::{
+        CheckpointStore, CreatedIndexes, ElementIndex, FutureQueue, IndexBackendPlugin, IndexError,
+        LiveResultsWriter, OutboxWriter, PushType, RowMutation, SessionControl, SourceCheckpoint,
+        TransactionDomain,
+    },
+    models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
+    query::{ContinuousQuery, QueryBuilder},
+};
+use drasi_functions_cypher::CypherFunctionSet;
+use drasi_index_rocksdb::RocksDbIndexProvider;
+use drasi_query_ast::api::QueryConfiguration;
+use drasi_query_cypher::CypherParser;
+use serde_json::json;
+use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex, Notify, RwLock};
+
+use super::*;
+use crate::{
+    channels::ChangeReceiver,
+    config::{QueryConfig, QueryLanguage},
+};
+
+const QUERY_ID: &str = "atomic-host-query";
+const SOURCE_ID: &str = "atomic-host-source";
+
+struct AtomicTestQueryConfig;
+
+impl QueryConfiguration for AtomicTestQueryConfig {
+    fn get_aggregating_function_names(&self) -> HashSet<String> {
+        ["count", "sum", "min", "max", "avg", "collect", "stdev", "stdevp"]
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy)]
+enum BackendFault {
+    None,
+    Commit,
+    OutboxStage,
+    LiveResultsStage,
+}
+
+struct FailingCommitSessionControl {
+    inner: Arc<dyn SessionControl>,
+    transaction_domain: TransactionDomain,
+}
+
+#[async_trait]
+impl SessionControl for FailingCommitSessionControl {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.transaction_domain.clone())
+    }
+
+    async fn begin(&self) -> std::result::Result<(), IndexError> {
+        self.inner.begin().await
+    }
+
+    async fn commit(&self) -> std::result::Result<(), IndexError> {
+        Err(IndexError::CorruptedData)
+    }
+
+    fn rollback(&self) -> std::result::Result<(), IndexError> {
+        self.inner.rollback()
+    }
+}
+
+struct FailingOutboxWriter {
+    inner: Arc<dyn OutboxWriter>,
+}
+
+struct FailingLiveResultsWriter {
+    inner: Arc<dyn LiveResultsWriter>,
+}
+
+#[async_trait]
+impl LiveResultsWriter for FailingLiveResultsWriter {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        self.inner.transaction_domain()
+    }
+
+    async fn apply_mutations(
+        &self,
+        _query_id: &str,
+        _mutations: &[RowMutation<'_>],
+    ) -> std::result::Result<(), IndexError> {
+        Err(IndexError::other(std::io::Error::other(
+            "injected atomic live-results stage failure",
+        )))
+    }
+
+    async fn read_snapshot(
+        &self,
+        query_id: &str,
+    ) -> std::result::Result<Vec<(u64, Vec<u8>)>, IndexError> {
+        self.inner.read_snapshot(query_id).await
+    }
+
+    async fn clear(&self, query_id: &str) -> std::result::Result<(), IndexError> {
+        self.inner.clear(query_id).await
+    }
+
+    async fn row_count(&self, query_id: &str) -> std::result::Result<usize, IndexError> {
+        self.inner.row_count(query_id).await
+    }
+}
+
+#[async_trait]
+impl OutboxWriter for FailingOutboxWriter {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        self.inner.transaction_domain()
+    }
+
+    async fn append(
+        &self,
+        _query_id: &str,
+        _sequence: u64,
+        _data: &[u8],
+    ) -> std::result::Result<(), IndexError> {
+        Err(IndexError::other(std::io::Error::other(
+            "injected atomic outbox stage failure",
+        )))
+    }
+
+    async fn read_from(
+        &self,
+        query_id: &str,
+        after_sequence: u64,
+    ) -> std::result::Result<Vec<(u64, Vec<u8>)>, IndexError> {
+        self.inner.read_from(query_id, after_sequence).await
+    }
+
+    async fn read_latest_sequence(
+        &self,
+        query_id: &str,
+    ) -> std::result::Result<Option<u64>, IndexError> {
+        self.inner.read_latest_sequence(query_id).await
+    }
+
+    async fn clear(&self, query_id: &str) -> std::result::Result<(), IndexError> {
+        self.inner.clear(query_id).await
+    }
+
+    async fn trim_to_capacity(
+        &self,
+        query_id: &str,
+        capacity: usize,
+    ) -> std::result::Result<usize, IndexError> {
+        self.inner.trim_to_capacity(query_id, capacity).await
+    }
+}
+
+struct RecordingDispatcher {
+    count: Arc<AtomicUsize>,
+    tx: mpsc::UnboundedSender<Arc<QueryResult>>,
+}
+
+#[async_trait]
+impl ChangeDispatcher<QueryResult> for RecordingDispatcher {
+    async fn dispatch_change(&self, change: Arc<QueryResult>) -> anyhow::Result<()> {
+        self.count.fetch_add(1, Ordering::AcqRel);
+        self.tx
+            .send(change)
+            .map_err(|_| anyhow::anyhow!("atomic test result receiver dropped"))
+    }
+
+    async fn create_receiver(&self) -> anyhow::Result<Box<dyn ChangeReceiver<QueryResult>>> {
+        Err(anyhow::anyhow!(
+            "atomic test dispatcher does not create receivers"
+        ))
+    }
+}
+
+struct AtomicHostFixture {
+    base: QueryBase,
+    bootstrap_gate: Arc<Notify>,
+    priority_queue: PriorityQueue,
+    output_state: Arc<RwLock<QueryOutputState>>,
+    output_rx: mpsc::UnboundedReceiver<Arc<QueryResult>>,
+    dispatch_count: Arc<AtomicUsize>,
+    future_queue_source: Arc<FutureQueueSource>,
+    checkpoint_store: Arc<dyn CheckpointStore>,
+    outbox_writer: Arc<dyn OutboxWriter>,
+    live_results_writer: Arc<dyn LiveResultsWriter>,
+    element_index: Arc<dyn ElementIndex>,
+    future_queue: Arc<dyn FutureQueue>,
+    session_control: Arc<dyn SessionControl>,
+    continuous_query: Arc<ContinuousQuery>,
+    position_handle: Arc<AtomicU64>,
+}
+
+async fn build_host(
+    path: &Path,
+    query_text: &str,
+    fault: BackendFault,
+    force_legacy: bool,
+    observer: Option<Arc<dyn QueryProcessingObserver>>,
+) -> (QueryCompositeHost, AtomicHostFixture) {
+    let provider = RocksDbIndexProvider::new(path, true, false);
+    let mut created = provider
+        .create_indexes(QUERY_ID)
+        .await
+        .expect("create RocksDB indexes");
+
+    match fault {
+        BackendFault::None => {}
+        BackendFault::Commit => {
+            let inner = created.set.session_control.clone();
+            let transaction_domain = inner
+                .transaction_domain()
+                .expect("RocksDB session transaction domain");
+            created.set.session_control = Arc::new(FailingCommitSessionControl {
+                inner,
+                transaction_domain,
+            });
+        }
+        BackendFault::OutboxStage => {
+            let inner = created
+                .outbox_writer
+                .as_ref()
+                .expect("RocksDB outbox writer")
+                .clone();
+            created.outbox_writer = Some(Arc::new(FailingOutboxWriter { inner }));
+        }
+        BackendFault::LiveResultsStage => {
+            let inner = created
+                .live_results_writer
+                .as_ref()
+                .expect("RocksDB live-results writer")
+                .clone();
+            created.live_results_writer = Some(Arc::new(FailingLiveResultsWriter { inner }));
+        }
+    }
+
+    let mode = if force_legacy {
+        QueryProcessingMode::legacy()
+    } else {
+        QueryProcessingMode::from_created_indexes(&created)
+    };
+    if !force_legacy {
+        assert_eq!(mode.diagnostic_name(), "atomic");
+    }
+
+    let checkpoint_store = created
+        .checkpoint_store
+        .as_ref()
+        .expect("RocksDB checkpoint store")
+        .clone();
+    let outbox_writer = created
+        .outbox_writer
+        .as_ref()
+        .expect("RocksDB outbox writer")
+        .clone();
+    let live_results_writer = created
+        .live_results_writer
+        .as_ref()
+        .expect("RocksDB live-results writer")
+        .clone();
+    let indexes = created.set;
+    let element_index = indexes.element_index.clone();
+    let future_queue = indexes.future_queue.clone();
+    let session_control = indexes.session_control.clone();
+
+    let functions = Arc::new(FunctionRegistry::new()).with_cypher_function_set();
+    let parser = Arc::new(CypherParser::new(Arc::new(AtomicTestQueryConfig)));
+    let continuous_query = Arc::new(
+        QueryBuilder::new(query_text, parser)
+            .with_function_registry(functions)
+            .with_element_index(indexes.element_index)
+            .with_archive_index(indexes.archive_index)
+            .with_result_index(indexes.result_index)
+            .with_future_queue(indexes.future_queue)
+            .with_session_control(indexes.session_control)
+            .build()
+            .await,
+    );
+
+    let base = QueryBase::new(QueryConfig {
+        id: QUERY_ID.to_string(),
+        query: query_text.to_string(),
+        query_language: QueryLanguage::Cypher,
+        middleware: vec![],
+        sources: vec![],
+        auto_start: false,
+        joins: None,
+        enable_bootstrap: false,
+        bootstrap_buffer_size: 10,
+        priority_queue_capacity: Some(16),
+        dispatch_buffer_capacity: Some(16),
+        dispatch_mode: None,
+        storage_backend: None,
+        recovery_policy: None,
+        outbox_capacity: 16,
+        bootstrap_timeout_secs: 1,
+    })
+    .expect("create query base");
+    base.set_status(ComponentStatus::Starting, None).await;
+
+    let (result_tx, output_rx) = mpsc::unbounded_channel();
+    let dispatch_count = Arc::new(AtomicUsize::new(0));
+    let dispatchers: Arc<RwLock<Vec<Box<dyn ChangeDispatcher<QueryResult> + Send + Sync>>>> =
+        Arc::new(RwLock::new(vec![Box::new(RecordingDispatcher {
+            count: dispatch_count.clone(),
+            tx: result_tx,
+        })]));
+    let output_state = Arc::new(RwLock::new(QueryOutputState::new(16)));
+    let priority_queue = PriorityQueue::new(16);
+    let bootstrap_gate = Arc::new(Notify::new());
+    let future_queue_source = Arc::new(FutureQueueSource::new(
+        continuous_query.future_queue(),
+        QUERY_ID.to_string(),
+    ));
+    let position_handle = Arc::new(AtomicU64::new(u64::MAX));
+    let position_handles = HashMap::from([(SOURCE_ID.to_string(), position_handle.clone())]);
+
+    let output_dependencies = QueryOutputDependencies::new(
+        QUERY_ID.to_string(),
+        output_state.clone(),
+        dispatchers,
+        Some(outbox_writer.clone()),
+        Some(live_results_writer.clone()),
+        Some(checkpoint_store.clone()),
+        16,
+        Arc::new(QueryOutputMetrics::new()),
+    );
+    let output_dependencies = match observer {
+        Some(observer) => output_dependencies.with_observer(observer),
+        None => output_dependencies,
+    };
+
+    let host = QueryCompositeHost::new(
+        QueryHostRuntime::new(
+            "atomic-host-test".to_string(),
+            QUERY_ID.to_string(),
+            priority_queue.clone(),
+            bootstrap_gate.clone(),
+            base.status_handle(),
+            future_queue_source.clone(),
+        ),
+        mode,
+        QueryLiveDependencies::new(
+            continuous_query.clone(),
+            checkpoint_store.clone(),
+            HashMap::new(),
+            position_handles,
+        ),
+        output_dependencies,
+    );
+
+    (
+        host,
+        AtomicHostFixture {
+            base,
+            bootstrap_gate,
+            priority_queue,
+            output_state,
+            output_rx,
+            dispatch_count,
+            future_queue_source,
+            checkpoint_store,
+            outbox_writer,
+            live_results_writer,
+            element_index,
+            future_queue,
+            session_control,
+            continuous_query,
+            position_handle,
+        },
+    )
+}
+
+fn person_change(id: &str, name: &str, effective_from: u64) -> SourceChange {
+    SourceChange::Insert {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new(SOURCE_ID, id),
+                labels: vec![Arc::from("Person")].into(),
+                effective_from,
+            },
+            properties: ElementPropertyMap::from(json!({
+                "name": name,
+                "age": 30,
+            })),
+        },
+    }
+}
+
+fn sequenced_event(
+    change: SourceChange,
+    sequence: u64,
+    source_position: Bytes,
+) -> Arc<SourceEventWrapper> {
+    let timestamp = chrono::DateTime::from_timestamp_millis(change.get_realtime() as i64)
+        .expect("valid event timestamp");
+    let mut event = SourceEventWrapper::with_sequence(
+        SOURCE_ID.to_string(),
+        SourceEvent::Change(change),
+        timestamp,
+        sequence,
+        Some(ProfilingMetadata {
+            source_ns: Some(101),
+            source_receive_ns: Some(202),
+            source_send_ns: Some(303),
+            ..Default::default()
+        }),
+    );
+    event.set_source_position(source_position);
+    Arc::new(event)
+}
+
+async fn start_host(host: QueryCompositeHost, fixture: &AtomicHostFixture) {
+    host.start(&fixture.base).await;
+    fixture.bootstrap_gate.notify_one();
+    wait_for_status(&fixture.base, ComponentStatus::Running).await;
+}
+
+async fn wait_for_status(base: &QueryBase, expected: ComponentStatus) {
+    if base.get_status().await == expected {
+        return;
+    }
+    let mut status_rx = base.status_handle().subscribe_status();
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        status_rx.wait_for(|status| *status == expected),
+    )
+    .await
+    .expect("status transition timed out")
+    .expect("status channel closed");
+}
+
+async fn stop_host(fixture: &AtomicHostFixture) {
+    fixture
+        .base
+        .set_status(ComponentStatus::Stopping, None)
+        .await;
+    QueryCompositeHost::stop(&fixture.base)
+        .await
+        .expect("stop query host");
+}
+
+async fn enqueue_source_change(
+    fixture: &AtomicHostFixture,
+    id: &str,
+    name: &str,
+    sequence: u64,
+    source_position: Bytes,
+) {
+    assert!(
+        fixture
+            .priority_queue
+            .enqueue(sequenced_event(
+                person_change(id, name, sequence * 1_000),
+                sequence,
+                source_position,
+            ))
+            .await
+    );
+}
+
+async fn receive_result(
+    receiver: &mut mpsc::UnboundedReceiver<Arc<QueryResult>>,
+) -> Arc<QueryResult> {
+    tokio::time::timeout(Duration::from_secs(5), receiver.recv())
+        .await
+        .expect("query result timed out")
+        .expect("query result channel closed")
+}
+
+async fn element_exists(fixture: &AtomicHostFixture, id: &str) -> bool {
+    fixture
+        .session_control
+        .begin()
+        .await
+        .expect("begin verification session");
+    let element = fixture
+        .element_index
+        .get_element(&ElementReference::new(SOURCE_ID, id))
+        .await
+        .expect("read element");
+    fixture
+        .session_control
+        .rollback()
+        .expect("end verification session");
+    element.is_some()
+}
+
+async fn assert_no_durable_output(fixture: &AtomicHostFixture) {
+    assert!(fixture
+        .checkpoint_store
+        .read_checkpoint(SOURCE_ID)
+        .await
+        .expect("read checkpoint")
+        .is_none());
+    assert!(fixture
+        .outbox_writer
+        .read_from(QUERY_ID, 0)
+        .await
+        .expect("read outbox")
+        .is_empty());
+    assert!(fixture
+        .live_results_writer
+        .read_snapshot(QUERY_ID)
+        .await
+        .expect("read live results")
+        .is_empty());
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read result sequence"),
+        None
+    );
+}
+
+struct FailAfterStagingObserver;
+
+#[async_trait]
+impl QueryProcessingObserver for FailAfterStagingObserver {
+    async fn after_output_staged(&self) -> std::result::Result<(), IndexError> {
+        Err(IndexError::other(std::io::Error::other(
+            "injected failure after all output staging",
+        )))
+    }
+}
+
+struct BlockAfterStagingObserver {
+    staged_tx: Mutex<Option<oneshot::Sender<()>>>,
+    release_rx: AsyncMutex<Option<oneshot::Receiver<()>>>,
+}
+
+#[async_trait]
+impl QueryProcessingObserver for BlockAfterStagingObserver {
+    async fn after_output_staged(&self) -> std::result::Result<(), IndexError> {
+        if let Some(staged_tx) = self
+            .staged_tx
+            .lock()
+            .expect("staged signal lock poisoned")
+            .take()
+        {
+            let _ = staged_tx.send(());
+        }
+        let release_rx = self
+            .release_rx
+            .lock()
+            .await
+            .take()
+            .expect("release receiver already consumed");
+        release_rx.await.map_err(|_| {
+            IndexError::other(std::io::Error::other(
+                "atomic staging release signal dropped",
+            ))
+        })
+    }
+}
+
+struct FailAfterCommitObserver;
+
+#[async_trait]
+impl QueryProcessingObserver for FailAfterCommitObserver {
+    async fn after_commit_before_publish(&self) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!(
+            "injected failure after commit before in-memory publication"
+        ))
+    }
+}
+
+struct StaleSequenceAfterCommitObserver {
+    output_state: Mutex<Option<Arc<RwLock<QueryOutputState>>>>,
+}
+
+#[async_trait]
+impl QueryProcessingObserver for StaleSequenceAfterCommitObserver {
+    async fn after_commit_before_publish(&self) -> anyhow::Result<()> {
+        let output_state = self
+            .output_state
+            .lock()
+            .expect("stale-sequence state lock poisoned")
+            .as_ref()
+            .expect("stale-sequence state not initialized")
+            .clone();
+        let mut state = output_state.write().await;
+        state.advance_sequence_and_push(QueryResult::new(
+            QUERY_ID.to_string(),
+            0,
+            chrono::Utc::now(),
+            vec![],
+            HashMap::new(),
+        ));
+        Ok(())
+    }
+}
+
+struct AckSignalObserver {
+    ack_tx: Mutex<Option<oneshot::Sender<()>>>,
+}
+
+#[async_trait]
+impl QueryProcessingObserver for AckSignalObserver {
+    fn after_source_acknowledged(&self) {
+        if let Some(ack_tx) = self.ack_tx.lock().expect("ack signal lock poisoned").take() {
+            let _ = ack_tx.send(());
+        }
+    }
+}
+
+#[derive(Default)]
+struct CountingObserver {
+    staged: AtomicUsize,
+    committed: AtomicUsize,
+}
+
+#[async_trait]
+impl QueryProcessingObserver for CountingObserver {
+    async fn after_output_staged(&self) -> std::result::Result<(), IndexError> {
+        self.staged.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+
+    async fn after_commit_before_publish(&self) -> anyhow::Result<()> {
+        self.committed.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn rocksdb_atomic_source_commits_every_resource_before_ack_and_dispatch() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (host, mut fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        None,
+    )
+    .await;
+    start_host(host, &fixture).await;
+
+    let source_position = Bytes::from_static(b"atomic-position-1");
+    enqueue_source_change(
+        &fixture,
+        "person-success",
+        "Ada",
+        1,
+        source_position.clone(),
+    )
+    .await;
+    let dispatched = receive_result(&mut fixture.output_rx).await;
+
+    assert_eq!(dispatched.sequence, 1);
+    assert_eq!(dispatched.metadata["source_id"], SOURCE_ID);
+    let profiling = dispatched
+        .profiling
+        .as_ref()
+        .expect("atomic result profiling");
+    assert!(profiling.query_core_return_ns.is_some());
+    assert!(profiling.query_send_ns.is_some());
+    assert!(
+        profiling.query_core_return_ns <= profiling.query_send_ns,
+        "output staging begins after evaluation completes"
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint(SOURCE_ID)
+            .await
+            .expect("read checkpoint"),
+        Some(SourceCheckpoint::new(1, Some(source_position)))
+    );
+    let outbox = fixture
+        .outbox_writer
+        .read_from(QUERY_ID, 0)
+        .await
+        .expect("read outbox");
+    assert_eq!(outbox.len(), 1);
+    assert_eq!(
+        outbox[0].1,
+        rmp_serde::to_vec(dispatched.as_ref()).expect("serialize dispatched result"),
+        "the persisted and live-dispatched QueryResult must be byte-identical"
+    );
+    let row_signature = match &dispatched.results[0] {
+        ResultDiff::Add {
+            data,
+            row_signature,
+        } => {
+            assert_eq!(data, &json!({ "name": "Ada" }));
+            *row_signature
+        }
+        other => panic!("expected Add result, got {other:?}"),
+    };
+    assert_eq!(
+        fixture
+            .live_results_writer
+            .read_snapshot(QUERY_ID)
+            .await
+            .expect("read live results"),
+        vec![(
+            row_signature,
+            rmp_serde::to_vec(&json!({ "name": "Ada" })).expect("serialize expected live row"),
+        )]
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read result sequence"),
+        Some(1)
+    );
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 1);
+    assert_eq!(fixture.position_handle.load(Ordering::Acquire), 1);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 1);
+    assert!(element_exists(&fixture, "person-success").await);
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn rocksdb_atomic_source_fault_matrix_rolls_back_and_fences() {
+    let cases: Vec<(
+        &'static str,
+        BackendFault,
+        Option<Arc<dyn QueryProcessingObserver>>,
+    )> = vec![
+        (
+            "hook-after-staging",
+            BackendFault::None,
+            Some(Arc::new(FailAfterStagingObserver)),
+        ),
+        ("commit", BackendFault::Commit, None),
+        ("writer-stage", BackendFault::LiveResultsStage, None),
+    ];
+
+    for (name, fault, observer) in cases {
+        let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+        let (host, fixture) = build_host(
+            temp_dir.path(),
+            "MATCH (n:Person) RETURN n.name AS name",
+            fault,
+            false,
+            observer,
+        )
+        .await;
+        start_host(host, &fixture).await;
+
+        enqueue_source_change(
+            &fixture,
+            &format!("person-{name}"),
+            name,
+            7,
+            Bytes::from_static(b"failed-position"),
+        )
+        .await;
+        wait_for_status(&fixture.base, ComponentStatus::Error).await;
+
+        assert_no_durable_output(&fixture).await;
+        assert_eq!(
+            fixture.output_state.read().await.as_of_sequence(),
+            0,
+            "{name}: in-memory sequence changed"
+        );
+        assert_eq!(
+            fixture.position_handle.load(Ordering::Acquire),
+            u64::MAX,
+            "{name}: source position was acknowledged"
+        );
+        assert_eq!(
+            fixture.dispatch_count.load(Ordering::Acquire),
+            0,
+            "{name}: result was dispatched"
+        );
+        assert!(
+            !element_exists(&fixture, &format!("person-{name}")).await,
+            "{name}: core element state committed"
+        );
+
+        stop_host(&fixture).await;
+    }
+}
+
+#[tokio::test]
+async fn cancellation_during_atomic_hook_rolls_back_without_ack_or_dispatch() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (staged_tx, staged_rx) = oneshot::channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    let observer = Arc::new(BlockAfterStagingObserver {
+        staged_tx: Mutex::new(Some(staged_tx)),
+        release_rx: AsyncMutex::new(Some(release_rx)),
+    });
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        Some(observer),
+    )
+    .await;
+    start_host(host, &fixture).await;
+
+    enqueue_source_change(
+        &fixture,
+        "person-cancelled",
+        "Cancelled",
+        9,
+        Bytes::from_static(b"cancelled-position"),
+    )
+    .await;
+    staged_rx
+        .await
+        .expect("observer should report fully staged output");
+    assert!(fixture
+        .outbox_writer
+        .read_from(QUERY_ID, 0)
+        .await
+        .expect("read in-flight outbox")
+        .is_empty());
+    assert!(fixture
+        .live_results_writer
+        .read_snapshot(QUERY_ID)
+        .await
+        .expect("read in-flight live results")
+        .is_empty());
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read in-flight result sequence"),
+        None,
+        "snapshot readers must not observe a staged sequence before commit"
+    );
+
+    let task = fixture
+        .base
+        .task_handle
+        .write()
+        .await
+        .take()
+        .expect("host task handle");
+    task.abort();
+    assert!(task
+        .await
+        .expect_err("aborted host task should not complete")
+        .is_cancelled());
+
+    assert_no_durable_output(&fixture).await;
+    assert!(!element_exists(&fixture, "person-cancelled").await);
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fixture.position_handle.load(Ordering::Acquire), u64::MAX);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+    fixture.future_queue_source.stop().await;
+}
+
+#[tokio::test]
+async fn failure_after_commit_leaves_authoritative_output_without_publication() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        Some(Arc::new(FailAfterCommitObserver)),
+    )
+    .await;
+    start_host(host, &fixture).await;
+
+    let source_position = Bytes::from_static(b"committed-before-publish");
+    enqueue_source_change(
+        &fixture,
+        "person-committed",
+        "Committed",
+        11,
+        source_position.clone(),
+    )
+    .await;
+    wait_for_status(&fixture.base, ComponentStatus::Error).await;
+
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint(SOURCE_ID)
+            .await
+            .expect("read committed checkpoint"),
+        Some(SourceCheckpoint::new(11, Some(source_position)))
+    );
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .read_from(QUERY_ID, 0)
+            .await
+            .expect("read committed outbox")
+            .len(),
+        1
+    );
+    assert_eq!(
+        fixture
+            .live_results_writer
+            .read_snapshot(QUERY_ID)
+            .await
+            .expect("read committed live results")
+            .len(),
+        1
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read committed result sequence"),
+        Some(1)
+    );
+    assert!(element_exists(&fixture, "person-committed").await);
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fixture.position_handle.load(Ordering::Acquire), u64::MAX);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn stale_prepared_sequence_after_commit_is_fatal_and_not_acknowledged() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let observer = Arc::new(StaleSequenceAfterCommitObserver {
+        output_state: Mutex::new(None),
+    });
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        Some(observer.clone()),
+    )
+    .await;
+    *observer
+        .output_state
+        .lock()
+        .expect("stale-sequence state lock poisoned") = Some(fixture.output_state.clone());
+    start_host(host, &fixture).await;
+
+    enqueue_source_change(
+        &fixture,
+        "person-stale",
+        "Stale",
+        13,
+        Bytes::from_static(b"stale-position"),
+    )
+    .await;
+    wait_for_status(&fixture.base, ComponentStatus::Error).await;
+
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read committed result sequence"),
+        Some(1)
+    );
+    assert_eq!(fixture.position_handle.load(Ordering::Acquire), u64::MAX);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 1);
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn no_result_commits_checkpoint_and_ack_without_allocating_output_sequence() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (ack_tx, ack_rx) = oneshot::channel();
+    let observer = Arc::new(AckSignalObserver {
+        ack_tx: Mutex::new(Some(ack_tx)),
+    });
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) WHERE n.age > 100 RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        Some(observer),
+    )
+    .await;
+    start_host(host, &fixture).await;
+
+    let source_position = Bytes::from_static(b"no-result-position");
+    enqueue_source_change(
+        &fixture,
+        "person-no-result",
+        "Invisible",
+        17,
+        source_position.clone(),
+    )
+    .await;
+    ack_rx.await.expect("source acknowledgement signal");
+
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint(SOURCE_ID)
+            .await
+            .expect("read no-result checkpoint"),
+        Some(SourceCheckpoint::new(17, Some(source_position)))
+    );
+    assert!(element_exists(&fixture, "person-no-result").await);
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fixture.position_handle.load(Ordering::Acquire), 17);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+    assert!(fixture
+        .outbox_writer
+        .read_from(QUERY_ID, 0)
+        .await
+        .expect("read no-result outbox")
+        .is_empty());
+    assert!(fixture
+        .live_results_writer
+        .read_snapshot(QUERY_ID)
+        .await
+        .expect("read no-result live results")
+        .is_empty());
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read no-result result sequence"),
+        None
+    );
+
+    stop_host(&fixture).await;
+}
+
+async fn seed_due_future(fixture: &AtomicHostFixture) {
+    let initial = fixture
+        .continuous_query
+        .process_source_change(person_change("person-future", "Future", 1_000))
+        .await
+        .expect("seed due future");
+    assert!(initial.is_empty());
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek seeded future"),
+        Some(2_000)
+    );
+}
+
+async fn seed_later_future(fixture: &AtomicHostFixture) -> u64 {
+    let due_time = current_time_millis().saturating_add(60_000);
+    fixture
+        .session_control
+        .begin()
+        .await
+        .expect("begin later-future session");
+    fixture
+        .future_queue
+        .push(
+            PushType::Always,
+            999,
+            u64::MAX,
+            &ElementReference::new(SOURCE_ID, "person-future"),
+            due_time.saturating_sub(1),
+            due_time,
+        )
+        .await
+        .expect("stage later future");
+    fixture
+        .session_control
+        .commit()
+        .await
+        .expect("commit later future");
+    due_time
+}
+
+async fn enqueue_futures_due(fixture: &AtomicHostFixture) {
+    assert!(
+        fixture
+            .priority_queue
+            .enqueue(Arc::new(SourceEventWrapper::new(
+                "__future_queue__".to_string(),
+                SourceEvent::Control(SourceControl::FuturesDue),
+                chrono::Utc::now(),
+            )))
+            .await
+    );
+}
+
+#[tokio::test]
+async fn rocksdb_due_future_output_commits_with_pop_before_dispatch() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (host, mut fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) WHERE drasi.trueLater(true, 2000) RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        None,
+    )
+    .await;
+    seed_due_future(&fixture).await;
+    let later_due_time = seed_later_future(&fixture).await;
+    start_host(host, &fixture).await;
+    enqueue_futures_due(&fixture).await;
+
+    let dispatched = receive_result(&mut fixture.output_rx).await;
+    assert_eq!(dispatched.sequence, 1);
+    assert_eq!(dispatched.metadata["source_id"], SOURCE_ID);
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek retained later future"),
+        Some(later_due_time),
+        "one due signal must not consume a future scheduled for later"
+    );
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .read_from(QUERY_ID, 0)
+            .await
+            .expect("read future outbox")[0]
+            .1,
+        rmp_serde::to_vec(dispatched.as_ref()).expect("serialize future result")
+    );
+    assert_eq!(
+        fixture
+            .live_results_writer
+            .read_snapshot(QUERY_ID)
+            .await
+            .expect("read future live results")
+            .len(),
+        1
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read future result sequence"),
+        Some(1)
+    );
+    assert!(fixture
+        .checkpoint_store
+        .read_checkpoint(SOURCE_ID)
+        .await
+        .expect("read future source checkpoint")
+        .is_none());
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 1);
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn due_future_stage_failure_retains_future_and_publishes_nothing() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) WHERE drasi.trueLater(true, 2000) RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        Some(Arc::new(FailAfterStagingObserver)),
+    )
+    .await;
+    seed_due_future(&fixture).await;
+    start_host(host, &fixture).await;
+    enqueue_futures_due(&fixture).await;
+    wait_for_status(&fixture.base, ComponentStatus::Error).await;
+
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek retained future"),
+        Some(2_000)
+    );
+    assert_no_durable_output(&fixture).await;
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn explicit_legacy_mode_keeps_a1_loss_window_and_skips_atomic_observers() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let observer = Arc::new(CountingObserver::default());
+    let (host, mut fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::OutboxStage,
+        true,
+        Some(observer.clone()),
+    )
+    .await;
+    start_host(host, &fixture).await;
+
+    enqueue_source_change(
+        &fixture,
+        "person-legacy",
+        "Legacy",
+        19,
+        Bytes::from_static(b"legacy-position"),
+    )
+    .await;
+    let dispatched = receive_result(&mut fixture.output_rx).await;
+
+    assert_eq!(dispatched.sequence, 1);
+    assert_eq!(fixture.base.get_status().await, ComponentStatus::Running);
+    assert_eq!(fixture.position_handle.load(Ordering::Acquire), 19);
+    assert!(element_exists(&fixture, "person-legacy").await);
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint(SOURCE_ID)
+            .await
+            .expect("read legacy checkpoint")
+            .expect("legacy checkpoint committed")
+            .sequence,
+        19
+    );
+    assert!(fixture
+        .outbox_writer
+        .read_from(QUERY_ID, 0)
+        .await
+        .expect("read failed legacy outbox")
+        .is_empty());
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read legacy result sequence"),
+        None
+    );
+    assert_eq!(observer.staged.load(Ordering::Acquire), 0);
+    assert_eq!(observer.committed.load(Ordering::Acquire), 0);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 1);
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn capability_selection_requires_the_complete_created_indexes_bundle() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
+    let mut created: CreatedIndexes = provider
+        .create_indexes("capability-selection")
+        .await
+        .expect("create RocksDB indexes");
+    assert_eq!(
+        QueryProcessingMode::from_created_indexes(&created).diagnostic_name(),
+        "atomic"
+    );
+
+    created.outbox_writer = None;
+    assert_eq!(
+        QueryProcessingMode::from_created_indexes(&created).diagnostic_name(),
+        "legacy",
+        "a Garnet/custom/missing-writer-shaped bundle must not enter atomic mode"
+    );
+}
+
+#[tokio::test]
+async fn a6_does_not_hydrate_atomic_output_sequence_during_startup() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
+    let created = provider
+        .create_indexes("unhydrated-sequence")
+        .await
+        .expect("create RocksDB indexes");
+    let checkpoint_store = created
+        .checkpoint_store
+        .as_ref()
+        .expect("checkpoint store")
+        .clone();
+    checkpoint_store
+        .write_result_sequence("unhydrated-sequence", 41)
+        .await
+        .expect("seed durable result sequence");
+    let output_state = Arc::new(RwLock::new(QueryOutputState::new(16)));
+    let output = OutputPublicationStage::new(QueryOutputDependencies::new(
+        "unhydrated-sequence".to_string(),
+        output_state,
+        Arc::new(RwLock::new(Vec::new())),
+        created.outbox_writer,
+        created.live_results_writer,
+        Some(checkpoint_store),
+        16,
+        Arc::new(QueryOutputMetrics::new()),
+    ));
+    let contexts = [QueryPartEvaluationContext::Adding {
+        after: QueryVariables::from([(
+            Box::<str>::from("name"),
+            VariableValue::String("A7".to_string()),
+        )]),
+        row_signature: 7,
+    }];
+
+    let prepared = output
+        .prepare_atomic(&contexts, SOURCE_ID, ProfilingMetadata::default())
+        .await
+        .expect("prepare unhydrated output");
+    assert_eq!(
+        prepared.result.sequence, 1,
+        "A7 owns startup hydration from durable result sequence 41"
+    );
+}


### PR DESCRIPTION
Stack A layer 6 of 7.

Depends on #869.

RocksDB-capable index bundles atomically stage live source checkpoints, core/future state, outbox entries, live-result mutations, and persisted result sequences before in-memory publication, acknowledgement, and dispatch. Unsupported in-memory, Garnet, custom, missing, or mismatched bundles retain the legacy weaker semantics.

Atomic fatal errors immediately fence and reap source/future ingress so a failed query cannot backpressure shared sources. Public and bulk lifecycle cleanup now allow Error -> Stopping, and start/stop paths safely cancel and reap partial or prior runtime tasks.

If output commits but in-memory publication does not complete, the in-process runtime is marked recovery-required: restart and reconfiguration are rejected without reusing the durable sequence. A7 completes durable bootstrap/restart reconciliation and output-state hydration.