### PR TITLE
fix(lib): reconcile query bootstrap and recovery

### DIFF
--- a/core/src/query/continuous_query.rs
+++ b/core/src/query/continuous_query.rs
@@ -152,6 +152,34 @@ impl ContinuousQuery {
         Ok(result)
     }
 
+    /// Process a source change with a result-aware hook in the active legacy session.
+    ///
+    /// Unlike [`Self::process_source_change_with_result_hook`], this method does not
+    /// claim that every query output writer participates in the transaction. It is
+    /// used by orchestration that must atomically stage metadata with core/source
+    /// progress before the legacy session commits.
+    #[tracing::instrument(skip_all, err, level = "debug")]
+    pub async fn process_source_change_with_legacy_result_hook<F, Fut>(
+        &self,
+        change: SourceChange,
+        pre_commit_hook: F,
+    ) -> Result<Arc<[QueryPartEvaluationContext]>, EvaluationError>
+    where
+        F: FnOnce(Arc<[QueryPartEvaluationContext]>) -> Fut + Send,
+        Fut: Future<Output = Result<(), IndexError>> + Send,
+    {
+        let _lock = self.change_lock.lock().await;
+        let guard = SessionGuard::begin(self.session_control.clone()).await?;
+
+        let changes = self.execute_source_middleware(change).await?;
+        let result: Arc<[QueryPartEvaluationContext]> =
+            self.process_changes_inner(changes).await?.into();
+
+        pre_commit_hook(result.clone()).await?;
+        guard.commit().await?;
+        Ok(result)
+    }
+
     /// Process a source change with a result-aware pre-commit hook.
     ///
     /// The hook receives an immutable [`Arc`] containing the exact typed result
@@ -219,6 +247,44 @@ impl ContinuousQuery {
         let results = self.process_changes_inner(changes).await?;
         guard.commit().await?;
         Ok(Some(DueFutureResult { results, source_id }))
+    }
+
+    /// Pop and process one due future with a result-aware hook in the active
+    /// legacy session.
+    ///
+    /// The hook runs after evaluation but before commit. Hook failure rolls back
+    /// the future pop and all core mutations on transaction-capable backends.
+    #[tracing::instrument(skip_all, err, level = "debug")]
+    pub async fn process_due_futures_with_legacy_result_hook<F, Fut>(
+        &self,
+        pre_commit_hook: F,
+    ) -> Result<Option<Arc<DueFutureResult>>, EvaluationError>
+    where
+        F: FnOnce(Arc<DueFutureResult>) -> Fut + Send,
+        Fut: Future<Output = Result<(), IndexError>> + Send,
+    {
+        let _lock = self.change_lock.lock().await;
+        let guard = SessionGuard::begin(self.session_control.clone()).await?;
+
+        let future_ref = match self.future_queue.pop().await {
+            Ok(Some(future_ref)) => future_ref,
+            Ok(None) => {
+                guard.commit().await?;
+                return Ok(None);
+            }
+            Err(error) => return Err(EvaluationError::from(error)),
+        };
+
+        let source_id = future_ref.element_ref.source_id.clone();
+        let change = SourceChange::Future { future_ref };
+        let changes = self.execute_source_middleware(change).await?;
+        let result = Arc::new(DueFutureResult {
+            results: self.process_changes_inner(changes).await?,
+            source_id,
+        });
+        pre_commit_hook(result.clone()).await?;
+        guard.commit().await?;
+        Ok(Some(result))
     }
 
     /// Atomically process a due future with a result-aware pre-commit hook.

--- a/lib/src/channels/events.rs
+++ b/lib/src/channels/events.rs
@@ -446,7 +446,7 @@ pub struct QueryResult {
     pub results: Vec<ResultDiff>,
     pub metadata: HashMap<String, serde_json::Value>,
     /// Optional profiling metadata for performance tracking
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profiling: Option<ProfilingMetadata>,
 }
 

--- a/lib/src/queries/atomic_lifecycle_tests.rs
+++ b/lib/src/queries/atomic_lifecycle_tests.rs
@@ -629,6 +629,85 @@ fn query_config_with_policy(
     config
 }
 
+#[derive(Clone, Copy, Debug)]
+enum InvalidLegacyMarker {
+    MalformedPayload,
+    UnknownVersion,
+    MissingPayload,
+}
+
+async fn seed_invalid_legacy_marker(
+    path: &std::path::Path,
+    query_id: &str,
+    marker: InvalidLegacyMarker,
+) {
+    let provider = RocksDbIndexProvider::new(path, true, false);
+    let created = provider
+        .create_indexes(query_id)
+        .await
+        .expect("create invalid-marker indexes");
+    let checkpoint_store = created.checkpoint_store.clone().expect("checkpoint store");
+    let outbox = created.outbox_writer.clone().expect("outbox writer");
+    let live_results = created
+        .live_results_writer
+        .clone()
+        .expect("live-results writer");
+    let result = QueryResult::new(
+        query_id.to_string(),
+        5,
+        chrono::Utc::now(),
+        vec![ResultDiff::Add {
+            data: json!({ "name": "preserved" }),
+            row_signature: 5,
+        }],
+        HashMap::new(),
+    );
+    outbox
+        .append(
+            query_id,
+            5,
+            &rmp_serde::to_vec(&result).expect("serialize preserved result"),
+        )
+        .await
+        .expect("seed preserved outbox");
+    let row = rmp_serde::to_vec(&json!({ "name": "preserved" })).expect("serialize preserved row");
+    live_results
+        .apply_mutations(
+            query_id,
+            &[RowMutation {
+                row_signature: 5,
+                data: Some(&row),
+            }],
+        )
+        .await
+        .expect("seed preserved live row");
+    checkpoint_store
+        .write_result_sequence(query_id, 5)
+        .await
+        .expect("seed preserved result sequence");
+    created
+        .set
+        .session_control
+        .begin()
+        .await
+        .expect("begin invalid marker transaction");
+    let (version, payload) = match marker {
+        InvalidLegacyMarker::MalformedPayload => (1, Some(Bytes::from_static(b"bad"))),
+        InvalidLegacyMarker::UnknownVersion => (99, None),
+        InvalidLegacyMarker::MissingPayload => (1, None),
+    };
+    checkpoint_store
+        .stage_checkpoint(LEGACY_OUTPUT_PENDING_MARKER_V1, version, payload.as_ref())
+        .await
+        .expect("seed invalid Legacy marker");
+    created
+        .set
+        .session_control
+        .commit()
+        .await
+        .expect("commit invalid Legacy marker");
+}
+
 fn query_config_with_sources(query_id: &str, source_ids: &[&str]) -> QueryConfig {
     QueryConfig {
         id: query_id.to_string(),
@@ -1377,6 +1456,137 @@ async fn fresh_process_auto_reset_recovers_legacy_pending_marker_high_water() {
         .stop_source(SOURCE_ID.to_string())
         .await
         .expect("stop second-process source");
+}
+
+#[tokio::test]
+async fn invalid_legacy_pending_markers_follow_strict_and_auto_reset_policy() {
+    for marker in [
+        InvalidLegacyMarker::MalformedPayload,
+        InvalidLegacyMarker::UnknownVersion,
+        InvalidLegacyMarker::MissingPayload,
+    ] {
+        let strict_dir = tempfile::TempDir::new().expect("create Strict marker temp directory");
+        let strict_id = format!("legacy-invalid-strict-{marker:?}");
+        seed_invalid_legacy_marker(strict_dir.path(), &strict_id, marker).await;
+        let strict_provider: Arc<dyn IndexBackendPlugin> = Arc::new(LegacyFailureProvider {
+            inner: RocksDbIndexProvider::new(strict_dir.path(), true, false),
+            stage: LegacyFailureStage::Outbox,
+            failed: Arc::new(AtomicBool::new(true)),
+        });
+        let strict_harness = LifecycleHarness::new_with_provider(strict_provider).await;
+        let strict_query = strict_harness
+            .add_query_config(query_config_with_policy(
+                &strict_id,
+                crate::recovery::RecoveryPolicy::Strict,
+            ))
+            .await;
+        let error = strict_harness
+            .manager
+            .start_query(strict_id.clone())
+            .await
+            .expect_err("Strict must reject an invalid Legacy pending marker");
+        assert!(
+            format!("{error:#}").contains("invalid persistent Legacy pending-publication marker"),
+            "{marker:?}: unexpected Strict error: {error:#}"
+        );
+        let strict_store = concrete_query(&strict_query)
+            .get_checkpoint_store()
+            .await
+            .expect("Strict invalid-marker checkpoint store");
+        assert_eq!(
+            strict_store
+                .read_result_sequence(&strict_id)
+                .await
+                .expect("read unmodified Strict sequence"),
+            Some(5)
+        );
+        assert!(strict_store
+            .read_checkpoint(LEGACY_OUTPUT_PENDING_MARKER_V1)
+            .await
+            .expect("read unmodified Strict marker")
+            .is_some());
+        strict_harness
+            .manager
+            .stop_query(strict_id)
+            .await
+            .expect("stop Strict invalid-marker query");
+        strict_harness
+            .source_manager
+            .stop_source(SOURCE_ID.to_string())
+            .await
+            .expect("stop Strict source");
+
+        let reset_dir = tempfile::TempDir::new().expect("create AutoReset marker temp directory");
+        let reset_id = format!("legacy-invalid-reset-{marker:?}");
+        seed_invalid_legacy_marker(reset_dir.path(), &reset_id, marker).await;
+        let reset_provider: Arc<dyn IndexBackendPlugin> = Arc::new(LegacyFailureProvider {
+            inner: RocksDbIndexProvider::new(reset_dir.path(), true, false),
+            stage: LegacyFailureStage::Outbox,
+            failed: Arc::new(AtomicBool::new(true)),
+        });
+        let reset_harness = LifecycleHarness::new_with_provider(reset_provider).await;
+        let reset_query = reset_harness
+            .add_query_config(query_config_with_policy(
+                &reset_id,
+                crate::recovery::RecoveryPolicy::AutoReset,
+            ))
+            .await;
+        let mut results = reset_query
+            .subscribe(format!("{reset_id}-results"))
+            .await
+            .expect("subscribe AutoReset invalid-marker output")
+            .receiver;
+        reset_harness.start_query(&reset_id).await;
+        let reset_concrete = concrete_query(&reset_query);
+        assert_eq!(reset_concrete.output_sequence_for_test().await, 5);
+        let reset_store = reset_concrete
+            .get_checkpoint_store()
+            .await
+            .expect("AutoReset invalid-marker checkpoint store");
+        assert_eq!(
+            read_legacy_pending_state(reset_store.as_ref())
+                .await
+                .expect("read cleared invalid marker"),
+            LegacyPendingState::Absent
+        );
+        reset_harness
+            .source
+            .inject(1, "after-invalid-marker-reset")
+            .await
+            .expect("inject after invalid-marker reset");
+        assert_eq!(receive_result(&mut results).await.sequence, 6);
+
+        reset_harness
+            .manager
+            .stop_query(reset_id.clone())
+            .await
+            .expect("stop reset invalid-marker query");
+        wait_for_status(&reset_harness.manager, &reset_id, ComponentStatus::Stopped).await;
+        drop(reset_store);
+        reset_harness
+            .manager
+            .start_query(reset_id.clone())
+            .await
+            .expect("subsequent invalid-marker restart should be clean");
+        wait_for_status(&reset_harness.manager, &reset_id, ComponentStatus::Running).await;
+        reset_harness
+            .source
+            .inject(2, "after-clean-restart")
+            .await
+            .expect("inject after clean marker restart");
+        assert_eq!(receive_result(&mut results).await.sequence, 7);
+
+        reset_harness
+            .manager
+            .stop_query(reset_id)
+            .await
+            .expect("stop recovered invalid-marker query");
+        reset_harness
+            .source_manager
+            .stop_source(SOURCE_ID.to_string())
+            .await
+            .expect("stop AutoReset source");
+    }
 }
 
 #[tokio::test]

--- a/lib/src/queries/atomic_lifecycle_tests.rs
+++ b/lib/src/queries/atomic_lifecycle_tests.rs
@@ -35,7 +35,7 @@ use tokio::sync::{oneshot, Mutex, Notify, RwLock};
 
 use super::{
     manager::{DrasiQuery, Query, QueryManager},
-    query_composite_host::{QueryIngressFence, QueryProcessingObserver},
+    query_composite_host::{QueryIngressFence, QueryProcessingObserver, QUERY_BOOTSTRAP_MARKER_V1},
 };
 use crate::{
     channels::{
@@ -394,6 +394,15 @@ fn query_config(query_id: &str) -> QueryConfig {
     query_config_with_sources(query_id, &[SOURCE_ID])
 }
 
+fn query_config_with_policy(
+    query_id: &str,
+    recovery_policy: crate::recovery::RecoveryPolicy,
+) -> QueryConfig {
+    let mut config = query_config(query_id);
+    config.recovery_policy = Some(recovery_policy);
+    config
+}
+
 fn query_config_with_sources(query_id: &str, source_ids: &[&str]) -> QueryConfig {
     QueryConfig {
         id: query_id.to_string(),
@@ -606,10 +615,15 @@ async fn start_reaps_existing_forwarders_before_installing_replacements() {
 }
 
 #[tokio::test]
-async fn post_commit_fence_rejects_restart_without_reusing_durable_sequence() {
+async fn post_commit_fence_reconciles_and_replays_without_reusing_sequence() {
     let temp_dir = tempfile::TempDir::new().expect("create temp directory");
     let harness = LifecycleHarness::new(temp_dir.path()).await;
     let query = harness.add_query("atomic-post-commit").await;
+    let mut results = query
+        .subscribe("post-commit-recovery".to_string())
+        .await
+        .expect("subscribe before post-commit failure")
+        .receiver;
     concrete_query(&query)
         .set_processing_observer(Some(Arc::new(FailAfterCommit)))
         .await;
@@ -640,18 +654,7 @@ async fn post_commit_fence_rejects_restart_without_reusing_durable_sequence() {
         .expect("read committed outbox");
     assert_eq!(durable.len(), 1);
     assert_eq!(durable[0].0, 1);
-    let reconfigure = harness
-        .manager
-        .update_query(
-            "atomic-post-commit".to_string(),
-            query_config("atomic-post-commit"),
-        )
-        .await
-        .expect_err("reconfiguration must preserve the recovery fence");
-    assert!(
-        reconfigure.to_string().contains("A7 output reconciliation"),
-        "unexpected reconfiguration error: {reconfigure:#}"
-    );
+    drop(outbox);
 
     harness
         .manager
@@ -664,34 +667,48 @@ async fn post_commit_fence_rejects_restart_without_reusing_durable_sequence() {
         ComponentStatus::Stopped,
     )
     .await;
+    concrete.set_processing_observer(None).await;
 
-    let restart = harness
+    harness
         .manager
         .start_query("atomic-post-commit".to_string())
         .await
-        .expect_err("unsafe in-process restart must be rejected");
-    assert!(
-        restart.to_string().contains("A7 output reconciliation"),
-        "unexpected restart error: {restart:#}"
-    );
+        .expect("post-commit restart should reconcile durable output");
     wait_for_status(
         &harness.manager,
         "atomic-post-commit",
-        ComponentStatus::Error,
+        ComponentStatus::Running,
     )
     .await;
-    assert_eq!(query.subscription_count().await, 0);
-    assert_eq!(concrete.output_sequence_for_test().await, 0);
+    let recovered = receive_result(&mut results).await;
+    assert_eq!(recovered.sequence, 1);
     assert_eq!(
-        outbox
+        rmp_serde::to_vec(recovered.as_ref()).expect("serialize recovered result"),
+        durable[0].1,
+        "recovered and persisted QueryResult bytes must remain identical"
+    );
+    assert!(!concrete.publication_recovery_required());
+    assert_eq!(concrete.output_sequence_for_test().await, 1);
+
+    harness
+        .source
+        .inject(2, "after-recovery")
+        .await
+        .expect("inject after post-commit recovery");
+    assert_eq!(receive_result(&mut results).await.sequence, 2);
+    assert_eq!(
+        concrete
+            .get_outbox_writer()
+            .await
+            .expect("reopened atomic outbox writer")
             .read_from("atomic-post-commit", 0)
             .await
             .expect("reread committed outbox")
             .into_iter()
             .map(|(sequence, _)| sequence)
             .collect::<Vec<_>>(),
-        vec![1],
-        "rejected restart must not reuse or overwrite the durable sequence"
+        vec![1, 2],
+        "restart must continue after the durable sequence"
     );
 
     let first_stop = harness.manager.stop_query("atomic-post-commit".to_string());
@@ -707,6 +724,288 @@ async fn post_commit_fence_rejects_restart_without_reusing_durable_sequence() {
     .await;
     assert_eq!(query.subscription_count().await, 0);
 
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn strict_recovery_rejects_missing_durable_outbox() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let harness = LifecycleHarness::new(temp_dir.path()).await;
+    let query = harness
+        .add_query_config(query_config_with_policy(
+            "atomic-strict-output",
+            crate::recovery::RecoveryPolicy::Strict,
+        ))
+        .await;
+    let mut results = query
+        .subscribe("strict-output".to_string())
+        .await
+        .expect("subscribe strict output")
+        .receiver;
+    harness.start_query("atomic-strict-output").await;
+    harness
+        .source
+        .inject(1, "durable")
+        .await
+        .expect("inject durable result");
+    assert_eq!(receive_result(&mut results).await.sequence, 1);
+    harness
+        .manager
+        .stop_query("atomic-strict-output".to_string())
+        .await
+        .expect("stop strict query");
+
+    let outbox = concrete_query(&query)
+        .get_outbox_writer()
+        .await
+        .expect("strict outbox");
+    outbox
+        .clear("atomic-strict-output")
+        .await
+        .expect("corrupt durable outbox");
+    drop(outbox);
+
+    let error = harness
+        .manager
+        .start_query("atomic-strict-output".to_string())
+        .await
+        .expect_err("Strict recovery must reject an incomplete durable bundle");
+    assert!(
+        format!("{error:#}").contains("outbox"),
+        "unexpected reconciliation error: {error:#}"
+    );
+    wait_for_status(
+        &harness.manager,
+        "atomic-strict-output",
+        ComponentStatus::Error,
+    )
+    .await;
+    assert_eq!(query.subscription_count().await, 0);
+
+    harness
+        .manager
+        .stop_query("atomic-strict-output".to_string())
+        .await
+        .expect("stop strict query from Error");
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn auto_reset_clears_inconsistent_durable_output_before_live_processing() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let harness = LifecycleHarness::new(temp_dir.path()).await;
+    let query = harness
+        .add_query_config(query_config_with_policy(
+            "atomic-reset-output",
+            crate::recovery::RecoveryPolicy::AutoReset,
+        ))
+        .await;
+    let mut results = query
+        .subscribe("reset-output".to_string())
+        .await
+        .expect("subscribe reset output")
+        .receiver;
+    harness.start_query("atomic-reset-output").await;
+    harness
+        .source
+        .inject(1, "before-reset")
+        .await
+        .expect("inject result before reset");
+    assert_eq!(receive_result(&mut results).await.sequence, 1);
+    harness
+        .manager
+        .stop_query("atomic-reset-output".to_string())
+        .await
+        .expect("stop reset query");
+
+    let outbox = concrete_query(&query)
+        .get_outbox_writer()
+        .await
+        .expect("reset outbox");
+    outbox
+        .clear("atomic-reset-output")
+        .await
+        .expect("corrupt durable outbox");
+    drop(outbox);
+
+    harness
+        .manager
+        .start_query("atomic-reset-output".to_string())
+        .await
+        .expect("AutoReset should recover an incomplete durable bundle");
+    wait_for_status(
+        &harness.manager,
+        "atomic-reset-output",
+        ComponentStatus::Running,
+    )
+    .await;
+    assert_eq!(concrete_query(&query).output_sequence_for_test().await, 0);
+
+    harness
+        .source
+        .inject(2, "after-reset")
+        .await
+        .expect("inject after reset");
+    assert_eq!(receive_result(&mut results).await.sequence, 1);
+
+    harness
+        .manager
+        .stop_query("atomic-reset-output".to_string())
+        .await
+        .expect("stop reset query");
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn reconfigure_after_post_commit_fence_hydrates_replacement_runtime() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let harness = LifecycleHarness::new(temp_dir.path()).await;
+    let query = harness.add_query("atomic-reconfigure").await;
+    concrete_query(&query)
+        .set_processing_observer(Some(Arc::new(FailAfterCommit)))
+        .await;
+    harness.start_query("atomic-reconfigure").await;
+    harness
+        .source
+        .inject(1, "committed")
+        .await
+        .expect("inject post-commit failure");
+    wait_for_status(
+        &harness.manager,
+        "atomic-reconfigure",
+        ComponentStatus::Error,
+    )
+    .await;
+
+    harness
+        .manager
+        .update_query(
+            "atomic-reconfigure".to_string(),
+            query_config("atomic-reconfigure"),
+        )
+        .await
+        .expect("reconfigure should replace the fenced runtime");
+    let replacement = harness
+        .manager
+        .get_query_instance("atomic-reconfigure")
+        .await
+        .expect("replacement query");
+    harness.start_query("atomic-reconfigure").await;
+    let recovered = replacement
+        .fetch_outbox(0)
+        .await
+        .expect("replacement should expose durable outbox");
+    assert_eq!(recovered.latest_sequence, 1);
+    assert_eq!(
+        recovered
+            .results
+            .iter()
+            .map(|result| result.sequence)
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(
+        concrete_query(&replacement)
+            .output_sequence_for_test()
+            .await,
+        1
+    );
+
+    harness
+        .manager
+        .stop_query("atomic-reconfigure".to_string())
+        .await
+        .expect("stop reconfigured query");
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn incomplete_atomic_bootstrap_marker_clears_partial_state_before_restart() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let query_id = "atomic-bootstrap-recovery";
+    let config = query_config(query_id);
+    let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
+    let created = provider
+        .create_indexes(query_id)
+        .await
+        .expect("create bootstrap recovery indexes");
+    let checkpoint_store = created.checkpoint_store.clone().expect("checkpoint store");
+    let live_results = created
+        .live_results_writer
+        .clone()
+        .expect("live-results writer");
+    checkpoint_store
+        .write_config_hash(super::compute_config_hash(&config))
+        .await
+        .expect("seed config hash");
+    created
+        .set
+        .session_control
+        .begin()
+        .await
+        .expect("begin marker transaction");
+    checkpoint_store
+        .stage_checkpoint(QUERY_BOOTSTRAP_MARKER_V1, 0, None)
+        .await
+        .expect("seed in-progress marker");
+    created
+        .set
+        .session_control
+        .commit()
+        .await
+        .expect("commit marker transaction");
+    let partial_row =
+        rmp_serde::to_vec(&json!({ "name": "partial" })).expect("serialize partial bootstrap row");
+    live_results
+        .apply_mutations(
+            query_id,
+            &[drasi_core::interface::RowMutation {
+                row_signature: 99,
+                data: Some(&partial_row),
+            }],
+        )
+        .await
+        .expect("seed partial live row");
+    drop(live_results);
+    drop(checkpoint_store);
+    drop(created);
+
+    let harness = LifecycleHarness::new(temp_dir.path()).await;
+    let query = harness.add_query_config(config).await;
+    harness.start_query(query_id).await;
+    let concrete = concrete_query(&query);
+    assert_eq!(concrete.output_sequence_for_test().await, 0);
+    let checkpoint_store = concrete
+        .get_checkpoint_store()
+        .await
+        .expect("reopened checkpoint store");
+    assert!(checkpoint_store
+        .read_checkpoint(QUERY_BOOTSTRAP_MARKER_V1)
+        .await
+        .expect("read cleared bootstrap marker")
+        .is_none());
+
+    harness
+        .manager
+        .stop_query(query_id.to_string())
+        .await
+        .expect("stop recovered query");
     harness
         .source_manager
         .stop_source(SOURCE_ID.to_string())

--- a/lib/src/queries/atomic_lifecycle_tests.rs
+++ b/lib/src/queries/atomic_lifecycle_tests.rs
@@ -15,7 +15,7 @@
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -25,7 +25,10 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 use drasi_core::{
-    interface::{IndexBackendPlugin, IndexError},
+    interface::{
+        CheckpointStore, CreatedIndexes, IndexBackendPlugin, IndexError, LiveResultsWriter,
+        OutboxWriter, RowMutation, SourceCheckpoint,
+    },
     middleware::MiddlewareTypeRegistry,
     models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
 };
@@ -289,6 +292,204 @@ impl QueryProcessingObserver for FailAfterCommit {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LegacyFailureStage {
+    Outbox,
+    LiveResults,
+    ResultSequence,
+}
+
+struct LegacyFailureProvider {
+    inner: RocksDbIndexProvider,
+    stage: LegacyFailureStage,
+    failed: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl IndexBackendPlugin for LegacyFailureProvider {
+    async fn create_indexes(&self, query_id: &str) -> Result<CreatedIndexes, IndexError> {
+        let mut created = self.inner.create_indexes(query_id).await?;
+        let outbox = created.outbox_writer.take().expect("RocksDB outbox");
+        created.outbox_writer = Some(Arc::new(LegacyFailureOutbox {
+            inner: outbox,
+            stage: self.stage,
+            failed: self.failed.clone(),
+        }));
+        let live_results = created
+            .live_results_writer
+            .take()
+            .expect("RocksDB live-results writer");
+        created.live_results_writer = Some(Arc::new(LegacyFailureLiveResults {
+            inner: live_results,
+            stage: self.stage,
+            failed: self.failed.clone(),
+        }));
+        let checkpoints = created
+            .checkpoint_store
+            .take()
+            .expect("RocksDB checkpoint store");
+        created.checkpoint_store = Some(Arc::new(LegacyFailureCheckpointStore {
+            inner: checkpoints,
+            stage: self.stage,
+            failed: self.failed.clone(),
+        }));
+        Ok(created)
+    }
+
+    fn is_volatile(&self) -> bool {
+        false
+    }
+}
+
+struct LegacyFailureOutbox {
+    inner: Arc<dyn OutboxWriter>,
+    stage: LegacyFailureStage,
+    failed: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl OutboxWriter for LegacyFailureOutbox {
+    fn transaction_domain(&self) -> Option<drasi_core::interface::TransactionDomain> {
+        None
+    }
+
+    async fn append(&self, query_id: &str, sequence: u64, data: &[u8]) -> Result<(), IndexError> {
+        if self.stage == LegacyFailureStage::Outbox && !self.failed.swap(true, Ordering::AcqRel) {
+            return Err(IndexError::other(std::io::Error::other(
+                "injected persistent Legacy outbox failure",
+            )));
+        }
+        self.inner.append(query_id, sequence, data).await
+    }
+
+    async fn read_from(
+        &self,
+        query_id: &str,
+        after_sequence: u64,
+    ) -> Result<Vec<(u64, Vec<u8>)>, IndexError> {
+        self.inner.read_from(query_id, after_sequence).await
+    }
+
+    async fn read_latest_sequence(&self, query_id: &str) -> Result<Option<u64>, IndexError> {
+        self.inner.read_latest_sequence(query_id).await
+    }
+
+    async fn clear(&self, query_id: &str) -> Result<(), IndexError> {
+        self.inner.clear(query_id).await
+    }
+
+    async fn trim_to_capacity(&self, query_id: &str, capacity: usize) -> Result<usize, IndexError> {
+        self.inner.trim_to_capacity(query_id, capacity).await
+    }
+}
+
+struct LegacyFailureLiveResults {
+    inner: Arc<dyn LiveResultsWriter>,
+    stage: LegacyFailureStage,
+    failed: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl LiveResultsWriter for LegacyFailureLiveResults {
+    fn transaction_domain(&self) -> Option<drasi_core::interface::TransactionDomain> {
+        self.inner.transaction_domain()
+    }
+
+    async fn apply_mutations(
+        &self,
+        query_id: &str,
+        mutations: &[RowMutation<'_>],
+    ) -> Result<(), IndexError> {
+        if self.stage == LegacyFailureStage::LiveResults
+            && !self.failed.swap(true, Ordering::AcqRel)
+        {
+            return Err(IndexError::other(std::io::Error::other(
+                "injected persistent Legacy live-result failure",
+            )));
+        }
+        self.inner.apply_mutations(query_id, mutations).await
+    }
+
+    async fn read_snapshot(&self, query_id: &str) -> Result<Vec<(u64, Vec<u8>)>, IndexError> {
+        self.inner.read_snapshot(query_id).await
+    }
+
+    async fn clear(&self, query_id: &str) -> Result<(), IndexError> {
+        self.inner.clear(query_id).await
+    }
+
+    async fn row_count(&self, query_id: &str) -> Result<usize, IndexError> {
+        self.inner.row_count(query_id).await
+    }
+}
+
+struct LegacyFailureCheckpointStore {
+    inner: Arc<dyn CheckpointStore>,
+    stage: LegacyFailureStage,
+    failed: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl CheckpointStore for LegacyFailureCheckpointStore {
+    fn transaction_domain(&self) -> Option<drasi_core::interface::TransactionDomain> {
+        self.inner.transaction_domain()
+    }
+
+    fn is_persistent(&self) -> bool {
+        true
+    }
+
+    async fn stage_checkpoint(
+        &self,
+        source_id: &str,
+        sequence: u64,
+        source_position: Option<&Bytes>,
+    ) -> Result<(), IndexError> {
+        self.inner
+            .stage_checkpoint(source_id, sequence, source_position)
+            .await
+    }
+
+    async fn read_checkpoint(
+        &self,
+        source_id: &str,
+    ) -> Result<Option<SourceCheckpoint>, IndexError> {
+        self.inner.read_checkpoint(source_id).await
+    }
+
+    async fn read_all_checkpoints(&self) -> Result<HashMap<String, SourceCheckpoint>, IndexError> {
+        self.inner.read_all_checkpoints().await
+    }
+
+    async fn clear_checkpoints(&self) -> Result<(), IndexError> {
+        self.inner.clear_checkpoints().await
+    }
+
+    async fn write_config_hash(&self, hash: u64) -> Result<(), IndexError> {
+        self.inner.write_config_hash(hash).await
+    }
+
+    async fn read_config_hash(&self) -> Result<Option<u64>, IndexError> {
+        self.inner.read_config_hash().await
+    }
+
+    async fn write_result_sequence(&self, query_id: &str, sequence: u64) -> Result<(), IndexError> {
+        if self.stage == LegacyFailureStage::ResultSequence
+            && sequence > 0
+            && !self.failed.swap(true, Ordering::AcqRel)
+        {
+            return Err(IndexError::other(std::io::Error::other(
+                "injected persistent Legacy result-sequence failure",
+            )));
+        }
+        self.inner.write_result_sequence(query_id, sequence).await
+    }
+
+    async fn read_result_sequence(&self, query_id: &str) -> Result<Option<u64>, IndexError> {
+        self.inner.read_result_sequence(query_id).await
+    }
+}
+
 struct LifecycleHarness {
     manager: Arc<QueryManager>,
     source_manager: Arc<SourceManager>,
@@ -298,6 +499,10 @@ struct LifecycleHarness {
 
 impl LifecycleHarness {
     async fn new(path: &std::path::Path) -> Self {
+        Self::new_with_provider(Arc::new(RocksDbIndexProvider::new(path, true, false))).await
+    }
+
+    async fn new_with_provider(provider: Arc<dyn IndexBackendPlugin>) -> Self {
         let log_registry = get_or_init_global_registry();
         let (graph, mut update_rx) = ComponentGraph::new("atomic-lifecycle");
         let update_tx = graph.update_sender();
@@ -315,8 +520,6 @@ impl LifecycleHarness {
             graph.clone(),
             update_tx.clone(),
         ));
-        let provider: Arc<dyn IndexBackendPlugin> =
-            Arc::new(RocksDbIndexProvider::new(path, true, false));
         let index_factory = Arc::new(IndexFactory::new(
             vec![],
             HashMap::from([(BACKEND_NAME.to_string(), provider)]),
@@ -866,6 +1069,196 @@ async fn auto_reset_clears_inconsistent_durable_output_before_live_processing() 
         .stop_source(SOURCE_ID.to_string())
         .await
         .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn persistent_legacy_write_failures_make_strict_restart_fail_closed() {
+    for stage in [
+        LegacyFailureStage::Outbox,
+        LegacyFailureStage::LiveResults,
+        LegacyFailureStage::ResultSequence,
+    ] {
+        let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+        let provider: Arc<dyn IndexBackendPlugin> = Arc::new(LegacyFailureProvider {
+            inner: RocksDbIndexProvider::new(temp_dir.path(), true, false),
+            stage,
+            failed: Arc::new(AtomicBool::new(false)),
+        });
+        let harness = LifecycleHarness::new_with_provider(provider).await;
+        let query_id = format!("legacy-strict-{stage:?}");
+        let query = harness
+            .add_query_config(query_config_with_policy(
+                &query_id,
+                crate::recovery::RecoveryPolicy::Strict,
+            ))
+            .await;
+        let mut results = query
+            .subscribe(format!("{query_id}-results"))
+            .await
+            .expect("subscribe Legacy output")
+            .receiver;
+        harness.start_query(&query_id).await;
+
+        harness
+            .source
+            .inject(1, "failed-output")
+            .await
+            .expect("inject Legacy output failure");
+        wait_for_status(&harness.manager, &query_id, ComponentStatus::Error).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), results.recv())
+                .await
+                .is_err(),
+            "{stage:?}: failed persistent output was delivered"
+        );
+        let concrete = concrete_query(&query);
+        assert!(concrete.publication_recovery_required());
+        assert_eq!(
+            concrete
+                .get_checkpoint_store()
+                .await
+                .expect("Legacy checkpoint store")
+                .read_checkpoint(SOURCE_ID)
+                .await
+                .expect("read causative Legacy checkpoint")
+                .expect("causative Legacy checkpoint")
+                .sequence,
+            1
+        );
+
+        harness
+            .manager
+            .stop_query(query_id.clone())
+            .await
+            .expect("stop failed Legacy query");
+        wait_for_status(&harness.manager, &query_id, ComponentStatus::Stopped).await;
+        let error = harness
+            .manager
+            .start_query(query_id.clone())
+            .await
+            .expect_err("Strict restart must reject partial Legacy output");
+        assert!(
+            format!("{error:#}").contains("durable output reconciliation failed"),
+            "{stage:?}: unexpected Strict restart error: {error:#}"
+        );
+        assert!(concrete.publication_recovery_required());
+
+        harness
+            .manager
+            .stop_query(query_id)
+            .await
+            .expect("stop Strict query from Error");
+        harness
+            .source_manager
+            .stop_source(SOURCE_ID.to_string())
+            .await
+            .expect("stop lifecycle source");
+    }
+}
+
+#[tokio::test]
+async fn persistent_legacy_write_failures_auto_reset_and_resume() {
+    for stage in [
+        LegacyFailureStage::Outbox,
+        LegacyFailureStage::LiveResults,
+        LegacyFailureStage::ResultSequence,
+    ] {
+        let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+        let provider: Arc<dyn IndexBackendPlugin> = Arc::new(LegacyFailureProvider {
+            inner: RocksDbIndexProvider::new(temp_dir.path(), true, false),
+            stage,
+            failed: Arc::new(AtomicBool::new(false)),
+        });
+        let harness = LifecycleHarness::new_with_provider(provider).await;
+        let query_id = format!("legacy-reset-{stage:?}");
+        let query = harness
+            .add_query_config(query_config_with_policy(
+                &query_id,
+                crate::recovery::RecoveryPolicy::AutoReset,
+            ))
+            .await;
+        let mut results = query
+            .subscribe(format!("{query_id}-results"))
+            .await
+            .expect("subscribe Legacy reset output")
+            .receiver;
+        harness.start_query(&query_id).await;
+        harness
+            .source
+            .inject(1, "failed-output")
+            .await
+            .expect("inject Legacy output failure");
+        wait_for_status(&harness.manager, &query_id, ComponentStatus::Error).await;
+        let concrete = concrete_query(&query);
+        assert!(concrete.publication_recovery_required());
+
+        harness
+            .manager
+            .stop_query(query_id.clone())
+            .await
+            .expect("stop failed Legacy query");
+        wait_for_status(&harness.manager, &query_id, ComponentStatus::Stopped).await;
+        harness
+            .manager
+            .start_query(query_id.clone())
+            .await
+            .expect("AutoReset restart should clear partial Legacy output");
+        wait_for_status(&harness.manager, &query_id, ComponentStatus::Running).await;
+        assert!(!concrete.publication_recovery_required());
+        assert_eq!(concrete.output_sequence_for_test().await, 0);
+        let checkpoint_store = concrete
+            .get_checkpoint_store()
+            .await
+            .expect("reopened Legacy checkpoint store");
+        assert!(checkpoint_store
+            .read_checkpoint(QUERY_BOOTSTRAP_MARKER_V1)
+            .await
+            .expect("read cleared bootstrap marker")
+            .is_none());
+
+        harness
+            .source
+            .inject(2, "after-reset")
+            .await
+            .expect("inject after Legacy AutoReset");
+        let delivered = receive_result(&mut results).await;
+        assert_eq!(delivered.sequence, 1);
+        assert_eq!(
+            checkpoint_store
+                .read_checkpoint(SOURCE_ID)
+                .await
+                .expect("read resumed source checkpoint")
+                .expect("resumed source checkpoint")
+                .sequence,
+            2
+        );
+        let outbox = concrete
+            .get_outbox_writer()
+            .await
+            .expect("Legacy outbox after reset")
+            .read_from(&query_id, 0)
+            .await
+            .expect("read Legacy outbox after reset");
+        assert_eq!(
+            outbox
+                .iter()
+                .map(|(sequence, _)| *sequence)
+                .collect::<Vec<_>>(),
+            vec![1],
+            "{stage:?}: stale or reused outbox entries survived AutoReset"
+        );
+
+        harness
+            .manager
+            .stop_query(query_id)
+            .await
+            .expect("stop recovered Legacy query");
+        harness
+            .source_manager
+            .stop_source(SOURCE_ID.to_string())
+            .await
+            .expect("stop lifecycle source");
+    }
 }
 
 #[tokio::test]

--- a/lib/src/queries/atomic_lifecycle_tests.rs
+++ b/lib/src/queries/atomic_lifecycle_tests.rs
@@ -38,11 +38,14 @@ use tokio::sync::{oneshot, Mutex, Notify, RwLock};
 
 use super::{
     manager::{DrasiQuery, Query, QueryManager},
-    query_composite_host::{QueryIngressFence, QueryProcessingObserver, QUERY_BOOTSTRAP_MARKER_V1},
+    query_composite_host::{
+        read_legacy_pending_state, LegacyPendingState, QueryIngressFence, QueryProcessingObserver,
+        LEGACY_OUTPUT_PENDING_MARKER_V1, QUERY_BOOTSTRAP_MARKER_V1,
+    },
 };
 use crate::{
     channels::{
-        ChangeReceiver, ComponentStatus, DispatchMode, QueryResult, SourceEvent,
+        ChangeReceiver, ComponentStatus, DispatchMode, QueryResult, ResultDiff, SourceEvent,
         SourceEventWrapper, SubscriptionResponse,
     },
     component_graph::ComponentGraph,
@@ -297,6 +300,8 @@ enum LegacyFailureStage {
     Outbox,
     LiveResults,
     ResultSequence,
+    MarkerStage,
+    MarkerClear,
 }
 
 struct LegacyFailureProvider {
@@ -445,6 +450,24 @@ impl CheckpointStore for LegacyFailureCheckpointStore {
         sequence: u64,
         source_position: Option<&Bytes>,
     ) -> Result<(), IndexError> {
+        if self.stage == LegacyFailureStage::MarkerStage
+            && source_id == LEGACY_OUTPUT_PENDING_MARKER_V1
+            && sequence == 1
+            && !self.failed.swap(true, Ordering::AcqRel)
+        {
+            return Err(IndexError::other(std::io::Error::other(
+                "injected Legacy pending-marker stage failure",
+            )));
+        }
+        if self.stage == LegacyFailureStage::MarkerClear
+            && source_id == LEGACY_OUTPUT_PENDING_MARKER_V1
+            && sequence == 0
+            && !self.failed.swap(true, Ordering::AcqRel)
+        {
+            return Err(IndexError::other(std::io::Error::other(
+                "injected Legacy pending-marker clear failure",
+            )));
+        }
         self.inner
             .stage_checkpoint(source_id, sequence, source_position)
             .await
@@ -1050,14 +1073,14 @@ async fn auto_reset_clears_inconsistent_durable_output_before_live_processing() 
         ComponentStatus::Running,
     )
     .await;
-    assert_eq!(concrete_query(&query).output_sequence_for_test().await, 0);
+    assert_eq!(concrete_query(&query).output_sequence_for_test().await, 1);
 
     harness
         .source
         .inject(2, "after-reset")
         .await
         .expect("inject after reset");
-    assert_eq!(receive_result(&mut results).await.sequence, 1);
+    assert_eq!(receive_result(&mut results).await.sequence, 2);
 
     harness
         .manager
@@ -1138,7 +1161,7 @@ async fn persistent_legacy_write_failures_make_strict_restart_fail_closed() {
             .await
             .expect_err("Strict restart must reject partial Legacy output");
         assert!(
-            format!("{error:#}").contains("durable output reconciliation failed"),
+            format!("{error:#}").contains("unfinished persistent Legacy publication"),
             "{stage:?}: unexpected Strict restart error: {error:#}"
         );
         assert!(concrete.publication_recovery_required());
@@ -1205,7 +1228,7 @@ async fn persistent_legacy_write_failures_auto_reset_and_resume() {
             .expect("AutoReset restart should clear partial Legacy output");
         wait_for_status(&harness.manager, &query_id, ComponentStatus::Running).await;
         assert!(!concrete.publication_recovery_required());
-        assert_eq!(concrete.output_sequence_for_test().await, 0);
+        assert_eq!(concrete.output_sequence_for_test().await, 1);
         let checkpoint_store = concrete
             .get_checkpoint_store()
             .await
@@ -1222,7 +1245,7 @@ async fn persistent_legacy_write_failures_auto_reset_and_resume() {
             .await
             .expect("inject after Legacy AutoReset");
         let delivered = receive_result(&mut results).await;
-        assert_eq!(delivered.sequence, 1);
+        assert_eq!(delivered.sequence, 2);
         assert_eq!(
             checkpoint_store
                 .read_checkpoint(SOURCE_ID)
@@ -1244,7 +1267,7 @@ async fn persistent_legacy_write_failures_auto_reset_and_resume() {
                 .iter()
                 .map(|(sequence, _)| *sequence)
                 .collect::<Vec<_>>(),
-            vec![1],
+            vec![2],
             "{stage:?}: stale or reused outbox entries survived AutoReset"
         );
 
@@ -1259,6 +1282,329 @@ async fn persistent_legacy_write_failures_auto_reset_and_resume() {
             .await
             .expect("stop lifecycle source");
     }
+}
+
+#[tokio::test]
+async fn fresh_process_auto_reset_recovers_legacy_pending_marker_high_water() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let failed = Arc::new(AtomicBool::new(false));
+    let provider1: Arc<dyn IndexBackendPlugin> = Arc::new(LegacyFailureProvider {
+        inner: RocksDbIndexProvider::new(temp_dir.path(), true, false),
+        stage: LegacyFailureStage::Outbox,
+        failed: failed.clone(),
+    });
+    let harness1 = LifecycleHarness::new_with_provider(provider1).await;
+    let query_id = "legacy-fresh-process";
+    let query1 = harness1
+        .add_query_config(query_config_with_policy(
+            query_id,
+            crate::recovery::RecoveryPolicy::AutoReset,
+        ))
+        .await;
+    harness1.start_query(query_id).await;
+    harness1
+        .source
+        .inject(1, "lost-before-process-restart")
+        .await
+        .expect("inject Legacy failure");
+    wait_for_status(&harness1.manager, query_id, ComponentStatus::Error).await;
+    assert_eq!(
+        read_legacy_pending_state(
+            concrete_query(&query1)
+                .get_checkpoint_store()
+                .await
+                .expect("first-process checkpoint store")
+                .as_ref()
+        )
+        .await
+        .expect("read first-process pending marker"),
+        LegacyPendingState::Pending {
+            output_sequence: Some(1)
+        }
+    );
+    harness1
+        .manager
+        .stop_query(query_id.to_string())
+        .await
+        .expect("stop first-process query");
+    wait_for_status(&harness1.manager, query_id, ComponentStatus::Stopped).await;
+    query1.release_persistent_handles().await;
+    harness1
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop first-process source");
+    drop(query1);
+    drop(harness1);
+
+    let provider2: Arc<dyn IndexBackendPlugin> = Arc::new(LegacyFailureProvider {
+        inner: RocksDbIndexProvider::new(temp_dir.path(), true, false),
+        stage: LegacyFailureStage::Outbox,
+        failed,
+    });
+    let harness2 = LifecycleHarness::new_with_provider(provider2).await;
+    let query2 = harness2
+        .add_query_config(query_config_with_policy(
+            query_id,
+            crate::recovery::RecoveryPolicy::AutoReset,
+        ))
+        .await;
+    let mut results = query2
+        .subscribe("fresh-process-results".to_string())
+        .await
+        .expect("subscribe fresh-process output")
+        .receiver;
+    harness2.start_query(query_id).await;
+    assert_eq!(
+        concrete_query(&query2).output_sequence_for_test().await,
+        1,
+        "fresh process did not preserve the pending output high-water"
+    );
+    harness2
+        .source
+        .inject(2, "after-process-reset")
+        .await
+        .expect("inject after fresh-process AutoReset");
+    assert_eq!(receive_result(&mut results).await.sequence, 2);
+
+    harness2
+        .manager
+        .stop_query(query_id.to_string())
+        .await
+        .expect("stop recovered fresh-process query");
+    harness2
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop second-process source");
+}
+
+#[tokio::test]
+async fn legacy_pending_marker_stage_failure_rolls_back_source_progress() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let provider: Arc<dyn IndexBackendPlugin> = Arc::new(LegacyFailureProvider {
+        inner: RocksDbIndexProvider::new(temp_dir.path(), true, false),
+        stage: LegacyFailureStage::MarkerStage,
+        failed: Arc::new(AtomicBool::new(false)),
+    });
+    let harness = LifecycleHarness::new_with_provider(provider).await;
+    let query_id = "legacy-marker-stage";
+    let query = harness.add_query(query_id).await;
+    let mut results = query
+        .subscribe("legacy-marker-stage-results".to_string())
+        .await
+        .expect("subscribe marker-stage output")
+        .receiver;
+    harness.start_query(query_id).await;
+
+    harness
+        .source
+        .inject(1, "first")
+        .await
+        .expect("inject marker-stage failure");
+    wait_for_status(&harness.manager, query_id, ComponentStatus::Error).await;
+    let concrete = concrete_query(&query);
+    let checkpoint_store = concrete
+        .get_checkpoint_store()
+        .await
+        .expect("marker-stage checkpoint store");
+    assert!(checkpoint_store
+        .read_checkpoint(SOURCE_ID)
+        .await
+        .expect("read rolled-back source checkpoint")
+        .is_none());
+    assert!(checkpoint_store
+        .read_checkpoint(LEGACY_OUTPUT_PENDING_MARKER_V1)
+        .await
+        .expect("read failed marker")
+        .is_none());
+    assert_eq!(concrete.output_sequence_for_test().await, 0);
+    assert!(!concrete.publication_recovery_required());
+    assert_eq!(harness.source.base.compute_confirmed_position().await, None);
+    drop(checkpoint_store);
+
+    harness
+        .manager
+        .stop_query(query_id.to_string())
+        .await
+        .expect("stop marker-stage query");
+    wait_for_status(&harness.manager, query_id, ComponentStatus::Stopped).await;
+    harness
+        .manager
+        .start_query(query_id.to_string())
+        .await
+        .expect("restart after marker-stage rollback");
+    wait_for_status(&harness.manager, query_id, ComponentStatus::Running).await;
+    harness
+        .source
+        .inject(1, "retry")
+        .await
+        .expect("retry rolled-back input");
+    let retried = receive_result(&mut results).await;
+    assert_eq!(retried.sequence, 1);
+    assert!(matches!(retried.results[0], ResultDiff::Add { .. }));
+
+    harness
+        .manager
+        .stop_query(query_id.to_string())
+        .await
+        .expect("stop recovered marker-stage query");
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn legacy_marker_clear_failure_stays_detectable_after_output_success() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let provider: Arc<dyn IndexBackendPlugin> = Arc::new(LegacyFailureProvider {
+        inner: RocksDbIndexProvider::new(temp_dir.path(), true, false),
+        stage: LegacyFailureStage::MarkerClear,
+        failed: Arc::new(AtomicBool::new(false)),
+    });
+    let harness = LifecycleHarness::new_with_provider(provider).await;
+    let query_id = "legacy-marker-clear";
+    let query = harness.add_query(query_id).await;
+    let mut results = query
+        .subscribe("legacy-marker-clear-results".to_string())
+        .await
+        .expect("subscribe marker-clear output")
+        .receiver;
+    harness.start_query(query_id).await;
+    harness
+        .source
+        .inject(1, "committed")
+        .await
+        .expect("inject marker-clear failure");
+    let delivered = receive_result(&mut results).await;
+    assert_eq!(delivered.sequence, 1);
+    wait_for_status(&harness.manager, query_id, ComponentStatus::Error).await;
+
+    let concrete = concrete_query(&query);
+    let checkpoint_store = concrete
+        .get_checkpoint_store()
+        .await
+        .expect("marker-clear checkpoint store");
+    assert_eq!(
+        checkpoint_store
+            .read_checkpoint(LEGACY_OUTPUT_PENDING_MARKER_V1)
+            .await
+            .expect("read retained marker")
+            .expect("pending marker retained")
+            .sequence,
+        1
+    );
+    assert_eq!(
+        checkpoint_store
+            .read_result_sequence(query_id)
+            .await
+            .expect("read committed output sequence"),
+        Some(1)
+    );
+    assert_eq!(
+        harness.source.base.compute_confirmed_position().await,
+        None,
+        "marker-clear failure must prevent source acknowledgement"
+    );
+    drop(checkpoint_store);
+
+    harness
+        .manager
+        .stop_query(query_id.to_string())
+        .await
+        .expect("stop marker-clear query");
+    wait_for_status(&harness.manager, query_id, ComponentStatus::Stopped).await;
+    let error = harness
+        .manager
+        .start_query(query_id.to_string())
+        .await
+        .expect_err("Strict restart must detect retained pending marker");
+    assert!(format!("{error:#}").contains("unfinished persistent Legacy publication"));
+
+    harness
+        .manager
+        .stop_query(query_id.to_string())
+        .await
+        .expect("stop marker-clear query from Error");
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
+}
+
+#[tokio::test]
+async fn persistent_legacy_noop_clears_marker_without_allocating_sequence() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let provider: Arc<dyn IndexBackendPlugin> = Arc::new(LegacyFailureProvider {
+        inner: RocksDbIndexProvider::new(temp_dir.path(), true, false),
+        stage: LegacyFailureStage::ResultSequence,
+        failed: Arc::new(AtomicBool::new(false)),
+    });
+    let harness = LifecycleHarness::new_with_provider(provider).await;
+    let query_id = "legacy-noop";
+    let mut config = query_config(query_id);
+    config.query = "MATCH (n:Person) WHERE n.name = 'visible' RETURN n.name AS name".to_string();
+    let query = harness.add_query_config(config).await;
+    harness.start_query(query_id).await;
+    harness
+        .source
+        .inject(1, "hidden")
+        .await
+        .expect("inject no-output input");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if harness.source.base.compute_confirmed_position().await == Some(1) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("Noop input should be acknowledged after marker clear");
+
+    let concrete = concrete_query(&query);
+    let checkpoint_store = concrete
+        .get_checkpoint_store()
+        .await
+        .expect("Noop checkpoint store");
+    assert_eq!(
+        checkpoint_store
+            .read_checkpoint(LEGACY_OUTPUT_PENDING_MARKER_V1)
+            .await
+            .expect("read cleared Noop marker")
+            .expect("logical clear marker")
+            .sequence,
+        0
+    );
+    assert_eq!(
+        read_legacy_pending_state(checkpoint_store.as_ref())
+            .await
+            .expect("read logical Noop marker state"),
+        LegacyPendingState::Absent
+    );
+    assert_eq!(concrete.output_sequence_for_test().await, 0);
+    assert_eq!(
+        checkpoint_store
+            .read_result_sequence(query_id)
+            .await
+            .expect("read Noop result sequence"),
+        None
+    );
+    assert_eq!(query.status().await, ComponentStatus::Running);
+
+    harness
+        .manager
+        .stop_query(query_id.to_string())
+        .await
+        .expect("stop Noop query");
+    harness
+        .source_manager
+        .stop_source(SOURCE_ID.to_string())
+        .await
+        .expect("stop lifecycle source");
 }
 
 #[tokio::test]

--- a/lib/src/queries/checkpoint_tests.rs
+++ b/lib/src/queries/checkpoint_tests.rs
@@ -1350,18 +1350,47 @@ mod tests {
     /// Used for testing config hash check logic which only runs for persistent backends.
     struct PersistentInMemoryCheckpointStore {
         inner: drasi_core::in_memory_index::in_memory_checkpoint_store::InMemoryCheckpointStore,
+        transaction_domain: drasi_core::interface::TransactionDomain,
     }
 
     impl PersistentInMemoryCheckpointStore {
         fn new() -> Self {
             Self {
                 inner: drasi_core::in_memory_index::in_memory_checkpoint_store::InMemoryCheckpointStore::new(),
+                transaction_domain: drasi_core::interface::TransactionDomain::new(),
             }
+        }
+    }
+
+    struct DomainNoOpSessionControl {
+        transaction_domain: drasi_core::interface::TransactionDomain,
+    }
+
+    #[async_trait::async_trait]
+    impl drasi_core::interface::SessionControl for DomainNoOpSessionControl {
+        fn transaction_domain(&self) -> Option<drasi_core::interface::TransactionDomain> {
+            Some(self.transaction_domain.clone())
+        }
+
+        async fn begin(&self) -> Result<(), drasi_core::interface::IndexError> {
+            Ok(())
+        }
+
+        async fn commit(&self) -> Result<(), drasi_core::interface::IndexError> {
+            Ok(())
+        }
+
+        fn rollback(&self) -> Result<(), drasi_core::interface::IndexError> {
+            Ok(())
         }
     }
 
     #[async_trait::async_trait]
     impl CheckpointStore for PersistentInMemoryCheckpointStore {
+        fn transaction_domain(&self) -> Option<drasi_core::interface::TransactionDomain> {
+            Some(self.transaction_domain.clone())
+        }
+
         fn is_persistent(&self) -> bool {
             true
         }
@@ -1410,6 +1439,21 @@ mod tests {
         async fn read_config_hash(&self) -> Result<Option<u64>, drasi_core::interface::IndexError> {
             self.inner.read_config_hash().await
         }
+
+        async fn write_result_sequence(
+            &self,
+            query_id: &str,
+            sequence: u64,
+        ) -> Result<(), drasi_core::interface::IndexError> {
+            self.inner.write_result_sequence(query_id, sequence).await
+        }
+
+        async fn read_result_sequence(
+            &self,
+            query_id: &str,
+        ) -> Result<Option<u64>, drasi_core::interface::IndexError> {
+            self.inner.read_result_sequence(query_id).await
+        }
     }
 
     /// Mock persistent plugin that gives each query its own
@@ -1438,7 +1482,7 @@ mod tests {
             use drasi_core::in_memory_index::in_memory_element_index::InMemoryElementIndex;
             use drasi_core::in_memory_index::in_memory_future_queue::InMemoryFutureQueue;
             use drasi_core::in_memory_index::in_memory_result_index::InMemoryResultIndex;
-            use drasi_core::interface::{IndexSet, NoOpSessionControl};
+            use drasi_core::interface::IndexSet;
 
             let checkpoint_store = {
                 let mut map = self.stores.write().await;
@@ -1454,7 +1498,9 @@ mod tests {
                     archive_index: element_index,
                     result_index: Arc::new(InMemoryResultIndex::new()),
                     future_queue: Arc::new(InMemoryFutureQueue::new()),
-                    session_control: Arc::new(NoOpSessionControl),
+                    session_control: Arc::new(DomainNoOpSessionControl {
+                        transaction_domain: checkpoint_store.transaction_domain.clone(),
+                    }),
                 },
                 checkpoint_store: Some(checkpoint_store),
                 live_results_writer: None,
@@ -1888,8 +1934,15 @@ mod tests {
             .expect("Should have checkpoint store");
         let all_cp = cp_store.read_all_checkpoints().await.unwrap();
         assert!(
-            all_cp.is_empty(),
-            "Checkpoints should be cleared after config change"
+            !all_cp.contains_key("mismatch-src"),
+            "Source checkpoints should be cleared after config change"
+        );
+        assert_eq!(
+            all_cp
+                .get(crate::queries::query_composite_host::QUERY_OUTPUT_RESET_MARKER_V1)
+                .map(|marker| marker.sequence),
+            Some(1),
+            "Config reset should preserve the public output high-water"
         );
 
         // Verify the new config hash was written
@@ -2116,6 +2169,10 @@ mod tests {
 
     #[async_trait::async_trait]
     impl CheckpointStore for FailableCheckpointStore {
+        fn transaction_domain(&self) -> Option<drasi_core::interface::TransactionDomain> {
+            self.inner.transaction_domain()
+        }
+
         fn is_persistent(&self) -> bool {
             true
         }
@@ -2186,6 +2243,21 @@ mod tests {
             }
             self.inner.read_config_hash().await
         }
+
+        async fn write_result_sequence(
+            &self,
+            query_id: &str,
+            sequence: u64,
+        ) -> Result<(), drasi_core::interface::IndexError> {
+            self.inner.write_result_sequence(query_id, sequence).await
+        }
+
+        async fn read_result_sequence(
+            &self,
+            query_id: &str,
+        ) -> Result<Option<u64>, drasi_core::interface::IndexError> {
+            self.inner.read_result_sequence(query_id).await
+        }
     }
 
     /// Mock plugin that uses a pre-created FailableCheckpointStore.
@@ -2218,7 +2290,7 @@ mod tests {
             use drasi_core::in_memory_index::in_memory_element_index::InMemoryElementIndex;
             use drasi_core::in_memory_index::in_memory_future_queue::InMemoryFutureQueue;
             use drasi_core::in_memory_index::in_memory_result_index::InMemoryResultIndex;
-            use drasi_core::interface::{IndexSet, NoOpSessionControl};
+            use drasi_core::interface::IndexSet;
 
             let checkpoint_store = self.get_store(query_id).await;
 
@@ -2229,7 +2301,9 @@ mod tests {
                     archive_index: element_index,
                     result_index: Arc::new(InMemoryResultIndex::new()),
                     future_queue: Arc::new(InMemoryFutureQueue::new()),
-                    session_control: Arc::new(NoOpSessionControl),
+                    session_control: Arc::new(DomainNoOpSessionControl {
+                        transaction_domain: checkpoint_store.inner.transaction_domain.clone(),
+                    }),
                 },
                 checkpoint_store: Some(checkpoint_store),
                 live_results_writer: None,
@@ -2629,18 +2703,47 @@ mod orchestration_tests {
 
     struct PersistentInMemoryCheckpointStore {
         inner: InMemoryCheckpointStore,
+        transaction_domain: drasi_core::interface::TransactionDomain,
     }
 
     impl PersistentInMemoryCheckpointStore {
         fn new() -> Self {
             Self {
                 inner: InMemoryCheckpointStore::new(),
+                transaction_domain: drasi_core::interface::TransactionDomain::new(),
             }
+        }
+    }
+
+    struct DomainNoOpSessionControl {
+        transaction_domain: drasi_core::interface::TransactionDomain,
+    }
+
+    #[async_trait::async_trait]
+    impl drasi_core::interface::SessionControl for DomainNoOpSessionControl {
+        fn transaction_domain(&self) -> Option<drasi_core::interface::TransactionDomain> {
+            Some(self.transaction_domain.clone())
+        }
+
+        async fn begin(&self) -> Result<(), drasi_core::interface::IndexError> {
+            Ok(())
+        }
+
+        async fn commit(&self) -> Result<(), drasi_core::interface::IndexError> {
+            Ok(())
+        }
+
+        fn rollback(&self) -> Result<(), drasi_core::interface::IndexError> {
+            Ok(())
         }
     }
 
     #[async_trait::async_trait]
     impl CheckpointStore for PersistentInMemoryCheckpointStore {
+        fn transaction_domain(&self) -> Option<drasi_core::interface::TransactionDomain> {
+            Some(self.transaction_domain.clone())
+        }
+
         fn is_persistent(&self) -> bool {
             true
         }
@@ -2683,6 +2786,21 @@ mod orchestration_tests {
         async fn clear_checkpoints(&self) -> Result<(), drasi_core::interface::IndexError> {
             self.inner.clear_checkpoints().await
         }
+
+        async fn write_result_sequence(
+            &self,
+            query_id: &str,
+            sequence: u64,
+        ) -> Result<(), drasi_core::interface::IndexError> {
+            self.inner.write_result_sequence(query_id, sequence).await
+        }
+
+        async fn read_result_sequence(
+            &self,
+            query_id: &str,
+        ) -> Result<Option<u64>, drasi_core::interface::IndexError> {
+            self.inner.read_result_sequence(query_id).await
+        }
     }
 
     struct MockPersistentPlugin {
@@ -2707,7 +2825,7 @@ mod orchestration_tests {
             use drasi_core::in_memory_index::in_memory_element_index::InMemoryElementIndex;
             use drasi_core::in_memory_index::in_memory_future_queue::InMemoryFutureQueue;
             use drasi_core::in_memory_index::in_memory_result_index::InMemoryResultIndex;
-            use drasi_core::interface::{IndexSet, NoOpSessionControl};
+            use drasi_core::interface::IndexSet;
 
             let checkpoint_store = {
                 let mut stores = self.stores.write().await;
@@ -2723,7 +2841,9 @@ mod orchestration_tests {
                     archive_index: element_index,
                     result_index: Arc::new(InMemoryResultIndex::new()),
                     future_queue: Arc::new(InMemoryFutureQueue::new()),
-                    session_control: Arc::new(NoOpSessionControl),
+                    session_control: Arc::new(DomainNoOpSessionControl {
+                        transaction_domain: checkpoint_store.transaction_domain.clone(),
+                    }),
                 },
                 checkpoint_store: Some(checkpoint_store),
                 live_results_writer: None,

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -502,6 +502,7 @@ enum QueryRecoveryResetReason {
     IncompleteBootstrap,
     CheckpointReadFailed,
     InvalidBootstrapMarker,
+    InvalidLegacyPendingMarker,
     LegacyPublicationPending,
     OutputReconciliationFailed,
     PositionUnavailable,
@@ -524,8 +525,12 @@ impl PersistentQueryState {
             None
         } else {
             Some(
-                self.safe_output_high_water(output_state, publication_recovery)
-                    .await?,
+                self.safe_output_high_water(
+                    output_state,
+                    publication_recovery,
+                    reason == QueryRecoveryResetReason::InvalidLegacyPendingMarker,
+                )
+                .await?,
             )
         };
         self.clear_persistent(config_hash, preserved_sequence)
@@ -542,6 +547,7 @@ impl PersistentQueryState {
         &self,
         output_state: &RwLock<QueryOutputState>,
         publication_recovery: &AtomicPublicationRecovery,
+        ignore_invalid_legacy_marker: bool,
     ) -> anyhow::Result<u64> {
         let in_memory = output_state.read().await.as_of_sequence();
         let durable = self
@@ -559,10 +565,18 @@ impl PersistentQueryState {
             None => 0,
         };
         let atomic_pending = publication_recovery.pending_sequence().unwrap_or(0);
-        let legacy_pending = match read_legacy_pending_state(self.checkpoint_store.as_ref()).await?
-        {
-            LegacyPendingState::Absent => 0,
-            LegacyPendingState::Pending { output_sequence } => output_sequence.unwrap_or(0),
+        let legacy_pending = match read_legacy_pending_state(self.checkpoint_store.as_ref()).await {
+            Ok(LegacyPendingState::Absent) => 0,
+            Ok(LegacyPendingState::Pending { output_sequence }) => output_sequence.unwrap_or(0),
+            Err(error) if ignore_invalid_legacy_marker => {
+                warn!(
+                    "Query '{}' ignoring unreadable Legacy pending marker while computing \
+                     reset high-water: {error:#}",
+                    self.query_id
+                );
+                0
+            }
+            Err(error) => return Err(error),
         };
         let reset_baseline = read_output_reset_high_water(self.checkpoint_store.as_ref())
             .await?
@@ -710,6 +724,7 @@ mod recovery_reset_tests {
             QueryRecoveryResetReason::IncompleteBootstrap,
             QueryRecoveryResetReason::CheckpointReadFailed,
             QueryRecoveryResetReason::InvalidBootstrapMarker,
+            QueryRecoveryResetReason::InvalidLegacyPendingMarker,
             QueryRecoveryResetReason::LegacyPublicationPending,
             QueryRecoveryResetReason::OutputReconciliationFailed,
             QueryRecoveryResetReason::PositionUnavailable,
@@ -1172,6 +1187,61 @@ impl DrasiQuery {
             std::collections::HashMap::new();
         if has_persistent_backend {
             let current_hash = super::compute_config_hash(&self.base.config);
+            match processing_mode.read_legacy_pending_state().await {
+                Ok(LegacyPendingState::Absent) => {}
+                Ok(LegacyPendingState::Pending { output_sequence }) => {
+                    let detail = format!(
+                        "Query '{}' has an unfinished persistent Legacy publication \
+                         (output sequence {output_sequence:?})",
+                        self.base.config.id
+                    );
+                    match self.resolved_recovery_policy {
+                        crate::recovery::RecoveryPolicy::Strict => {
+                            self.base
+                                .set_status(ComponentStatus::Error, Some(detail.clone()))
+                                .await;
+                            return Err(anyhow::anyhow!(detail));
+                        }
+                        crate::recovery::RecoveryPolicy::AutoReset => {
+                            warn!("{detail}; AutoReset is clearing persistent state");
+                            persistent_state
+                                .clear_recovery_state(
+                                    &self.output_state,
+                                    &self.publication_recovery,
+                                    Some(current_hash),
+                                    QueryRecoveryResetReason::LegacyPublicationPending,
+                                )
+                                .await?;
+                        }
+                    }
+                }
+                Err(error) => {
+                    let detail = format!(
+                        "Query '{}' has an invalid persistent Legacy pending-publication \
+                         marker: {error:#}",
+                        self.base.config.id
+                    );
+                    match self.resolved_recovery_policy {
+                        crate::recovery::RecoveryPolicy::Strict => {
+                            self.base
+                                .set_status(ComponentStatus::Error, Some(detail.clone()))
+                                .await;
+                            return Err(anyhow::anyhow!(detail));
+                        }
+                        crate::recovery::RecoveryPolicy::AutoReset => {
+                            warn!("{detail}; AutoReset is clearing persistent state");
+                            persistent_state
+                                .clear_recovery_state(
+                                    &self.output_state,
+                                    &self.publication_recovery,
+                                    Some(current_hash),
+                                    QueryRecoveryResetReason::InvalidLegacyPendingMarker,
+                                )
+                                .await?;
+                        }
+                    }
+                }
+            }
             let config_matches = match checkpoint_store.read_config_hash().await {
                 Ok(Some(stored_hash)) if stored_hash == current_hash => {
                     debug!(
@@ -1342,40 +1412,6 @@ impl DrasiQuery {
 
             for settings in &mut subscription_settings {
                 settings.request_position_handle = true;
-            }
-        }
-
-        if let LegacyPendingState::Pending { output_sequence } =
-            processing_mode.read_legacy_pending_state().await?
-        {
-            let detail = format!(
-                "Query '{}' has an unfinished persistent Legacy publication \
-                 (output sequence {output_sequence:?})",
-                self.base.config.id
-            );
-            match self.resolved_recovery_policy {
-                crate::recovery::RecoveryPolicy::Strict => {
-                    self.base
-                        .set_status(ComponentStatus::Error, Some(detail.clone()))
-                        .await;
-                    return Err(anyhow::anyhow!(detail));
-                }
-                crate::recovery::RecoveryPolicy::AutoReset => {
-                    warn!("{detail}; AutoReset is clearing persistent state");
-                    persistent_state
-                        .clear_recovery_state(
-                            &self.output_state,
-                            &self.publication_recovery,
-                            Some(super::compute_config_hash(&self.base.config)),
-                            QueryRecoveryResetReason::OutputReconciliationFailed,
-                        )
-                        .await?;
-                    checkpoint_sequences_per_source.clear();
-                    for settings in &mut subscription_settings {
-                        settings.resume_from = None;
-                        settings.resume_sequence = None;
-                    }
-                }
             }
         }
 

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -493,8 +493,37 @@ struct PersistentQueryState {
     live_results_writer: Option<Arc<dyn LiveResultsWriter>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QueryRecoveryResetReason {
+    ConfigChanged,
+    ConfigHashReadFailed,
+    IncompleteBootstrap,
+    CheckpointReadFailed,
+    InvalidBootstrapMarker,
+    OutputReconciliationFailed,
+    PositionUnavailable,
+    Deprovision,
+}
+
 impl PersistentQueryState {
-    async fn clear(&self, config_hash: Option<u64>) -> anyhow::Result<()> {
+    async fn clear_recovery_state(
+        &self,
+        output_state: &RwLock<QueryOutputState>,
+        publication_recovery: &AtomicPublicationRecovery,
+        config_hash: Option<u64>,
+        reason: QueryRecoveryResetReason,
+    ) -> anyhow::Result<()> {
+        info!(
+            "Query '{}' clearing persistent and process-local recovery state ({reason:?})",
+            self.query_id
+        );
+        self.clear_persistent(config_hash).await?;
+        output_state.write().await.reset();
+        publication_recovery.reconcile_in_memory();
+        Ok(())
+    }
+
+    async fn clear_persistent(&self, config_hash: Option<u64>) -> anyhow::Result<()> {
         clear_persistent_indexes(
             &self.query_id,
             &self.element_index,
@@ -590,6 +619,175 @@ async fn clear_persistent_indexes(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod recovery_reset_tests {
+    use super::*;
+    use drasi_core::interface::{IndexBackendPlugin, RowMutation};
+    use drasi_index_rocksdb::RocksDbIndexProvider;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn every_destructive_reset_clears_output_and_publication_recovery() {
+        let reasons = [
+            QueryRecoveryResetReason::ConfigChanged,
+            QueryRecoveryResetReason::ConfigHashReadFailed,
+            QueryRecoveryResetReason::IncompleteBootstrap,
+            QueryRecoveryResetReason::CheckpointReadFailed,
+            QueryRecoveryResetReason::InvalidBootstrapMarker,
+            QueryRecoveryResetReason::OutputReconciliationFailed,
+            QueryRecoveryResetReason::PositionUnavailable,
+            QueryRecoveryResetReason::Deprovision,
+        ];
+
+        let temp_dir = tempfile::TempDir::new().expect("create reset temp directory");
+        let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
+        for (index, reason) in reasons.into_iter().enumerate() {
+            let query_id = format!("reset-reason-{index}");
+            let created = provider
+                .create_indexes(&query_id)
+                .await
+                .expect("create reset indexes");
+            let checkpoint_store = created
+                .checkpoint_store
+                .as_ref()
+                .expect("checkpoint store")
+                .clone();
+            let outbox_writer = created
+                .outbox_writer
+                .as_ref()
+                .expect("outbox writer")
+                .clone();
+            let live_results_writer = created
+                .live_results_writer
+                .as_ref()
+                .expect("live-results writer")
+                .clone();
+            let result = Arc::new(QueryResult::new(
+                query_id.clone(),
+                1,
+                chrono::Utc::now(),
+                vec![ResultDiff::Add {
+                    data: json!({ "name": "stale" }),
+                    row_signature: 7,
+                }],
+                HashMap::new(),
+            ));
+            outbox_writer
+                .append(
+                    &query_id,
+                    1,
+                    &rmp_serde::to_vec(result.as_ref()).expect("serialize stale output"),
+                )
+                .await
+                .expect("seed stale outbox");
+            let row =
+                rmp_serde::to_vec(&json!({ "name": "stale" })).expect("serialize stale live row");
+            live_results_writer
+                .apply_mutations(
+                    &query_id,
+                    &[RowMutation {
+                        row_signature: 7,
+                        data: Some(&row),
+                    }],
+                )
+                .await
+                .expect("seed stale live row");
+            checkpoint_store
+                .write_result_sequence(&query_id, 1)
+                .await
+                .expect("seed stale result sequence");
+            created
+                .set
+                .session_control
+                .begin()
+                .await
+                .expect("begin stale marker transaction");
+            checkpoint_store
+                .stage_checkpoint(QUERY_BOOTSTRAP_MARKER_V1, 0, None)
+                .await
+                .expect("seed stale bootstrap marker");
+            created
+                .set
+                .session_control
+                .commit()
+                .await
+                .expect("commit stale marker");
+
+            let output_state = Arc::new(RwLock::new(QueryOutputState::new(8)));
+            output_state
+                .write()
+                .await
+                .apply_committed_arc(result.clone())
+                .expect("seed process-local output");
+            let publication_recovery = AtomicPublicationRecovery::default();
+            publication_recovery.require(result);
+            let state = PersistentQueryState {
+                query_id: query_id.clone(),
+                element_index: Some(created.set.element_index.clone()),
+                archive_index: Some(created.set.archive_index.clone()),
+                result_index: Some(created.set.result_index.clone()),
+                future_queue: Some(created.set.future_queue.clone()),
+                checkpoint_store: checkpoint_store.clone(),
+                outbox_writer: Some(outbox_writer.clone()),
+                live_results_writer: Some(live_results_writer.clone()),
+            };
+            let config_hash = (reason != QueryRecoveryResetReason::Deprovision).then_some(99);
+
+            state
+                .clear_recovery_state(&output_state, &publication_recovery, config_hash, reason)
+                .await
+                .expect("clear recovery state");
+
+            let output = output_state.read().await;
+            assert_eq!(output.as_of_sequence(), 0, "{reason:?}");
+            assert_eq!(output.results_len(), 0, "{reason:?}");
+            assert_eq!(output.outbox_len(), 0, "{reason:?}");
+            drop(output);
+            assert!(!publication_recovery.is_required(), "{reason:?}");
+            assert!(
+                outbox_writer
+                    .read_from(&query_id, 0)
+                    .await
+                    .expect("read cleared outbox")
+                    .is_empty(),
+                "{reason:?}"
+            );
+            assert!(
+                live_results_writer
+                    .read_snapshot(&query_id)
+                    .await
+                    .expect("read cleared live rows")
+                    .is_empty(),
+                "{reason:?}"
+            );
+            assert_eq!(
+                checkpoint_store
+                    .read_result_sequence(&query_id)
+                    .await
+                    .expect("read reset sequence"),
+                Some(0),
+                "{reason:?}"
+            );
+            assert!(
+                checkpoint_store
+                    .read_checkpoint(QUERY_BOOTSTRAP_MARKER_V1)
+                    .await
+                    .expect("read cleared marker")
+                    .is_none(),
+                "{reason:?}"
+            );
+            assert_eq!(
+                checkpoint_store
+                    .read_config_hash()
+                    .await
+                    .expect("read reset config hash"),
+                config_hash,
+                "{reason:?}"
+            );
+        }
+    }
 }
 
 impl DrasiQuery {
@@ -883,7 +1081,15 @@ impl DrasiQuery {
                         "Query '{}' config hash changed ({stored_hash} -> {current_hash}), clearing all persistent state for full bootstrap",
                         self.base.config.id
                     );
-                    if let Err(e) = persistent_state.clear(Some(current_hash)).await {
+                    if let Err(e) = persistent_state
+                        .clear_recovery_state(
+                            &self.output_state,
+                            &self.publication_recovery,
+                            Some(current_hash),
+                            QueryRecoveryResetReason::ConfigChanged,
+                        )
+                        .await
+                    {
                         let msg = format!(
                             "Query '{}' failed to clear persistent state on config change: {e:#}",
                             self.base.config.id
@@ -894,7 +1100,6 @@ impl DrasiQuery {
                             .await;
                         return Err(anyhow::anyhow!(msg));
                     }
-                    self.output_state.write().await.reset();
                     false
                 }
                 Ok(None) => {
@@ -915,7 +1120,15 @@ impl DrasiQuery {
                         "Query '{}' failed to read config hash, clearing persistent state and starting fresh: {e}",
                         self.base.config.id
                     );
-                    if let Err(reset_error) = persistent_state.clear(Some(current_hash)).await {
+                    if let Err(reset_error) = persistent_state
+                        .clear_recovery_state(
+                            &self.output_state,
+                            &self.publication_recovery,
+                            Some(current_hash),
+                            QueryRecoveryResetReason::ConfigHashReadFailed,
+                        )
+                        .await
+                    {
                         let msg = format!(
                             "Query '{}' failed to clear persistent state after config hash read failure: {reset_error:#}",
                             self.base.config.id
@@ -926,7 +1139,6 @@ impl DrasiQuery {
                             .await;
                         return Err(anyhow::anyhow!(msg));
                     }
-                    self.output_state.write().await.reset();
                     false
                 }
             };
@@ -941,10 +1153,14 @@ impl DrasiQuery {
                             self.base.config.id
                         );
                         persistent_state
-                            .clear(Some(current_hash))
+                            .clear_recovery_state(
+                                &self.output_state,
+                                &self.publication_recovery,
+                                Some(current_hash),
+                                QueryRecoveryResetReason::IncompleteBootstrap,
+                            )
                             .await
                             .context("failed to clear an incomplete bootstrap")?;
-                        self.output_state.write().await.reset();
                     }
                     Ok(
                         QueryBootstrapRecoveryState::Absent | QueryBootstrapRecoveryState::Complete,
@@ -980,8 +1196,14 @@ impl DrasiQuery {
                                 }
                                 crate::recovery::RecoveryPolicy::AutoReset => {
                                     warn!("{detail}; AutoReset is clearing persistent state");
-                                    persistent_state.clear(Some(current_hash)).await?;
-                                    self.output_state.write().await.reset();
+                                    persistent_state
+                                        .clear_recovery_state(
+                                            &self.output_state,
+                                            &self.publication_recovery,
+                                            Some(current_hash),
+                                            QueryRecoveryResetReason::CheckpointReadFailed,
+                                        )
+                                        .await?;
                                 }
                             }
                         }
@@ -1000,8 +1222,14 @@ impl DrasiQuery {
                             }
                             crate::recovery::RecoveryPolicy::AutoReset => {
                                 warn!("{detail}; AutoReset is clearing persistent state");
-                                persistent_state.clear(Some(current_hash)).await?;
-                                self.output_state.write().await.reset();
+                                persistent_state
+                                    .clear_recovery_state(
+                                        &self.output_state,
+                                        &self.publication_recovery,
+                                        Some(current_hash),
+                                        QueryRecoveryResetReason::InvalidBootstrapMarker,
+                                    )
+                                    .await?;
                             }
                         }
                     }
@@ -1047,9 +1275,13 @@ impl DrasiQuery {
                 crate::recovery::RecoveryPolicy::AutoReset => {
                     warn!("{detail}; AutoReset is clearing persistent state");
                     persistent_state
-                        .clear(Some(super::compute_config_hash(&self.base.config)))
+                        .clear_recovery_state(
+                            &self.output_state,
+                            &self.publication_recovery,
+                            Some(super::compute_config_hash(&self.base.config)),
+                            QueryRecoveryResetReason::OutputReconciliationFailed,
+                        )
                         .await?;
-                    self.output_state.write().await.reset();
                     checkpoint_sequences_per_source.clear();
                     for settings in &mut subscription_settings {
                         settings.resume_from = None;
@@ -1310,9 +1542,14 @@ impl DrasiQuery {
                                             // fails, abort rather than mixing old and fresh state.
                                             if has_persistent_backend {
                                                 if let Err(reset_error) = persistent_state
-                                                    .clear(Some(super::compute_config_hash(
-                                                        &self.base.config,
-                                                    )))
+                                                    .clear_recovery_state(
+                                                        &self.output_state,
+                                                        &self.publication_recovery,
+                                                        Some(super::compute_config_hash(
+                                                            &self.base.config,
+                                                        )),
+                                                        QueryRecoveryResetReason::PositionUnavailable,
+                                                    )
                                                     .await
                                                 {
                                                     let msg = format!(
@@ -1330,8 +1567,6 @@ impl DrasiQuery {
                                                         "AutoReset aborted: {reset_error:#}",
                                                     ));
                                                 }
-                                                self.output_state.write().await.reset();
-                                                self.publication_recovery.reconcile_in_memory();
                                             }
 
                                             auto_reset_retry = true;
@@ -2043,12 +2278,13 @@ impl QueryManager {
         // Before teardown: grab the query config to determine if persistent
         // state cleanup is needed. After teardown_component, the runtime is
         // removed from the graph and we can no longer inspect it.
-        let query_config = {
+        let query_runtime = {
             let graph = self.graph.read().await;
-            graph
-                .get_runtime::<Arc<dyn Query>>(&id)
-                .map(|q| q.get_config().clone())
+            graph.get_runtime::<Arc<dyn Query>>(&id).cloned()
         };
+        let query_config = query_runtime
+            .as_ref()
+            .map(|query| query.get_config().clone());
 
         self.label_cache.write().await.remove(&id);
         crate::managers::lifecycle_helpers::teardown_component::<Arc<dyn Query>, _, _>(
@@ -2062,6 +2298,9 @@ impl QueryManager {
             || async {},
         )
         .await?;
+        if let Some(query) = &query_runtime {
+            query.release_persistent_handles().await;
+        }
 
         // After teardown: clear persistent indexes + checkpoints so a future
         // query with the same ID starts fresh. Only needed for persistent backends.
@@ -2088,7 +2327,23 @@ impl QueryManager {
                                     outbox_writer: created.outbox_writer.clone(),
                                     live_results_writer: created.live_results_writer.clone(),
                                 };
-                                if let Err(error) = state.clear(None).await {
+                                let reset_result = match query_runtime
+                                    .as_ref()
+                                    .and_then(|query| query.as_any().downcast_ref::<DrasiQuery>())
+                                {
+                                    Some(query) => {
+                                        state
+                                            .clear_recovery_state(
+                                                &query.output_state,
+                                                &query.publication_recovery,
+                                                None,
+                                                QueryRecoveryResetReason::Deprovision,
+                                            )
+                                            .await
+                                    }
+                                    None => state.clear_persistent(None).await,
+                                };
+                                if let Err(error) = reset_result {
                                     warn!(
                                         "Query '{id}' failed to clear persistent state on removal: {error:#}"
                                     );

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -51,10 +51,11 @@ use crate::queries::output_state::{
 #[cfg(test)]
 use crate::queries::query_composite_host::dispatch_query_results;
 use crate::queries::query_composite_host::{
-    AtomicPublicationRecovery, QueryBootstrapInput, QueryBootstrapRecoveryState,
-    QueryBootstrapScope, QueryCompositeHost, QueryHostRuntime, QueryIngressFence,
-    QueryLiveDependencies, QueryOutputDependencies, QueryProcessingMode, QueryProcessingObserver,
-    QUERY_BOOTSTRAP_MARKER_V1,
+    read_legacy_pending_state, read_output_reset_high_water, AtomicPublicationRecovery,
+    LegacyPendingState, QueryBootstrapInput, QueryBootstrapRecoveryState, QueryBootstrapScope,
+    QueryCompositeHost, QueryHostRuntime, QueryIngressFence, QueryLiveDependencies,
+    QueryOutputDependencies, QueryProcessingMode, QueryProcessingObserver,
+    LEGACY_OUTPUT_PENDING_MARKER_V1, QUERY_BOOTSTRAP_MARKER_V1, QUERY_OUTPUT_RESET_MARKER_V1,
 };
 use crate::queries::PriorityQueue;
 use crate::queries::QueryBase;
@@ -489,6 +490,7 @@ struct PersistentQueryState {
     result_index: Option<Arc<dyn drasi_core::interface::ResultIndex>>,
     future_queue: Option<Arc<dyn drasi_core::interface::FutureQueue>>,
     checkpoint_store: Arc<dyn CheckpointStore>,
+    session_control: Arc<dyn drasi_core::interface::SessionControl>,
     outbox_writer: Option<Arc<dyn OutboxWriter>>,
     live_results_writer: Option<Arc<dyn LiveResultsWriter>>,
 }
@@ -500,6 +502,7 @@ enum QueryRecoveryResetReason {
     IncompleteBootstrap,
     CheckpointReadFailed,
     InvalidBootstrapMarker,
+    LegacyPublicationPending,
     OutputReconciliationFailed,
     PositionUnavailable,
     Deprovision,
@@ -517,13 +520,66 @@ impl PersistentQueryState {
             "Query '{}' clearing persistent and process-local recovery state ({reason:?})",
             self.query_id
         );
-        self.clear_persistent(config_hash).await?;
-        output_state.write().await.reset();
+        let preserved_sequence = if reason == QueryRecoveryResetReason::Deprovision {
+            None
+        } else {
+            Some(
+                self.safe_output_high_water(output_state, publication_recovery)
+                    .await?,
+            )
+        };
+        self.clear_persistent(config_hash, preserved_sequence)
+            .await?;
+        output_state
+            .write()
+            .await
+            .reset_to_sequence(preserved_sequence.unwrap_or(0));
         publication_recovery.reconcile_in_memory();
         Ok(())
     }
 
-    async fn clear_persistent(&self, config_hash: Option<u64>) -> anyhow::Result<()> {
+    async fn safe_output_high_water(
+        &self,
+        output_state: &RwLock<QueryOutputState>,
+        publication_recovery: &AtomicPublicationRecovery,
+    ) -> anyhow::Result<u64> {
+        let in_memory = output_state.read().await.as_of_sequence();
+        let durable = self
+            .checkpoint_store
+            .read_result_sequence(&self.query_id)
+            .await
+            .context("failed to read durable result sequence before reset")?
+            .unwrap_or(0);
+        let outbox = match &self.outbox_writer {
+            Some(writer) => writer
+                .read_latest_sequence(&self.query_id)
+                .await
+                .context("failed to read durable outbox high-water before reset")?
+                .unwrap_or(0),
+            None => 0,
+        };
+        let atomic_pending = publication_recovery.pending_sequence().unwrap_or(0);
+        let legacy_pending = match read_legacy_pending_state(self.checkpoint_store.as_ref()).await?
+        {
+            LegacyPendingState::Absent => 0,
+            LegacyPendingState::Pending { output_sequence } => output_sequence.unwrap_or(0),
+        };
+        let reset_baseline = read_output_reset_high_water(self.checkpoint_store.as_ref())
+            .await?
+            .unwrap_or(0);
+        Ok(in_memory
+            .max(durable)
+            .max(outbox)
+            .max(atomic_pending)
+            .max(legacy_pending)
+            .max(reset_baseline))
+    }
+
+    async fn clear_persistent(
+        &self,
+        config_hash: Option<u64>,
+        preserved_sequence: Option<u64>,
+    ) -> anyhow::Result<()> {
         clear_persistent_indexes(
             &self.query_id,
             &self.element_index,
@@ -549,10 +605,28 @@ impl PersistentQueryState {
             .clear_checkpoints()
             .await
             .context("failed to clear query checkpoints")?;
-        self.checkpoint_store
-            .write_result_sequence(&self.query_id, 0)
-            .await
-            .context("failed to reset the durable result sequence")?;
+        if let Some(preserved_sequence) = preserved_sequence {
+            let session = drasi_core::interface::SessionGuard::begin(self.session_control.clone())
+                .await
+                .context("failed to begin output reset-baseline transaction")?;
+            self.checkpoint_store
+                .stage_checkpoint(QUERY_OUTPUT_RESET_MARKER_V1, preserved_sequence, None)
+                .await
+                .context("failed to stage output reset baseline")?;
+            self.checkpoint_store
+                .write_result_sequence(&self.query_id, preserved_sequence)
+                .await
+                .context("failed to preserve durable result sequence")?;
+            session
+                .commit()
+                .await
+                .context("failed to commit output reset baseline")?;
+        } else {
+            self.checkpoint_store
+                .write_result_sequence(&self.query_id, 0)
+                .await
+                .context("failed to clear durable result sequence")?;
+        }
         if let Some(config_hash) = config_hash {
             self.checkpoint_store
                 .write_config_hash(config_hash)
@@ -636,6 +710,7 @@ mod recovery_reset_tests {
             QueryRecoveryResetReason::IncompleteBootstrap,
             QueryRecoveryResetReason::CheckpointReadFailed,
             QueryRecoveryResetReason::InvalidBootstrapMarker,
+            QueryRecoveryResetReason::LegacyPublicationPending,
             QueryRecoveryResetReason::OutputReconciliationFailed,
             QueryRecoveryResetReason::PositionUnavailable,
             QueryRecoveryResetReason::Deprovision,
@@ -730,6 +805,7 @@ mod recovery_reset_tests {
                 result_index: Some(created.set.result_index.clone()),
                 future_queue: Some(created.set.future_queue.clone()),
                 checkpoint_store: checkpoint_store.clone(),
+                session_control: created.set.session_control.clone(),
                 outbox_writer: Some(outbox_writer.clone()),
                 live_results_writer: Some(live_results_writer.clone()),
             };
@@ -740,8 +816,13 @@ mod recovery_reset_tests {
                 .await
                 .expect("clear recovery state");
 
+            let preserved_sequence = (reason != QueryRecoveryResetReason::Deprovision).then_some(1);
             let output = output_state.read().await;
-            assert_eq!(output.as_of_sequence(), 0, "{reason:?}");
+            assert_eq!(
+                output.as_of_sequence(),
+                preserved_sequence.unwrap_or(0),
+                "{reason:?}"
+            );
             assert_eq!(output.results_len(), 0, "{reason:?}");
             assert_eq!(output.outbox_len(), 0, "{reason:?}");
             drop(output);
@@ -767,7 +848,16 @@ mod recovery_reset_tests {
                     .read_result_sequence(&query_id)
                     .await
                     .expect("read reset sequence"),
-                Some(0),
+                preserved_sequence.or(Some(0)),
+                "{reason:?}"
+            );
+            assert_eq!(
+                checkpoint_store
+                    .read_checkpoint(QUERY_OUTPUT_RESET_MARKER_V1)
+                    .await
+                    .expect("read output reset marker")
+                    .map(|marker| marker.sequence),
+                preserved_sequence,
                 "{reason:?}"
             );
             assert!(
@@ -978,9 +1068,22 @@ impl DrasiQuery {
             result_index: result_index.clone(),
             future_queue: future_queue.clone(),
             checkpoint_store: checkpoint_store.clone(),
+            session_control: session_control
+                .clone()
+                .unwrap_or_else(|| Arc::new(drasi_core::interface::NoOpSessionControl)),
             outbox_writer: outbox_writer.clone(),
             live_results_writer: live_results_writer.clone(),
         };
+        if let Err(error) = processing_mode.validate_legacy_pending_capability() {
+            let message = format!(
+                "Query '{}' cannot start persistent Legacy processing safely: {error:#}",
+                self.base.config.id
+            );
+            self.base
+                .set_status(ComponentStatus::Error, Some(message.clone()))
+                .await;
+            return Err(anyhow::anyhow!(message));
+        }
 
         let continuous_query = match builder.try_build().await {
             Ok(query) => query,
@@ -1037,13 +1140,14 @@ impl DrasiQuery {
                     ));
                 }
             };
-        if self
-            .base
-            .config
-            .sources
-            .iter()
-            .any(|source| source.source_id == QUERY_BOOTSTRAP_MARKER_V1)
-        {
+        if self.base.config.sources.iter().any(|source| {
+            matches!(
+                source.source_id.as_str(),
+                QUERY_BOOTSTRAP_MARKER_V1
+                    | QUERY_OUTPUT_RESET_MARKER_V1
+                    | LEGACY_OUTPUT_PENDING_MARKER_V1
+            )
+        }) {
             let message = format!(
                 "Query '{}' uses a source id reserved for bootstrap recovery",
                 self.base.config.id
@@ -1238,6 +1342,40 @@ impl DrasiQuery {
 
             for settings in &mut subscription_settings {
                 settings.request_position_handle = true;
+            }
+        }
+
+        if let LegacyPendingState::Pending { output_sequence } =
+            processing_mode.read_legacy_pending_state().await?
+        {
+            let detail = format!(
+                "Query '{}' has an unfinished persistent Legacy publication \
+                 (output sequence {output_sequence:?})",
+                self.base.config.id
+            );
+            match self.resolved_recovery_policy {
+                crate::recovery::RecoveryPolicy::Strict => {
+                    self.base
+                        .set_status(ComponentStatus::Error, Some(detail.clone()))
+                        .await;
+                    return Err(anyhow::anyhow!(detail));
+                }
+                crate::recovery::RecoveryPolicy::AutoReset => {
+                    warn!("{detail}; AutoReset is clearing persistent state");
+                    persistent_state
+                        .clear_recovery_state(
+                            &self.output_state,
+                            &self.publication_recovery,
+                            Some(super::compute_config_hash(&self.base.config)),
+                            QueryRecoveryResetReason::OutputReconciliationFailed,
+                        )
+                        .await?;
+                    checkpoint_sequences_per_source.clear();
+                    for settings in &mut subscription_settings {
+                        settings.resume_from = None;
+                        settings.resume_sequence = None;
+                    }
+                }
             }
         }
 
@@ -2324,6 +2462,7 @@ impl QueryManager {
                                     result_index: Some(created.set.result_index.clone()),
                                     future_queue: Some(created.set.future_queue.clone()),
                                     checkpoint_store,
+                                    session_control: created.set.session_control.clone(),
                                     outbox_writer: created.outbox_writer.clone(),
                                     live_results_writer: created.live_results_writer.clone(),
                                 };
@@ -2341,7 +2480,7 @@ impl QueryManager {
                                             )
                                             .await
                                     }
-                                    None => state.clear_persistent(None).await,
+                                    None => state.clear_persistent(None, None).await,
                                 };
                                 if let Err(error) = reset_result {
                                     warn!(

--- a/lib/src/queries/manager.rs
+++ b/lib/src/queries/manager.rs
@@ -19,13 +19,11 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
-use tokio::sync::{oneshot, Mutex, Notify, RwLock};
+use tokio::sync::{oneshot, Mutex, RwLock};
 
 // Import drasi-core components
 use drasi_core::{
-    evaluation::context::{QueryPartEvaluationContext, QueryVariables},
     evaluation::functions::FunctionRegistry,
-    evaluation::variable_value::VariableValue,
     in_memory_index::in_memory_checkpoint_store::InMemoryCheckpointStore,
     interface::{CheckpointStore, LiveResultsWriter, OutboxWriter},
     middleware::MiddlewareTypeRegistry,
@@ -53,8 +51,10 @@ use crate::queries::output_state::{
 #[cfg(test)]
 use crate::queries::query_composite_host::dispatch_query_results;
 use crate::queries::query_composite_host::{
-    AtomicPublicationRecovery, QueryCompositeHost, QueryHostRuntime, QueryIngressFence,
+    AtomicPublicationRecovery, QueryBootstrapInput, QueryBootstrapRecoveryState,
+    QueryBootstrapScope, QueryCompositeHost, QueryHostRuntime, QueryIngressFence,
     QueryLiveDependencies, QueryOutputDependencies, QueryProcessingMode, QueryProcessingObserver,
+    QUERY_BOOTSTRAP_MARKER_V1,
 };
 use crate::queries::PriorityQueue;
 use crate::queries::QueryBase;
@@ -81,65 +81,11 @@ impl QueryConfiguration for DefaultQueryConfig {
     }
 }
 
-/// Convert QueryVariables (`BTreeMap<Box<str>, VariableValue>`) to JSON
-fn convert_query_variables_to_json(vars: &QueryVariables) -> serde_json::Value {
-    let mut result = serde_json::Map::new();
-    for (key, value) in vars.iter() {
-        result.insert(key.to_string(), convert_variable_value_to_json(value));
-    }
-    serde_json::Value::Object(result)
-}
-
-/// Convert a single VariableValue to JSON
-fn convert_variable_value_to_json(value: &VariableValue) -> serde_json::Value {
-    match value {
-        VariableValue::Null => serde_json::Value::Null,
-        VariableValue::Bool(b) => serde_json::Value::Bool(*b),
-        VariableValue::Float(f) => {
-            if f.is_f64() {
-                // from_f64 returns None for NaN/Infinity, but is_f64() already checks finiteness
-                let s = f.to_string();
-                s.parse::<f64>()
-                    .ok()
-                    .and_then(serde_json::Number::from_f64)
-                    .map(serde_json::Value::Number)
-                    .unwrap_or_else(|| serde_json::Value::String(s))
-            } else {
-                serde_json::Value::String(f.to_string())
-            }
-        }
-        VariableValue::Integer(i) => {
-            if let Some(val) = i.as_i64() {
-                serde_json::Value::Number(serde_json::Number::from(val))
-            } else if let Some(val) = i.as_u64() {
-                serde_json::Value::Number(serde_json::Number::from(val))
-            } else {
-                serde_json::Value::String(i.to_string())
-            }
-        }
-        VariableValue::String(s) => serde_json::Value::String(s.clone()),
-        VariableValue::List(list) => {
-            serde_json::Value::Array(list.iter().map(convert_variable_value_to_json).collect())
-        }
-        VariableValue::Object(map) => {
-            let mut result = serde_json::Map::new();
-            for (k, v) in map.iter() {
-                result.insert(k.clone(), convert_variable_value_to_json(v));
-            }
-            serde_json::Value::Object(result)
-        }
-        VariableValue::Date(d) => serde_json::Value::String(d.to_string()),
-        VariableValue::LocalTime(t) => serde_json::Value::String(t.to_string()),
-        VariableValue::ZonedTime(t) => serde_json::Value::String(t.to_string()),
-        // Query/reaction output uses plain strings for temporal values.
-        // The tagged datetime envelope in ElementValue JSON is internal-only.
-        VariableValue::LocalDateTime(dt) => serde_json::Value::String(dt.to_string()),
-        VariableValue::ZonedDateTime(dt) => serde_json::Value::String(dt.datetime().to_rfc3339()),
-        VariableValue::Duration(d) => serde_json::Value::String(d.to_string()),
-        // For complex types, convert to string representation
-        _ => serde_json::Value::String(format!("{value:?}")),
-    }
-}
+#[cfg(test)]
+use crate::queries::query_composite_host::{
+    query_variables_to_json as convert_query_variables_to_json,
+    variable_value_to_json as convert_variable_value_to_json,
+};
 
 #[cfg(test)]
 mod tests {
@@ -264,37 +210,6 @@ pub trait Query: Send + Sync {
     async fn release_persistent_handles(&self) {}
 }
 
-/// Bootstrap phase tracking for each source
-#[derive(Debug, Clone, PartialEq)]
-enum BootstrapPhase {
-    NotStarted,
-    InProgress,
-    Completed,
-}
-
-#[derive(Default)]
-struct PendingBootstrapAborts {
-    handles: Vec<tokio::task::AbortHandle>,
-}
-
-impl PendingBootstrapAborts {
-    fn push(&mut self, handle: tokio::task::AbortHandle) {
-        self.handles.push(handle);
-    }
-
-    fn into_handles(mut self) -> Vec<tokio::task::AbortHandle> {
-        std::mem::take(&mut self.handles)
-    }
-}
-
-impl Drop for PendingBootstrapAborts {
-    fn drop(&mut self) {
-        for handle in &self.handles {
-            handle.abort();
-        }
-    }
-}
-
 struct StartupCancellationRegistration {
     slot: Arc<StdMutex<Option<oneshot::Sender<()>>>>,
 }
@@ -352,12 +267,8 @@ pub struct DrasiQuery {
     startup_cancel: Arc<StdMutex<Option<oneshot::Sender<()>>>>,
     // Level-triggered stop intent closes the gap before startup registers its sender.
     stop_requested: Arc<AtomicBool>,
-    // Blocks unsafe in-process restart after committed output missed in-memory apply.
+    // Tracks committed output that still needs durable reconciliation.
     publication_recovery: AtomicPublicationRecovery,
-    // Abort handles for bootstrap + supervisor tasks (for cleanup on stop)
-    bootstrap_abort_handles: Arc<RwLock<Vec<tokio::task::AbortHandle>>>,
-    // Track bootstrap state per source
-    bootstrap_state: Arc<RwLock<HashMap<String, BootstrapPhase>>>,
     // IndexFactory for creating storage backend indexes
     index_factory: Arc<crate::indexes::IndexFactory>,
     // Middleware registry for query middleware
@@ -420,8 +331,6 @@ impl DrasiQuery {
             startup_cancel: Arc::new(StdMutex::new(None)),
             stop_requested: Arc::new(AtomicBool::new(false)),
             publication_recovery: AtomicPublicationRecovery::default(),
-            bootstrap_abort_handles: Arc::new(RwLock::new(Vec::new())),
-            bootstrap_state: Arc::new(RwLock::new(HashMap::new())),
             index_factory,
             middleware_registry,
             future_queue_source: Arc::new(RwLock::new(None)),
@@ -443,16 +352,6 @@ impl DrasiQuery {
     /// pattern as Source and Reaction initialization.
     pub async fn initialize(&self, context: crate::context::QueryRuntimeContext) {
         self.base.initialize(context).await;
-    }
-
-    async fn abort_bootstrap_tasks(&self) {
-        let bootstrap_aborts: Vec<_> = {
-            let mut handles = self.bootstrap_abort_handles.write().await;
-            handles.drain(..).collect()
-        };
-        for handle in bootstrap_aborts {
-            handle.abort();
-        }
     }
 
     async fn stop_future_queue_source(&self) {
@@ -479,7 +378,6 @@ impl DrasiQuery {
 
     async fn reap_previous_runtime(&self) {
         self.ingress_fence.close().await;
-        self.abort_bootstrap_tasks().await;
         self.stop_future_queue_source().await;
         self.base.reap_task().await;
         self.release_position_handles().await;
@@ -583,10 +481,61 @@ impl DrasiQuery {
     }
 }
 
-/// Clear all persistent indexes on config hash mismatch or hash read failure.
-///
-/// Called to remove stale element/archive/result/future data so that
-/// the subsequent bootstrap runs against a clean state.
+#[derive(Clone)]
+struct PersistentQueryState {
+    query_id: String,
+    element_index: Option<Arc<dyn drasi_core::interface::ElementIndex>>,
+    archive_index: Option<Arc<dyn drasi_core::interface::ElementArchiveIndex>>,
+    result_index: Option<Arc<dyn drasi_core::interface::ResultIndex>>,
+    future_queue: Option<Arc<dyn drasi_core::interface::FutureQueue>>,
+    checkpoint_store: Arc<dyn CheckpointStore>,
+    outbox_writer: Option<Arc<dyn OutboxWriter>>,
+    live_results_writer: Option<Arc<dyn LiveResultsWriter>>,
+}
+
+impl PersistentQueryState {
+    async fn clear(&self, config_hash: Option<u64>) -> anyhow::Result<()> {
+        clear_persistent_indexes(
+            &self.query_id,
+            &self.element_index,
+            &self.archive_index,
+            &self.result_index,
+            &self.future_queue,
+        )
+        .await?;
+
+        if let Some(writer) = &self.outbox_writer {
+            writer
+                .clear(&self.query_id)
+                .await
+                .context("failed to clear the durable query outbox")?;
+        }
+        if let Some(writer) = &self.live_results_writer {
+            writer
+                .clear(&self.query_id)
+                .await
+                .context("failed to clear durable live results")?;
+        }
+        self.checkpoint_store
+            .clear_checkpoints()
+            .await
+            .context("failed to clear query checkpoints")?;
+        self.checkpoint_store
+            .write_result_sequence(&self.query_id, 0)
+            .await
+            .context("failed to reset the durable result sequence")?;
+        if let Some(config_hash) = config_hash {
+            self.checkpoint_store
+                .write_config_hash(config_hash)
+                .await
+                .context("failed to write the query config hash after reset")?;
+        }
+        Ok(())
+    }
+}
+
+/// Clear persistent core indexes. Durable query output and checkpoints are
+/// cleared by [`PersistentQueryState::clear`] in the same reset workflow.
 async fn clear_persistent_indexes(
     query_id: &str,
     element_index: &Option<Arc<dyn drasi_core::interface::ElementIndex>>,
@@ -648,21 +597,6 @@ impl DrasiQuery {
         log_component_start("Query", &self.base.config.id);
 
         self.reap_previous_runtime().await;
-        if self.publication_recovery.is_required() {
-            let message = format!(
-                "Query '{}' cannot restart in process because atomic output committed before \
-                 in-memory publication; A7 output reconciliation is required to preserve the \
-                 durable result sequence",
-                self.base.config.id
-            );
-            error!("{message}");
-            self.base
-                .set_status(ComponentStatus::Error, Some(message.clone()))
-                .await;
-            return Err(anyhow::anyhow!(message));
-        }
-
-        self.bootstrap_state.write().await.clear();
 
         // Set Starting on the local status handle. The manager has already validated
         // and applied the Starting transition on the graph via validate_and_transition().
@@ -755,6 +689,8 @@ impl DrasiQuery {
         let result_index: Option<Arc<dyn drasi_core::interface::ResultIndex>>;
         let future_queue: Option<Arc<dyn drasi_core::interface::FutureQueue>>;
         let session_control: Option<Arc<dyn drasi_core::interface::SessionControl>>;
+        let outbox_writer: Option<Arc<dyn OutboxWriter>>;
+        let live_results_writer: Option<Arc<dyn LiveResultsWriter>>;
         let processing_mode: QueryProcessingMode;
 
         if let Some(backend_ref) = self
@@ -790,8 +726,8 @@ impl DrasiQuery {
             );
 
             // Use backend-provided checkpoint store, or create in-memory fallback
-            checkpoint_store = match created.checkpoint_store {
-                Some(store) => store,
+            checkpoint_store = match created.checkpoint_store.as_ref() {
+                Some(store) => store.clone(),
                 None => {
                     // Backend didn't provide one; reuse persisted or create new
                     let existing = self.checkpoint_store.read().await.clone();
@@ -800,8 +736,10 @@ impl DrasiQuery {
             };
 
             // Store persistent writers if provided by the backend
-            *self.outbox_writer.write().await = created.outbox_writer;
-            *self.live_results_writer.write().await = created.live_results_writer;
+            outbox_writer = created.outbox_writer.clone();
+            live_results_writer = created.live_results_writer.clone();
+            *self.outbox_writer.write().await = outbox_writer.clone();
+            *self.live_results_writer.write().await = live_results_writer.clone();
             // Hold references for potential clearing before passing to builder
             element_index = Some(created.set.element_index.clone());
             archive_index = Some(created.set.archive_index.clone());
@@ -828,11 +766,23 @@ impl DrasiQuery {
             result_index = None;
             future_queue = None;
             session_control = None;
+            outbox_writer = None;
+            live_results_writer = None;
             processing_mode = QueryProcessingMode::legacy();
         };
 
         // Persist the checkpoint_store for future stop/start cycles
         *self.checkpoint_store.write().await = Some(checkpoint_store.clone());
+        let persistent_state = PersistentQueryState {
+            query_id: self.base.config.id.clone(),
+            element_index: element_index.clone(),
+            archive_index: archive_index.clone(),
+            result_index: result_index.clone(),
+            future_queue: future_queue.clone(),
+            checkpoint_store: checkpoint_store.clone(),
+            outbox_writer: outbox_writer.clone(),
+            live_results_writer: live_results_writer.clone(),
+        };
 
         let continuous_query = match builder.try_build().await {
             Ok(query) => query,
@@ -889,6 +839,22 @@ impl DrasiQuery {
                     ));
                 }
             };
+        if self
+            .base
+            .config
+            .sources
+            .iter()
+            .any(|source| source.source_id == QUERY_BOOTSTRAP_MARKER_V1)
+        {
+            let message = format!(
+                "Query '{}' uses a source id reserved for bootstrap recovery",
+                self.base.config.id
+            );
+            self.base
+                .set_status(ComponentStatus::Error, Some(message.clone()))
+                .await;
+            return Err(anyhow::anyhow!(message));
+        }
 
         // Read the last checkpoints and propagate source_position to subscription settings
         // so sources can resume from where they left off.
@@ -903,20 +869,7 @@ impl DrasiQuery {
         let mut checkpoint_sequences_per_source: std::collections::HashMap<String, u64> =
             std::collections::HashMap::new();
         if has_persistent_backend {
-            // Config hash check: detect query configuration changes that require
-            // a full re-bootstrap. If the stored hash doesn't match the current
-            // config, all checkpoints are cleared so sources bootstrap from scratch.
-            //
-            // Checkpoint operations require an active session for transactional
-            // backends (e.g., RocksDB). Wrap read/write/clear calls in begin/commit.
             let current_hash = super::compute_config_hash(&self.base.config);
-
-            if let Some(sc) = &session_control {
-                sc.begin()
-                    .await
-                    .context("Failed to begin session for config hash check")?;
-            }
-
             let config_matches = match checkpoint_store.read_config_hash().await {
                 Ok(Some(stored_hash)) if stored_hash == current_hash => {
                     debug!(
@@ -930,44 +883,9 @@ impl DrasiQuery {
                         "Query '{}' config hash changed ({stored_hash} -> {current_hash}), clearing all persistent state for full bootstrap",
                         self.base.config.id
                     );
-                    // Clear checkpoints first. Only write the new config hash if
-                    // clearing succeeded — otherwise stale checkpoints would be
-                    // resumed with the wrong config on the next restart.
-                    match checkpoint_store.clear_checkpoints().await {
-                        Ok(()) => {
-                            if let Err(e) = checkpoint_store.write_config_hash(current_hash).await {
-                                warn!(
-                                    "Query '{}' failed to write new config hash: {e}",
-                                    self.base.config.id
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            let msg = format!(
-                                "Query '{}' failed to clear checkpoints on config change: {e}. \
-                                 Cannot start with stale checkpoint data from a different config.",
-                                self.base.config.id
-                            );
-                            error!("{msg}");
-                            self.base
-                                .set_status(ComponentStatus::Error, Some(msg.clone()))
-                                .await;
-                            return Err(anyhow::anyhow!(msg));
-                        }
-                    }
-                    // Also clear persistent element/result/archive/future indexes
-                    // so stale data from the old config cannot be read during bootstrap.
-                    if let Err(e) = clear_persistent_indexes(
-                        &self.base.config.id,
-                        &element_index,
-                        &archive_index,
-                        &result_index,
-                        &future_queue,
-                    )
-                    .await
-                    {
+                    if let Err(e) = persistent_state.clear(Some(current_hash)).await {
                         let msg = format!(
-                            "Query '{}' failed to clear persistent indexes on config change: {e}",
+                            "Query '{}' failed to clear persistent state on config change: {e:#}",
                             self.base.config.id
                         );
                         error!("{msg}");
@@ -976,6 +894,7 @@ impl DrasiQuery {
                             .await;
                         return Err(anyhow::anyhow!(msg));
                     }
+                    self.output_state.write().await.reset();
                     false
                 }
                 Ok(None) => {
@@ -996,11 +915,9 @@ impl DrasiQuery {
                         "Query '{}' failed to read config hash, clearing persistent state and starting fresh: {e}",
                         self.base.config.id
                     );
-                    // Cannot trust persistent state if config hash is unreadable —
-                    // clear indexes and checkpoints to ensure a clean bootstrap.
-                    if let Err(ce) = checkpoint_store.clear_checkpoints().await {
+                    if let Err(reset_error) = persistent_state.clear(Some(current_hash)).await {
                         let msg = format!(
-                            "Query '{}' failed to clear checkpoints on hash read failure: {ce}",
+                            "Query '{}' failed to clear persistent state after config hash read failure: {reset_error:#}",
                             self.base.config.id
                         );
                         error!("{msg}");
@@ -1009,73 +926,141 @@ impl DrasiQuery {
                             .await;
                         return Err(anyhow::anyhow!(msg));
                     }
-                    if let Err(ie) = clear_persistent_indexes(
-                        &self.base.config.id,
-                        &element_index,
-                        &archive_index,
-                        &result_index,
-                        &future_queue,
-                    )
-                    .await
-                    {
-                        let msg = format!(
-                            "Query '{}' failed to clear persistent indexes on hash read failure: {ie}",
-                            self.base.config.id
-                        );
-                        error!("{msg}");
-                        self.base
-                            .set_status(ComponentStatus::Error, Some(msg.clone()))
-                            .await;
-                        return Err(anyhow::anyhow!(msg));
-                    }
+                    self.output_state.write().await.reset();
                     false
                 }
             };
 
-            // Only read checkpoints if the config hash matched — otherwise we
-            // cleared them above and a full bootstrap will run.
             if config_matches {
-                match checkpoint_store.read_all_checkpoints().await {
-                    Ok(checkpoints) => {
-                        for settings in &mut subscription_settings {
-                            if let Some(cp) = checkpoints.get(&settings.source_id) {
-                                checkpoint_sequences_per_source
-                                    .insert(settings.source_id.clone(), cp.sequence);
-                                settings.request_position_handle = true;
-                                settings.resume_sequence = Some(cp.sequence);
-                                if let Some(pos) = &cp.source_position {
-                                    settings.resume_from = Some(pos.clone());
+                let recovery_state =
+                    QueryBootstrapScope::read_recovery_state(checkpoint_store.as_ref()).await;
+                match recovery_state {
+                    Ok(QueryBootstrapRecoveryState::InProgress) => {
+                        info!(
+                            "Query '{}' found an incomplete bootstrap marker; clearing partial state before retry",
+                            self.base.config.id
+                        );
+                        persistent_state
+                            .clear(Some(current_hash))
+                            .await
+                            .context("failed to clear an incomplete bootstrap")?;
+                        self.output_state.write().await.reset();
+                    }
+                    Ok(
+                        QueryBootstrapRecoveryState::Absent | QueryBootstrapRecoveryState::Complete,
+                    ) => match checkpoint_store.read_all_checkpoints().await {
+                        Ok(checkpoints) => {
+                            for settings in &mut subscription_settings {
+                                if let Some(cp) = checkpoints.get(&settings.source_id) {
+                                    checkpoint_sequences_per_source
+                                        .insert(settings.source_id.clone(), cp.sequence);
+                                    settings.request_position_handle = true;
+                                    settings.resume_sequence = Some(cp.sequence);
+                                    if let Some(pos) = &cp.source_position {
+                                        settings.resume_from = Some(pos.clone());
+                                    }
+                                    debug!(
+                                        "Query '{}' resuming source '{}' from checkpoint: seq={}",
+                                        self.base.config.id, settings.source_id, cp.sequence
+                                    );
                                 }
-                                debug!(
-                                    "Query '{}' resuming source '{}' from checkpoint: seq={}",
-                                    self.base.config.id, settings.source_id, cp.sequence
-                                );
+                            }
+                        }
+                        Err(error) => {
+                            let detail = format!(
+                                "Query '{}' failed to read durable checkpoints: {error}",
+                                self.base.config.id
+                            );
+                            match self.resolved_recovery_policy {
+                                crate::recovery::RecoveryPolicy::Strict => {
+                                    self.base
+                                        .set_status(ComponentStatus::Error, Some(detail.clone()))
+                                        .await;
+                                    return Err(anyhow::anyhow!(detail));
+                                }
+                                crate::recovery::RecoveryPolicy::AutoReset => {
+                                    warn!("{detail}; AutoReset is clearing persistent state");
+                                    persistent_state.clear(Some(current_hash)).await?;
+                                    self.output_state.write().await.reset();
+                                }
+                            }
+                        }
+                    },
+                    Err(error) => {
+                        let detail = format!(
+                            "Query '{}' has an invalid bootstrap recovery marker: {error:#}",
+                            self.base.config.id
+                        );
+                        match self.resolved_recovery_policy {
+                            crate::recovery::RecoveryPolicy::Strict => {
+                                self.base
+                                    .set_status(ComponentStatus::Error, Some(detail.clone()))
+                                    .await;
+                                return Err(anyhow::anyhow!(detail));
+                            }
+                            crate::recovery::RecoveryPolicy::AutoReset => {
+                                warn!("{detail}; AutoReset is clearing persistent state");
+                                persistent_state.clear(Some(current_hash)).await?;
+                                self.output_state.write().await.reset();
                             }
                         }
                     }
-                    Err(e) => {
-                        warn!(
-                            "Query '{}' failed to read checkpoints, starting fresh: {e}",
-                            self.base.config.id
-                        );
-                    }
-                }
+                };
             }
 
-            // For persistent queries, always request position handles so sources
-            // can track the query's durable progress for min-watermark advancement,
-            // even on first run before any checkpoints exist.
             for settings in &mut subscription_settings {
                 settings.request_position_handle = true;
             }
+        }
 
-            // Commit the startup session used for config hash + checkpoint reads/writes.
-            if let Some(sc) = &session_control {
-                if let Err(e) = sc.commit().await {
-                    warn!(
-                        "Query '{}' failed to commit startup session: {e}",
-                        self.base.config.id
-                    );
+        let output_dependencies = QueryOutputDependencies::new(
+            self.base.config.id.clone(),
+            self.output_state.clone(),
+            self.base.dispatchers.clone(),
+            outbox_writer.clone(),
+            live_results_writer.clone(),
+            Some(checkpoint_store.clone()),
+            self.output_state.read().await.outbox_capacity(),
+            self.output_metrics.clone(),
+        )
+        .with_publication_recovery(self.publication_recovery.clone());
+        #[cfg(test)]
+        let output_dependencies = match self.processing_observer.read().await.clone() {
+            Some(observer) => output_dependencies.with_observer(observer),
+            None => output_dependencies,
+        };
+
+        if let Err(error) =
+            QueryCompositeHost::reconcile_output_state(&processing_mode, &output_dependencies).await
+        {
+            let detail = format!(
+                "Query '{}' durable output reconciliation failed: {error:#}",
+                self.base.config.id
+            );
+            match self.resolved_recovery_policy {
+                crate::recovery::RecoveryPolicy::Strict => {
+                    self.base
+                        .set_status(ComponentStatus::Error, Some(detail.clone()))
+                        .await;
+                    return Err(anyhow::anyhow!(detail));
+                }
+                crate::recovery::RecoveryPolicy::AutoReset => {
+                    warn!("{detail}; AutoReset is clearing persistent state");
+                    persistent_state
+                        .clear(Some(super::compute_config_hash(&self.base.config)))
+                        .await?;
+                    self.output_state.write().await.reset();
+                    checkpoint_sequences_per_source.clear();
+                    for settings in &mut subscription_settings {
+                        settings.resume_from = None;
+                        settings.resume_sequence = None;
+                    }
+                    QueryCompositeHost::reconcile_output_state(
+                        &processing_mode,
+                        &output_dependencies,
+                    )
+                    .await
+                    .context("durable output reconciliation still failed after AutoReset")?;
                 }
             }
         }
@@ -1115,13 +1100,7 @@ impl DrasiQuery {
                 .collect::<Vec<_>>()
         );
 
-        let mut bootstrap_channels: Vec<(
-            String,
-            tokio::sync::mpsc::Receiver<crate::channels::BootstrapEvent>,
-            Option<
-                tokio::sync::oneshot::Receiver<anyhow::Result<crate::bootstrap::BootstrapResult>>,
-            >,
-        )> = Vec::new();
+        let mut bootstrap_channels = Vec::new();
         // Build list of sources to subscribe to
         let mut sources_to_subscribe: Vec<(String, Arc<dyn Source>, SourceSubscriptionSettings)> =
             Vec::new();
@@ -1224,7 +1203,6 @@ impl DrasiQuery {
                 bootstrap_channels.clear();
                 self.ingress_fence.close().await;
                 position_handles.clear();
-                self.bootstrap_state.write().await.clear();
                 checkpoint_sequences_per_source.clear();
             }
 
@@ -1328,101 +1306,32 @@ impl DrasiQuery {
                                                 }
                                             }
 
-                                            // Clear all persistent state. If clearing fails,
-                                            // abort startup rather than mixing stale state with
-                                            // a fresh bootstrap.
+                                            // Clear every core and output artifact. If clearing
+                                            // fails, abort rather than mixing old and fresh state.
                                             if has_persistent_backend {
-                                                // Begin a session for the clear operations
-                                                if let Some(sc) = &session_control {
-                                                    if let Err(e) = sc.begin().await {
-                                                        let msg = format!(
-                                                            "Query '{}' auto-reset failed: could not begin session: {e}",
-                                                            self.base.config.id
-                                                        );
-                                                        error!("{msg}");
-                                                        self.base
-                                                            .set_status(
-                                                                ComponentStatus::Error,
-                                                                Some(msg),
-                                                            )
-                                                            .await;
-                                                        return Err(anyhow::anyhow!(
-                                                            "AutoReset aborted: failed to begin session for clearing: {e}",
-                                                        ));
-                                                    }
-                                                }
-
-                                                if let Err(ie) = clear_persistent_indexes(
-                                                    &self.base.config.id,
-                                                    &element_index,
-                                                    &archive_index,
-                                                    &result_index,
-                                                    &future_queue,
-                                                )
-                                                .await
-                                                {
-                                                    if let Some(sc) = &session_control {
-                                                        let _ = sc.rollback();
-                                                    }
-                                                    let msg = format!(
-                                                        "Query '{}' auto-reset failed: could not clear persistent indexes: {ie}",
-                                                        self.base.config.id
-                                                    );
-                                                    error!("{msg}");
-                                                    self.base
-                                                        .set_status(
-                                                            ComponentStatus::Error,
-                                                            Some(msg),
-                                                        )
-                                                        .await;
-                                                    return Err(anyhow::anyhow!(
-                                                        "AutoReset aborted: failed to clear persistent indexes: {ie}",
-                                                    ));
-                                                }
-                                                if let Err(ce) =
-                                                    checkpoint_store.clear_checkpoints().await
-                                                {
-                                                    // Rollback on failure
-                                                    if let Some(sc) = &session_control {
-                                                        let _ = sc.rollback();
-                                                    }
-                                                    let msg = format!(
-                                                        "Query '{}' auto-reset failed: could not clear checkpoints: {ce}",
-                                                        self.base.config.id
-                                                    );
-                                                    error!("{msg}");
-                                                    self.base
-                                                        .set_status(
-                                                            ComponentStatus::Error,
-                                                            Some(msg),
-                                                        )
-                                                        .await;
-                                                    return Err(anyhow::anyhow!(
-                                                        "AutoReset aborted: failed to clear checkpoints: {ce}",
-                                                    ));
-                                                }
-                                                // Write current config hash so next normal restart resumes correctly
-                                                let current_hash =
-                                                    super::compute_config_hash(&self.base.config);
-                                                if let Err(he) = checkpoint_store
-                                                    .write_config_hash(current_hash)
+                                                if let Err(reset_error) = persistent_state
+                                                    .clear(Some(super::compute_config_hash(
+                                                        &self.base.config,
+                                                    )))
                                                     .await
                                                 {
-                                                    warn!(
-                                                        "Query '{}' failed to write config hash during auto-reset: {he}",
+                                                    let msg = format!(
+                                                        "Query '{}' auto-reset failed while clearing persistent state: {reset_error:#}",
                                                         self.base.config.id
                                                     );
+                                                    error!("{msg}");
+                                                    self.base
+                                                        .set_status(
+                                                            ComponentStatus::Error,
+                                                            Some(msg),
+                                                        )
+                                                        .await;
+                                                    return Err(anyhow::anyhow!(
+                                                        "AutoReset aborted: {reset_error:#}",
+                                                    ));
                                                 }
-
-                                                // Commit the clearing session
-                                                if let Some(sc) = &session_control {
-                                                    if let Err(e) = sc.commit().await {
-                                                        warn!(
-                                                            "Query '{}' failed to commit auto-reset session: {e}",
-                                                            self.base.config.id
-                                                        );
-                                                    }
-                                                }
+                                                self.output_state.write().await.reset();
+                                                self.publication_recovery.reconcile_in_memory();
                                             }
 
                                             auto_reset_retry = true;
@@ -1464,17 +1373,12 @@ impl DrasiQuery {
                 );
 
                 // Store bootstrap channel if provided
-                // Also initialize bootstrap state only for sources that support bootstrap
                 if let Some(bootstrap_rx) = subscription_response.bootstrap_receiver {
-                    bootstrap_channels.push((
+                    bootstrap_channels.push(QueryBootstrapInput::new(
                         source_id.clone(),
                         bootstrap_rx,
                         subscription_response.bootstrap_result_receiver,
                     ));
-                    self.bootstrap_state
-                        .write()
-                        .await
-                        .insert(source_id.to_string(), BootstrapPhase::NotStarted);
                 }
 
                 // Collect position handle if source provides one
@@ -1560,406 +1464,11 @@ impl DrasiQuery {
 
         // Wrap continuous_query in Arc for sharing across tasks
         let continuous_query = Arc::new(continuous_query);
-
-        // Gate that blocks the streaming event processor until bootstrap completes.
-        // Events buffer safely in the priority queue during bootstrap.
-        let bootstrap_gate = Arc::new(Notify::new());
-
-        // NEW: Handle bootstrap channels
-        if !bootstrap_channels.is_empty() {
-            info!(
-                "Query '{}' starting bootstrap from {} sources",
-                self.base.config.id,
-                bootstrap_channels.len()
-            );
-
-            // Emit bootstrapStarted control signal
-            let mut metadata = HashMap::new();
-            metadata.insert(
-                "control_signal".to_string(),
-                serde_json::json!("bootstrapStarted"),
-            );
-            metadata.insert(
-                "source_count".to_string(),
-                serde_json::json!(bootstrap_channels.len()),
-            );
-
-            let control_result = QueryResult::new(
-                self.base.config.id.clone(),
-                0,
-                chrono::Utc::now(),
-                vec![],
-                metadata,
-            );
-
-            // Dispatch the control signal to all subscribed reactions
-            self.base.dispatch_query_result(control_result).await.ok();
-            info!(
-                "[BOOTSTRAP] Emitted bootstrapStarted signal for query '{}'",
-                self.base.config.id
-            );
-
-            // Process bootstrap events from each source
-            let continuous_query_clone = continuous_query.clone();
-            let base_dispatchers = self.base.dispatchers.clone();
-            let query_id = self.base.config.id.clone();
-            let bootstrap_state = self.bootstrap_state.clone();
-            let instance_id = self.instance_id.clone();
-            let bootstrap_output_state = self.output_state.clone();
-
-            let mut bootstrap_handles = Vec::new();
-            let mut abort_handles = PendingBootstrapAborts::default();
-
-            for (source_id, mut bootstrap_rx, bootstrap_result_rx) in bootstrap_channels {
-                // Mark source bootstrap as in progress
-                bootstrap_state
-                    .write()
-                    .await
-                    .insert(source_id.to_string(), BootstrapPhase::InProgress);
-
-                info!(
-                    "[BOOTSTRAP] Query '{query_id}' processing bootstrap from source '{source_id}'"
-                );
-
-                let continuous_query_ref = continuous_query_clone.clone();
-                let query_id_clone = query_id.clone();
-                let source_id_clone = source_id.clone();
-                let bootstrap_state_clone = bootstrap_state.clone();
-                let instance_id_clone = instance_id.clone();
-                let output_state_clone = bootstrap_output_state.clone();
-
-                let span = tracing::info_span!(
-                    "query_bootstrap",
-                    instance_id = %instance_id_clone,
-                    component_id = %query_id,
-                    component_type = "query"
-                );
-                let handle: tokio::task::JoinHandle<(String, anyhow::Result<Option<crate::bootstrap::BootstrapResult>>)> = tokio::spawn(
-                    async move {
-                        let mut count = 0u64;
-
-                        while let Some(bootstrap_event) = bootstrap_rx.recv().await {
-                            count += 1;
-
-                            // Process bootstrap change through ContinuousQuery
-                            match continuous_query_ref
-                                .process_source_change(bootstrap_event.change)
-                                .await
-                            {
-                                Ok(results) => {
-                                    if !results.is_empty() {
-                                        debug!(
-                                            "[BOOTSTRAP] Query '{}' received {} results from bootstrap event {}",
-                                            query_id_clone, results.len(), count
-                                        );
-
-                                        // Convert results to ResultDiffs and apply to output state.
-                                        // During bootstrap, we only update the result set (no outbox
-                                        // push, no sequence increment, no dispatch to reactions).
-                                        let diffs: Vec<ResultDiff> = results
-                                            .iter()
-                                            .map(|ctx| match ctx {
-                                                QueryPartEvaluationContext::Adding { after, row_signature } => {
-                                                    ResultDiff::Add {
-                                                        data: convert_query_variables_to_json(after),
-                                                        row_signature: *row_signature,
-                                                    }
-                                                }
-                                                QueryPartEvaluationContext::Removing { before, row_signature } => {
-                                                    ResultDiff::Delete {
-                                                        data: convert_query_variables_to_json(before),
-                                                        row_signature: *row_signature,
-                                                    }
-                                                }
-                                                QueryPartEvaluationContext::Updating { before, after, row_signature } => {
-                                                    let after_json = convert_query_variables_to_json(after);
-                                                    ResultDiff::Update {
-                                                        data: after_json.clone(),
-                                                        before: convert_query_variables_to_json(before),
-                                                        after: after_json,
-                                                        grouping_keys: None,
-                                                        row_signature: *row_signature,
-                                                    }
-                                                }
-                                                QueryPartEvaluationContext::Aggregation { before, after, row_signature, .. } => {
-                                                    ResultDiff::Aggregation {
-                                                        before: before.as_ref().map(convert_query_variables_to_json),
-                                                        after: convert_query_variables_to_json(after),
-                                                        row_signature: *row_signature,
-                                                    }
-                                                }
-                                                QueryPartEvaluationContext::Noop => ResultDiff::Noop,
-                                            })
-                                            .collect();
-
-                                        let mut state = output_state_clone.write().await;
-                                        state.apply_diffs(&diffs);
-                                    }
-                                }
-                                Err(e) => {
-                                    error!(
-                                        "[BOOTSTRAP] Query '{query_id_clone}' failed to process bootstrap event from source '{source_id_clone}': {e}"
-                                    );
-                                }
-                            }
-                        }
-
-                        info!(
-                            "[BOOTSTRAP] Query '{query_id_clone}' completed bootstrap from source '{source_id_clone}' ({count} events)"
-                        );
-
-                        // Mark source bootstrap as completed
-                        {
-                            let mut state = bootstrap_state_clone.write().await;
-                            state.insert(source_id_clone.to_string(), BootstrapPhase::Completed);
-                        }
-
-                        // Await the BootstrapResult from the source's bootstrap provider.
-                        // This carries the optional source_position snapshot boundary.
-                        // A provider failure (Ok(Err)) or a dropped result channel
-                        // (Err) is propagated as an Err so the supervisor can
-                        // transition the query to the Error state. Errors are carried
-                        // as anyhow::Error to preserve the context chain, matching the
-                        // internal-module convention.
-                        let bootstrap_result: anyhow::Result<Option<crate::bootstrap::BootstrapResult>> =
-                            if let Some(rx) = bootstrap_result_rx {
-                                match rx.await {
-                                    Ok(Ok(result)) => {
-                                        debug!(
-                                            "[BOOTSTRAP] Query '{}' received handover from source '{}': \
-                                             source_position={:?}",
-                                            query_id_clone, source_id_clone,
-                                            result.source_position.as_ref().map(|p| p.len())
-                                        );
-                                        Ok(Some(result))
-                                    }
-                                    Ok(Err(e)) => {
-                                        error!(
-                                            "[BOOTSTRAP] Query '{query_id_clone}' bootstrap provider failed for source '{source_id_clone}': {e:#}"
-                                        );
-                                        Err(e).context(format!("source '{source_id_clone}'"))
-                                    }
-                                    Err(_) => {
-                                        // The sender was dropped without producing a
-                                        // result. This is a silent-failure path (e.g. a
-                                        // provider task panicked before sending), so
-                                        // treat it as a bootstrap failure rather than
-                                        // letting the query proceed to Running.
-                                        error!(
-                                            "[BOOTSTRAP] Query '{query_id_clone}' bootstrap result channel dropped for source '{source_id_clone}' (provider may have failed)"
-                                        );
-                                        Err(anyhow::anyhow!(
-                                            "source '{source_id_clone}': bootstrap result channel dropped without a result"
-                                        ))
-                                    }
-                                }
-                            } else {
-                                Ok(None)
-                            };
-
-                        (source_id_clone, bootstrap_result)
-                    }
-                    .instrument(span),
-                );
-                abort_handles.push(handle.abort_handle());
-                bootstrap_handles.push(handle);
-            }
-
-            // Supervisor task: joins all bootstrap tasks, computes handover
-            // checkpoints, emits the bootstrapCompleted signal, and opens the gate.
-            // Also handles panics by transitioning to Error.
-            {
-                let bootstrap_gate_clone = bootstrap_gate.clone();
-                let reporter_clone = self.base.status_handle();
-                let query_id_clone = self.base.config.id.clone();
-                let instance_id_clone = self.instance_id.clone();
-                let base_dispatchers_clone = base_dispatchers.clone();
-                let checkpoint_store_for_supervisor = checkpoint_store.clone();
-                let session_control_for_supervisor = session_control.clone();
-
-                let span = tracing::info_span!(
-                    "bootstrap_supervisor",
-                    instance_id = %instance_id_clone,
-                    component_id = %query_id_clone,
-                    component_type = "query"
-                );
-                let supervisor_handle = tokio::spawn(
-                    async move {
-                        let join_results = futures::future::join_all(bootstrap_handles).await;
-                        let panic_count = join_results.iter().filter(|r| matches!(r, Err(e) if e.is_panic())).count();
-
-                        // Collect bootstrap provider failures reported by the per-source
-                        // tasks. Each error already carries the source id via anyhow
-                        // context; render the full chain single-line with `{:#}`.
-                        let failures: Vec<String> = join_results
-                            .iter()
-                            .filter_map(|r| r.as_ref().ok())
-                            .filter_map(|(_, result)| {
-                                result.as_ref().err().map(|e| format!("{e:#}"))
-                            })
-                            .collect();
-
-                        if panic_count > 0 || !failures.is_empty() {
-                            let mut details = Vec::new();
-                            if panic_count > 0 {
-                                details.push(format!("{panic_count} task(s) panicked"));
-                            }
-                            details.extend(failures.iter().cloned());
-                            let detail = details.join("; ");
-
-                            error!(
-                                "[BOOTSTRAP] Query '{query_id_clone}' bootstrap failed ({detail}), \
-                                 transitioning to Error and opening gate"
-                            );
-
-                            // The same failure reason is reported in the status so callers
-                            // of get_query_status() can see why bootstrap failed without
-                            // having to correlate against logs. This is an embedded,
-                            // in-process API and the identical text is already emitted to
-                            // the operator log above, so the status carries no information
-                            // not already present there.
-                            reporter_clone.set_status(
-                                ComponentStatus::Error,
-                                Some(format!("Bootstrap failed: {detail}")),
-                            ).await;
-
-                            // Open the gate so the processor doesn't block
-                            bootstrap_gate_clone.notify_one();
-                            return;
-                        }
-
-                        // Persist the bootstrap snapshot boundary (source_position)
-                        // as a recovery checkpoint so a crash after bootstrap but
-                        // before the first streaming event doesn't lose progress and
-                        // avoids a redundant re-bootstrap. Bootstrap events don't go
-                        // through dispatch_event(), so there is no sequence yet; use
-                        // 0 as the sentinel sequence alongside the source_position.
-                        let mut handover_positions: std::collections::HashMap<String, Option<bytes::Bytes>> =
-                            std::collections::HashMap::new();
-
-                        for (source_id, bootstrap_result) in join_results.iter().filter_map(|r| r.as_ref().ok()) {
-                            if let Ok(Some(br)) = bootstrap_result {
-                                if let Some(pos) = &br.source_position {
-                                    // Validate source_position size (same limit as dispatch_event)
-                                    if pos.len() > crate::sources::base::SourceBase::MAX_SOURCE_POSITION_BYTES {
-                                        warn!(
-                                            "[BOOTSTRAP] Query '{query_id_clone}' source '{source_id}' \
-                                             bootstrap source_position is {} bytes (> {} limit); \
-                                             dropping position, no recovery checkpoint persisted",
-                                            pos.len(),
-                                            crate::sources::base::SourceBase::MAX_SOURCE_POSITION_BYTES
-                                        );
-                                    } else {
-                                        handover_positions.insert(source_id.clone(), Some(pos.clone()));
-                                    }
-                                }
-                            }
-                        }
-
-                        info!(
-                            "[BOOTSTRAP] Query '{query_id_clone}' all sources completed bootstrap, \
-                             {} recovery checkpoint(s) to persist",
-                            handover_positions.len()
-                        );
-
-                        // Persist recovery checkpoints before opening the gate.
-                        // This ensures crash-after-bootstrap-before-first-streaming-event
-                        // doesn't lose progress and avoids a redundant re-bootstrap.
-                        if !handover_positions.is_empty() {
-                            let session_ok = if let Some(sc) = &session_control_for_supervisor {
-                                match sc.begin().await {
-                                    Ok(()) => true,
-                                    Err(e) => {
-                                        warn!(
-                                            "[BOOTSTRAP] Query '{query_id_clone}' failed to begin session \
-                                             for handover persistence: {e}; checkpoints will not be \
-                                             persisted until the first streaming event"
-                                        );
-                                        false
-                                    }
-                                }
-                            } else {
-                                true // no session control needed (e.g. in-memory store)
-                            };
-
-                            if session_ok {
-                                for (source_id, position) in &handover_positions {
-                                    if let Err(e) = checkpoint_store_for_supervisor
-                                        .stage_checkpoint(source_id, 0, position.as_ref())
-                                        .await
-                                    {
-                                        warn!(
-                                            "[BOOTSTRAP] Query '{query_id_clone}' failed to persist \
-                                             handover checkpoint for '{source_id}': {e}"
-                                        );
-                                    }
-                                }
-                                if let Some(sc) = &session_control_for_supervisor {
-                                    if let Err(e) = sc.commit().await {
-                                        warn!(
-                                            "[BOOTSTRAP] Query '{query_id_clone}' failed to commit \
-                                             handover checkpoints: {e}"
-                                        );
-                                    }
-                                }
-                            }
-                        }
-
-                        // Emit bootstrapCompleted control signal
-                        let mut metadata = HashMap::new();
-                        metadata.insert(
-                            "control_signal".to_string(),
-                            serde_json::json!("bootstrapCompleted"),
-                        );
-
-                        let control_result = QueryResult::new(
-                            query_id_clone.clone(),
-                            0,
-                            chrono::Utc::now(),
-                            vec![],
-                            metadata,
-                        );
-
-                        let arc_result = Arc::new(control_result);
-
-                        // Dispatch bootstrapCompleted signal to all reactions
-                        let dispatchers = base_dispatchers_clone.read().await;
-                        let mut dispatched = false;
-                        for dispatcher in dispatchers.iter() {
-                            if dispatcher.dispatch_change(arc_result.clone()).await.is_ok() {
-                                dispatched = true;
-                            }
-                        }
-
-                        if !dispatched {
-                            debug!(
-                                "No reactions subscribed to query '{query_id_clone}' for bootstrapCompleted signal"
-                            );
-                        } else {
-                            info!(
-                                "[BOOTSTRAP] Emitted bootstrapCompleted signal for query '{query_id_clone}'"
-                            );
-                        }
-
-                        // Open the bootstrap gate so the event processor can start
-                        bootstrap_gate_clone.notify_one();
-                        info!("[BOOTSTRAP] Query '{query_id_clone}' bootstrap gate opened");
-                    }
-                    .instrument(span),
-                );
-                abort_handles.push(supervisor_handle.abort_handle());
-            }
-
-            // Store abort handles for cleanup on stop()
-            *self.bootstrap_abort_handles.write().await = abort_handles.into_handles();
-        } else {
-            info!(
-                "Query '{}' no bootstrap channels, skipping bootstrap",
-                self.base.config.id
-            );
-            // No bootstrap needed — open the gate immediately
-            bootstrap_gate.notify_one();
-        }
+        let bootstrap_scope = QueryBootstrapScope::new(
+            bootstrap_channels,
+            checkpoint_store.clone(),
+            session_control.clone(),
+        );
 
         // Spawn FutureQueueSource forwarder task (same pattern as other sources)
         {
@@ -1973,33 +1482,16 @@ impl DrasiQuery {
             self.ingress_fence.push(fq_forwarder).await;
         }
 
-        let output_dependencies = QueryOutputDependencies::new(
-            self.base.config.id.clone(),
-            self.output_state.clone(),
-            self.base.dispatchers.clone(),
-            self.outbox_writer.read().await.clone(),
-            self.live_results_writer.read().await.clone(),
-            Some(checkpoint_store.clone()),
-            self.output_state.read().await.outbox_capacity(),
-            self.output_metrics.clone(),
-        )
-        .with_publication_recovery(self.publication_recovery.clone());
-        #[cfg(test)]
-        let output_dependencies = match self.processing_observer.read().await.clone() {
-            Some(observer) => output_dependencies.with_observer(observer),
-            None => output_dependencies,
-        };
-
         let host = QueryCompositeHost::new(
             QueryHostRuntime::new(
                 self.instance_id.clone(),
                 self.base.config.id.clone(),
                 self.priority_queue.clone(),
-                bootstrap_gate,
                 self.base.status_handle(),
                 future_queue_source,
                 self.ingress_fence.clone(),
             ),
+            bootstrap_scope,
             processing_mode,
             QueryLiveDependencies::new(
                 continuous_query,
@@ -2104,7 +1596,6 @@ impl Query for DrasiQuery {
         }
 
         self.ingress_fence.close().await;
-        self.abort_bootstrap_tasks().await;
         self.stop_future_queue_source().await;
         self.release_position_handles().await;
 
@@ -2522,9 +2013,7 @@ impl QueryManager {
                     id
                 ));
             }
-            let recovery_query = old_query.clone();
-            let recovery_id = id.clone();
-
+            let old_query_for_release = old_query.clone();
             crate::managers::lifecycle_helpers::reconfigure_component::<Arc<dyn Query>, _, _, _>(
                 &self.graph,
                 &id,
@@ -2532,17 +2021,7 @@ impl QueryManager {
                 &old_query,
                 || async {},
                 || async move {
-                    if recovery_query
-                        .as_any()
-                        .downcast_ref::<DrasiQuery>()
-                        .is_some_and(|query| query.publication_recovery.is_required())
-                    {
-                        return Err(anyhow::anyhow!(
-                            "Query '{recovery_id}' cannot be reconfigured because atomic output \
-                             committed before in-memory publication; A7 output reconciliation is \
-                             required first"
-                        ));
-                    }
+                    old_query_for_release.release_persistent_handles().await;
                     self.provision_query(new_config).await
                 },
                 || self.start_query(id.clone()),
@@ -2598,13 +2077,24 @@ impl QueryManager {
                     info!("Query '{id}' removed — clearing persistent indexes and checkpoints");
                     match self.index_factory.build(backend_ref, &id).await {
                         Ok(created) => {
-                            // Wrap clearing in a session for transactional backends
-                            if let Err(e) = created.set.session_control.begin().await {
-                                warn!(
-                                    "Query '{id}' failed to begin session for removal cleanup: {e}"
-                                );
+                            if let Some(checkpoint_store) = created.checkpoint_store.clone() {
+                                let state = PersistentQueryState {
+                                    query_id: id.clone(),
+                                    element_index: Some(created.set.element_index.clone()),
+                                    archive_index: Some(created.set.archive_index.clone()),
+                                    result_index: Some(created.set.result_index.clone()),
+                                    future_queue: Some(created.set.future_queue.clone()),
+                                    checkpoint_store,
+                                    outbox_writer: created.outbox_writer.clone(),
+                                    live_results_writer: created.live_results_writer.clone(),
+                                };
+                                if let Err(error) = state.clear(None).await {
+                                    warn!(
+                                        "Query '{id}' failed to clear persistent state on removal: {error:#}"
+                                    );
+                                }
                             } else {
-                                if let Err(e) = clear_persistent_indexes(
+                                if let Err(error) = clear_persistent_indexes(
                                     &id,
                                     &Some(created.set.element_index),
                                     &Some(created.set.archive_index),
@@ -2614,21 +2104,7 @@ impl QueryManager {
                                 .await
                                 {
                                     warn!(
-                                        "Query '{id}' failed to clear persistent indexes on removal: {e}"
-                                    );
-                                }
-
-                                if let Some(checkpoint_store) = created.checkpoint_store {
-                                    if let Err(e) = checkpoint_store.clear_checkpoints().await {
-                                        warn!(
-                                            "Query '{id}' failed to clear checkpoints on removal: {e}"
-                                        );
-                                    }
-                                }
-
-                                if let Err(e) = created.set.session_control.commit().await {
-                                    warn!(
-                                        "Query '{id}' failed to commit removal cleanup session: {e}"
+                                        "Query '{id}' failed to clear persistent indexes on removal: {error:#}"
                                     );
                                 }
                             }

--- a/lib/src/queries/manager/pipeline_characterization_tests.rs
+++ b/lib/src/queries/manager/pipeline_characterization_tests.rs
@@ -15,9 +15,8 @@
 //! Characterization tests for the fixed Source -> Continuous Query -> Reaction pipeline.
 //!
 //! These tests intentionally pin the legacy transaction and output boundaries. Their
-//! non-domain backend remains in legacy mode and documents the weaker durability gap
-//! where source progress commits before query output is persisted. Fully capable
-//! bundles use the atomic `QueryCompositeHost` path instead.
+//! output writers remain outside the core transaction, while the checkpoint store
+//! shares the core domain so the Legacy pending-publication marker is load-bearing.
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -40,6 +39,7 @@ use drasi_core::{
     interface::{
         CheckpointStore, CreatedIndexes, ElementIndex, FutureQueue, IndexBackendPlugin, IndexError,
         IndexSet, LiveResultsWriter, OutboxWriter, RowMutation, SessionControl, SourceCheckpoint,
+        TransactionDomain,
     },
     middleware::MiddlewareTypeRegistry,
     models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
@@ -123,10 +123,15 @@ struct TransactionState {
 struct RecordingSessionControl {
     state: Arc<Mutex<TransactionState>>,
     trace: EventTrace,
+    transaction_domain: TransactionDomain,
 }
 
 #[async_trait]
 impl SessionControl for RecordingSessionControl {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.transaction_domain.clone())
+    }
+
     async fn begin(&self) -> Result<(), IndexError> {
         let mut state = self.state.lock().unwrap();
         if state.active {
@@ -165,10 +170,15 @@ impl SessionControl for RecordingSessionControl {
 struct TransactionalCheckpointStore {
     state: Arc<Mutex<TransactionState>>,
     trace: EventTrace,
+    transaction_domain: TransactionDomain,
 }
 
 #[async_trait]
 impl CheckpointStore for TransactionalCheckpointStore {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        Some(self.transaction_domain.clone())
+    }
+
     fn is_persistent(&self) -> bool {
         true
     }
@@ -440,6 +450,7 @@ impl CharacterizationBackend {
     fn new(fail_output_writes: bool) -> Self {
         let trace = EventTrace::default();
         let state = Arc::new(Mutex::new(TransactionState::default()));
+        let transaction_domain = TransactionDomain::new();
         Self {
             trace: trace.clone(),
             element_index: Arc::new(InMemoryElementIndex::new()),
@@ -448,10 +459,12 @@ impl CharacterizationBackend {
             session_control: Arc::new(RecordingSessionControl {
                 state: state.clone(),
                 trace: trace.clone(),
+                transaction_domain: transaction_domain.clone(),
             }),
             checkpoint_store: Arc::new(TransactionalCheckpointStore {
                 state,
                 trace: trace.clone(),
+                transaction_domain,
             }),
             output_store: Arc::new(RecordingOutputStore::new(fail_output_writes, trace)),
         }
@@ -836,6 +849,7 @@ async fn evaluation_results_map_to_ordered_query_result_and_sequence() {
     let checkpoint_store = Arc::new(TransactionalCheckpointStore {
         state: checkpoint_state,
         trace: trace.clone(),
+        transaction_domain: TransactionDomain::new(),
     });
     let output_state = RwLock::new(QueryOutputState::new(16));
     let output_metrics = Arc::new(QueryOutputMetrics::new());
@@ -1108,6 +1122,11 @@ async fn live_source_change_envelope_path_preserves_legacy_result_metadata() {
         vec![
             TraceEvent::SessionBegin,
             TraceEvent::CheckpointStaged {
+                source_id: LEGACY_OUTPUT_PENDING_MARKER_V1.to_string(),
+                sequence: 1,
+                source_position: Some(Bytes::from_static(b"\x91\x01")),
+            },
+            TraceEvent::CheckpointStaged {
                 source_id: SOURCE_ID.to_string(),
                 sequence: 7,
                 source_position: Some(source_position),
@@ -1126,6 +1145,13 @@ async fn live_source_change_envelope_path_preserves_legacy_result_metadata() {
                 sequence: 1,
             },
             TraceEvent::ReactionDispatch { sequence: 1 },
+            TraceEvent::SessionBegin,
+            TraceEvent::CheckpointStaged {
+                source_id: LEGACY_OUTPUT_PENDING_MARKER_V1.to_string(),
+                sequence: 0,
+                source_position: None,
+            },
+            TraceEvent::SessionCommit,
         ]
     );
     assert_eq!(
@@ -1180,6 +1206,11 @@ async fn persistent_legacy_output_failure_fences_before_delivery() {
         vec![
             TraceEvent::SessionBegin,
             TraceEvent::CheckpointStaged {
+                source_id: LEGACY_OUTPUT_PENDING_MARKER_V1.to_string(),
+                sequence: 1,
+                source_position: Some(Bytes::from_static(b"\x91\x01")),
+            },
+            TraceEvent::CheckpointStaged {
                 source_id: SOURCE_ID.to_string(),
                 sequence: 1,
                 source_position: Some(first_position.clone()),
@@ -1189,13 +1220,9 @@ async fn persistent_legacy_output_failure_fences_before_delivery() {
                 query_id: QUERY_ID.to_string(),
                 sequence: 1,
             },
-            TraceEvent::ResultSequenceWritten {
-                query_id: QUERY_ID.to_string(),
-                sequence: 1,
-            },
         ],
-        "the Legacy checkpoint commit remains visible, but persistent output failure \
-         is marked and fenced before later persistence or dispatch"
+        "the pending marker and source checkpoint commit together before persistent \
+         output failure fences later persistence and dispatch"
     );
 
     assert!(
@@ -1240,8 +1267,8 @@ async fn persistent_legacy_output_failure_fences_before_delivery() {
             .read_result_sequence(QUERY_ID)
             .await
             .unwrap(),
-        Some(1),
-        "the attempted result sequence must expose the partial durable bundle on restart"
+        None,
+        "result sequence remains the committed output high-water, not an error marker"
     );
     assert!(query.publication_recovery_required());
     query.stop().await.unwrap();
@@ -1257,13 +1284,16 @@ async fn persistent_legacy_output_failure_fences_before_delivery() {
 async fn due_future_output_is_dispatched_after_core_commit() {
     let trace = EventTrace::default();
     let state = Arc::new(Mutex::new(TransactionState::default()));
+    let transaction_domain = TransactionDomain::new();
     let session_control = Arc::new(RecordingSessionControl {
         state: state.clone(),
         trace: trace.clone(),
+        transaction_domain: transaction_domain.clone(),
     });
     let checkpoint_store = Arc::new(TransactionalCheckpointStore {
         state,
         trace: trace.clone(),
+        transaction_domain,
     });
     let output_store = Arc::new(RecordingOutputStore::new(false, trace.clone()));
     let element_index = Arc::new(InMemoryElementIndex::new());

--- a/lib/src/queries/manager/pipeline_characterization_tests.rs
+++ b/lib/src/queries/manager/pipeline_characterization_tests.rs
@@ -886,6 +886,7 @@ async fn evaluation_results_map_to_ordered_query_result_and_sequence() {
         16,
         ProfilingMetadata::default(),
         &output_metrics,
+        None,
     )
     .await
     .unwrap();
@@ -985,6 +986,7 @@ async fn evaluation_results_map_to_ordered_query_result_and_sequence() {
         16,
         ProfilingMetadata::default(),
         &output_metrics,
+        None,
     )
     .await
     .unwrap();
@@ -1015,6 +1017,7 @@ async fn evaluation_results_map_to_ordered_query_result_and_sequence() {
         16,
         ProfilingMetadata::default(),
         &output_metrics,
+        None,
     )
     .await
     .unwrap();
@@ -1140,7 +1143,7 @@ async fn live_source_change_envelope_path_preserves_legacy_result_metadata() {
 }
 
 #[tokio::test]
-async fn committed_input_has_no_recoverable_output_when_persistence_fails() {
+async fn persistent_legacy_output_failure_fences_before_delivery() {
     let backend = Arc::new(CharacterizationBackend::new(true));
     let mut harness = PipelineHarness::new(backend.clone()).await;
 
@@ -1158,15 +1161,18 @@ async fn committed_input_has_no_recoverable_output_when_persistence_fails() {
             first_position.clone(),
         )
         .await;
-    let delivered = next_result(&mut result_rx).await;
-    assert_eq!(delivered.sequence, 1);
-    assert_eq!(delivered.results.len(), 1);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while query.status().await != ComponentStatus::Error {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("persistent Legacy write failure should fence the query");
     assert!(
-        matches!(
-            &delivered.results[0],
-            ResultDiff::Add { data, .. } if data == &json!({ "name": "Alice" })
-        ),
-        "the committed input should produce Alice's Add result"
+        tokio::time::timeout(Duration::from_millis(100), result_rx.recv())
+            .await
+            .is_err(),
+        "a persistent Legacy write failure must not be delivered"
     );
 
     assert_eq!(
@@ -1183,13 +1189,13 @@ async fn committed_input_has_no_recoverable_output_when_persistence_fails() {
                 query_id: QUERY_ID.to_string(),
                 sequence: 1,
             },
-            TraceEvent::LiveResultsApplyAttempt {
+            TraceEvent::ResultSequenceWritten {
                 query_id: QUERY_ID.to_string(),
-                mutation_count: 1,
+                sequence: 1,
             },
-            TraceEvent::ReactionDispatch { sequence: 1 },
         ],
-        "current DrasiQuery commits input progress before best-effort output persistence and dispatch"
+        "the Legacy checkpoint commit remains visible, but persistent output failure \
+         is marked and fenced before later persistence or dispatch"
     );
 
     assert!(
@@ -1234,75 +1240,11 @@ async fn committed_input_has_no_recoverable_output_when_persistence_fails() {
             .read_result_sequence(QUERY_ID)
             .await
             .unwrap(),
-        None,
-        "failed output writes must not claim a durable result sequence"
+        Some(1),
+        "the attempted result sequence must expose the partial durable bundle on restart"
     );
-
+    assert!(query.publication_recovery_required());
     query.stop().await.unwrap();
-
-    let (restarted_query, mut restarted_result_rx) =
-        harness.start_query(backend.trace.clone()).await;
-    let resumed_subscription = harness.next_subscription().await;
-    assert_eq!(resumed_subscription.resume_sequence, Some(1));
-    assert_eq!(resumed_subscription.resume_from, Some(first_position));
-
-    let recovered_snapshot = restarted_query.fetch_snapshot().await.unwrap();
-    assert_eq!(recovered_snapshot.as_of_sequence, 0);
-    assert!(
-        recovered_snapshot.is_empty(),
-        "after a fresh host starts from committed input position 1, output 1 cannot be recovered"
-    );
-
-    backend.trace.clear();
-    harness
-        .inject(
-            person_insert("person-1", "Alice", 1_000),
-            1,
-            Bytes::from_static(b"position-2"),
-        )
-        .await;
-    harness
-        .inject(
-            person_insert("person-2", "Bob", 2_000),
-            2,
-            Bytes::from_static(b"position-3"),
-        )
-        .await;
-
-    let after_restart = next_result(&mut restarted_result_rx).await;
-    assert_eq!(after_restart.sequence, 1);
-    assert_eq!(after_restart.results.len(), 1);
-    assert!(
-        matches!(
-            &after_restart.results[0],
-            ResultDiff::Add { data, .. } if data == &json!({ "name": "Bob" })
-        ),
-        "checkpoint-seeded dedup must suppress replayed source sequence 1",
-    );
-    assert_eq!(
-        backend.trace.snapshot(),
-        vec![
-            TraceEvent::SessionBegin,
-            TraceEvent::CheckpointStaged {
-                source_id: SOURCE_ID.to_string(),
-                sequence: 2,
-                source_position: Some(Bytes::from_static(b"position-3")),
-            },
-            TraceEvent::SessionCommit,
-            TraceEvent::OutboxAppendAttempt {
-                query_id: QUERY_ID.to_string(),
-                sequence: 1,
-            },
-            TraceEvent::LiveResultsApplyAttempt {
-                query_id: QUERY_ID.to_string(),
-                mutation_count: 1,
-            },
-            TraceEvent::ReactionDispatch { sequence: 1 },
-        ],
-        "the replayed sequence is skipped before a core session begins"
-    );
-
-    restarted_query.stop().await.unwrap();
     harness
         .source_manager
         .stop_source(SOURCE_ID.to_string())
@@ -1411,6 +1353,7 @@ async fn due_future_output_is_dispatched_after_core_commit() {
         16,
         profiling.clone(),
         &output_metrics,
+        None,
     )
     .await
     .unwrap();

--- a/lib/src/queries/output_state.rs
+++ b/lib/src/queries/output_state.rs
@@ -182,6 +182,14 @@ impl QueryOutputState {
         self.outbox.clear();
     }
 
+    /// Clear only the current row projection before rebuilding it from bootstrap.
+    ///
+    /// Volatile stop/start reuses this `QueryOutputState`, so its sequence and
+    /// outbox remain the reaction recovery timeline across re-bootstrap.
+    pub(crate) fn clear_results(&mut self) {
+        self.results.clear();
+    }
+
     /// Apply a result prepared for the current next sequence.
     ///
     /// Returns `None` when another writer advanced the state while the result was
@@ -732,6 +740,37 @@ mod tests {
         let arc = state.advance_sequence_and_push(result);
         assert_eq!(arc.sequence, 2);
         assert_eq!(state.outbox.len(), 2);
+    }
+
+    #[test]
+    fn clear_results_preserves_sequence_and_outbox_history() {
+        let mut state = QueryOutputState::new(4);
+        state.apply_diffs(&[ResultDiff::Add {
+            data: serde_json::json!({"name": "bootstrap"}),
+            row_signature: 1,
+        }]);
+        state.advance_sequence_and_push(make_query_result(
+            "q1",
+            vec![ResultDiff::Add {
+                data: serde_json::json!({"name": "live"}),
+                row_signature: 2,
+            }],
+        ));
+
+        state.clear_results();
+
+        assert_eq!(state.results_len(), 0);
+        assert_eq!(state.as_of_sequence(), 1);
+        assert_eq!(state.outbox_len(), 1);
+        assert_eq!(
+            state
+                .fetch_outbox_after(0)
+                .expect("preserved outbox")
+                .first()
+                .expect("preserved result")
+                .sequence,
+            1
+        );
     }
 
     #[test]

--- a/lib/src/queries/output_state.rs
+++ b/lib/src/queries/output_state.rs
@@ -177,8 +177,14 @@ impl QueryOutputState {
 
     /// Reset all process-local output state after persistent state is cleared.
     pub(crate) fn reset(&mut self) {
+        self.reset_to_sequence(0);
+    }
+
+    /// Clear the result projection and outbox while preserving a monotonic
+    /// public output high-water across a destructive reset.
+    pub(crate) fn reset_to_sequence(&mut self, as_of_sequence: u64) {
         self.results.clear();
-        self.as_of_sequence = 0;
+        self.as_of_sequence = as_of_sequence;
         self.outbox.clear();
     }
 

--- a/lib/src/queries/output_state.rs
+++ b/lib/src/queries/output_state.rs
@@ -155,6 +155,33 @@ impl QueryOutputState {
         self.as_of_sequence.saturating_add(1)
     }
 
+    /// Replace the process-local projection with a verified durable snapshot.
+    ///
+    /// Callers must validate the sequence, outbox, and live-result bundle before
+    /// invoking this method. The in-memory outbox retains the newest entries when
+    /// the configured capacity is lower than the durable history.
+    pub(crate) fn hydrate(
+        &mut self,
+        results: im::HashMap<u64, serde_json::Value>,
+        as_of_sequence: u64,
+        mut outbox: Vec<Arc<QueryResult>>,
+    ) {
+        if outbox.len() > self.outbox_capacity {
+            outbox.drain(..outbox.len() - self.outbox_capacity);
+        }
+
+        self.results = results;
+        self.as_of_sequence = as_of_sequence;
+        self.outbox = outbox.into();
+    }
+
+    /// Reset all process-local output state after persistent state is cleared.
+    pub(crate) fn reset(&mut self) {
+        self.results.clear();
+        self.as_of_sequence = 0;
+        self.outbox.clear();
+    }
+
     /// Apply a result prepared for the current next sequence.
     ///
     /// Returns `None` when another writer advanced the state while the result was
@@ -164,14 +191,24 @@ impl QueryOutputState {
         &mut self,
         result: QueryResult,
     ) -> Option<Arc<QueryResult>> {
+        self.try_apply_prepared_arc(Arc::new(result))
+    }
+
+    pub(crate) fn try_apply_prepared_arc(
+        &mut self,
+        result: Arc<QueryResult>,
+    ) -> Option<Arc<QueryResult>> {
         let expected_sequence = self.next_sequence();
         if result.sequence != expected_sequence {
             return None;
         }
 
         self.apply_diffs(&result.results);
-        let result = self.advance_sequence_and_push(result);
-        debug_assert_eq!(result.sequence, expected_sequence);
+        self.as_of_sequence = result.sequence;
+        if self.outbox.len() >= self.outbox_capacity {
+            self.outbox.pop_front();
+        }
+        self.outbox.push_back(result.clone());
         Some(result)
     }
 
@@ -184,6 +221,14 @@ impl QueryOutputState {
         &mut self,
         result: QueryResult,
     ) -> Result<Arc<QueryResult>, PreparedSequenceMismatch> {
+        self.apply_committed_arc(Arc::new(result))
+    }
+
+    /// Apply the exact result allocation that was serialized into durable output.
+    pub(crate) fn apply_committed_arc(
+        &mut self,
+        result: Arc<QueryResult>,
+    ) -> Result<Arc<QueryResult>, PreparedSequenceMismatch> {
         let expected = self.next_sequence();
         if result.sequence != expected {
             return Err(PreparedSequenceMismatch {
@@ -193,8 +238,11 @@ impl QueryOutputState {
         }
 
         self.apply_diffs(&result.results);
-        let result = self.advance_sequence_and_push(result);
-        debug_assert_eq!(result.sequence, expected);
+        self.as_of_sequence = result.sequence;
+        if self.outbox.len() >= self.outbox_capacity {
+            self.outbox.pop_front();
+        }
+        self.outbox.push_back(result.clone());
         Ok(result)
     }
 

--- a/lib/src/queries/query_composite_host.rs
+++ b/lib/src/queries/query_composite_host.rs
@@ -200,7 +200,7 @@ impl AtomicPublicationRecovery {
             .is_some()
     }
 
-    fn require(&self, result: Arc<QueryResult>) {
+    pub(super) fn require(&self, result: Arc<QueryResult>) {
         *self
             .pending
             .lock()
@@ -492,7 +492,7 @@ impl QueryBootstrapScope {
                 .await
                 .context("failed to persist the bootstrap in-progress marker")?;
         } else {
-            output.reset_bootstrap_state().await;
+            output.reset_bootstrap_projection().await;
         }
         output
             .dispatch_bootstrap_control("bootstrapStarted", Some(self.inputs.len()))
@@ -1124,9 +1124,8 @@ impl QueryCompositeHost {
                         self.runtime.ingress_fence.close().await;
                         let status_detail = if self.publication_recovery.is_required() {
                             format!(
-                                "Atomic output committed before in-memory publication; \
-                                 ingress is fenced and will be reconciled from durable \
-                                 output before restart: {detail}"
+                                "Durable query output requires reconciliation; ingress is \
+                                 fenced and AutoReset may be required before restart: {detail}"
                             )
                         } else {
                             format!(
@@ -1325,10 +1324,7 @@ impl LiveInputStage {
             QueryProcessingMode::Atomic(resources) => {
                 self.process_atomic(input, acknowledgement, resources).await
             }
-            QueryProcessingMode::Legacy => {
-                self.process_legacy(input, acknowledgement).await;
-                Ok(())
-            }
+            QueryProcessingMode::Legacy => self.process_legacy(input, acknowledgement).await,
         }
     }
 
@@ -1336,7 +1332,7 @@ impl LiveInputStage {
         &self,
         input: LiveChangeContext,
         acknowledgement: &mut SourceAcknowledgement,
-    ) {
+    ) -> Result<()> {
         let mut profiling = match input.profiling {
             Some(profiling) => profiling,
             None => ProfilingMetadata::new(),
@@ -1376,21 +1372,14 @@ impl LiveInputStage {
             Ok(results) => {
                 profiling.query_core_return_ns = Some(crate::profiling::timestamp_ns());
 
-                acknowledgement.advance(input.source_id.as_ref(), input.sequence);
-
                 if !results.is_empty() {
                     profiling.query_send_ns = Some(crate::profiling::timestamp_ns());
-                    if let Err(e) = self
-                        .output
+                    self.output
                         .publish(&results, input.source_id.as_ref(), profiling)
                         .await
-                    {
-                        error!(
-                            "Query '{}' failed to adapt query results: {e}",
-                            self.output.query_id
-                        );
-                    }
+                        .context("Legacy query output publication failed")?;
                 }
+                acknowledgement.advance(input.source_id.as_ref(), input.sequence);
             }
             Err(e) => {
                 error!(
@@ -1399,6 +1388,7 @@ impl LiveInputStage {
                 );
             }
         }
+        Ok(())
     }
 
     async fn process_atomic(
@@ -1584,29 +1574,20 @@ impl FutureProcessingStage {
     async fn drain_due(&self) -> Result<()> {
         match &self.mode {
             QueryProcessingMode::Atomic(resources) => self.drain_due_atomic(resources).await,
-            QueryProcessingMode::Legacy => {
-                self.drain_due_legacy().await;
-                Ok(())
-            }
+            QueryProcessingMode::Legacy => self.drain_due_legacy().await,
         }
     }
 
-    async fn drain_due_legacy(&self) {
+    async fn drain_due_legacy(&self) -> Result<()> {
         loop {
             match self.continuous_query.process_due_futures().await {
                 Ok(Some(due_result)) => {
                     if !due_result.results.is_empty() {
                         let profiling = ProfilingMetadata::new();
-                        if let Err(e) = self
-                            .output
+                        self.output
                             .publish(&due_result.results, &due_result.source_id, profiling)
                             .await
-                        {
-                            error!(
-                                "Query '{}' failed to adapt due-future results: {e}",
-                                self.output.query_id
-                            );
-                        }
+                            .context("Legacy due-future output publication failed")?;
                     }
                 }
                 Ok(None) => break,
@@ -1619,6 +1600,7 @@ impl FutureProcessingStage {
                 }
             }
         }
+        Ok(())
     }
 
     async fn drain_due_atomic(&self, resources: &AtomicQueryResources) -> Result<()> {
@@ -1755,6 +1737,19 @@ struct OutputPublicationStage {
     publication_recovery: AtomicPublicationRecovery,
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "persistent Legacy output write failed for query '{query_id}' at sequence {sequence} \
+     during {stage}; query is fenced and AutoReset may be required: {source}"
+)]
+struct LegacyOutputPersistenceError {
+    query_id: String,
+    sequence: u64,
+    stage: &'static str,
+    #[source]
+    source: anyhow::Error,
+}
+
 impl OutputPublicationStage {
     fn new(dependencies: QueryOutputDependencies) -> Self {
         Self {
@@ -1799,10 +1794,13 @@ impl OutputPublicationStage {
         }
     }
 
-    async fn reset_bootstrap_state(&self) {
-        self.output_state.write().await.reset();
+    async fn reset_bootstrap_projection(&self) {
+        let mut state = self.output_state.write().await;
+        state.clear_results();
         self.output_metrics.record_live_results_count(0);
-        self.output_metrics.update_outbox(0, 0, 0);
+        let earliest = state.outbox_earliest_seq().unwrap_or(0);
+        self.output_metrics
+            .update_outbox(state.outbox_len(), earliest, state.as_of_sequence());
     }
 
     async fn stage_bootstrap_live_results(
@@ -1824,9 +1822,30 @@ impl OutputPublicationStage {
         };
         let diffs = result_diffs_from_evaluation(results);
         let serialized = materialize_live_result_data(&diffs)?;
-        apply_live_result_data(writer.as_ref(), &self.query_id, &serialized)
-            .await
-            .map_err(anyhow::Error::from)
+        match apply_live_result_data(writer.as_ref(), &self.query_id, &serialized).await {
+            Ok(()) => Ok(()),
+            Err(error)
+                if self
+                    .checkpoint_store
+                    .as_ref()
+                    .is_some_and(|store| store.is_persistent()) =>
+            {
+                Err(LegacyOutputPersistenceError {
+                    query_id: self.query_id.clone(),
+                    sequence: self.output_state.read().await.next_sequence(),
+                    stage: "bootstrap live-result mutation",
+                    source: error.into(),
+                }
+                .into())
+            }
+            Err(error) => {
+                warn!(
+                    "Query '{}' failed optional volatile bootstrap live-result persistence: {error}",
+                    self.query_id
+                );
+                Ok(())
+            }
+        }
     }
 
     async fn apply_bootstrap_results(&self, results: &[QueryPartEvaluationContext]) {
@@ -1859,6 +1878,7 @@ impl OutputPublicationStage {
             self.outbox_capacity,
             profiling,
             &self.output_metrics,
+            Some(&self.publication_recovery),
         )
         .await
     }
@@ -1869,8 +1889,6 @@ impl OutputPublicationStage {
         source_id: &str,
         profiling: ProfilingMetadata,
     ) -> Result<PreparedQueryOutput> {
-        // A7 will hydrate this state from durable output during startup. A6
-        // intentionally preserves the existing in-memory sequence origin.
         let expected_sequence = self.output_state.read().await.next_sequence();
         let mut prepared = PreparedQueryOutput::from_evaluation(
             results,
@@ -2247,6 +2265,7 @@ pub(super) async fn dispatch_query_results(
     outbox_capacity: usize,
     profiling: ProfilingMetadata,
     output_metrics: &Arc<QueryOutputMetrics>,
+    publication_recovery: Option<&AtomicPublicationRecovery>,
 ) -> Result<()> {
     let tx_start = Instant::now();
 
@@ -2281,8 +2300,175 @@ pub(super) async fn dispatch_query_results(
         break result;
     };
 
-    // Keep the characterized ordering: core/checkpoint commit precedes these
-    // best-effort output writes, and delivery still occurs after persistence attempts.
+    let persistent_output = checkpoint_store
+        .as_ref()
+        .is_some_and(|store| store.is_persistent());
+    if persistent_output {
+        if let Some(recovery) = publication_recovery {
+            recovery.require(arc_result.clone());
+        }
+        persist_required_legacy_output(
+            query_id,
+            &arc_result,
+            outbox_writer,
+            live_results_writer,
+            checkpoint_store
+                .as_ref()
+                .expect("persistent output requires a checkpoint store"),
+            outbox_capacity,
+        )
+        .await?;
+        if let Some(recovery) = publication_recovery {
+            recovery.reconcile_in_memory();
+        }
+    } else {
+        persist_optional_legacy_output(
+            query_id,
+            &arc_result,
+            outbox_writer,
+            live_results_writer,
+            checkpoint_store,
+            outbox_capacity,
+        )
+        .await;
+    }
+
+    debug!(
+        "Query '{query_id}' sending {} results to reactions (seq={})",
+        arc_result.results.len(),
+        arc_result.sequence
+    );
+
+    let dispatchers = dispatchers.read().await;
+    for dispatcher in dispatchers.iter() {
+        if let Err(e) = dispatcher.dispatch_change(arc_result.clone()).await {
+            debug!("Failed to dispatch result for query '{query_id}': {e}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn persist_required_legacy_output(
+    query_id: &str,
+    result: &Arc<QueryResult>,
+    outbox_writer: &Option<Arc<dyn OutboxWriter>>,
+    live_results_writer: &Option<Arc<dyn LiveResultsWriter>>,
+    checkpoint_store: &Arc<dyn CheckpointStore>,
+    outbox_capacity: usize,
+) -> Result<()> {
+    if let Some(writer) = outbox_writer {
+        let data = match rmp_serde::to_vec(result.as_ref()) {
+            Ok(data) => data,
+            Err(error) => {
+                return Err(legacy_output_failure(
+                    query_id,
+                    result.sequence,
+                    "outbox serialization",
+                    error.into(),
+                    checkpoint_store,
+                )
+                .await
+                .into());
+            }
+        };
+        if let Err(error) = writer.append(query_id, result.sequence, &data).await {
+            return Err(legacy_output_failure(
+                query_id,
+                result.sequence,
+                "outbox append",
+                error.into(),
+                checkpoint_store,
+            )
+            .await
+            .into());
+        }
+        if let Err(error) = writer.trim_to_capacity(query_id, outbox_capacity).await {
+            return Err(legacy_output_failure(
+                query_id,
+                result.sequence,
+                "outbox trim",
+                error.into(),
+                checkpoint_store,
+            )
+            .await
+            .into());
+        }
+    }
+
+    if let Some(writer) = live_results_writer {
+        let serialized = match materialize_live_result_data(&result.results) {
+            Ok(serialized) => serialized,
+            Err(error) => {
+                return Err(legacy_output_failure(
+                    query_id,
+                    result.sequence,
+                    "live-result serialization",
+                    error,
+                    checkpoint_store,
+                )
+                .await
+                .into());
+            }
+        };
+        if let Err(error) = apply_live_result_data(writer.as_ref(), query_id, &serialized).await {
+            return Err(legacy_output_failure(
+                query_id,
+                result.sequence,
+                "live-result mutation",
+                error.into(),
+                checkpoint_store,
+            )
+            .await
+            .into());
+        }
+    }
+
+    checkpoint_store
+        .write_result_sequence(query_id, result.sequence)
+        .await
+        .map_err(|error| LegacyOutputPersistenceError {
+            query_id: query_id.to_string(),
+            sequence: result.sequence,
+            stage: "result-sequence write",
+            source: error.into(),
+        })?;
+    Ok(())
+}
+
+async fn legacy_output_failure(
+    query_id: &str,
+    sequence: u64,
+    stage: &'static str,
+    source: anyhow::Error,
+    checkpoint_store: &Arc<dyn CheckpointStore>,
+) -> LegacyOutputPersistenceError {
+    if let Err(marker_error) = checkpoint_store
+        .write_result_sequence(query_id, sequence)
+        .await
+    {
+        error!(
+            "Query '{query_id}' could not persist failed Legacy output sequence {sequence} \
+             after {stage} failed: {marker_error}"
+        );
+    }
+    LegacyOutputPersistenceError {
+        query_id: query_id.to_string(),
+        sequence,
+        stage,
+        source,
+    }
+}
+
+async fn persist_optional_legacy_output(
+    query_id: &str,
+    arc_result: &Arc<QueryResult>,
+    outbox_writer: &Option<Arc<dyn OutboxWriter>>,
+    live_results_writer: &Option<Arc<dyn LiveResultsWriter>>,
+    checkpoint_store: &Option<Arc<dyn CheckpointStore>>,
+    outbox_capacity: usize,
+) {
+    // Volatile/optional writers retain the pre-A7 best-effort behavior.
     let mut outbox_ok = true;
     if let Some(writer) = outbox_writer {
         match rmp_serde::to_vec(arc_result.as_ref()) {
@@ -2394,21 +2580,6 @@ pub(super) async fn dispatch_query_results(
             }
         }
     }
-
-    debug!(
-        "Query '{query_id}' sending {} results to reactions (seq={})",
-        arc_result.results.len(),
-        arc_result.sequence
-    );
-
-    let dispatchers = dispatchers.read().await;
-    for dispatcher in dispatchers.iter() {
-        if let Err(e) = dispatcher.dispatch_change(arc_result.clone()).await {
-            debug!("Failed to dispatch result for query '{query_id}': {e}");
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -2422,6 +2593,7 @@ mod tests {
     use async_trait::async_trait;
     use drasi_core::{
         evaluation::{
+            context::QueryVariables,
             functions::{Function, FunctionRegistry, ScalarFunction},
             variable_value::VariableValue,
             ExpressionEvaluationContext, FunctionError, FunctionEvaluationError,
@@ -2429,6 +2601,7 @@ mod tests {
         in_memory_index::{
             in_memory_checkpoint_store::InMemoryCheckpointStore,
             in_memory_future_queue::InMemoryFutureQueue,
+            in_memory_outbox_writer::InMemoryOutboxWriter,
         },
         interface::{FutureElementRef, FutureQueue, IndexError, PushType, SourceCheckpoint},
         models::{
@@ -2480,6 +2653,51 @@ mod tests {
                 function_name: expression.name.to_string(),
                 error: FunctionEvaluationError::InvalidArgumentCount,
             })
+        }
+    }
+
+    struct OptionalFailingOutbox {
+        inner: InMemoryOutboxWriter,
+    }
+
+    #[async_trait]
+    impl OutboxWriter for OptionalFailingOutbox {
+        async fn append(
+            &self,
+            _query_id: &str,
+            _sequence: u64,
+            _data: &[u8],
+        ) -> std::result::Result<(), IndexError> {
+            Err(IndexError::other(std::io::Error::other(
+                "injected optional outbox failure",
+            )))
+        }
+
+        async fn read_from(
+            &self,
+            query_id: &str,
+            after_sequence: u64,
+        ) -> std::result::Result<Vec<(u64, Vec<u8>)>, IndexError> {
+            self.inner.read_from(query_id, after_sequence).await
+        }
+
+        async fn read_latest_sequence(
+            &self,
+            query_id: &str,
+        ) -> std::result::Result<Option<u64>, IndexError> {
+            self.inner.read_latest_sequence(query_id).await
+        }
+
+        async fn clear(&self, query_id: &str) -> std::result::Result<(), IndexError> {
+            self.inner.clear(query_id).await
+        }
+
+        async fn trim_to_capacity(
+            &self,
+            query_id: &str,
+            capacity: usize,
+        ) -> std::result::Result<usize, IndexError> {
+            self.inner.trim_to_capacity(query_id, capacity).await
         }
     }
 
@@ -2723,6 +2941,55 @@ mod tests {
         assert_eq!(fixture.priority_queue.metrics().await.total_dequeued, 1);
 
         stop_host(&fixture).await;
+    }
+
+    #[tokio::test]
+    async fn volatile_optional_output_writer_failure_remains_best_effort() {
+        let output_state = RwLock::new(QueryOutputState::new(4));
+        let output_metrics = Arc::new(QueryOutputMetrics::new());
+        let dispatcher = ChannelChangeDispatcher::<QueryResult>::new(4);
+        let mut result_rx = dispatcher
+            .create_receiver()
+            .await
+            .expect("create optional writer result receiver");
+        let dispatchers: RwLock<Vec<Box<dyn ChangeDispatcher<QueryResult> + Send + Sync>>> =
+            RwLock::new(vec![Box::new(dispatcher)]);
+        let outbox_writer: Option<Arc<dyn OutboxWriter>> = Some(Arc::new(OptionalFailingOutbox {
+            inner: InMemoryOutboxWriter::new(),
+        }));
+        let checkpoint_store: Option<Arc<dyn CheckpointStore>> =
+            Some(Arc::new(InMemoryCheckpointStore::new()));
+        let recovery = AtomicPublicationRecovery::default();
+
+        dispatch_query_results(
+            &[QueryPartEvaluationContext::Adding {
+                after: QueryVariables::from([(
+                    Box::<str>::from("name"),
+                    VariableValue::String("volatile".to_string()),
+                )]),
+                row_signature: 1,
+            }],
+            SOURCE_ID,
+            QUERY_ID,
+            &output_state,
+            &dispatchers,
+            &outbox_writer,
+            &None,
+            &checkpoint_store,
+            4,
+            ProfilingMetadata::default(),
+            &output_metrics,
+            Some(&recovery),
+        )
+        .await
+        .expect("optional volatile persistence remains best effort");
+
+        assert_eq!(
+            receive_result(&mut result_rx).await.sequence,
+            1,
+            "optional volatile persistence failure must not suppress live output"
+        );
+        assert!(!recovery.is_required());
     }
 
     #[tokio::test]

--- a/lib/src/queries/query_composite_host.rs
+++ b/lib/src/queries/query_composite_host.rs
@@ -63,12 +63,28 @@ use crate::{
 /// A NUL-prefixed identifier is rejected as a configured source id by
 /// `DrasiQuery`, so it cannot collide with a real source checkpoint.
 pub(super) const QUERY_BOOTSTRAP_MARKER_V1: &str = "\0drasi:query-bootstrap:v1";
+pub(super) const QUERY_OUTPUT_RESET_MARKER_V1: &str = "\0drasi:query-output-reset:v1";
+pub(super) const LEGACY_OUTPUT_PENDING_MARKER_V1: &str = "\0drasi:legacy-output-pending:v1";
+
+const LEGACY_OUTPUT_PENDING_VERSION: u64 = 1;
+const LEGACY_OUTPUT_PENDING_CLEARED: u64 = 0;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct LegacyOutputPendingRecord {
+    output_sequence: Option<u64>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum QueryBootstrapRecoveryState {
     Absent,
     InProgress,
     Complete,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LegacyPendingState {
+    Absent,
+    Pending { output_sequence: Option<u64> },
 }
 
 pub(super) struct QueryBootstrapInput {
@@ -214,6 +230,10 @@ impl AtomicPublicationRecovery {
             .clone()
     }
 
+    pub(super) fn pending_sequence(&self) -> Option<u64> {
+        self.pending_result().map(|result| result.sequence)
+    }
+
     pub(super) fn reconcile_in_memory(&self) {
         self.pending
             .lock()
@@ -312,7 +332,7 @@ impl QueryLiveDependencies {
 #[derive(Clone)]
 pub(super) enum QueryProcessingMode {
     Atomic(AtomicQueryResources),
-    Legacy,
+    Legacy(LegacyQueryResources),
 }
 
 #[derive(Clone)]
@@ -324,15 +344,34 @@ pub(super) struct AtomicQueryResources {
     live_results_writer: Arc<dyn LiveResultsWriter>,
 }
 
+#[derive(Clone)]
+pub(super) struct LegacyQueryResources {
+    pending_publication: LegacyPendingPublication,
+}
+
+#[derive(Clone)]
+enum LegacyPendingPublication {
+    Volatile,
+    Persistent {
+        session_control: Arc<dyn SessionControl>,
+        checkpoint_store: Arc<dyn CheckpointStore>,
+    },
+    Unsupported {
+        reason: Arc<str>,
+    },
+}
+
 impl QueryProcessingMode {
-    pub(super) const fn legacy() -> Self {
-        Self::Legacy
+    pub(super) fn legacy() -> Self {
+        Self::Legacy(LegacyQueryResources {
+            pending_publication: LegacyPendingPublication::Volatile,
+        })
     }
 
     /// Capture the bundle-level capability before `CreatedIndexes` is distributed.
     pub(super) fn from_created_indexes(created: &CreatedIndexes) -> Self {
         let Some(transaction) = created.atomic_result_transaction() else {
-            return Self::Legacy;
+            return Self::legacy_from_created_indexes(created);
         };
 
         let (Some(checkpoint_store), Some(outbox_writer), Some(live_results_writer)) = (
@@ -344,7 +383,7 @@ impl QueryProcessingMode {
                 "Atomic result capability was issued without every persistent output writer; \
                  falling back to legacy processing"
             );
-            return Self::Legacy;
+            return Self::legacy_from_created_indexes(created);
         };
 
         Self::Atomic(AtomicQueryResources {
@@ -359,9 +398,158 @@ impl QueryProcessingMode {
     pub(super) const fn diagnostic_name(&self) -> &'static str {
         match self {
             Self::Atomic(_) => "atomic",
-            Self::Legacy => "legacy",
+            Self::Legacy(_) => "legacy",
         }
     }
+
+    fn legacy_from_created_indexes(created: &CreatedIndexes) -> Self {
+        let pending_publication = match created.checkpoint_store.as_ref() {
+            Some(checkpoint_store) if checkpoint_store.is_persistent() => {
+                match (
+                    created.set.session_control.transaction_domain(),
+                    checkpoint_store.transaction_domain(),
+                ) {
+                    (Some(session_domain), Some(checkpoint_domain))
+                        if session_domain == checkpoint_domain =>
+                    {
+                        LegacyPendingPublication::Persistent {
+                            session_control: created.set.session_control.clone(),
+                            checkpoint_store: checkpoint_store.clone(),
+                        }
+                    }
+                    _ => LegacyPendingPublication::Unsupported {
+                        reason: Arc::from(
+                            "persistent Legacy source progress cannot atomically stage the \
+                             pending-publication marker in the core transaction",
+                        ),
+                    },
+                }
+            }
+            _ => LegacyPendingPublication::Volatile,
+        };
+        Self::Legacy(LegacyQueryResources {
+            pending_publication,
+        })
+    }
+
+    pub(super) fn validate_legacy_pending_capability(&self) -> Result<()> {
+        if let Self::Legacy(LegacyQueryResources {
+            pending_publication: LegacyPendingPublication::Unsupported { reason },
+        }) = self
+        {
+            anyhow::bail!("{reason}");
+        }
+        Ok(())
+    }
+
+    pub(super) async fn read_legacy_pending_state(&self) -> Result<LegacyPendingState> {
+        match self {
+            Self::Legacy(LegacyQueryResources {
+                pending_publication:
+                    LegacyPendingPublication::Persistent {
+                        checkpoint_store, ..
+                    },
+            }) => read_legacy_pending_state(checkpoint_store.as_ref()).await,
+            _ => Ok(LegacyPendingState::Absent),
+        }
+    }
+}
+
+impl LegacyQueryResources {
+    fn persistent(&self) -> Result<Option<(&Arc<dyn SessionControl>, &Arc<dyn CheckpointStore>)>> {
+        match &self.pending_publication {
+            LegacyPendingPublication::Volatile => Ok(None),
+            LegacyPendingPublication::Persistent {
+                session_control,
+                checkpoint_store,
+            } => Ok(Some((session_control, checkpoint_store))),
+            LegacyPendingPublication::Unsupported { reason } => anyhow::bail!("{reason}"),
+        }
+    }
+
+    async fn stage_pending_in_active_session(
+        &self,
+        output_sequence: Option<u64>,
+    ) -> std::result::Result<(), IndexError> {
+        let Some((_, checkpoint_store)) = self.persistent().map_err(index_error)? else {
+            return Ok(());
+        };
+        let record = LegacyOutputPendingRecord { output_sequence };
+        let data = rmp_serde::to_vec(&record).map_err(|error| {
+            IndexError::other(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("failed to serialize Legacy pending-publication marker: {error}"),
+            ))
+        })?;
+        checkpoint_store
+            .stage_checkpoint(
+                LEGACY_OUTPUT_PENDING_MARKER_V1,
+                LEGACY_OUTPUT_PENDING_VERSION,
+                Some(&Bytes::from(data)),
+            )
+            .await
+    }
+
+    async fn clear_pending(&self) -> Result<()> {
+        let Some((session_control, checkpoint_store)) = self.persistent()? else {
+            return Ok(());
+        };
+        let session = SessionGuard::begin(session_control.clone())
+            .await
+            .context("failed to begin Legacy pending-marker clear transaction")?;
+        checkpoint_store
+            .stage_checkpoint(
+                LEGACY_OUTPUT_PENDING_MARKER_V1,
+                LEGACY_OUTPUT_PENDING_CLEARED,
+                None,
+            )
+            .await
+            .context("failed to clear Legacy pending-publication marker")?;
+        session
+            .commit()
+            .await
+            .context("failed to commit Legacy pending-marker clear")
+    }
+}
+
+pub(super) async fn read_legacy_pending_state(
+    checkpoint_store: &dyn CheckpointStore,
+) -> Result<LegacyPendingState> {
+    let marker = checkpoint_store
+        .read_checkpoint(LEGACY_OUTPUT_PENDING_MARKER_V1)
+        .await
+        .context("failed to read Legacy pending-publication marker")?;
+    match marker {
+        None
+        | Some(drasi_core::interface::SourceCheckpoint {
+            sequence: LEGACY_OUTPUT_PENDING_CLEARED,
+            ..
+        }) => Ok(LegacyPendingState::Absent),
+        Some(marker) if marker.sequence == LEGACY_OUTPUT_PENDING_VERSION => {
+            let data = marker
+                .source_position
+                .context("Legacy pending-publication marker is missing its versioned payload")?;
+            let record: LegacyOutputPendingRecord = rmp_serde::from_slice(&data)
+                .context("failed to deserialize Legacy pending-publication marker")?;
+            Ok(LegacyPendingState::Pending {
+                output_sequence: record.output_sequence,
+            })
+        }
+        Some(marker) => anyhow::bail!(
+            "invalid Legacy pending-publication marker version {}",
+            marker.sequence
+        ),
+    }
+}
+
+pub(super) async fn read_output_reset_high_water(
+    checkpoint_store: &dyn CheckpointStore,
+) -> Result<Option<u64>> {
+    checkpoint_store
+        .read_checkpoint(QUERY_OUTPUT_RESET_MARKER_V1)
+        .await
+        .context("failed to read query output reset marker")
+        .map(|marker| marker.map(|marker| marker.sequence))
 }
 
 /// Deterministic crate-private seam for transaction-boundary tests.
@@ -693,7 +881,7 @@ async fn process_bootstrap_change(
             )
             .await
             .context("atomic bootstrap envelope transaction failed")?,
-        QueryProcessingMode::Legacy => {
+        QueryProcessingMode::Legacy(_) => {
             let results: Arc<[QueryPartEvaluationContext]> = continuous_query
                 .process_source_change(change)
                 .await
@@ -787,27 +975,55 @@ impl QueryCompositeHost {
         mode: &QueryProcessingMode,
         dependencies: &QueryOutputDependencies,
     ) -> Result<()> {
+        if let LegacyPendingState::Pending { output_sequence } =
+            mode.read_legacy_pending_state().await?
+        {
+            anyhow::bail!(
+                "persistent Legacy publication is pending for output sequence {output_sequence:?}"
+            );
+        }
         let (checkpoint_store, outbox_writer, live_results_writer) = match mode {
             QueryProcessingMode::Atomic(resources) => (
                 resources.checkpoint_store.clone(),
                 resources.outbox_writer.clone(),
                 resources.live_results_writer.clone(),
             ),
-            QueryProcessingMode::Legacy => {
-                let (Some(checkpoint_store), Some(outbox_writer), Some(live_results_writer)) = (
-                    dependencies.checkpoint_store.clone(),
-                    dependencies.outbox_writer.clone(),
-                    dependencies.live_results_writer.clone(),
-                ) else {
+            QueryProcessingMode::Legacy(_) => {
+                let Some(checkpoint_store) = dependencies.checkpoint_store.clone() else {
                     anyhow::ensure!(
                         !dependencies.publication_recovery.is_required(),
-                        "atomic publication recovery requires a complete durable output bundle"
+                        "publication recovery requires a durable checkpoint store"
                     );
                     return Ok(());
                 };
                 if !checkpoint_store.is_persistent() {
                     return Ok(());
                 }
+                let (Some(outbox_writer), Some(live_results_writer)) = (
+                    dependencies.outbox_writer.clone(),
+                    dependencies.live_results_writer.clone(),
+                ) else {
+                    anyhow::ensure!(
+                        !dependencies.publication_recovery.is_required(),
+                        "publication recovery requires a complete durable output bundle"
+                    );
+                    let sequence = checkpoint_store
+                        .read_result_sequence(&dependencies.query_id)
+                        .await
+                        .context("failed to read Legacy result sequence")?
+                        .unwrap_or(0);
+                    let reset_high_water =
+                        read_output_reset_high_water(checkpoint_store.as_ref()).await?;
+                    anyhow::ensure!(
+                        reset_high_water.map_or(true, |baseline| baseline <= sequence),
+                        "query output reset baseline {reset_high_water:?} is ahead of Legacy sequence {sequence}"
+                    );
+                    let mut state = dependencies.output_state.write().await;
+                    state.hydrate(im::HashMap::new(), sequence, Vec::new());
+                    dependencies.output_metrics.record_live_results_count(0);
+                    dependencies.output_metrics.update_outbox(0, 0, sequence);
+                    return Ok(());
+                };
                 (checkpoint_store, outbox_writer, live_results_writer)
             }
         };
@@ -823,6 +1039,7 @@ impl QueryCompositeHost {
             live_results_writer.read_snapshot(query_id),
         )
         .context("failed to read the durable query output bundle")?;
+        let reset_high_water = read_output_reset_high_water(checkpoint_store.as_ref()).await?;
         let durable_sequence = result_sequence.unwrap_or(0);
         anyhow::ensure!(
             durable_sequence < u64::MAX,
@@ -835,15 +1052,23 @@ impl QueryCompositeHost {
                 "durable output is inconsistent: result sequence is 0 but the outbox is not empty"
             );
         } else {
+            match outbox_latest {
+                Some(outbox_latest) => anyhow::ensure!(
+                    outbox_latest == durable_sequence,
+                    "durable output is inconsistent: result sequence is {durable_sequence}, \
+                     outbox latest is {outbox_latest}"
+                ),
+                None => anyhow::ensure!(
+                    reset_high_water == Some(durable_sequence),
+                    "durable output is inconsistent: result sequence is {durable_sequence}, \
+                     but the outbox has no retained entry or matching reset baseline"
+                ),
+            }
+        }
+        if let Some(reset_high_water) = reset_high_water {
             anyhow::ensure!(
-                outbox_latest == Some(durable_sequence),
-                "durable output is inconsistent: result sequence is {durable_sequence}, \
-                 outbox latest is {outbox_latest:?}"
-            );
-            anyhow::ensure!(
-                !durable_outbox.is_empty(),
-                "durable output is inconsistent: result sequence is {durable_sequence}, \
-                 but the outbox has no retained entry"
+                reset_high_water <= durable_sequence,
+                "query output reset baseline {reset_high_water} is ahead of durable sequence {durable_sequence}"
             );
         }
 
@@ -1129,7 +1354,7 @@ impl QueryCompositeHost {
                             )
                         } else {
                             format!(
-                                "Atomic query processing failed before publication; \
+                                "Query processing failed before publication; \
                                  ingress is fenced and a clean stop/start can replay it: {detail}"
                             )
                         };
@@ -1324,7 +1549,9 @@ impl LiveInputStage {
             QueryProcessingMode::Atomic(resources) => {
                 self.process_atomic(input, acknowledgement, resources).await
             }
-            QueryProcessingMode::Legacy => self.process_legacy(input, acknowledgement).await,
+            QueryProcessingMode::Legacy(resources) => {
+                self.process_legacy(input, acknowledgement, resources).await
+            }
         }
     }
 
@@ -1332,6 +1559,7 @@ impl LiveInputStage {
         &self,
         input: LiveChangeContext,
         acknowledgement: &mut SourceAcknowledgement,
+        resources: &LegacyQueryResources,
     ) -> Result<()> {
         let mut profiling = match input.profiling {
             Some(profiling) => profiling,
@@ -1340,13 +1568,19 @@ impl LiveInputStage {
         profiling.query_receive_ns = Some(crate::profiling::timestamp_ns());
         profiling.query_core_call_ns = Some(crate::profiling::timestamp_ns());
 
-        // Legacy mode intentionally retains the A1 ordering. Atomic mode stages
-        // checkpoint and output together in its result-aware hook.
+        let persistent = resources.persistent()?.is_some();
+        let output_sequence = self.output.output_state.read().await.next_sequence();
         let checkpoint_store = self.checkpoint_store.clone();
         let checkpoint_source_id = input.source_id.clone();
         let checkpoint_position = input.source_position.clone();
         let sequence = input.sequence;
-        let hook = move || async move {
+        let pending_resources = resources.clone();
+        let hook = move |results: Arc<[QueryPartEvaluationContext]>| async move {
+            pending_resources
+                .stage_pending_in_active_session(
+                    has_query_output(&results).then_some(output_sequence),
+                )
+                .await?;
             if let Some(sequence) = sequence {
                 let position = match &checkpoint_position {
                     Some(position)
@@ -1366,7 +1600,7 @@ impl LiveInputStage {
 
         match self
             .continuous_query
-            .process_source_change_with_hook(input.source_change, hook)
+            .process_source_change_with_legacy_result_hook(input.source_change, hook)
             .await
         {
             Ok(results) => {
@@ -1379,9 +1613,18 @@ impl LiveInputStage {
                         .await
                         .context("Legacy query output publication failed")?;
                 }
+                resources
+                    .clear_pending()
+                    .await
+                    .context("Legacy source output completed but pending-marker clear failed")?;
                 acknowledgement.advance(input.source_id.as_ref(), input.sequence);
             }
             Err(e) => {
+                if persistent {
+                    return Err(e).context(
+                        "persistent Legacy source transaction or pending-marker stage failed",
+                    );
+                }
                 error!(
                     "Query '{}' failed to process source change: {e}",
                     self.output.query_id
@@ -1574,13 +1817,26 @@ impl FutureProcessingStage {
     async fn drain_due(&self) -> Result<()> {
         match &self.mode {
             QueryProcessingMode::Atomic(resources) => self.drain_due_atomic(resources).await,
-            QueryProcessingMode::Legacy => self.drain_due_legacy().await,
+            QueryProcessingMode::Legacy(resources) => self.drain_due_legacy(resources).await,
         }
     }
 
-    async fn drain_due_legacy(&self) -> Result<()> {
+    async fn drain_due_legacy(&self, resources: &LegacyQueryResources) -> Result<()> {
+        let persistent = resources.persistent()?.is_some();
         loop {
-            match self.continuous_query.process_due_futures().await {
+            let output_sequence = self.output.output_state.read().await.next_sequence();
+            let pending_resources = resources.clone();
+            match self
+                .continuous_query
+                .process_due_futures_with_legacy_result_hook(move |due_result| async move {
+                    pending_resources
+                        .stage_pending_in_active_session(
+                            has_query_output(&due_result.results).then_some(output_sequence),
+                        )
+                        .await
+                })
+                .await
+            {
                 Ok(Some(due_result)) => {
                     if !due_result.results.is_empty() {
                         let profiling = ProfilingMetadata::new();
@@ -1589,9 +1845,18 @@ impl FutureProcessingStage {
                             .await
                             .context("Legacy due-future output publication failed")?;
                     }
+                    resources
+                        .clear_pending()
+                        .await
+                        .context("Legacy due future completed but pending-marker clear failed")?;
                 }
                 Ok(None) => break,
                 Err(e) => {
+                    if persistent {
+                        return Err(e).context(
+                            "persistent Legacy due-future transaction or pending-marker stage failed",
+                        );
+                    }
                     error!(
                         "Query '{}' failed to process due futures: {e}",
                         self.output.query_id
@@ -2366,9 +2631,7 @@ async fn persist_required_legacy_output(
                     result.sequence,
                     "outbox serialization",
                     error.into(),
-                    checkpoint_store,
                 )
-                .await
                 .into());
             }
         };
@@ -2378,9 +2641,7 @@ async fn persist_required_legacy_output(
                 result.sequence,
                 "outbox append",
                 error.into(),
-                checkpoint_store,
             )
-            .await
             .into());
         }
         if let Err(error) = writer.trim_to_capacity(query_id, outbox_capacity).await {
@@ -2389,9 +2650,7 @@ async fn persist_required_legacy_output(
                 result.sequence,
                 "outbox trim",
                 error.into(),
-                checkpoint_store,
             )
-            .await
             .into());
         }
     }
@@ -2405,9 +2664,7 @@ async fn persist_required_legacy_output(
                     result.sequence,
                     "live-result serialization",
                     error,
-                    checkpoint_store,
                 )
-                .await
                 .into());
             }
         };
@@ -2417,9 +2674,7 @@ async fn persist_required_legacy_output(
                 result.sequence,
                 "live-result mutation",
                 error.into(),
-                checkpoint_store,
             )
-            .await
             .into());
         }
     }
@@ -2436,22 +2691,12 @@ async fn persist_required_legacy_output(
     Ok(())
 }
 
-async fn legacy_output_failure(
+fn legacy_output_failure(
     query_id: &str,
     sequence: u64,
     stage: &'static str,
     source: anyhow::Error,
-    checkpoint_store: &Arc<dyn CheckpointStore>,
 ) -> LegacyOutputPersistenceError {
-    if let Err(marker_error) = checkpoint_store
-        .write_result_sequence(query_id, sequence)
-        .await
-    {
-        error!(
-            "Query '{query_id}' could not persist failed Legacy output sequence {sequence} \
-             after {stage} failed: {marker_error}"
-        );
-    }
     LegacyOutputPersistenceError {
         query_id: query_id.to_string(),
         sequence,

--- a/lib/src/queries/query_composite_host.rs
+++ b/lib/src/queries/query_composite_host.rs
@@ -14,14 +14,13 @@
 
 //! Fixed query pipeline host.
 //!
-//! `DrasiQuery` still owns construction, source subscriptions, and bootstrap
-//! coordination. The bootstrap gate is therefore an explicit dependency of this
-//! host until that coordination moves with the rest of startup in a later layer.
+//! `DrasiQuery` owns construction and source subscription setup. This host owns
+//! bootstrap supervision, durable output reconciliation, and live processing.
 
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicU64, Ordering},
         Arc, Mutex,
     },
     time::{Instant, SystemTime},
@@ -34,14 +33,15 @@ use drasi_core::{
     evaluation::context::QueryPartEvaluationContext,
     interface::{
         AtomicResultTransaction, CheckpointStore, CreatedIndexes, IndexError, LiveResultsWriter,
-        OutboxWriter, RowMutation,
+        OutboxWriter, RowMutation, SessionControl, SessionGuard,
     },
     models::SourceChange,
     query::ContinuousQuery,
 };
+use futures::StreamExt;
 use log::{debug, error, info, warn};
 use tokio::{
-    sync::{oneshot, Mutex as AsyncMutex, Notify, RwLock},
+    sync::{oneshot, Mutex as AsyncMutex, RwLock},
     task::JoinHandle,
 };
 use tracing::Instrument;
@@ -49,14 +49,49 @@ use tracing::Instrument;
 use super::{PriorityQueue, QueryBase, QueryOutputState, SequenceDedup};
 use crate::{
     channels::{
-        ChangeDispatcher, ComponentStatus, QueryResult, ResultDiff, SourceControl, SourceEvent,
-        SourceEventWrapper,
+        BootstrapEventReceiver, ChangeDispatcher, ComponentStatus, QueryResult, ResultDiff,
+        SourceControl, SourceEvent, SourceEventWrapper,
     },
     component_graph::ComponentStatusHandle,
     metrics::QueryOutputMetrics,
     profiling::ProfilingMetadata,
     sources::FutureQueueSource,
 };
+
+/// Versioned private marker stored through the existing checkpoint store.
+///
+/// A NUL-prefixed identifier is rejected as a configured source id by
+/// `DrasiQuery`, so it cannot collide with a real source checkpoint.
+pub(super) const QUERY_BOOTSTRAP_MARKER_V1: &str = "\0drasi:query-bootstrap:v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum QueryBootstrapRecoveryState {
+    Absent,
+    InProgress,
+    Complete,
+}
+
+pub(super) struct QueryBootstrapInput {
+    source_id: String,
+    receiver: BootstrapEventReceiver,
+    result_receiver: Option<oneshot::Receiver<anyhow::Result<crate::bootstrap::BootstrapResult>>>,
+}
+
+impl QueryBootstrapInput {
+    pub(super) fn new(
+        source_id: String,
+        receiver: BootstrapEventReceiver,
+        result_receiver: Option<
+            oneshot::Receiver<anyhow::Result<crate::bootstrap::BootstrapResult>>,
+        >,
+    ) -> Self {
+        Self {
+            source_id,
+            receiver,
+            result_receiver,
+        }
+    }
+}
 
 /// Shared owner for every task that can enqueue into one query's priority queue.
 ///
@@ -154,20 +189,36 @@ impl QueryIngressFence {
 /// to the host's in-memory output state.
 #[derive(Clone, Default)]
 pub(super) struct AtomicPublicationRecovery {
-    required: Arc<AtomicBool>,
+    pending: Arc<Mutex<Option<Arc<QueryResult>>>>,
 }
 
 impl AtomicPublicationRecovery {
     pub(super) fn is_required(&self) -> bool {
-        self.required.load(Ordering::Acquire)
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some()
     }
 
-    fn require(&self) {
-        self.required.store(true, Ordering::Release);
+    fn require(&self, result: Arc<QueryResult>) {
+        *self
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(result);
     }
 
-    fn reconcile_in_memory(&self) {
-        self.required.store(false, Ordering::Release);
+    fn pending_result(&self) -> Option<Arc<QueryResult>> {
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    pub(super) fn reconcile_in_memory(&self) {
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
     }
 }
 
@@ -178,9 +229,7 @@ struct CommittedPublicationGuard {
 
 impl CommittedPublicationGuard {
     fn new(recovery: AtomicPublicationRecovery, has_output: bool) -> Self {
-        if has_output {
-            recovery.require();
-        }
+        debug_assert!(!has_output || recovery.is_required());
         Self {
             recovery,
             armed: has_output,
@@ -197,9 +246,7 @@ impl CommittedPublicationGuard {
 
 impl Drop for CommittedPublicationGuard {
     fn drop(&mut self) {
-        if self.armed {
-            self.recovery.require();
-        }
+        debug_assert!(!self.armed || self.recovery.is_required());
     }
 }
 
@@ -208,7 +255,6 @@ pub(super) struct QueryHostRuntime {
     instance_id: String,
     query_id: String,
     priority_queue: PriorityQueue,
-    bootstrap_gate: Arc<Notify>,
     status_handle: ComponentStatusHandle,
     future_queue_source: Arc<FutureQueueSource>,
     ingress_fence: QueryIngressFence,
@@ -219,7 +265,6 @@ impl QueryHostRuntime {
         instance_id: String,
         query_id: String,
         priority_queue: PriorityQueue,
-        bootstrap_gate: Arc<Notify>,
         status_handle: ComponentStatusHandle,
         future_queue_source: Arc<FutureQueueSource>,
         ingress_fence: QueryIngressFence,
@@ -228,7 +273,6 @@ impl QueryHostRuntime {
             instance_id,
             query_id,
             priority_queue,
-            bootstrap_gate,
             status_handle,
             future_queue_source,
             ingress_fence,
@@ -274,6 +318,7 @@ pub(super) enum QueryProcessingMode {
 #[derive(Clone)]
 pub(super) struct AtomicQueryResources {
     transaction: AtomicResultTransaction,
+    session_control: Arc<dyn SessionControl>,
     checkpoint_store: Arc<dyn CheckpointStore>,
     outbox_writer: Arc<dyn OutboxWriter>,
     live_results_writer: Arc<dyn LiveResultsWriter>,
@@ -304,6 +349,7 @@ impl QueryProcessingMode {
 
         Self::Atomic(AtomicQueryResources {
             transaction,
+            session_control: created.set.session_control.clone(),
             checkpoint_store: checkpoint_store.clone(),
             outbox_writer: outbox_writer.clone(),
             live_results_writer: live_results_writer.clone(),
@@ -387,12 +433,291 @@ impl QueryOutputDependencies {
     }
 }
 
+/// Host-owned bootstrap lifecycle for one query start.
+pub(super) struct QueryBootstrapScope {
+    inputs: Vec<QueryBootstrapInput>,
+    checkpoint_store: Arc<dyn CheckpointStore>,
+    session_control: Option<Arc<dyn SessionControl>>,
+}
+
+impl QueryBootstrapScope {
+    pub(super) fn new(
+        inputs: Vec<QueryBootstrapInput>,
+        checkpoint_store: Arc<dyn CheckpointStore>,
+        session_control: Option<Arc<dyn SessionControl>>,
+    ) -> Self {
+        Self {
+            inputs,
+            checkpoint_store,
+            session_control,
+        }
+    }
+
+    pub(super) async fn read_recovery_state(
+        checkpoint_store: &dyn CheckpointStore,
+    ) -> Result<QueryBootstrapRecoveryState> {
+        let marker = checkpoint_store
+            .read_checkpoint(QUERY_BOOTSTRAP_MARKER_V1)
+            .await
+            .context("failed to read the query bootstrap recovery marker")?;
+        match marker.map(|checkpoint| checkpoint.sequence) {
+            None => Ok(QueryBootstrapRecoveryState::Absent),
+            Some(0) => Ok(QueryBootstrapRecoveryState::InProgress),
+            Some(1) => Ok(QueryBootstrapRecoveryState::Complete),
+            Some(sequence) => {
+                anyhow::bail!("invalid query bootstrap recovery marker sequence {sequence}")
+            }
+        }
+    }
+
+    async fn run(
+        &mut self,
+        instance_id: &str,
+        query_id: &str,
+        continuous_query: Arc<ContinuousQuery>,
+        mode: QueryProcessingMode,
+        output: Arc<OutputPublicationStage>,
+    ) -> Result<Vec<String>> {
+        if self.inputs.is_empty() {
+            info!("Query '{query_id}' has no bootstrap channels");
+            return Ok(Vec::new());
+        }
+
+        info!(
+            "Query '{query_id}' starting bootstrap from {} sources",
+            self.inputs.len()
+        );
+        if self.checkpoint_store.is_persistent() {
+            self.persist_checkpoints(&[(QUERY_BOOTSTRAP_MARKER_V1, 0, None)])
+                .await
+                .context("failed to persist the bootstrap in-progress marker")?;
+        } else {
+            output.reset_bootstrap_state().await;
+        }
+        output
+            .dispatch_bootstrap_control("bootstrapStarted", Some(self.inputs.len()))
+            .await;
+
+        let processing_lock = Arc::new(AsyncMutex::new(()));
+        let mut tasks = futures::stream::FuturesUnordered::new();
+        let mut aborts = PendingBootstrapTaskAborts::default();
+        for input in std::mem::take(&mut self.inputs) {
+            let source_id = input.source_id.clone();
+            let task = tokio::spawn(
+                process_bootstrap_source(
+                    query_id.to_string(),
+                    input,
+                    continuous_query.clone(),
+                    mode.clone(),
+                    output.clone(),
+                    processing_lock.clone(),
+                )
+                .instrument(tracing::info_span!(
+                    "query_bootstrap",
+                    instance_id = %instance_id,
+                    component_id = %query_id,
+                    component_type = "query",
+                    source_id = %source_id,
+                )),
+            );
+            aborts.push(task.abort_handle());
+            tasks.push(task);
+        }
+
+        let mut handoffs = Vec::new();
+        while let Some(joined) = tasks.next().await {
+            let handoff = joined
+                .context("query bootstrap task failed to join")?
+                .context("query bootstrap source failed")?;
+            handoffs.push(handoff);
+        }
+
+        let checkpoints: Vec<(&str, u64, Option<&Bytes>)> = handoffs
+            .iter()
+            .map(|handoff| {
+                (
+                    handoff.source_id.as_str(),
+                    0,
+                    handoff.source_position.as_ref(),
+                )
+            })
+            .chain(self.checkpoint_store.is_persistent().then_some((
+                QUERY_BOOTSTRAP_MARKER_V1,
+                1,
+                None,
+            )))
+            .collect();
+        self.persist_checkpoints(&checkpoints)
+            .await
+            .context("failed to persist the final bootstrap handoff")?;
+
+        output
+            .dispatch_bootstrap_control("bootstrapCompleted", None)
+            .await;
+        info!("[BOOTSTRAP] Query '{query_id}' bootstrap completed");
+
+        Ok(handoffs
+            .into_iter()
+            .map(|handoff| handoff.source_id)
+            .collect())
+    }
+
+    async fn persist_checkpoints(&self, checkpoints: &[(&str, u64, Option<&Bytes>)]) -> Result<()> {
+        let session = match &self.session_control {
+            Some(session_control) => Some(
+                SessionGuard::begin(session_control.clone())
+                    .await
+                    .context("failed to begin bootstrap checkpoint transaction")?,
+            ),
+            None => None,
+        };
+
+        for (source_id, sequence, source_position) in checkpoints {
+            self.checkpoint_store
+                .stage_checkpoint(source_id, *sequence, *source_position)
+                .await
+                .with_context(|| {
+                    format!("failed to stage bootstrap checkpoint for '{source_id}'")
+                })?;
+        }
+
+        if let Some(session) = session {
+            session
+                .commit()
+                .await
+                .context("failed to commit bootstrap checkpoints")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct PendingBootstrapTaskAborts {
+    handles: Vec<tokio::task::AbortHandle>,
+}
+
+impl PendingBootstrapTaskAborts {
+    fn push(&mut self, handle: tokio::task::AbortHandle) {
+        self.handles.push(handle);
+    }
+}
+
+impl Drop for PendingBootstrapTaskAborts {
+    fn drop(&mut self) {
+        for handle in &self.handles {
+            handle.abort();
+        }
+    }
+}
+
+struct BootstrapSourceHandoff {
+    source_id: String,
+    source_position: Option<Bytes>,
+}
+
+async fn process_bootstrap_source(
+    query_id: String,
+    mut input: QueryBootstrapInput,
+    continuous_query: Arc<ContinuousQuery>,
+    mode: QueryProcessingMode,
+    output: Arc<OutputPublicationStage>,
+    processing_lock: Arc<AsyncMutex<()>>,
+) -> Result<BootstrapSourceHandoff> {
+    let mut count = 0u64;
+    while let Some(event) = input.receiver.recv().await {
+        count = count.saturating_add(1);
+        let _processing = processing_lock.lock().await;
+        process_bootstrap_change(&continuous_query, &mode, &output, event.change)
+            .await
+            .with_context(|| {
+                format!(
+                    "query '{query_id}' failed bootstrap event {count} from source '{}'",
+                    input.source_id
+                )
+            })?;
+    }
+
+    let source_position = match input.result_receiver {
+        Some(receiver) => {
+            let result = receiver
+                .await
+                .with_context(|| {
+                    format!(
+                        "source '{}': bootstrap result channel dropped without a result",
+                        input.source_id
+                    )
+                })?
+                .with_context(|| {
+                    format!("source '{}' bootstrap provider failed", input.source_id)
+                })?;
+            if result.source_position.as_ref().is_some_and(|position| {
+                position.len() > crate::sources::base::SourceBase::MAX_SOURCE_POSITION_BYTES
+            }) {
+                anyhow::bail!(
+                    "source '{}' bootstrap position exceeds the {} byte limit",
+                    input.source_id,
+                    crate::sources::base::SourceBase::MAX_SOURCE_POSITION_BYTES
+                );
+            }
+            result.source_position
+        }
+        None => None,
+    };
+
+    info!(
+        "[BOOTSTRAP] Query '{query_id}' completed bootstrap from source '{}' ({count} events)",
+        input.source_id
+    );
+    Ok(BootstrapSourceHandoff {
+        source_id: input.source_id,
+        source_position,
+    })
+}
+
+async fn process_bootstrap_change(
+    continuous_query: &ContinuousQuery,
+    mode: &QueryProcessingMode,
+    output: &OutputPublicationStage,
+    change: SourceChange,
+) -> Result<()> {
+    let results = match mode {
+        QueryProcessingMode::Atomic(resources) => continuous_query
+            .process_source_change_with_result_hook(
+                change,
+                &resources.transaction,
+                |results| async move {
+                    output
+                        .stage_bootstrap_live_results(&resources.live_results_writer, &results)
+                        .await
+                },
+            )
+            .await
+            .context("atomic bootstrap envelope transaction failed")?,
+        QueryProcessingMode::Legacy => {
+            let results: Arc<[QueryPartEvaluationContext]> = continuous_query
+                .process_source_change(change)
+                .await
+                .context("legacy bootstrap envelope evaluation failed")?
+                .into();
+            output
+                .persist_bootstrap_live_results(&results)
+                .await
+                .context("legacy bootstrap live-result persistence failed")?;
+            results
+        }
+    };
+
+    output.apply_bootstrap_results(&results).await;
+    Ok(())
+}
+
 /// Static, query-specific host for the current fixed live pipeline.
 ///
 /// This intentionally has no generic pipeline traits. It gives each existing live
 /// responsibility one owner while preserving the current orchestration contract.
 pub(super) struct QueryCompositeHost {
     runtime: QueryHostRuntime,
+    bootstrap: QueryBootstrapScope,
     live_input: LiveInputStage,
     future_processing: FutureProcessingStage,
     source_acknowledgement: SourceAcknowledgement,
@@ -402,6 +727,7 @@ pub(super) struct QueryCompositeHost {
 impl QueryCompositeHost {
     pub(super) fn new(
         runtime: QueryHostRuntime,
+        bootstrap: QueryBootstrapScope,
         mode: QueryProcessingMode,
         live: QueryLiveDependencies,
         output: QueryOutputDependencies,
@@ -412,6 +738,7 @@ impl QueryCompositeHost {
 
         Self {
             runtime,
+            bootstrap,
             live_input: LiveInputStage {
                 continuous_query: continuous_query.clone(),
                 checkpoint_store: live.checkpoint_store,
@@ -451,33 +778,281 @@ impl QueryCompositeHost {
         base.stop_common().await
     }
 
+    /// Rebuild process-local output state from the authoritative durable bundle.
+    ///
+    /// This runs before source subscriptions are installed. Atomic bundles must
+    /// reconcile successfully; persistent legacy bundles are reconciled when all
+    /// three durable output resources are available.
+    pub(super) async fn reconcile_output_state(
+        mode: &QueryProcessingMode,
+        dependencies: &QueryOutputDependencies,
+    ) -> Result<()> {
+        let (checkpoint_store, outbox_writer, live_results_writer) = match mode {
+            QueryProcessingMode::Atomic(resources) => (
+                resources.checkpoint_store.clone(),
+                resources.outbox_writer.clone(),
+                resources.live_results_writer.clone(),
+            ),
+            QueryProcessingMode::Legacy => {
+                let (Some(checkpoint_store), Some(outbox_writer), Some(live_results_writer)) = (
+                    dependencies.checkpoint_store.clone(),
+                    dependencies.outbox_writer.clone(),
+                    dependencies.live_results_writer.clone(),
+                ) else {
+                    anyhow::ensure!(
+                        !dependencies.publication_recovery.is_required(),
+                        "atomic publication recovery requires a complete durable output bundle"
+                    );
+                    return Ok(());
+                };
+                if !checkpoint_store.is_persistent() {
+                    return Ok(());
+                }
+                (checkpoint_store, outbox_writer, live_results_writer)
+            }
+        };
+
+        let query_id = dependencies.query_id.as_str();
+        let previous_sequence = dependencies.output_state.read().await.as_of_sequence();
+        let recovery_required = dependencies.publication_recovery.is_required();
+        let pending_result = dependencies.publication_recovery.pending_result();
+        let (result_sequence, outbox_latest, durable_outbox, durable_rows) = tokio::try_join!(
+            checkpoint_store.read_result_sequence(query_id),
+            outbox_writer.read_latest_sequence(query_id),
+            outbox_writer.read_from(query_id, 0),
+            live_results_writer.read_snapshot(query_id),
+        )
+        .context("failed to read the durable query output bundle")?;
+        let durable_sequence = result_sequence.unwrap_or(0);
+        anyhow::ensure!(
+            durable_sequence < u64::MAX,
+            "durable result sequence is exhausted at u64::MAX"
+        );
+
+        if durable_sequence == 0 {
+            anyhow::ensure!(
+                outbox_latest.is_none() && durable_outbox.is_empty(),
+                "durable output is inconsistent: result sequence is 0 but the outbox is not empty"
+            );
+        } else {
+            anyhow::ensure!(
+                outbox_latest == Some(durable_sequence),
+                "durable output is inconsistent: result sequence is {durable_sequence}, \
+                 outbox latest is {outbox_latest:?}"
+            );
+            anyhow::ensure!(
+                !durable_outbox.is_empty(),
+                "durable output is inconsistent: result sequence is {durable_sequence}, \
+                 but the outbox has no retained entry"
+            );
+        }
+
+        let mut decoded_outbox = Vec::with_capacity(durable_outbox.len());
+        let mut prior = None;
+        for (stored_sequence, data) in durable_outbox {
+            if let Some(prior) = prior {
+                anyhow::ensure!(
+                    stored_sequence == prior + 1,
+                    "durable outbox gap between sequences {prior} and {stored_sequence}"
+                );
+            }
+            let result: QueryResult = rmp_serde::from_slice(&data).with_context(|| {
+                format!("failed to deserialize durable outbox sequence {stored_sequence}")
+            })?;
+            anyhow::ensure!(
+                result.query_id == query_id,
+                "durable outbox sequence {stored_sequence} belongs to query '{}', expected '{query_id}'",
+                result.query_id
+            );
+            anyhow::ensure!(
+                result.sequence == stored_sequence,
+                "durable outbox key {stored_sequence} contains result sequence {}",
+                result.sequence
+            );
+            let result = match pending_result
+                .as_ref()
+                .filter(|pending| pending.sequence == stored_sequence)
+            {
+                Some(pending) => {
+                    anyhow::ensure!(
+                        rmp_serde::to_vec(pending.as_ref())? == data,
+                        "process-local fenced result sequence {stored_sequence} does not match durable outbox bytes"
+                    );
+                    pending.clone()
+                }
+                None => Arc::new(result),
+            };
+            prior = Some(stored_sequence);
+            decoded_outbox.push(result);
+        }
+        anyhow::ensure!(
+            prior == outbox_latest,
+            "durable outbox latest metadata {outbox_latest:?} does not match retained entries ending at {prior:?}"
+        );
+
+        let mut results = im::HashMap::new();
+        for (row_signature, data) in durable_rows {
+            let value = rmp_serde::from_slice(&data).with_context(|| {
+                format!("failed to deserialize durable live-result row {row_signature}")
+            })?;
+            anyhow::ensure!(
+                results.insert(row_signature, value).is_none(),
+                "durable live-result snapshot contains duplicate row {row_signature}"
+            );
+        }
+
+        if let Some(latest) = decoded_outbox.last() {
+            let mut latest_mutations = HashMap::new();
+            for diff in &latest.results {
+                match diff {
+                    ResultDiff::Add {
+                        data,
+                        row_signature,
+                    } => {
+                        latest_mutations.insert(*row_signature, Some(data));
+                    }
+                    ResultDiff::Update {
+                        after,
+                        row_signature,
+                        ..
+                    }
+                    | ResultDiff::Aggregation {
+                        after,
+                        row_signature,
+                        ..
+                    } => {
+                        latest_mutations.insert(*row_signature, Some(after));
+                    }
+                    ResultDiff::Delete { row_signature, .. } => {
+                        latest_mutations.insert(*row_signature, None);
+                    }
+                    ResultDiff::Noop => {}
+                }
+            }
+            for (row_signature, expected) in latest_mutations {
+                match expected {
+                    Some(expected) => anyhow::ensure!(
+                        results.get(&row_signature) == Some(expected),
+                        "durable live-result row {row_signature} does not reflect outbox sequence {}",
+                        latest.sequence
+                    ),
+                    None => anyhow::ensure!(
+                        !results.contains_key(&row_signature),
+                        "durable live-result row {row_signature} survived delete in outbox sequence {}",
+                        latest.sequence
+                    ),
+                }
+            }
+        }
+
+        anyhow::ensure!(
+            previous_sequence <= durable_sequence,
+            "process-local output sequence {previous_sequence} is ahead of durable sequence {durable_sequence}"
+        );
+        let recovered = if recovery_required {
+            let pending_sequence = pending_result
+                .as_ref()
+                .map(|result| result.sequence)
+                .context("publication recovery was required without a pending result")?;
+            anyhow::ensure!(
+                pending_sequence == durable_sequence,
+                "fenced output sequence {pending_sequence} does not match durable sequence {durable_sequence}"
+            );
+            // The fence records the one commit that missed publication. Older
+            // retained outbox entries were already delivered and must not be rebroadcast.
+            let recovered: Vec<_> = decoded_outbox
+                .iter()
+                .filter(|result| result.sequence == pending_sequence)
+                .cloned()
+                .collect();
+            anyhow::ensure!(
+                recovered.len() == 1,
+                "durable outbox does not contain fenced output sequence {pending_sequence}"
+            );
+            recovered
+        } else {
+            Vec::new()
+        };
+
+        {
+            let mut state = dependencies.output_state.write().await;
+            state.hydrate(results, durable_sequence, decoded_outbox);
+            dependencies
+                .output_metrics
+                .record_live_results_count(state.results_len());
+            let earliest = state.outbox_earliest_seq().unwrap_or(0);
+            dependencies.output_metrics.update_outbox(
+                state.outbox_len(),
+                earliest,
+                state.as_of_sequence(),
+            );
+        }
+
+        dependencies.publication_recovery.reconcile_in_memory();
+        for result in recovered {
+            let dispatchers = dependencies.dispatchers.read().await;
+            for dispatcher in dispatchers.iter() {
+                if let Err(error) = dispatcher.dispatch_change(result.clone()).await {
+                    debug!(
+                        "Query '{query_id}' could not deliver recovered sequence {} to an existing subscriber: {error}",
+                        result.sequence
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn run(mut self, mut shutdown_rx: oneshot::Receiver<()>) {
         info!(
-            "Query '{}' waiting for bootstrap gate before processing events",
+            "Query '{}' starting host-owned bootstrap",
             self.runtime.query_id
         );
 
-        tokio::select! {
+        let bootstrap_result = tokio::select! {
             biased;
 
             _ = &mut shutdown_rx => {
                 info!(
-                    "Query '{}' received shutdown during bootstrap wait, exiting",
+                    "Query '{}' received shutdown during bootstrap, exiting",
                     self.runtime.query_id
                 );
                 return;
             }
 
-            _ = self.runtime.bootstrap_gate.notified() => {
-                info!(
-                    "Query '{}' bootstrap gate opened, starting event processing",
+            result = self.bootstrap.run(
+                &self.runtime.instance_id,
+                &self.runtime.query_id,
+                self.live_input.continuous_query.clone(),
+                self.live_input.mode.clone(),
+                self.live_input.output.clone(),
+            ) => result,
+        };
+
+        let bootstrapped_sources = match bootstrap_result {
+            Ok(sources) => sources,
+            Err(error) => {
+                let detail = format!("{error:#}");
+                error!(
+                    "[BOOTSTRAP] Query '{}' bootstrap failed: {detail}",
                     self.runtime.query_id
                 );
+                self.runtime.ingress_fence.close().await;
+                self.runtime.future_queue_source.stop().await;
+                self.runtime
+                    .status_handle
+                    .set_status(
+                        ComponentStatus::Error,
+                        Some(format!("Bootstrap failed: {detail}")),
+                    )
+                    .await;
+                return;
             }
+        };
+        for source_id in bootstrapped_sources {
+            self.source_acknowledgement.advance(&source_id, Some(0));
         }
 
-        // Bootstrap coordination remains in DrasiQuery for now. The host owns the
-        // post-gate transition without overriding a concurrent stop/error transition.
         let should_run = matches!(
             self.runtime.status_handle.get_status().await,
             ComponentStatus::Starting
@@ -493,10 +1068,11 @@ impl QueryCompositeHost {
         } else {
             let current = self.runtime.status_handle.get_status().await;
             warn!(
-                "Query '{}' bootstrap completed but status is {current:?}, \
-                 skipping transition to Running",
+                "Query '{}' bootstrap completed with status {current:?}; skipping live processing",
                 self.runtime.query_id
             );
+            self.runtime.ingress_fence.close().await;
+            return;
         }
 
         if let Err(e) = self.runtime.future_queue_source.start().await {
@@ -549,8 +1125,8 @@ impl QueryCompositeHost {
                         let status_detail = if self.publication_recovery.is_required() {
                             format!(
                                 "Atomic output committed before in-memory publication; \
-                                 ingress is fenced and in-process restart requires A7 \
-                                 output reconciliation: {detail}"
+                                 ingress is fenced and will be reconciled from durable \
+                                 output before restart: {detail}"
                             )
                         } else {
                             format!(
@@ -876,19 +1452,20 @@ impl LiveInputStage {
                             .await
                             .map_err(index_error)?;
                         output.stage_atomic(&staging_resources, &prepared).await?;
-                        let mut slot = hook_slot.lock().map_err(|_| {
-                            IndexError::other(std::io::Error::new(
-                                std::io::ErrorKind::Other,
-                                "prepared query output slot was poisoned",
-                            ))
-                        })?;
-                        *slot = Some(prepared);
-                    }
-
-                    output.observe_output_staged().await?;
-                    if has_query_output(&results) {
-                        // Arm before the cancellable backend commit begins.
-                        output.arm_publication_recovery();
+                        let recovery_result = prepared.result.clone();
+                        {
+                            let mut slot = hook_slot.lock().map_err(|_| {
+                                IndexError::other(std::io::Error::new(
+                                    std::io::ErrorKind::Other,
+                                    "prepared query output slot was poisoned",
+                                ))
+                            })?;
+                            *slot = Some(prepared);
+                        }
+                        output.observe_output_staged().await?;
+                        output.arm_publication_recovery(recovery_result);
+                    } else {
+                        output.observe_output_staged().await?;
                     }
                     Ok(())
                 },
@@ -1084,19 +1661,20 @@ impl FutureProcessingStage {
                                 .await
                                 .map_err(index_error)?;
                             output.stage_atomic(&staging_resources, &prepared).await?;
-                            let mut slot = hook_slot.lock().map_err(|_| {
-                                IndexError::other(std::io::Error::new(
-                                    std::io::ErrorKind::Other,
-                                    "prepared due-future output slot was poisoned",
-                                ))
-                            })?;
-                            *slot = Some(prepared);
-                        }
-
-                        output.observe_output_staged().await?;
-                        if has_query_output(&due_result.results) {
-                            // Arm before the cancellable backend commit begins.
-                            output.arm_publication_recovery();
+                            let recovery_result = prepared.result.clone();
+                            {
+                                let mut slot = hook_slot.lock().map_err(|_| {
+                                    IndexError::other(std::io::Error::new(
+                                        std::io::ErrorKind::Other,
+                                        "prepared due-future output slot was poisoned",
+                                    ))
+                                })?;
+                                *slot = Some(prepared);
+                            }
+                            output.observe_output_staged().await?;
+                            output.arm_publication_recovery(recovery_result);
+                        } else {
+                            output.observe_output_staged().await?;
                         }
                         Ok(())
                     },
@@ -1191,6 +1769,76 @@ impl OutputPublicationStage {
             observer: dependencies.observer,
             publication_recovery: dependencies.publication_recovery,
         }
+    }
+
+    async fn dispatch_bootstrap_control(&self, signal: &str, source_count: Option<usize>) {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "control_signal".to_string(),
+            serde_json::Value::String(signal.to_string()),
+        );
+        if let Some(source_count) = source_count {
+            metadata.insert("source_count".to_string(), source_count.into());
+        }
+        let result = Arc::new(QueryResult::new(
+            self.query_id.clone(),
+            0,
+            chrono::Utc::now(),
+            Vec::new(),
+            metadata,
+        ));
+
+        let dispatchers = self.dispatchers.read().await;
+        for dispatcher in dispatchers.iter() {
+            if let Err(error) = dispatcher.dispatch_change(result.clone()).await {
+                debug!(
+                    "Query '{}' failed to dispatch {signal}: {error}",
+                    self.query_id
+                );
+            }
+        }
+    }
+
+    async fn reset_bootstrap_state(&self) {
+        self.output_state.write().await.reset();
+        self.output_metrics.record_live_results_count(0);
+        self.output_metrics.update_outbox(0, 0, 0);
+    }
+
+    async fn stage_bootstrap_live_results(
+        &self,
+        writer: &Arc<dyn LiveResultsWriter>,
+        results: &[QueryPartEvaluationContext],
+    ) -> std::result::Result<(), IndexError> {
+        let diffs = result_diffs_from_evaluation(results);
+        let serialized = materialize_live_result_data(&diffs).map_err(index_error)?;
+        apply_live_result_data(writer.as_ref(), &self.query_id, &serialized).await
+    }
+
+    async fn persist_bootstrap_live_results(
+        &self,
+        results: &[QueryPartEvaluationContext],
+    ) -> Result<()> {
+        let Some(writer) = &self.live_results_writer else {
+            return Ok(());
+        };
+        let diffs = result_diffs_from_evaluation(results);
+        let serialized = materialize_live_result_data(&diffs)?;
+        apply_live_result_data(writer.as_ref(), &self.query_id, &serialized)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+
+    async fn apply_bootstrap_results(&self, results: &[QueryPartEvaluationContext]) {
+        let diffs = result_diffs_from_evaluation(results);
+        if diffs.is_empty() {
+            return;
+        }
+
+        let mut state = self.output_state.write().await;
+        state.apply_diffs(&diffs);
+        self.output_metrics
+            .record_live_results_count(state.results_len());
     }
 
     async fn publish(
@@ -1298,8 +1946,8 @@ impl OutputPublicationStage {
         CommittedPublicationGuard::new(self.publication_recovery.clone(), has_output)
     }
 
-    fn arm_publication_recovery(&self) {
-        self.publication_recovery.require();
+    fn arm_publication_recovery(&self, result: Arc<QueryResult>) {
+        self.publication_recovery.require(result);
     }
 
     fn clear_publication_recovery(&self) {
@@ -1317,7 +1965,7 @@ impl OutputPublicationStage {
             result, started_at, ..
         } = prepared;
         let mut state = self.output_state.write().await;
-        let result = state.apply_committed_result(result)?;
+        let result = state.apply_committed_arc(result)?;
 
         let duration_ns = u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX);
         self.output_metrics
@@ -1352,8 +2000,171 @@ impl OutputPublicationStage {
     }
 }
 
+fn result_diffs_from_evaluation(results: &[QueryPartEvaluationContext]) -> Vec<ResultDiff> {
+    results
+        .iter()
+        .map(|context| match context {
+            QueryPartEvaluationContext::Adding {
+                after,
+                row_signature,
+            } => ResultDiff::Add {
+                data: query_variables_to_json(after),
+                row_signature: *row_signature,
+            },
+            QueryPartEvaluationContext::Removing {
+                before,
+                row_signature,
+            } => ResultDiff::Delete {
+                data: query_variables_to_json(before),
+                row_signature: *row_signature,
+            },
+            QueryPartEvaluationContext::Updating {
+                before,
+                after,
+                row_signature,
+            } => {
+                let after = query_variables_to_json(after);
+                ResultDiff::Update {
+                    data: after.clone(),
+                    before: query_variables_to_json(before),
+                    after,
+                    grouping_keys: None,
+                    row_signature: *row_signature,
+                }
+            }
+            QueryPartEvaluationContext::Aggregation {
+                before,
+                after,
+                row_signature,
+                ..
+            } => ResultDiff::Aggregation {
+                before: before.as_ref().map(query_variables_to_json),
+                after: query_variables_to_json(after),
+                row_signature: *row_signature,
+            },
+            QueryPartEvaluationContext::Noop => ResultDiff::Noop,
+        })
+        .collect()
+}
+
+pub(super) fn query_variables_to_json(
+    variables: &drasi_core::evaluation::context::QueryVariables,
+) -> serde_json::Value {
+    let values = variables
+        .iter()
+        .map(|(key, value)| (key.to_string(), variable_value_to_json(value)))
+        .collect();
+    serde_json::Value::Object(values)
+}
+
+pub(super) fn variable_value_to_json(
+    value: &drasi_core::evaluation::variable_value::VariableValue,
+) -> serde_json::Value {
+    use drasi_core::evaluation::variable_value::VariableValue;
+
+    match value {
+        VariableValue::Null => serde_json::Value::Null,
+        VariableValue::Bool(value) => serde_json::Value::Bool(*value),
+        VariableValue::Float(value) => {
+            if value.is_f64() {
+                let value = value.to_string();
+                value
+                    .parse::<f64>()
+                    .ok()
+                    .and_then(serde_json::Number::from_f64)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or_else(|| serde_json::Value::String(value))
+            } else {
+                serde_json::Value::String(value.to_string())
+            }
+        }
+        VariableValue::Integer(value) => value
+            .as_i64()
+            .map(serde_json::Number::from)
+            .or_else(|| value.as_u64().map(serde_json::Number::from))
+            .map(serde_json::Value::Number)
+            .unwrap_or_else(|| serde_json::Value::String(value.to_string())),
+        VariableValue::String(value) => serde_json::Value::String(value.clone()),
+        VariableValue::List(values) => {
+            serde_json::Value::Array(values.iter().map(variable_value_to_json).collect())
+        }
+        VariableValue::Object(values) => serde_json::Value::Object(
+            values
+                .iter()
+                .map(|(key, value)| (key.clone(), variable_value_to_json(value)))
+                .collect(),
+        ),
+        VariableValue::Date(value) => serde_json::Value::String(value.to_string()),
+        VariableValue::LocalTime(value) => serde_json::Value::String(value.to_string()),
+        VariableValue::ZonedTime(value) => serde_json::Value::String(value.to_string()),
+        VariableValue::LocalDateTime(value) => serde_json::Value::String(value.to_string()),
+        VariableValue::ZonedDateTime(value) => {
+            serde_json::Value::String(value.datetime().to_rfc3339())
+        }
+        VariableValue::Duration(value) => serde_json::Value::String(value.to_string()),
+        _ => serde_json::Value::String(format!("{value:?}")),
+    }
+}
+
+fn materialize_live_result_data(diffs: &[ResultDiff]) -> Result<Vec<(u64, Option<Vec<u8>>)>> {
+    let mut serialized = Vec::with_capacity(diffs.len());
+    for diff in diffs {
+        match diff {
+            ResultDiff::Add {
+                data,
+                row_signature,
+            } => serialized.push((
+                *row_signature,
+                Some(
+                    rmp_serde::to_vec(data)
+                        .with_context(|| format!("failed to serialize Add row {row_signature}"))?,
+                ),
+            )),
+            ResultDiff::Update {
+                after,
+                row_signature,
+                ..
+            }
+            | ResultDiff::Aggregation {
+                after,
+                row_signature,
+                ..
+            } => serialized.push((
+                *row_signature,
+                Some(
+                    rmp_serde::to_vec(after)
+                        .with_context(|| format!("failed to serialize row {row_signature}"))?,
+                ),
+            )),
+            ResultDiff::Delete { row_signature, .. } => {
+                serialized.push((*row_signature, None));
+            }
+            ResultDiff::Noop => {}
+        }
+    }
+    Ok(serialized)
+}
+
+async fn apply_live_result_data(
+    writer: &dyn LiveResultsWriter,
+    query_id: &str,
+    serialized: &[(u64, Option<Vec<u8>>)],
+) -> std::result::Result<(), IndexError> {
+    let mutations: Vec<_> = serialized
+        .iter()
+        .map(|(row_signature, data)| RowMutation {
+            row_signature: *row_signature,
+            data: data.as_deref(),
+        })
+        .collect();
+    if mutations.is_empty() {
+        return Ok(());
+    }
+    writer.apply_mutations(query_id, &mutations).await
+}
+
 struct PreparedQueryOutput {
-    result: QueryResult,
+    result: Arc<QueryResult>,
     started_at: Instant,
     outbox_data: Option<Vec<u8>>,
     live_result_data: Option<Vec<(u64, Option<Vec<u8>>)>>,
@@ -1403,7 +2214,7 @@ impl PreparedQueryOutput {
         .ok_or_else(|| anyhow::anyhow!("non-Noop query evaluation produced no change envelope"))?;
 
         Ok(Some(Self {
-            result: crate::change::query_result_from_envelope(&envelope)?,
+            result: Arc::new(crate::change::query_result_from_envelope(&envelope)?),
             started_at,
             outbox_data: None,
             live_result_data: None,
@@ -1412,48 +2223,10 @@ impl PreparedQueryOutput {
 
     fn materialize_atomic(&mut self) -> Result<()> {
         self.outbox_data = Some(
-            rmp_serde::to_vec(&self.result)
+            rmp_serde::to_vec(self.result.as_ref())
                 .context("failed to serialize prepared query result for the atomic outbox")?,
         );
-
-        let mut live_result_data = Vec::with_capacity(self.result.results.len());
-        for diff in &self.result.results {
-            match diff {
-                ResultDiff::Add {
-                    data,
-                    row_signature,
-                } => live_result_data.push((
-                    *row_signature,
-                    Some(rmp_serde::to_vec(data).with_context(|| {
-                        format!(
-                            "failed to serialize prepared Add row (sig={row_signature}) for atomic live results"
-                        )
-                    })?),
-                )),
-                ResultDiff::Update {
-                    after,
-                    row_signature,
-                    ..
-                }
-                | ResultDiff::Aggregation {
-                    after,
-                    row_signature,
-                    ..
-                } => live_result_data.push((
-                    *row_signature,
-                    Some(rmp_serde::to_vec(after).with_context(|| {
-                        format!(
-                            "failed to serialize prepared row (sig={row_signature}) for atomic live results"
-                        )
-                    })?),
-                )),
-                ResultDiff::Delete { row_signature, .. } => {
-                    live_result_data.push((*row_signature, None));
-                }
-                ResultDiff::Noop => {}
-            }
-        }
-        self.live_result_data = Some(live_result_data);
+        self.live_result_data = Some(materialize_live_result_data(&self.result.results)?);
         Ok(())
     }
 }
@@ -1493,7 +2266,7 @@ pub(super) async fn dispatch_query_results(
         let query_result = prepared.result;
 
         let mut state = output_state.write().await;
-        let result = match state.try_apply_prepared_result(query_result) {
+        let result = match state.try_apply_prepared_arc(query_result) {
             Some(result) => result,
             None => continue,
         };
@@ -1648,7 +2421,11 @@ mod tests {
 
     use async_trait::async_trait;
     use drasi_core::{
-        evaluation::functions::FunctionRegistry,
+        evaluation::{
+            functions::{Function, FunctionRegistry, ScalarFunction},
+            variable_value::VariableValue,
+            ExpressionEvaluationContext, FunctionError, FunctionEvaluationError,
+        },
         in_memory_index::{
             in_memory_checkpoint_store::InMemoryCheckpointStore,
             in_memory_future_queue::InMemoryFutureQueue,
@@ -1667,7 +2444,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        channels::{ChangeReceiver, ChannelChangeDispatcher, ControlOperation, SourceControl},
+        bootstrap::BootstrapResult,
+        channels::{
+            BootstrapEvent, ChangeReceiver, ChannelChangeDispatcher, ControlOperation,
+            SourceControl,
+        },
         config::{QueryConfig, QueryLanguage},
     };
 
@@ -1685,9 +2466,25 @@ mod tests {
         }
     }
 
+    struct FailingScalar;
+
+    #[async_trait]
+    impl ScalarFunction for FailingScalar {
+        async fn call(
+            &self,
+            _context: &ExpressionEvaluationContext,
+            expression: &drasi_query_ast::ast::FunctionExpression,
+            _args: Vec<VariableValue>,
+        ) -> std::result::Result<VariableValue, FunctionError> {
+            Err(FunctionError {
+                function_name: expression.name.to_string(),
+                error: FunctionEvaluationError::InvalidArgumentCount,
+            })
+        }
+    }
+
     struct HostFixture {
         base: QueryBase,
-        bootstrap_gate: Arc<Notify>,
         priority_queue: PriorityQueue,
         output_state: Arc<RwLock<QueryOutputState>>,
         output_rx: Box<dyn ChangeReceiver<QueryResult>>,
@@ -1708,11 +2505,40 @@ mod tests {
         Arc::new(builder.build().await)
     }
 
+    async fn build_failing_query() -> Arc<ContinuousQuery> {
+        let functions = Arc::new(FunctionRegistry::new());
+        functions.register_function("fail", Function::Scalar(Arc::new(FailingScalar)));
+        let parser = Arc::new(CypherParser::new(functions.clone()));
+        Arc::new(
+            QueryBuilder::new("MATCH (n:Person) RETURN fail() AS value", parser)
+                .with_function_registry(functions)
+                .build()
+                .await,
+        )
+    }
+
     async fn build_host(
         continuous_query: Arc<ContinuousQuery>,
         checkpoint_store: Arc<dyn CheckpointStore>,
         checkpoint_sequences: HashMap<String, u64>,
         position_handles: HashMap<String, Arc<AtomicU64>>,
+    ) -> (QueryCompositeHost, HostFixture) {
+        build_host_with_bootstrap(
+            continuous_query,
+            checkpoint_store,
+            checkpoint_sequences,
+            position_handles,
+            Vec::new(),
+        )
+        .await
+    }
+
+    async fn build_host_with_bootstrap(
+        continuous_query: Arc<ContinuousQuery>,
+        checkpoint_store: Arc<dyn CheckpointStore>,
+        checkpoint_sequences: HashMap<String, u64>,
+        position_handles: HashMap<String, Arc<AtomicU64>>,
+        bootstrap_inputs: Vec<QueryBootstrapInput>,
     ) -> (QueryCompositeHost, HostFixture) {
         let base = QueryBase::new(QueryConfig {
             id: QUERY_ID.to_string(),
@@ -1741,7 +2567,6 @@ mod tests {
             Arc::new(RwLock::new(vec![Box::new(dispatcher)]));
         let output_state = Arc::new(RwLock::new(QueryOutputState::new(16)));
         let priority_queue = PriorityQueue::new(16);
-        let bootstrap_gate = Arc::new(Notify::new());
         let future_queue_source = Arc::new(FutureQueueSource::new(
             continuous_query.future_queue(),
             QUERY_ID.to_string(),
@@ -1752,11 +2577,11 @@ mod tests {
                 "host-test".to_string(),
                 QUERY_ID.to_string(),
                 priority_queue.clone(),
-                bootstrap_gate.clone(),
                 base.status_handle(),
                 future_queue_source.clone(),
                 QueryIngressFence::new(priority_queue.clone()),
             ),
+            QueryBootstrapScope::new(bootstrap_inputs, checkpoint_store.clone(), None),
             QueryProcessingMode::legacy(),
             QueryLiveDependencies::new(
                 continuous_query,
@@ -1780,7 +2605,6 @@ mod tests {
             host,
             HostFixture {
                 base,
-                bootstrap_gate,
                 priority_queue,
                 output_state,
                 output_rx,
@@ -1857,7 +2681,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn host_gates_live_envelopes_and_terminates_through_query_base() {
+    async fn host_processes_live_envelopes_and_terminates_through_query_base() {
         let query = build_query("MATCH (n:Person) RETURN n.name AS name", None).await;
         let checkpoint_store = Arc::new(InMemoryCheckpointStore::new());
         let position_handle = Arc::new(AtomicU64::new(u64::MAX));
@@ -1884,12 +2708,6 @@ mod tests {
         );
 
         host.start(&fixture.base).await;
-        tokio::task::yield_now().await;
-        assert_eq!(fixture.base.get_status().await, ComponentStatus::Starting);
-        assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
-        assert_eq!(fixture.priority_queue.metrics().await.total_dequeued, 0);
-
-        fixture.bootstrap_gate.notify_one();
         wait_for_status(&fixture.base, ComponentStatus::Running).await;
         let result = receive_result(&mut fixture.output_rx).await;
 
@@ -1905,6 +2723,167 @@ mod tests {
         assert_eq!(fixture.priority_queue.metrics().await.total_dequeued, 1);
 
         stop_host(&fixture).await;
+    }
+
+    #[tokio::test]
+    async fn host_bootstrap_handoff_keeps_live_input_buffered_until_completion() {
+        let query = build_query("MATCH (n:Person) RETURN n.name AS name", None).await;
+        let checkpoint_store = Arc::new(InMemoryCheckpointStore::new());
+        let position_handle = Arc::new(AtomicU64::new(u64::MAX));
+        let (bootstrap_tx, bootstrap_rx) = mpsc::channel(4);
+        let (result_tx, result_rx) = oneshot::channel();
+        let (host, mut fixture) = build_host_with_bootstrap(
+            query,
+            checkpoint_store.clone(),
+            HashMap::new(),
+            HashMap::from([(SOURCE_ID.to_string(), position_handle.clone())]),
+            vec![QueryBootstrapInput::new(SOURCE_ID.to_string(), bootstrap_rx, Some(result_rx))],
+        )
+        .await;
+
+        assert!(
+            fixture
+                .priority_queue
+                .enqueue(sequenced_event(
+                    person_insert("person-live", "Live", 2_000),
+                    1,
+                    Bytes::from_static(b"live-position"),
+                ))
+                .await
+        );
+        host.start(&fixture.base).await;
+
+        let started = receive_result(&mut fixture.output_rx).await;
+        assert_eq!(started.sequence, 0);
+        assert_eq!(started.metadata["control_signal"], "bootstrapStarted");
+        bootstrap_tx
+            .send(BootstrapEvent {
+                source_id: SOURCE_ID.to_string(),
+                change: person_insert("person-bootstrap", "Bootstrap", 1_000),
+                timestamp: chrono::Utc::now(),
+                sequence: 0,
+            })
+            .await
+            .expect("send bootstrap event");
+        tokio::task::yield_now().await;
+        assert_eq!(fixture.base.get_status().await, ComponentStatus::Starting);
+        assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+        assert_eq!(fixture.priority_queue.metrics().await.total_dequeued, 0);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), fixture.output_rx.recv())
+                .await
+                .is_err(),
+            "live output must remain gated while bootstrap is open"
+        );
+
+        result_tx
+            .send(Ok(BootstrapResult {
+                event_count: 1,
+                source_position: Some(Bytes::from_static(b"bootstrap-boundary")),
+            }))
+            .expect("send bootstrap result");
+        drop(bootstrap_tx);
+
+        let completed = receive_result(&mut fixture.output_rx).await;
+        assert_eq!(completed.sequence, 0);
+        assert_eq!(completed.metadata["control_signal"], "bootstrapCompleted");
+        wait_for_status(&fixture.base, ComponentStatus::Running).await;
+        let live = receive_result(&mut fixture.output_rx).await;
+        assert_eq!(live.sequence, 1);
+        assert_eq!(fixture.output_state.read().await.results_len(), 2);
+        assert_eq!(
+            checkpoint_store
+                .read_checkpoint(SOURCE_ID)
+                .await
+                .expect("read live checkpoint"),
+            Some(SourceCheckpoint::new(
+                1,
+                Some(Bytes::from_static(b"live-position"))
+            ))
+        );
+        assert_eq!(position_handle.load(Ordering::Acquire), 1);
+
+        stop_host(&fixture).await;
+    }
+
+    #[tokio::test]
+    async fn bootstrap_evaluation_failure_fences_without_completion_and_can_rebootstrap() {
+        let checkpoint_store = Arc::new(InMemoryCheckpointStore::new());
+        let (bootstrap_tx, bootstrap_rx) = mpsc::channel(2);
+        let (result_tx, result_rx) = oneshot::channel();
+        let (host, mut failed_fixture) = build_host_with_bootstrap(
+            build_failing_query().await,
+            checkpoint_store.clone(),
+            HashMap::new(),
+            HashMap::new(),
+            vec![QueryBootstrapInput::new(SOURCE_ID.to_string(), bootstrap_rx, Some(result_rx))],
+        )
+        .await;
+        host.start(&failed_fixture.base).await;
+        let started = receive_result(&mut failed_fixture.output_rx).await;
+        assert_eq!(started.metadata["control_signal"], "bootstrapStarted");
+
+        bootstrap_tx
+            .send(BootstrapEvent {
+                source_id: SOURCE_ID.to_string(),
+                change: person_insert("person-fails", "Failure", 1_000),
+                timestamp: chrono::Utc::now(),
+                sequence: 0,
+            })
+            .await
+            .expect("send failing bootstrap event");
+        drop(bootstrap_tx);
+        let _ = result_tx.send(Ok(BootstrapResult::default()));
+        wait_for_status(&failed_fixture.base, ComponentStatus::Error).await;
+        assert_eq!(failed_fixture.output_state.read().await.results_len(), 0);
+        assert!(
+            checkpoint_store
+                .read_checkpoint(SOURCE_ID)
+                .await
+                .expect("read failed-bootstrap checkpoint")
+                .is_none(),
+            "a failed bootstrap must not publish its handoff checkpoint"
+        );
+        if let Ok(Ok(result)) =
+            tokio::time::timeout(Duration::from_millis(50), failed_fixture.output_rx.recv()).await
+        {
+            assert_ne!(
+                result.metadata["control_signal"], "bootstrapCompleted",
+                "a failed bootstrap must not emit bootstrapCompleted"
+            );
+        }
+        stop_host(&failed_fixture).await;
+
+        let (retry_tx, retry_rx) = mpsc::channel(2);
+        let (retry_result_tx, retry_result_rx) = oneshot::channel();
+        let (retry_host, mut retry_fixture) = build_host_with_bootstrap(
+            build_query("MATCH (n:Person) RETURN n.name AS name", None).await,
+            checkpoint_store.clone(),
+            HashMap::new(),
+            HashMap::new(),
+            vec![QueryBootstrapInput::new(SOURCE_ID.to_string(), retry_rx, Some(retry_result_rx))],
+        )
+        .await;
+        retry_host.start(&retry_fixture.base).await;
+        let _ = receive_result(&mut retry_fixture.output_rx).await;
+        retry_tx
+            .send(BootstrapEvent {
+                source_id: SOURCE_ID.to_string(),
+                change: person_insert("person-retry", "Recovered", 2_000),
+                timestamp: chrono::Utc::now(),
+                sequence: 0,
+            })
+            .await
+            .expect("send retry bootstrap event");
+        retry_result_tx
+            .send(Ok(BootstrapResult::default()))
+            .expect("send retry bootstrap result");
+        drop(retry_tx);
+        let completed = receive_result(&mut retry_fixture.output_rx).await;
+        assert_eq!(completed.metadata["control_signal"], "bootstrapCompleted");
+        wait_for_status(&retry_fixture.base, ComponentStatus::Running).await;
+        assert_eq!(retry_fixture.output_state.read().await.results_len(), 1);
+        stop_host(&retry_fixture).await;
     }
 
     #[tokio::test]
@@ -1943,7 +2922,6 @@ mod tests {
         let (host, mut fixture) =
             build_host(query, checkpoint_store, HashMap::new(), HashMap::new()).await;
         host.start(&fixture.base).await;
-        fixture.bootstrap_gate.notify_one();
         wait_for_status(&fixture.base, ComponentStatus::Running).await;
 
         let now = chrono::Utc::now();
@@ -2070,7 +3048,6 @@ mod tests {
         )
         .await;
         host.start(&fixture.base).await;
-        fixture.bootstrap_gate.notify_one();
         wait_for_status(&fixture.base, ComponentStatus::Running).await;
 
         let source_position = Bytes::from_static(b"retry-position");
@@ -2180,7 +3157,6 @@ mod tests {
         let (host, mut fixture) =
             build_host(query, checkpoint_store, HashMap::new(), HashMap::new()).await;
         host.start(&fixture.base).await;
-        fixture.bootstrap_gate.notify_one();
         wait_for_status(&fixture.base, ComponentStatus::Running).await;
 
         assert!(
@@ -2229,7 +3205,6 @@ mod tests {
 
         fixture.future_queue_source.start().await.unwrap();
         host.start(&fixture.base).await;
-        fixture.bootstrap_gate.notify_one();
         wait_for_status(&fixture.base, ComponentStatus::Error).await;
 
         fixture.future_queue_source.stop().await;

--- a/lib/src/queries/query_composite_host/atomic_tests.rs
+++ b/lib/src/queries/query_composite_host/atomic_tests.rs
@@ -16,7 +16,7 @@ use std::{
     collections::{HashMap, HashSet},
     path::Path,
     sync::{
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     time::Duration,
@@ -75,6 +75,8 @@ enum BackendFault {
     OutboxStage,
     LiveResultsStage,
     ResultSequenceWrite,
+    LegacyMarkerStage,
+    LegacyMarkerClear,
 }
 
 struct FailingCommitSessionControl {
@@ -167,6 +169,12 @@ struct FailingSecondCheckpointStore {
 
 struct FailingResultSequenceCheckpointStore {
     inner: Arc<dyn CheckpointStore>,
+}
+
+struct FailingLegacyMarkerCheckpointStore {
+    inner: Arc<dyn CheckpointStore>,
+    fail_clear: bool,
+    failed: AtomicBool,
 }
 
 #[async_trait]
@@ -288,6 +296,77 @@ impl CheckpointStore for FailingResultSequenceCheckpointStore {
         Err(IndexError::other(std::io::Error::other(
             "injected Legacy result-sequence write failure",
         )))
+    }
+
+    async fn read_result_sequence(
+        &self,
+        query_id: &str,
+    ) -> std::result::Result<Option<u64>, IndexError> {
+        self.inner.read_result_sequence(query_id).await
+    }
+}
+
+#[async_trait]
+impl CheckpointStore for FailingLegacyMarkerCheckpointStore {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        self.inner.transaction_domain()
+    }
+
+    fn is_persistent(&self) -> bool {
+        self.inner.is_persistent()
+    }
+
+    async fn stage_checkpoint(
+        &self,
+        source_id: &str,
+        sequence: u64,
+        source_position: Option<&Bytes>,
+    ) -> std::result::Result<(), IndexError> {
+        let target_sequence = if self.fail_clear { 0 } else { 1 };
+        if source_id == LEGACY_OUTPUT_PENDING_MARKER_V1
+            && sequence == target_sequence
+            && !self.failed.swap(true, Ordering::AcqRel)
+        {
+            return Err(IndexError::other(std::io::Error::other(
+                "injected Legacy marker failure",
+            )));
+        }
+        self.inner
+            .stage_checkpoint(source_id, sequence, source_position)
+            .await
+    }
+
+    async fn read_checkpoint(
+        &self,
+        source_id: &str,
+    ) -> std::result::Result<Option<SourceCheckpoint>, IndexError> {
+        self.inner.read_checkpoint(source_id).await
+    }
+
+    async fn read_all_checkpoints(
+        &self,
+    ) -> std::result::Result<HashMap<String, SourceCheckpoint>, IndexError> {
+        self.inner.read_all_checkpoints().await
+    }
+
+    async fn clear_checkpoints(&self) -> std::result::Result<(), IndexError> {
+        self.inner.clear_checkpoints().await
+    }
+
+    async fn write_config_hash(&self, hash: u64) -> std::result::Result<(), IndexError> {
+        self.inner.write_config_hash(hash).await
+    }
+
+    async fn read_config_hash(&self) -> std::result::Result<Option<u64>, IndexError> {
+        self.inner.read_config_hash().await
+    }
+
+    async fn write_result_sequence(
+        &self,
+        query_id: &str,
+        sequence: u64,
+    ) -> std::result::Result<(), IndexError> {
+        self.inner.write_result_sequence(query_id, sequence).await
     }
 
     async fn read_result_sequence(
@@ -499,10 +578,34 @@ async fn build_host_with_bootstrap(
             created.checkpoint_store =
                 Some(Arc::new(FailingResultSequenceCheckpointStore { inner }));
         }
+        BackendFault::LegacyMarkerStage => {
+            let inner = created
+                .checkpoint_store
+                .as_ref()
+                .expect("RocksDB checkpoint store")
+                .clone();
+            created.checkpoint_store = Some(Arc::new(FailingLegacyMarkerCheckpointStore {
+                inner,
+                fail_clear: false,
+                failed: AtomicBool::new(false),
+            }));
+        }
+        BackendFault::LegacyMarkerClear => {
+            let inner = created
+                .checkpoint_store
+                .as_ref()
+                .expect("RocksDB checkpoint store")
+                .clone();
+            created.checkpoint_store = Some(Arc::new(FailingLegacyMarkerCheckpointStore {
+                inner,
+                fail_clear: true,
+                failed: AtomicBool::new(false),
+            }));
+        }
     }
 
     let mode = if force_legacy {
-        QueryProcessingMode::legacy()
+        QueryProcessingMode::legacy_from_created_indexes(&created)
     } else {
         QueryProcessingMode::from_created_indexes(&created)
     };
@@ -1985,6 +2088,102 @@ async fn due_future_stage_failure_retains_future_and_publishes_nothing() {
 }
 
 #[tokio::test]
+async fn legacy_due_future_marker_stage_failure_rolls_back_pop() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (host, fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) WHERE drasi.trueLater(true, 2000) RETURN n.name AS name",
+        BackendFault::LegacyMarkerStage,
+        true,
+        None,
+    )
+    .await;
+    seed_due_future(&fixture).await;
+    start_host(host, &fixture).await;
+    enqueue_futures_due(&fixture).await;
+    wait_for_status(&fixture.base, ComponentStatus::Error).await;
+
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek future after marker failure"),
+        Some(2_000),
+        "marker stage failure must roll back the due-future pop"
+    );
+    assert!(fixture
+        .checkpoint_store
+        .read_checkpoint(LEGACY_OUTPUT_PENDING_MARKER_V1)
+        .await
+        .expect("read failed due marker")
+        .is_none());
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn legacy_due_future_success_clears_pending_marker_after_output() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (host, mut fixture) = build_host(
+        temp_dir.path(),
+        "MATCH (n:Person) WHERE drasi.trueLater(true, 2000) RETURN n.name AS name",
+        BackendFault::None,
+        true,
+        None,
+    )
+    .await;
+    seed_due_future(&fixture).await;
+    start_host(host, &fixture).await;
+    enqueue_futures_due(&fixture).await;
+    let result = receive_result(&mut fixture.output_rx).await;
+
+    assert_eq!(result.sequence, 1);
+    assert_eq!(
+        fixture
+            .future_queue
+            .peek_due_time()
+            .await
+            .expect("peek committed Legacy future"),
+        None
+    );
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if fixture
+                .checkpoint_store
+                .read_checkpoint(LEGACY_OUTPUT_PENDING_MARKER_V1)
+                .await
+                .expect("read cleared Legacy due marker")
+                .is_some_and(|marker| marker.sequence == 0)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("Legacy due marker should clear");
+    assert_eq!(
+        read_legacy_pending_state(fixture.checkpoint_store.as_ref())
+            .await
+            .expect("read logical Legacy due marker"),
+        LegacyPendingState::Absent
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read Legacy due sequence"),
+        Some(1)
+    );
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
 async fn due_future_post_commit_failure_requires_output_reconciliation() {
     let temp_dir = tempfile::TempDir::new().expect("create temp directory");
     let (host, fixture) = build_host(
@@ -2059,7 +2258,13 @@ async fn explicit_legacy_mode_preserves_a1_ordering_and_skips_atomic_observers()
 
     assert_eq!(dispatched.sequence, 1);
     assert_eq!(fixture.base.get_status().await, ComponentStatus::Running);
-    assert_eq!(fixture.position_handle.load(Ordering::Acquire), 19);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while fixture.position_handle.load(Ordering::Acquire) != 19 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("Legacy source acknowledgement should follow marker clear");
     assert!(element_exists(&fixture, "person-legacy").await);
     assert_eq!(
         fixture
@@ -2176,14 +2381,12 @@ async fn persistent_legacy_output_failures_fence_immediately_and_strict_restart_
             16,
             Arc::new(QueryOutputMetrics::new()),
         );
-        let error = QueryCompositeHost::reconcile_output_state(
-            &QueryProcessingMode::legacy(),
-            &dependencies,
-        )
-        .await
-        .expect_err("Strict restart must reject partial Legacy output");
+        let error = QueryCompositeHost::reconcile_output_state(&fixture.mode, &dependencies)
+            .await
+            .expect_err("Strict restart must reject partial Legacy output");
         assert!(
-            format!("{error:#}").contains(expected_stage)
+            format!("{error:#}").contains("pending")
+                || format!("{error:#}").contains(expected_stage)
                 || format!("{error:#}").contains("durable output is inconsistent"),
             "{name}: unexpected reconciliation error: {error:#}"
         );

--- a/lib/src/queries/query_composite_host/atomic_tests.rs
+++ b/lib/src/queries/query_composite_host/atomic_tests.rs
@@ -74,6 +74,7 @@ enum BackendFault {
     CheckpointStageAfterOne,
     OutboxStage,
     LiveResultsStage,
+    ResultSequenceWrite,
 }
 
 struct FailingCommitSessionControl {
@@ -164,6 +165,10 @@ struct FailingSecondCheckpointStore {
     stage_calls: AtomicUsize,
 }
 
+struct FailingResultSequenceCheckpointStore {
+    inner: Arc<dyn CheckpointStore>,
+}
+
 #[async_trait]
 impl CheckpointStore for FailingSecondCheckpointStore {
     fn transaction_domain(&self) -> Option<TransactionDomain> {
@@ -219,6 +224,70 @@ impl CheckpointStore for FailingSecondCheckpointStore {
         sequence: u64,
     ) -> std::result::Result<(), IndexError> {
         self.inner.write_result_sequence(query_id, sequence).await
+    }
+
+    async fn read_result_sequence(
+        &self,
+        query_id: &str,
+    ) -> std::result::Result<Option<u64>, IndexError> {
+        self.inner.read_result_sequence(query_id).await
+    }
+}
+
+#[async_trait]
+impl CheckpointStore for FailingResultSequenceCheckpointStore {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        self.inner.transaction_domain()
+    }
+
+    fn is_persistent(&self) -> bool {
+        self.inner.is_persistent()
+    }
+
+    async fn stage_checkpoint(
+        &self,
+        source_id: &str,
+        sequence: u64,
+        source_position: Option<&Bytes>,
+    ) -> std::result::Result<(), IndexError> {
+        self.inner
+            .stage_checkpoint(source_id, sequence, source_position)
+            .await
+    }
+
+    async fn read_checkpoint(
+        &self,
+        source_id: &str,
+    ) -> std::result::Result<Option<SourceCheckpoint>, IndexError> {
+        self.inner.read_checkpoint(source_id).await
+    }
+
+    async fn read_all_checkpoints(
+        &self,
+    ) -> std::result::Result<HashMap<String, SourceCheckpoint>, IndexError> {
+        self.inner.read_all_checkpoints().await
+    }
+
+    async fn clear_checkpoints(&self) -> std::result::Result<(), IndexError> {
+        self.inner.clear_checkpoints().await
+    }
+
+    async fn write_config_hash(&self, hash: u64) -> std::result::Result<(), IndexError> {
+        self.inner.write_config_hash(hash).await
+    }
+
+    async fn read_config_hash(&self) -> std::result::Result<Option<u64>, IndexError> {
+        self.inner.read_config_hash().await
+    }
+
+    async fn write_result_sequence(
+        &self,
+        _query_id: &str,
+        _sequence: u64,
+    ) -> std::result::Result<(), IndexError> {
+        Err(IndexError::other(std::io::Error::other(
+            "injected Legacy result-sequence write failure",
+        )))
     }
 
     async fn read_result_sequence(
@@ -420,6 +489,15 @@ async fn build_host_with_bootstrap(
                 .expect("RocksDB live-results writer")
                 .clone();
             created.live_results_writer = Some(Arc::new(FailingLiveResultsWriter { inner }));
+        }
+        BackendFault::ResultSequenceWrite => {
+            let inner = created
+                .checkpoint_store
+                .as_ref()
+                .expect("RocksDB checkpoint store")
+                .clone();
+            created.checkpoint_store =
+                Some(Arc::new(FailingResultSequenceCheckpointStore { inner }));
         }
     }
 
@@ -1956,13 +2034,13 @@ async fn due_future_post_commit_failure_requires_output_reconciliation() {
 }
 
 #[tokio::test]
-async fn explicit_legacy_mode_keeps_a1_loss_window_and_skips_atomic_observers() {
+async fn explicit_legacy_mode_preserves_a1_ordering_and_skips_atomic_observers() {
     let temp_dir = tempfile::TempDir::new().expect("create temp directory");
     let observer = Arc::new(CountingObserver::default());
     let (host, mut fixture) = build_host(
         temp_dir.path(),
         "MATCH (n:Person) RETURN n.name AS name",
-        BackendFault::OutboxStage,
+        BackendFault::None,
         true,
         Some(observer.clone()),
     )
@@ -1993,25 +2071,125 @@ async fn explicit_legacy_mode_keeps_a1_loss_window_and_skips_atomic_observers() 
             .sequence,
         19
     );
-    assert!(fixture
-        .outbox_writer
-        .read_from(QUERY_ID, 0)
-        .await
-        .expect("read failed legacy outbox")
-        .is_empty());
+    assert_eq!(
+        fixture
+            .outbox_writer
+            .read_from(QUERY_ID, 0)
+            .await
+            .expect("read legacy outbox")
+            .len(),
+        1
+    );
     assert_eq!(
         fixture
             .checkpoint_store
             .read_result_sequence(QUERY_ID)
             .await
             .expect("read legacy result sequence"),
-        None
+        Some(1)
     );
     assert_eq!(observer.staged.load(Ordering::Acquire), 0);
     assert_eq!(observer.committed.load(Ordering::Acquire), 0);
     assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 1);
 
     stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn persistent_legacy_output_failures_fence_immediately_and_strict_restart_rejects() {
+    for (name, fault, expected_stage) in [
+        ("outbox", BackendFault::OutboxStage, "outbox"),
+        (
+            "live-results",
+            BackendFault::LiveResultsStage,
+            "live-result",
+        ),
+        (
+            "result-sequence",
+            BackendFault::ResultSequenceWrite,
+            "result sequence",
+        ),
+    ] {
+        let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+        let (host, fixture) = build_host(
+            temp_dir.path(),
+            "MATCH (n:Person) RETURN n.name AS name",
+            fault,
+            true,
+            None,
+        )
+        .await;
+        start_host(host, &fixture).await;
+
+        enqueue_source_change(
+            &fixture,
+            &format!("legacy-{name}-first"),
+            "First",
+            1,
+            Bytes::from(format!("legacy-{name}-position-1")),
+        )
+        .await;
+        enqueue_source_change(
+            &fixture,
+            &format!("legacy-{name}-later"),
+            "Later",
+            2,
+            Bytes::from(format!("legacy-{name}-position-2")),
+        )
+        .await;
+        wait_for_status(&fixture.base, ComponentStatus::Error).await;
+
+        assert_eq!(
+            fixture
+                .checkpoint_store
+                .read_checkpoint(SOURCE_ID)
+                .await
+                .expect("read Legacy checkpoint")
+                .expect("causative Legacy checkpoint")
+                .sequence,
+            1,
+            "{name}: later source sequence advanced after the persistence failure"
+        );
+        assert_eq!(
+            fixture.position_handle.load(Ordering::Acquire),
+            u64::MAX,
+            "{name}: failed Legacy output was acknowledged"
+        );
+        assert_eq!(
+            fixture.dispatch_count.load(Ordering::Acquire),
+            0,
+            "{name}: failed Legacy output was dispatched"
+        );
+        assert!(
+            fixture.publication_recovery.is_required(),
+            "{name}: persistent Legacy failure did not arm recovery"
+        );
+
+        let fresh_state = Arc::new(RwLock::new(QueryOutputState::new(16)));
+        let dependencies = QueryOutputDependencies::new(
+            QUERY_ID.to_string(),
+            fresh_state,
+            Arc::new(RwLock::new(Vec::new())),
+            Some(fixture.outbox_writer.clone()),
+            Some(fixture.live_results_writer.clone()),
+            Some(fixture.checkpoint_store.clone()),
+            16,
+            Arc::new(QueryOutputMetrics::new()),
+        );
+        let error = QueryCompositeHost::reconcile_output_state(
+            &QueryProcessingMode::legacy(),
+            &dependencies,
+        )
+        .await
+        .expect_err("Strict restart must reject partial Legacy output");
+        assert!(
+            format!("{error:#}").contains(expected_stage)
+                || format!("{error:#}").contains("durable output is inconsistent"),
+            "{name}: unexpected reconciliation error: {error:#}"
+        );
+
+        stop_host(&fixture).await;
+    }
 }
 
 #[tokio::test]

--- a/lib/src/queries/query_composite_host/atomic_tests.rs
+++ b/lib/src/queries/query_composite_host/atomic_tests.rs
@@ -43,11 +43,12 @@ use drasi_index_rocksdb::RocksDbIndexProvider;
 use drasi_query_ast::api::QueryConfiguration;
 use drasi_query_cypher::CypherParser;
 use serde_json::json;
-use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex, Notify, RwLock};
+use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex, RwLock};
 
 use super::*;
 use crate::{
-    channels::ChangeReceiver,
+    bootstrap::BootstrapResult,
+    channels::{BootstrapEvent, ChangeReceiver},
     config::{QueryConfig, QueryLanguage},
 };
 
@@ -70,6 +71,7 @@ enum BackendFault {
     None,
     Commit,
     CommitThenBlock(Arc<CommitBlock>),
+    CheckpointStageAfterOne,
     OutboxStage,
     LiveResultsStage,
 }
@@ -155,6 +157,76 @@ struct FailingOutboxWriter {
 
 struct FailingLiveResultsWriter {
     inner: Arc<dyn LiveResultsWriter>,
+}
+
+struct FailingSecondCheckpointStore {
+    inner: Arc<dyn CheckpointStore>,
+    stage_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl CheckpointStore for FailingSecondCheckpointStore {
+    fn transaction_domain(&self) -> Option<TransactionDomain> {
+        self.inner.transaction_domain()
+    }
+
+    fn is_persistent(&self) -> bool {
+        self.inner.is_persistent()
+    }
+
+    async fn stage_checkpoint(
+        &self,
+        source_id: &str,
+        sequence: u64,
+        source_position: Option<&Bytes>,
+    ) -> std::result::Result<(), IndexError> {
+        if self.stage_calls.fetch_add(1, Ordering::AcqRel) == 1 {
+            return Err(IndexError::CorruptedData);
+        }
+        self.inner
+            .stage_checkpoint(source_id, sequence, source_position)
+            .await
+    }
+
+    async fn read_checkpoint(
+        &self,
+        source_id: &str,
+    ) -> std::result::Result<Option<SourceCheckpoint>, IndexError> {
+        self.inner.read_checkpoint(source_id).await
+    }
+
+    async fn read_all_checkpoints(
+        &self,
+    ) -> std::result::Result<HashMap<String, SourceCheckpoint>, IndexError> {
+        self.inner.read_all_checkpoints().await
+    }
+
+    async fn clear_checkpoints(&self) -> std::result::Result<(), IndexError> {
+        self.inner.clear_checkpoints().await
+    }
+
+    async fn write_config_hash(&self, hash: u64) -> std::result::Result<(), IndexError> {
+        self.inner.write_config_hash(hash).await
+    }
+
+    async fn read_config_hash(&self) -> std::result::Result<Option<u64>, IndexError> {
+        self.inner.read_config_hash().await
+    }
+
+    async fn write_result_sequence(
+        &self,
+        query_id: &str,
+        sequence: u64,
+    ) -> std::result::Result<(), IndexError> {
+        self.inner.write_result_sequence(query_id, sequence).await
+    }
+
+    async fn read_result_sequence(
+        &self,
+        query_id: &str,
+    ) -> std::result::Result<Option<u64>, IndexError> {
+        self.inner.read_result_sequence(query_id).await
+    }
 }
 
 #[async_trait]
@@ -257,9 +329,9 @@ impl ChangeDispatcher<QueryResult> for RecordingDispatcher {
 
 struct AtomicHostFixture {
     base: QueryBase,
-    bootstrap_gate: Arc<Notify>,
     priority_queue: PriorityQueue,
     output_state: Arc<RwLock<QueryOutputState>>,
+    dispatchers: Arc<RwLock<Vec<Box<dyn ChangeDispatcher<QueryResult> + Send + Sync>>>>,
     output_rx: mpsc::UnboundedReceiver<Arc<QueryResult>>,
     dispatch_count: Arc<AtomicUsize>,
     future_queue_source: Arc<FutureQueueSource>,
@@ -272,6 +344,7 @@ struct AtomicHostFixture {
     continuous_query: Arc<ContinuousQuery>,
     position_handle: Arc<AtomicU64>,
     publication_recovery: AtomicPublicationRecovery,
+    mode: QueryProcessingMode,
 }
 
 async fn build_host(
@@ -280,6 +353,17 @@ async fn build_host(
     fault: BackendFault,
     force_legacy: bool,
     observer: Option<Arc<dyn QueryProcessingObserver>>,
+) -> (QueryCompositeHost, AtomicHostFixture) {
+    build_host_with_bootstrap(path, query_text, fault, force_legacy, observer, Vec::new()).await
+}
+
+async fn build_host_with_bootstrap(
+    path: &Path,
+    query_text: &str,
+    fault: BackendFault,
+    force_legacy: bool,
+    observer: Option<Arc<dyn QueryProcessingObserver>>,
+    bootstrap_inputs: Vec<QueryBootstrapInput>,
 ) -> (QueryCompositeHost, AtomicHostFixture) {
     let provider = RocksDbIndexProvider::new(path, true, false);
     let mut created = provider
@@ -309,6 +393,17 @@ async fn build_host(
                 transaction_domain,
                 block,
             });
+        }
+        BackendFault::CheckpointStageAfterOne => {
+            let inner = created
+                .checkpoint_store
+                .as_ref()
+                .expect("RocksDB checkpoint store")
+                .clone();
+            created.checkpoint_store = Some(Arc::new(FailingSecondCheckpointStore {
+                inner,
+                stage_calls: AtomicUsize::new(0),
+            }));
         }
         BackendFault::OutboxStage => {
             let inner = created
@@ -401,7 +496,6 @@ async fn build_host(
         })]));
     let output_state = Arc::new(RwLock::new(QueryOutputState::new(16)));
     let priority_queue = PriorityQueue::new(16);
-    let bootstrap_gate = Arc::new(Notify::new());
     let future_queue_source = Arc::new(FutureQueueSource::new(
         continuous_query.future_queue(),
         QUERY_ID.to_string(),
@@ -414,7 +508,7 @@ async fn build_host(
     let output_dependencies = QueryOutputDependencies::new(
         QUERY_ID.to_string(),
         output_state.clone(),
-        dispatchers,
+        dispatchers.clone(),
         Some(outbox_writer.clone()),
         Some(live_results_writer.clone()),
         Some(checkpoint_store.clone()),
@@ -432,12 +526,16 @@ async fn build_host(
             "atomic-host-test".to_string(),
             QUERY_ID.to_string(),
             priority_queue.clone(),
-            bootstrap_gate.clone(),
             base.status_handle(),
             future_queue_source.clone(),
             ingress_fence,
         ),
-        mode,
+        QueryBootstrapScope::new(
+            bootstrap_inputs,
+            checkpoint_store.clone(),
+            Some(session_control.clone()),
+        ),
+        mode.clone(),
         QueryLiveDependencies::new(
             continuous_query.clone(),
             checkpoint_store.clone(),
@@ -451,9 +549,9 @@ async fn build_host(
         host,
         AtomicHostFixture {
             base,
-            bootstrap_gate,
             priority_queue,
             output_state,
+            dispatchers,
             output_rx,
             dispatch_count,
             future_queue_source,
@@ -466,6 +564,7 @@ async fn build_host(
             continuous_query,
             position_handle,
             publication_recovery,
+            mode,
         },
     )
 }
@@ -511,7 +610,6 @@ fn sequenced_event(
 
 async fn start_host(host: QueryCompositeHost, fixture: &AtomicHostFixture) {
     host.start(&fixture.base).await;
-    fixture.bootstrap_gate.notify_one();
     wait_for_status(&fixture.base, ComponentStatus::Running).await;
 }
 
@@ -612,6 +710,245 @@ async fn assert_no_durable_output(fixture: &AtomicHostFixture) {
             .expect("read result sequence"),
         None
     );
+}
+
+#[tokio::test]
+async fn rocksdb_multi_source_bootstrap_commits_live_rows_and_handoff_before_running() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (source_a_tx, source_a_rx) = mpsc::channel(4);
+    let (source_b_tx, source_b_rx) = mpsc::channel(4);
+    let (result_a_tx, result_a_rx) = oneshot::channel();
+    let (result_b_tx, result_b_rx) = oneshot::channel();
+    let (host, mut fixture) = build_host_with_bootstrap(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::None,
+        false,
+        None,
+        vec![
+            QueryBootstrapInput::new(SOURCE_ID.to_string(), source_a_rx, Some(result_a_rx)),
+            QueryBootstrapInput::new(
+                "atomic-host-source-b".to_string(),
+                source_b_rx,
+                Some(result_b_rx),
+            ),
+        ],
+    )
+    .await;
+    host.start(&fixture.base).await;
+    let started = receive_result(&mut fixture.output_rx).await;
+    assert_eq!(started.metadata["control_signal"], "bootstrapStarted");
+    assert_eq!(
+        QueryBootstrapScope::read_recovery_state(fixture.checkpoint_store.as_ref())
+            .await
+            .expect("read in-progress marker"),
+        QueryBootstrapRecoveryState::InProgress
+    );
+
+    source_a_tx
+        .send(BootstrapEvent {
+            source_id: SOURCE_ID.to_string(),
+            change: person_change("bootstrap-a", "Ada", 1_000),
+            timestamp: chrono::Utc::now(),
+            sequence: 0,
+        })
+        .await
+        .expect("send source A bootstrap event");
+    source_b_tx
+        .send(BootstrapEvent {
+            source_id: "atomic-host-source-b".to_string(),
+            change: person_change("bootstrap-b", "Grace", 2_000),
+            timestamp: chrono::Utc::now(),
+            sequence: 0,
+        })
+        .await
+        .expect("send source B bootstrap event");
+    result_a_tx
+        .send(Ok(BootstrapResult {
+            event_count: 1,
+            source_position: Some(Bytes::from_static(b"boundary-a")),
+        }))
+        .expect("send source A bootstrap result");
+    result_b_tx
+        .send(Ok(BootstrapResult {
+            event_count: 1,
+            source_position: Some(Bytes::from_static(b"boundary-b")),
+        }))
+        .expect("send source B bootstrap result");
+    drop(source_a_tx);
+    drop(source_b_tx);
+
+    let completed = receive_result(&mut fixture.output_rx).await;
+    assert_eq!(completed.metadata["control_signal"], "bootstrapCompleted");
+    wait_for_status(&fixture.base, ComponentStatus::Running).await;
+    assert_eq!(
+        QueryBootstrapScope::read_recovery_state(fixture.checkpoint_store.as_ref())
+            .await
+            .expect("read completed marker"),
+        QueryBootstrapRecoveryState::Complete
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint(SOURCE_ID)
+            .await
+            .expect("read source A checkpoint"),
+        Some(SourceCheckpoint::new(
+            0,
+            Some(Bytes::from_static(b"boundary-a"))
+        ))
+    );
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_checkpoint("atomic-host-source-b")
+            .await
+            .expect("read source B checkpoint"),
+        Some(SourceCheckpoint::new(
+            0,
+            Some(Bytes::from_static(b"boundary-b"))
+        ))
+    );
+    assert_eq!(
+        fixture
+            .live_results_writer
+            .read_snapshot(QUERY_ID)
+            .await
+            .expect("read bootstrap live rows")
+            .len(),
+        2
+    );
+    assert!(fixture
+        .outbox_writer
+        .read_from(QUERY_ID, 0)
+        .await
+        .expect("read bootstrap outbox")
+        .is_empty());
+    assert_eq!(
+        fixture
+            .checkpoint_store
+            .read_result_sequence(QUERY_ID)
+            .await
+            .expect("read bootstrap output sequence"),
+        None
+    );
+    assert_eq!(fixture.output_state.read().await.results_len(), 2);
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 0);
+    let fresh_state = Arc::new(RwLock::new(QueryOutputState::new(16)));
+    let dependencies = QueryOutputDependencies::new(
+        QUERY_ID.to_string(),
+        fresh_state.clone(),
+        Arc::new(RwLock::new(Vec::new())),
+        Some(fixture.outbox_writer.clone()),
+        Some(fixture.live_results_writer.clone()),
+        Some(fixture.checkpoint_store.clone()),
+        16,
+        Arc::new(QueryOutputMetrics::new()),
+    );
+    QueryCompositeHost::reconcile_output_state(&fixture.mode, &dependencies)
+        .await
+        .expect("hydrate the sequence-0 bootstrap snapshot");
+    assert_eq!(fresh_state.read().await.as_of_sequence(), 0);
+    assert_eq!(fresh_state.read().await.results_len(), 2);
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn atomic_bootstrap_persistence_failure_rolls_back_and_keeps_handoff_closed() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (bootstrap_tx, bootstrap_rx) = mpsc::channel(2);
+    let (result_tx, result_rx) = oneshot::channel();
+    let (host, mut fixture) = build_host_with_bootstrap(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::LiveResultsStage,
+        false,
+        None,
+        vec![QueryBootstrapInput::new(SOURCE_ID.to_string(), bootstrap_rx, Some(result_rx))],
+    )
+    .await;
+    host.start(&fixture.base).await;
+    let started = receive_result(&mut fixture.output_rx).await;
+    assert_eq!(started.metadata["control_signal"], "bootstrapStarted");
+    bootstrap_tx
+        .send(BootstrapEvent {
+            source_id: SOURCE_ID.to_string(),
+            change: person_change("bootstrap-rollback", "Rollback", 1_000),
+            timestamp: chrono::Utc::now(),
+            sequence: 0,
+        })
+        .await
+        .expect("send failing bootstrap event");
+    result_tx
+        .send(Ok(BootstrapResult::default()))
+        .expect("send bootstrap result");
+    drop(bootstrap_tx);
+
+    wait_for_status(&fixture.base, ComponentStatus::Error).await;
+    assert!(!element_exists(&fixture, "bootstrap-rollback").await);
+    assert_no_durable_output(&fixture).await;
+    assert_eq!(fixture.output_state.read().await.results_len(), 0);
+    assert_eq!(
+        QueryBootstrapScope::read_recovery_state(fixture.checkpoint_store.as_ref())
+            .await
+            .expect("read failed bootstrap marker"),
+        QueryBootstrapRecoveryState::InProgress
+    );
+    if let Ok(Some(result)) =
+        tokio::time::timeout(Duration::from_millis(50), fixture.output_rx.recv()).await
+    {
+        assert_ne!(result.metadata["control_signal"], "bootstrapCompleted");
+    }
+
+    stop_host(&fixture).await;
+}
+
+#[tokio::test]
+async fn atomic_bootstrap_checkpoint_failure_does_not_complete_handoff() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let (bootstrap_tx, bootstrap_rx) = mpsc::channel(1);
+    let (result_tx, result_rx) = oneshot::channel();
+    let (host, mut fixture) = build_host_with_bootstrap(
+        temp_dir.path(),
+        "MATCH (n:Person) RETURN n.name AS name",
+        BackendFault::CheckpointStageAfterOne,
+        false,
+        None,
+        vec![QueryBootstrapInput::new(SOURCE_ID.to_string(), bootstrap_rx, Some(result_rx))],
+    )
+    .await;
+    host.start(&fixture.base).await;
+    let started = receive_result(&mut fixture.output_rx).await;
+    assert_eq!(started.metadata["control_signal"], "bootstrapStarted");
+    result_tx
+        .send(Ok(BootstrapResult {
+            event_count: 0,
+            source_position: Some(Bytes::from_static(b"handoff")),
+        }))
+        .expect("send bootstrap result");
+    drop(bootstrap_tx);
+
+    wait_for_status(&fixture.base, ComponentStatus::Error).await;
+    assert!(fixture
+        .checkpoint_store
+        .read_checkpoint(SOURCE_ID)
+        .await
+        .expect("read failed handoff checkpoint")
+        .is_none());
+    assert_eq!(
+        QueryBootstrapScope::read_recovery_state(fixture.checkpoint_store.as_ref())
+            .await
+            .expect("read handoff marker"),
+        QueryBootstrapRecoveryState::InProgress
+    );
+    if let Ok(Some(result)) =
+        tokio::time::timeout(Duration::from_millis(50), fixture.output_rx.recv()).await
+    {
+        assert_ne!(result.metadata["control_signal"], "bootstrapCompleted");
+    }
+
+    stop_host(&fixture).await;
 }
 
 struct FailAfterStagingObserver;
@@ -861,7 +1198,7 @@ async fn rocksdb_atomic_source_fault_matrix_rolls_back_and_fences() {
 
     for (name, fault, observer) in cases {
         let temp_dir = tempfile::TempDir::new().expect("create temp directory");
-        let (host, fixture) = build_host(
+        let (host, mut fixture) = build_host(
             temp_dir.path(),
             "MATCH (n:Person) RETURN n.name AS name",
             fault,
@@ -919,7 +1256,7 @@ async fn cancellation_during_atomic_hook_rolls_back_without_ack_or_dispatch() {
         staged_tx: Mutex::new(Some(staged_tx)),
         release_rx: AsyncMutex::new(Some(release_rx)),
     });
-    let (host, fixture) = build_host(
+    let (host, mut fixture) = build_host(
         temp_dir.path(),
         "MATCH (n:Person) RETURN n.name AS name",
         BackendFault::None,
@@ -992,7 +1329,7 @@ async fn cancellation_after_commit_marks_output_recovery_required() {
         committed_tx: Mutex::new(Some(committed_tx)),
         release_rx: AsyncMutex::new(Some(release_rx)),
     });
-    let (host, fixture) = build_host(
+    let (host, mut fixture) = build_host(
         temp_dir.path(),
         "MATCH (n:Person) RETURN n.name AS name",
         BackendFault::None,
@@ -1040,6 +1377,33 @@ async fn cancellation_after_commit_marks_output_recovery_required() {
             .expect("read committed result sequence"),
         Some(1)
     );
+    let durable = fixture
+        .outbox_writer
+        .read_from(QUERY_ID, 0)
+        .await
+        .expect("read committed source outbox");
+    let dependencies = QueryOutputDependencies::new(
+        QUERY_ID.to_string(),
+        fixture.output_state.clone(),
+        fixture.dispatchers.clone(),
+        Some(fixture.outbox_writer.clone()),
+        Some(fixture.live_results_writer.clone()),
+        Some(fixture.checkpoint_store.clone()),
+        16,
+        Arc::new(QueryOutputMetrics::new()),
+    )
+    .with_publication_recovery(fixture.publication_recovery.clone());
+    QueryCompositeHost::reconcile_output_state(&fixture.mode, &dependencies)
+        .await
+        .expect("reconcile committed source output");
+    let recovered = receive_result(&mut fixture.output_rx).await;
+    assert_eq!(recovered.sequence, 1);
+    assert_eq!(
+        rmp_serde::to_vec(recovered.as_ref()).expect("serialize recovered source output"),
+        durable[0].1
+    );
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 1);
+    assert!(!fixture.publication_recovery.is_required());
     fixture.future_queue_source.stop().await;
 }
 
@@ -1116,7 +1480,7 @@ async fn cancellation_while_future_commit_returns_late_keeps_recovery_fence_arme
         committed_tx: Mutex::new(Some(committed_tx)),
         commits_before_block: AtomicUsize::new(1),
     });
-    let (host, fixture) = build_host(
+    let (host, mut fixture) = build_host(
         temp_dir.path(),
         "MATCH (n:Person) WHERE drasi.trueLater(true, 2000) RETURN n.name AS name",
         BackendFault::CommitThenBlock(commit_block),
@@ -1164,6 +1528,33 @@ async fn cancellation_while_future_commit_returns_late_keeps_recovery_fence_arme
             .expect("read future result sequence"),
         Some(1)
     );
+    let durable = fixture
+        .outbox_writer
+        .read_from(QUERY_ID, 0)
+        .await
+        .expect("read committed future outbox");
+    let dependencies = QueryOutputDependencies::new(
+        QUERY_ID.to_string(),
+        fixture.output_state.clone(),
+        fixture.dispatchers.clone(),
+        Some(fixture.outbox_writer.clone()),
+        Some(fixture.live_results_writer.clone()),
+        Some(fixture.checkpoint_store.clone()),
+        16,
+        Arc::new(QueryOutputMetrics::new()),
+    )
+    .with_publication_recovery(fixture.publication_recovery.clone());
+    QueryCompositeHost::reconcile_output_state(&fixture.mode, &dependencies)
+        .await
+        .expect("reconcile committed future");
+    let recovered = receive_result(&mut fixture.output_rx).await;
+    assert_eq!(recovered.sequence, 1);
+    assert_eq!(
+        rmp_serde::to_vec(recovered.as_ref()).expect("serialize recovered future"),
+        durable[0].1
+    );
+    assert_eq!(fixture.output_state.read().await.as_of_sequence(), 1);
+    assert!(!fixture.publication_recovery.is_required());
     fixture.future_queue_source.stop().await;
 }
 
@@ -1240,7 +1631,7 @@ async fn stale_prepared_sequence_after_commit_is_fatal_and_not_acknowledged() {
     let observer = Arc::new(StaleSequenceAfterCommitObserver {
         output_state: Mutex::new(None),
     });
-    let (host, fixture) = build_host(
+    let (host, mut fixture) = build_host(
         temp_dir.path(),
         "MATCH (n:Person) RETURN n.name AS name",
         BackendFault::None,
@@ -1276,6 +1667,24 @@ async fn stale_prepared_sequence_after_commit_is_fatal_and_not_acknowledged() {
     assert_eq!(fixture.dispatch_count.load(Ordering::Acquire), 0);
     assert_eq!(fixture.output_state.read().await.as_of_sequence(), 1);
     assert!(fixture.publication_recovery.is_required());
+    let dependencies = QueryOutputDependencies::new(
+        QUERY_ID.to_string(),
+        fixture.output_state.clone(),
+        fixture.dispatchers.clone(),
+        Some(fixture.outbox_writer.clone()),
+        Some(fixture.live_results_writer.clone()),
+        Some(fixture.checkpoint_store.clone()),
+        16,
+        Arc::new(QueryOutputMetrics::new()),
+    )
+    .with_publication_recovery(fixture.publication_recovery.clone());
+    QueryCompositeHost::reconcile_output_state(&fixture.mode, &dependencies)
+        .await
+        .expect("reconcile stale process-local output");
+    let recovered = receive_result(&mut fixture.output_rx).await;
+    assert_eq!(recovered.sequence, 1);
+    assert_eq!(recovered.results.len(), 1);
+    assert!(!fixture.publication_recovery.is_required());
 
     stop_host(&fixture).await;
 }
@@ -1627,33 +2036,88 @@ async fn capability_selection_requires_the_complete_created_indexes_bundle() {
 }
 
 #[tokio::test]
-async fn a6_does_not_hydrate_atomic_output_sequence_during_startup() {
+async fn atomic_startup_hydrates_durable_output_and_continues_sequence() {
     let temp_dir = tempfile::TempDir::new().expect("create temp directory");
     let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
     let created = provider
-        .create_indexes("unhydrated-sequence")
+        .create_indexes("hydrated-sequence")
         .await
         .expect("create RocksDB indexes");
+    let mode = QueryProcessingMode::from_created_indexes(&created);
     let checkpoint_store = created
         .checkpoint_store
         .as_ref()
         .expect("checkpoint store")
         .clone();
+    let outbox_writer = created
+        .outbox_writer
+        .as_ref()
+        .expect("outbox writer")
+        .clone();
+    let live_results_writer = created
+        .live_results_writer
+        .as_ref()
+        .expect("live-results writer")
+        .clone();
+    let durable_result = QueryResult::new(
+        "hydrated-sequence".to_string(),
+        41,
+        chrono::Utc::now(),
+        vec![ResultDiff::Add {
+            data: json!({ "name": "Durable" }),
+            row_signature: 7,
+        }],
+        HashMap::new(),
+    );
+    let durable_bytes = rmp_serde::to_vec(&durable_result).expect("serialize durable result");
+    created
+        .set
+        .session_control
+        .begin()
+        .await
+        .expect("begin durable seed transaction");
+    outbox_writer
+        .append("hydrated-sequence", 41, &durable_bytes)
+        .await
+        .expect("seed durable outbox");
+    let row_bytes =
+        rmp_serde::to_vec(&json!({ "name": "Durable" })).expect("serialize durable live row");
+    live_results_writer
+        .apply_mutations(
+            "hydrated-sequence",
+            &[RowMutation {
+                row_signature: 7,
+                data: Some(&row_bytes),
+            }],
+        )
+        .await
+        .expect("seed durable live row");
     checkpoint_store
-        .write_result_sequence("unhydrated-sequence", 41)
+        .write_result_sequence("hydrated-sequence", 41)
         .await
         .expect("seed durable result sequence");
+    created
+        .set
+        .session_control
+        .commit()
+        .await
+        .expect("commit durable seed transaction");
+
     let output_state = Arc::new(RwLock::new(QueryOutputState::new(16)));
-    let output = OutputPublicationStage::new(QueryOutputDependencies::new(
-        "unhydrated-sequence".to_string(),
-        output_state,
+    let dependencies = QueryOutputDependencies::new(
+        "hydrated-sequence".to_string(),
+        output_state.clone(),
         Arc::new(RwLock::new(Vec::new())),
-        created.outbox_writer,
-        created.live_results_writer,
+        Some(outbox_writer),
+        Some(live_results_writer),
         Some(checkpoint_store),
         16,
         Arc::new(QueryOutputMetrics::new()),
-    ));
+    );
+    QueryCompositeHost::reconcile_output_state(&mode, &dependencies)
+        .await
+        .expect("hydrate durable output");
+    let output = OutputPublicationStage::new(dependencies);
     let contexts = [QueryPartEvaluationContext::Adding {
         after: QueryVariables::from([(
             Box::<str>::from("name"),
@@ -1665,9 +2129,208 @@ async fn a6_does_not_hydrate_atomic_output_sequence_during_startup() {
     let prepared = output
         .prepare_atomic(&contexts, SOURCE_ID, ProfilingMetadata::default())
         .await
-        .expect("prepare unhydrated output");
+        .expect("prepare hydrated output");
+    assert_eq!(prepared.result.sequence, 42);
+    let state = output_state.read().await;
+    assert_eq!(state.as_of_sequence(), 41);
+    assert_eq!(state.get_result(&7), Some(&json!({ "name": "Durable" })));
     assert_eq!(
-        prepared.result.sequence, 1,
-        "A7 owns startup hydration from durable result sequence 41"
+        rmp_serde::to_vec(
+            state
+                .fetch_outbox_after(40)
+                .expect("hydrated outbox")
+                .first()
+                .expect("durable result")
+                .as_ref()
+        )
+        .expect("serialize hydrated result"),
+        durable_bytes
     );
+}
+
+#[tokio::test]
+async fn atomic_startup_rejects_a_gapped_durable_outbox() {
+    let temp_dir = tempfile::TempDir::new().expect("create temp directory");
+    let provider = RocksDbIndexProvider::new(temp_dir.path(), true, false);
+    let created = provider
+        .create_indexes("gapped-output")
+        .await
+        .expect("create RocksDB indexes");
+    let mode = QueryProcessingMode::from_created_indexes(&created);
+    let checkpoint_store = created.checkpoint_store.clone().expect("checkpoint store");
+    let outbox_writer = created.outbox_writer.clone().expect("outbox writer");
+    let live_results_writer = created
+        .live_results_writer
+        .clone()
+        .expect("live-results writer");
+    for sequence in [40, 42] {
+        let result = QueryResult::new(
+            "gapped-output".to_string(),
+            sequence,
+            chrono::Utc::now(),
+            vec![ResultDiff::Add {
+                data: json!({ "sequence": sequence }),
+                row_signature: sequence,
+            }],
+            HashMap::new(),
+        );
+        outbox_writer
+            .append(
+                "gapped-output",
+                sequence,
+                &rmp_serde::to_vec(&result).expect("serialize gapped result"),
+            )
+            .await
+            .expect("seed gapped outbox");
+    }
+    let row_bytes =
+        rmp_serde::to_vec(&json!({ "sequence": 42 })).expect("serialize latest live row");
+    live_results_writer
+        .apply_mutations(
+            "gapped-output",
+            &[RowMutation {
+                row_signature: 42,
+                data: Some(&row_bytes),
+            }],
+        )
+        .await
+        .expect("seed latest live row");
+    checkpoint_store
+        .write_result_sequence("gapped-output", 42)
+        .await
+        .expect("seed durable result sequence");
+
+    let output_state = Arc::new(RwLock::new(QueryOutputState::new(16)));
+    let dependencies = QueryOutputDependencies::new(
+        "gapped-output".to_string(),
+        output_state.clone(),
+        Arc::new(RwLock::new(Vec::new())),
+        Some(outbox_writer),
+        Some(live_results_writer),
+        Some(checkpoint_store),
+        16,
+        Arc::new(QueryOutputMetrics::new()),
+    );
+    let error = QueryCompositeHost::reconcile_output_state(&mode, &dependencies)
+        .await
+        .expect_err("gapped durable outbox must be rejected");
+    assert!(format!("{error:#}").contains("gap"));
+    assert_eq!(output_state.read().await.as_of_sequence(), 0);
+}
+
+#[tokio::test]
+async fn atomic_startup_rejects_missing_sequence_and_live_snapshot_artifacts() {
+    let sequence_dir = tempfile::TempDir::new().expect("create sequence temp directory");
+    let sequence_provider = RocksDbIndexProvider::new(sequence_dir.path(), true, false);
+    let sequence_created = sequence_provider
+        .create_indexes("missing-sequence")
+        .await
+        .expect("create missing-sequence indexes");
+    let sequence_mode = QueryProcessingMode::from_created_indexes(&sequence_created);
+    let sequence_outbox = sequence_created
+        .outbox_writer
+        .clone()
+        .expect("sequence outbox");
+    let sequence_live = sequence_created
+        .live_results_writer
+        .clone()
+        .expect("sequence live results");
+    let result = QueryResult::new(
+        "missing-sequence".to_string(),
+        1,
+        chrono::Utc::now(),
+        vec![ResultDiff::Add {
+            data: json!({ "name": "missing-sequence" }),
+            row_signature: 1,
+        }],
+        HashMap::new(),
+    );
+    sequence_outbox
+        .append(
+            "missing-sequence",
+            1,
+            &rmp_serde::to_vec(&result).expect("serialize missing-sequence result"),
+        )
+        .await
+        .expect("seed outbox without result sequence");
+    let row = rmp_serde::to_vec(&json!({ "name": "missing-sequence" }))
+        .expect("serialize missing-sequence row");
+    sequence_live
+        .apply_mutations(
+            "missing-sequence",
+            &[RowMutation {
+                row_signature: 1,
+                data: Some(&row),
+            }],
+        )
+        .await
+        .expect("seed live row without result sequence");
+    let sequence_state = Arc::new(RwLock::new(QueryOutputState::new(16)));
+    let sequence_dependencies = QueryOutputDependencies::new(
+        "missing-sequence".to_string(),
+        sequence_state,
+        Arc::new(RwLock::new(Vec::new())),
+        Some(sequence_outbox),
+        Some(sequence_live),
+        sequence_created.checkpoint_store.clone(),
+        16,
+        Arc::new(QueryOutputMetrics::new()),
+    );
+    let error = QueryCompositeHost::reconcile_output_state(&sequence_mode, &sequence_dependencies)
+        .await
+        .expect_err("outbox without a result sequence must be rejected");
+    assert!(format!("{error:#}").contains("result sequence is 0"));
+
+    let live_dir = tempfile::TempDir::new().expect("create live-result temp directory");
+    let live_provider = RocksDbIndexProvider::new(live_dir.path(), true, false);
+    let live_created = live_provider
+        .create_indexes("missing-live")
+        .await
+        .expect("create missing-live indexes");
+    let live_mode = QueryProcessingMode::from_created_indexes(&live_created);
+    let live_checkpoint = live_created
+        .checkpoint_store
+        .clone()
+        .expect("live checkpoint store");
+    let live_outbox = live_created.outbox_writer.clone().expect("live outbox");
+    let live_writer = live_created
+        .live_results_writer
+        .clone()
+        .expect("live results");
+    let result = QueryResult::new(
+        "missing-live".to_string(),
+        1,
+        chrono::Utc::now(),
+        vec![ResultDiff::Add {
+            data: json!({ "name": "missing-live" }),
+            row_signature: 1,
+        }],
+        HashMap::new(),
+    );
+    live_outbox
+        .append(
+            "missing-live",
+            1,
+            &rmp_serde::to_vec(&result).expect("serialize missing-live result"),
+        )
+        .await
+        .expect("seed outbox without live row");
+    live_checkpoint
+        .write_result_sequence("missing-live", 1)
+        .await
+        .expect("seed result sequence without live row");
+    let live_dependencies = QueryOutputDependencies::new(
+        "missing-live".to_string(),
+        Arc::new(RwLock::new(QueryOutputState::new(16))),
+        Arc::new(RwLock::new(Vec::new())),
+        Some(live_outbox),
+        Some(live_writer),
+        Some(live_checkpoint),
+        16,
+        Arc::new(QueryOutputMetrics::new()),
+    );
+    let error = QueryCompositeHost::reconcile_output_state(&live_mode, &live_dependencies)
+        .await
+        .expect_err("outbox mutation without a live row must be rejected");
+    assert!(format!("{error:#}").contains("live-result row"));
 }

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use log::{error, info, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -540,27 +540,18 @@ impl ReactionManager {
                             resp.results.len(),
                             resp.latest_sequence
                         );
-                        let mut last_ok_seq = 0u64;
                         for entry in &resp.results {
                             let result = (*entry).as_ref().clone();
-                            match reaction.enqueue_query_result(result).await {
-                                Ok(()) => last_ok_seq = entry.sequence,
-                                Err(e) => {
-                                    warn!(
-                                        "[{reaction_id}] Failed to replay outbox entry for query \
-                                         '{query_id}' seq={}: {e}",
+                            reaction
+                                .enqueue_query_result(result)
+                                .await
+                                .with_context(|| {
+                                    format!(
+                                        "[{reaction_id}] failed to replay outbox entry for query \
+                                     '{query_id}' at sequence {}",
                                         entry.sequence
-                                    );
-                                    break;
-                                }
-                            }
-                        }
-                        if last_ok_seq != resp.latest_sequence {
-                            info!(
-                                "[{reaction_id}] Partial outbox replay for query '{query_id}' — \
-                                 replayed up to seq={last_ok_seq}, latest_seq={}",
-                                resp.latest_sequence
-                            );
+                                    )
+                                })?;
                         }
                     }
                     resp.latest_sequence
@@ -626,17 +617,17 @@ impl ReactionManager {
                 let mut last_ok_seq = checkpoint.sequence;
                 for entry in &outbox_resp.results {
                     let result = (*entry).as_ref().clone();
-                    match reaction.enqueue_query_result(result).await {
-                        Ok(()) => last_ok_seq = entry.sequence,
-                        Err(e) => {
-                            warn!(
-                                "[{reaction_id}] Failed to replay outbox entry for query \
-                                 '{query_id}' seq={}: {e}",
+                    reaction
+                        .enqueue_query_result(result)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "[{reaction_id}] failed to replay outbox entry for query \
+                             '{query_id}' at sequence {}",
                                 entry.sequence
-                            );
-                            break;
-                        }
-                    }
+                            )
+                        })?;
+                    last_ok_seq = entry.sequence;
                 }
 
                 // Update checkpoint to the latest SUCCESSFULLY replayed sequence.
@@ -1153,7 +1144,7 @@ impl ReactionManager {
                         match receiver.recv().await {
                             Ok(query_result) => {
                                 // Skip events already covered by the bootstrap snapshot/outbox catchup.
-                                if query_result.sequence <= initial_seq {
+                                if query_result.sequence <= last_forwarded_seq {
                                     forwarder_metrics.record_dedup_skip();
                                     log::debug!(
                                         "[{reaction_id_owned}] Skipping seq={} <= last_forwarded={last_forwarded_seq} for query '{query_id_clone}'",
@@ -1213,7 +1204,6 @@ impl ReactionManager {
                                     }
                                 }
 
-                                last_forwarded_seq = query_result.sequence;
                                 let seq = query_result.sequence;
                                 let result = Arc::try_unwrap(query_result)
                                     .unwrap_or_else(|arc| (*arc).clone());
@@ -1221,7 +1211,9 @@ impl ReactionManager {
                                     log::error!(
                                         "[{reaction_id_owned}] Failed to enqueue result from query '{query_id_clone}': {e}"
                                     );
+                                    break;
                                 } else {
+                                    last_forwarded_seq = seq;
                                     // Advance in-memory checkpoint so forwarder tracks
                                     // position (skip stale events on reconnect).
                                     // NOTE: We do NOT persist to durable storage here.

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -62,6 +62,9 @@ struct BroadcastGapContext<'a> {
     checkpoints: &'a Arc<RwLock<HashMap<String, ReactionCheckpoint>>>,
     bootstrap_mutex: &'a Arc<tokio::sync::Mutex<()>>,
     metrics: &'a Arc<ReactionMetrics>,
+    /// The live event that exposed a sequence gap. `None` when the receiver
+    /// reported lag before yielding the next retained event.
+    received_sequence: Option<u64>,
 }
 
 pub struct ReactionManager {
@@ -1182,8 +1185,8 @@ impl ReactionManager {
                                 // §6: Detect sequence gaps (incoming seq > expected next).
                                 // This catches drops that don't manifest as broadcast lag
                                 // (e.g., outbox overflow while reaction was stopping).
-                                if last_forwarded_seq > 0
-                                    && query_result.sequence > last_forwarded_seq.saturating_add(1)
+                                if query_result.sequence
+                                    > last_forwarded_seq.saturating_add(1)
                                 {
                                     forwarder_metrics.record_gap_detection();
                                     forwarder_metrics.record_recovery_trigger(to_policy_kind(&policy));
@@ -1203,6 +1206,7 @@ impl ReactionManager {
                                         checkpoints: &checkpoints,
                                         bootstrap_mutex: &bootstrap_mutex,
                                         metrics: &forwarder_metrics,
+                                        received_sequence: Some(query_result.sequence),
                                     };
                                     match Self::handle_broadcast_gap(&gap_ctx)
                                     .await
@@ -1230,36 +1234,24 @@ impl ReactionManager {
                                     }
                                 }
 
-                                let seq = query_result.sequence;
-                                let result = Arc::try_unwrap(query_result)
-                                    .unwrap_or_else(|arc| (*arc).clone());
-                                if let Err(e) = reaction.enqueue_query_result(result).await {
-                                    log::error!(
-                                        "[{reaction_id_owned}] Failed to enqueue result from query '{query_id_clone}': {e}"
-                                    );
-                                    break;
-                                } else {
-                                    last_forwarded_seq = seq;
-                                    // Advance in-memory checkpoint so forwarder tracks
-                                    // position (skip stale events on reconnect).
-                                    // NOTE: We do NOT persist to durable storage here.
-                                    // The reaction should persist its checkpoint after
-                                    // successfully processing the event. This prevents
-                                    // permanent skipping if the process crashes between
-                                    // enqueue and handler processing.
-                                    let config_hash = {
-                                        let cps = checkpoints.read().await;
-                                        cps.get(&query_id_clone).map(|cp| cp.config_hash).unwrap_or(0)
-                                    };
-                                    let cp = ReactionCheckpoint { sequence: seq, config_hash };
-                                    checkpoints.write().await.insert(query_id_clone.clone(), cp);
-
-                                    // Update reaction metrics: checkpoint position
-                                    let query_latest = query_clone
-                                        .output_metrics()
-                                        .map(|m| m.load_outbox_latest_seq())
-                                        .unwrap_or(seq);
-                                    forwarder_metrics.record_checkpoint(seq, query_latest);
+                                match Self::enqueue_forwarded_result(
+                                    &reaction,
+                                    &query_clone,
+                                    &query_id_clone,
+                                    &checkpoints,
+                                    &forwarder_metrics,
+                                    query_result,
+                                )
+                                .await
+                                {
+                                    Ok(sequence) => last_forwarded_seq = sequence,
+                                    Err(error) => {
+                                        log::error!(
+                                            "[{reaction_id_owned}] Failed to enqueue result from query \
+                                             '{query_id_clone}': {error}"
+                                        );
+                                        break;
+                                    }
                                 }
                             }
                             Err(e) => {
@@ -1281,6 +1273,7 @@ impl ReactionManager {
                                         checkpoints: &checkpoints,
                                         bootstrap_mutex: &bootstrap_mutex,
                                         metrics: &forwarder_metrics,
+                                        received_sequence: None,
                                     };
                                     match Self::handle_broadcast_gap(&gap_ctx)
                                     .await
@@ -1359,12 +1352,47 @@ impl ReactionManager {
         Ok(())
     }
 
+    async fn enqueue_forwarded_result(
+        reaction: &Arc<dyn Reaction>,
+        query: &Arc<dyn Query>,
+        query_id: &str,
+        checkpoints: &Arc<RwLock<HashMap<String, ReactionCheckpoint>>>,
+        metrics: &Arc<ReactionMetrics>,
+        query_result: Arc<QueryResult>,
+    ) -> Result<u64> {
+        let sequence = query_result.sequence;
+        let result = Arc::try_unwrap(query_result).unwrap_or_else(|result| (*result).clone());
+        reaction.enqueue_query_result(result).await?;
+
+        // This checkpoint is process-local. Durable reactions persist their
+        // checkpoint only after successful handling of the enqueued result.
+        let config_hash = checkpoints
+            .read()
+            .await
+            .get(query_id)
+            .map(|checkpoint| checkpoint.config_hash)
+            .unwrap_or(0);
+        checkpoints.write().await.insert(
+            query_id.to_string(),
+            ReactionCheckpoint {
+                sequence,
+                config_hash,
+            },
+        );
+        let query_latest = query
+            .output_metrics()
+            .map(|metrics| metrics.load_outbox_latest_seq())
+            .unwrap_or(sequence);
+        metrics.record_checkpoint(sequence, query_latest);
+        Ok(sequence)
+    }
+
     /// Handle a broadcast gap (§6): `RecvError::Lagged` in the forwarder loop.
     ///
     /// Applies the reaction's recovery policy:
     /// - `Strict`: return error (forwarder will break)
     /// - `AutoReset`: re-bootstrap from snapshot, update checkpoint (serialized via mutex)
-    /// - `AutoSkipGap`: jump to current sequence, update checkpoint
+    /// - `AutoSkipGap`: persist only the missing floor before the triggering event
     async fn handle_broadcast_gap(ctx: &BroadcastGapContext<'_>) -> Result<()> {
         let config_hash = crate::queries::compute_config_hash(ctx.query.get_config());
 
@@ -1431,31 +1459,27 @@ impl ReactionManager {
                     ctx.reaction_id,
                     ctx.query_id
                 );
-                ctx.metrics.record_fetch_outbox();
-                let current_seq = match ctx.query.fetch_outbox(0).await {
-                    Ok(resp) => resp.latest_sequence,
-                    Err(FetchError::OutboxGap(gap)) => gap.latest_sequence,
-                    Err(FetchError::NotRunning { .. } | FetchError::TimedOut) => {
-                        // Query not running — fall back to existing checkpoint sequence.
-                        let existing_seq = ctx
-                            .checkpoints
-                            .read()
-                            .await
-                            .get(ctx.query_id)
-                            .map(|cp| cp.sequence)
-                            .unwrap_or(0);
-                        log::info!(
-                            "[{}] AutoSkipGap: query '{}' not running, \
-                             keeping checkpoint at seq={existing_seq}",
-                            ctx.reaction_id,
-                            ctx.query_id
-                        );
-                        existing_seq
-                    }
+                let Some(received_sequence) = ctx.received_sequence else {
+                    log::debug!(
+                        "[{}] AutoSkipGap for query '{}' is waiting for the next retained \
+                         event to determine the exact missing range",
+                        ctx.reaction_id,
+                        ctx.query_id
+                    );
+                    return Ok(());
                 };
+                let skipped_floor = received_sequence.saturating_sub(1);
+                let existing_sequence = ctx
+                    .checkpoints
+                    .read()
+                    .await
+                    .get(ctx.query_id)
+                    .map(|checkpoint| checkpoint.sequence)
+                    .unwrap_or(0);
+                let skipped_floor = skipped_floor.max(existing_sequence);
 
                 let cp = ReactionCheckpoint {
-                    sequence: current_seq,
+                    sequence: skipped_floor,
                     config_hash,
                 };
 
@@ -1627,6 +1651,7 @@ mod tests {
         status_handle: ComponentStatusHandle,
         enqueued: Arc<Mutex<Vec<QueryResult>>>,
         bootstrap_count: Arc<AtomicUsize>,
+        enqueue_failures: AtomicUsize,
     }
 
     impl MockReaction {
@@ -1640,6 +1665,7 @@ mod tests {
                 status_handle: ComponentStatusHandle::new(id),
                 enqueued: Arc::new(Mutex::new(Vec::new())),
                 bootstrap_count: Arc::new(AtomicUsize::new(0)),
+                enqueue_failures: AtomicUsize::new(0),
             }
         }
 
@@ -1656,6 +1682,10 @@ mod tests {
         fn with_policy(mut self, p: ReactionRecoveryPolicy) -> Self {
             self.policy = p;
             self
+        }
+
+        fn fail_next_enqueue(&self) {
+            self.enqueue_failures.store(1, Ordering::Release);
         }
     }
 
@@ -1704,6 +1734,15 @@ mod tests {
             self.policy
         }
         async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+            if self
+                .enqueue_failures
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                anyhow::bail!("injected reaction enqueue failure");
+            }
             self.enqueued.lock().await.push(result);
             Ok(())
         }
@@ -2090,6 +2129,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            received_sequence: None,
         })
         .await;
 
@@ -2124,6 +2164,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            received_sequence: None,
         })
         .await;
 
@@ -2154,7 +2195,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn broadcast_gap_auto_skip_gap_jumps_to_current_seq() {
+    async fn broadcast_gap_auto_skip_gap_skips_only_missing_range() {
         let query: Arc<dyn crate::queries::Query> = Arc::new(MockQuery::new(42, 50));
         let reaction = Arc::new(
             MockReaction::new("r1", vec!["q1".into()])
@@ -2174,6 +2215,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            received_sequence: Some(42),
         })
         .await;
 
@@ -2183,16 +2225,235 @@ mod tests {
             result.err()
         );
 
-        // Checkpoint should jump to current sequence.
+        // The triggering event (42) is still deliverable, so only its missing
+        // predecessor range may be checkpointed as skipped.
         let cps = checkpoints.read().await;
         let cp = cps.get("q1").expect("Checkpoint for q1 should exist");
-        assert_eq!(cp.sequence, 50, "Checkpoint should jump to latest sequence");
+        assert_eq!(cp.sequence, 41);
 
         // bootstrap() should NOT be called for AutoSkipGap.
         assert_eq!(
             reaction.bootstrap_count.load(Ordering::SeqCst),
             0,
             "bootstrap() should not be called for AutoSkipGap"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_skip_gap_persists_missing_floor_not_moving_query_latest() {
+        let query: Arc<dyn crate::queries::Query> = Arc::new(MockQuery::new(42, 100));
+        let reaction: Arc<dyn Reaction> = Arc::new(
+            MockReaction::new("r1", vec!["q1".into()])
+                .with_policy(ReactionRecoveryPolicy::AutoSkipGap),
+        );
+        let store: Arc<dyn StateStoreProvider> =
+            Arc::new(crate::state_store::MemoryStateStoreProvider::new());
+        let state_store = Some(store.clone());
+        let checkpoints = Arc::new(RwLock::new(HashMap::from([(
+            "q1".to_string(),
+            ReactionCheckpoint {
+                sequence: 10,
+                config_hash: 42,
+            },
+        )])));
+        let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
+
+        ReactionManager::handle_broadcast_gap(&BroadcastGapContext {
+            reaction_id: "r1",
+            query_id: "q1",
+            reaction: &reaction,
+            query: &query,
+            policy: ReactionRecoveryPolicy::AutoSkipGap,
+            state_store: &state_store,
+            checkpoints: &checkpoints,
+            bootstrap_mutex: &bootstrap_mutex,
+            metrics: &Arc::new(ReactionMetrics::new()),
+            received_sequence: Some(42),
+        })
+        .await
+        .expect("AutoSkipGap should persist the missing floor");
+
+        assert_eq!(checkpoints.read().await["q1"].sequence, 41);
+        assert_eq!(
+            crate::reactions::checkpoint::read_checkpoint(store.as_ref(), "r1", "q1")
+                .await
+                .expect("read persisted skipped floor")
+                .expect("persisted skipped floor")
+                .sequence,
+            41,
+            "query latest 100 must not checkpoint deliverable results 42..=100"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_skip_gap_waits_for_retained_event_before_advancing() {
+        let query: Arc<dyn crate::queries::Query> = Arc::new(MockQuery::new(42, 100));
+        let reaction: Arc<dyn Reaction> = Arc::new(
+            MockReaction::new("r1", vec!["q1".into()])
+                .with_policy(ReactionRecoveryPolicy::AutoSkipGap),
+        );
+        let checkpoints = Arc::new(RwLock::new(HashMap::from([(
+            "q1".to_string(),
+            ReactionCheckpoint {
+                sequence: 10,
+                config_hash: 42,
+            },
+        )])));
+        let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
+
+        ReactionManager::handle_broadcast_gap(&BroadcastGapContext {
+            reaction_id: "r1",
+            query_id: "q1",
+            reaction: &reaction,
+            query: &query,
+            policy: ReactionRecoveryPolicy::AutoSkipGap,
+            state_store: &None,
+            checkpoints: &checkpoints,
+            bootstrap_mutex: &bootstrap_mutex,
+            metrics: &Arc::new(ReactionMetrics::new()),
+            received_sequence: None,
+        })
+        .await
+        .expect("lag notification alone should not advance a checkpoint");
+
+        assert_eq!(checkpoints.read().await["q1"].sequence, 10);
+    }
+
+    #[tokio::test]
+    async fn auto_skip_gap_enqueue_failure_keeps_current_event_recoverable() {
+        let query: Arc<dyn crate::queries::Query> = Arc::new(MockQuery::new(42, 100));
+        let reaction = Arc::new(
+            MockReaction::new("r1", vec!["q1".into()])
+                .with_policy(ReactionRecoveryPolicy::AutoSkipGap),
+        );
+        let reaction_trait: Arc<dyn Reaction> = reaction.clone();
+        let checkpoints = Arc::new(RwLock::new(HashMap::from([(
+            "q1".to_string(),
+            ReactionCheckpoint {
+                sequence: 10,
+                config_hash: 42,
+            },
+        )])));
+        let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
+        let metrics = Arc::new(ReactionMetrics::new());
+
+        ReactionManager::handle_broadcast_gap(&BroadcastGapContext {
+            reaction_id: "r1",
+            query_id: "q1",
+            reaction: &reaction_trait,
+            query: &query,
+            policy: ReactionRecoveryPolicy::AutoSkipGap,
+            state_store: &None,
+            checkpoints: &checkpoints,
+            bootstrap_mutex: &bootstrap_mutex,
+            metrics: &metrics,
+            received_sequence: Some(42),
+        })
+        .await
+        .expect("skip missing range");
+        reaction.fail_next_enqueue();
+        let current = Arc::new(QueryResult::new(
+            "q1".to_string(),
+            42,
+            chrono::Utc::now(),
+            Vec::new(),
+            HashMap::new(),
+        ));
+        assert!(ReactionManager::enqueue_forwarded_result(
+            &reaction_trait,
+            &query,
+            "q1",
+            &checkpoints,
+            &metrics,
+            current.clone(),
+        )
+        .await
+        .is_err());
+        assert_eq!(
+            checkpoints.read().await["q1"].sequence,
+            41,
+            "failed enqueue must leave the current event above the checkpoint"
+        );
+        assert!(reaction.enqueued.lock().await.is_empty());
+
+        ReactionManager::enqueue_forwarded_result(
+            &reaction_trait,
+            &query,
+            "q1",
+            &checkpoints,
+            &metrics,
+            current,
+        )
+        .await
+        .expect("restart/retry should deliver the current event");
+        assert_eq!(checkpoints.read().await["q1"].sequence, 42);
+        assert_eq!(reaction.enqueued.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn auto_skip_gap_repeated_episodes_advance_only_after_delivery() {
+        let query: Arc<dyn crate::queries::Query> = Arc::new(MockQuery::new(42, 100));
+        let reaction = Arc::new(
+            MockReaction::new("r1", vec!["q1".into()])
+                .with_policy(ReactionRecoveryPolicy::AutoSkipGap),
+        );
+        let reaction_trait: Arc<dyn Reaction> = reaction.clone();
+        let checkpoints = Arc::new(RwLock::new(HashMap::from([(
+            "q1".to_string(),
+            ReactionCheckpoint {
+                sequence: 1,
+                config_hash: 42,
+            },
+        )])));
+        let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
+        let metrics = Arc::new(ReactionMetrics::new());
+
+        for received_sequence in [10, 20] {
+            ReactionManager::handle_broadcast_gap(&BroadcastGapContext {
+                reaction_id: "r1",
+                query_id: "q1",
+                reaction: &reaction_trait,
+                query: &query,
+                policy: ReactionRecoveryPolicy::AutoSkipGap,
+                state_store: &None,
+                checkpoints: &checkpoints,
+                bootstrap_mutex: &bootstrap_mutex,
+                metrics: &metrics,
+                received_sequence: Some(received_sequence),
+            })
+            .await
+            .expect("skip one missing range");
+            assert_eq!(
+                checkpoints.read().await["q1"].sequence,
+                received_sequence - 1
+            );
+            ReactionManager::enqueue_forwarded_result(
+                &reaction_trait,
+                &query,
+                "q1",
+                &checkpoints,
+                &metrics,
+                Arc::new(QueryResult::new(
+                    "q1".to_string(),
+                    received_sequence,
+                    chrono::Utc::now(),
+                    Vec::new(),
+                    HashMap::new(),
+                )),
+            )
+            .await
+            .expect("deliver retained gap-triggering event");
+            assert_eq!(checkpoints.read().await["q1"].sequence, received_sequence);
+        }
+        assert_eq!(
+            reaction
+                .enqueued
+                .lock()
+                .await
+                .iter()
+                .map(|result| result.sequence)
+                .collect::<Vec<_>>(),
+            vec![10, 20]
         );
     }
 
@@ -2344,6 +2605,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            received_sequence: None,
         })
         .await;
 
@@ -2472,6 +2734,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            received_sequence: None,
         })
         .await;
 
@@ -2524,6 +2787,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &metrics_q1,
+            received_sequence: None,
         };
         let ctx_q2 = BroadcastGapContext {
             reaction_id: "r1",
@@ -2535,6 +2799,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &metrics_q2,
+            received_sequence: None,
         };
         let (r1, r2) = tokio::join!(
             ReactionManager::handle_broadcast_gap(&ctx_q1),

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -655,21 +655,38 @@ impl ReactionManager {
 
                 Ok(cp)
             }
-            Err(FetchError::OutboxGap(_gap)) => {
+            Err(FetchError::OutboxGap(gap)) => {
                 info!(
                     "[{reaction_id}] Outbox gap for query '{query_id}' — applying recovery policy"
                 );
-                self.apply_recovery_policy(
-                    reaction_id,
-                    query_id,
-                    reaction,
-                    query,
-                    policy,
-                    state_store,
-                    bootstrap_queries,
-                    metrics,
-                )
-                .await
+                match policy {
+                    ReactionRecoveryPolicy::AutoSkipGap => {
+                        Self::replay_retained_outbox_after_gap(
+                            reaction_id,
+                            query_id,
+                            checkpoint,
+                            reaction,
+                            query,
+                            state_store,
+                            metrics,
+                            &gap,
+                        )
+                        .await
+                    }
+                    ReactionRecoveryPolicy::Strict | ReactionRecoveryPolicy::AutoReset => {
+                        self.apply_recovery_policy(
+                            reaction_id,
+                            query_id,
+                            reaction,
+                            query,
+                            policy,
+                            state_store,
+                            bootstrap_queries,
+                            metrics,
+                        )
+                        .await
+                    }
+                }
             }
             Err(FetchError::NotRunning { .. } | FetchError::TimedOut) => {
                 // Query not running — keep the existing checkpoint as-is.
@@ -682,6 +699,126 @@ impl ReactionManager {
                 Ok(checkpoint.clone())
             }
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn replay_retained_outbox_after_gap(
+        reaction_id: &str,
+        query_id: &str,
+        checkpoint: &ReactionCheckpoint,
+        reaction: &Arc<dyn Reaction>,
+        query: &Arc<dyn Query>,
+        state_store: &Option<Arc<dyn StateStoreProvider>>,
+        metrics: &Arc<ReactionMetrics>,
+        gap: &crate::queries::OutboxGap,
+    ) -> Result<ReactionCheckpoint> {
+        let mut skipped_floor = gap
+            .earliest_available
+            .saturating_sub(1)
+            .max(checkpoint.sequence);
+        let mut current = ReactionCheckpoint {
+            sequence: skipped_floor,
+            config_hash: checkpoint.config_hash,
+        };
+        let mut previous_sequence = checkpoint.sequence;
+
+        let retained = loop {
+            Self::persist_reaction_checkpoint(
+                state_store,
+                reaction_id,
+                query_id,
+                previous_sequence,
+                &current,
+            )
+            .await?;
+            previous_sequence = current.sequence;
+
+            metrics.record_fetch_outbox();
+            match query.fetch_outbox(skipped_floor).await {
+                Ok(retained) => break retained,
+                Err(FetchError::OutboxGap(next_gap)) => {
+                    let next_floor = next_gap
+                        .earliest_available
+                        .saturating_sub(1)
+                        .max(current.sequence);
+                    anyhow::ensure!(
+                        next_floor > skipped_floor,
+                        "[{reaction_id}] query '{query_id}' returned a non-advancing \
+                             outbox gap at floor {skipped_floor}"
+                    );
+                    skipped_floor = next_floor;
+                    current.sequence = next_floor;
+                }
+                Err(error) => {
+                    return Err(anyhow::anyhow!(
+                        "[{reaction_id}] failed to fetch retained outbox suffix for query \
+                             '{query_id}' after skipped floor {skipped_floor}: {error}"
+                    ));
+                }
+            }
+        };
+
+        let mut expected = skipped_floor.saturating_add(1);
+        for entry in retained.results {
+            anyhow::ensure!(
+                entry.sequence == expected,
+                "[{reaction_id}] retained outbox suffix for query '{query_id}' is not \
+                     contiguous: expected {expected}, got {}",
+                entry.sequence
+            );
+            reaction
+                .enqueue_query_result(entry.as_ref().clone())
+                .await
+                .with_context(|| {
+                    format!(
+                        "[{reaction_id}] failed to replay retained outbox entry for query \
+                             '{query_id}' at sequence {}",
+                        entry.sequence
+                    )
+                })?;
+            current.sequence = entry.sequence;
+            Self::persist_reaction_checkpoint(
+                state_store,
+                reaction_id,
+                query_id,
+                previous_sequence,
+                &current,
+            )
+            .await?;
+            previous_sequence = current.sequence;
+            expected = entry.sequence.saturating_add(1);
+        }
+        anyhow::ensure!(
+            current.sequence == retained.latest_sequence,
+            "[{reaction_id}] retained outbox replay for query '{query_id}' ended at {}, \
+                 expected latest {}",
+            current.sequence,
+            retained.latest_sequence
+        );
+
+        Ok(current)
+    }
+
+    async fn persist_reaction_checkpoint(
+        state_store: &Option<Arc<dyn StateStoreProvider>>,
+        reaction_id: &str,
+        query_id: &str,
+        previous_sequence: u64,
+        checkpoint: &ReactionCheckpoint,
+    ) -> Result<()> {
+        if checkpoint.sequence == previous_sequence {
+            return Ok(());
+        }
+        if let Some(store) = state_store.as_ref() {
+            crate::reactions::checkpoint::write_checkpoint(
+                store.as_ref(),
+                reaction_id,
+                query_id,
+                checkpoint,
+            )
+            .await?;
+        }
+        Ok(())
     }
 
     /// Apply the recovery policy when a gap or hash mismatch is detected.
@@ -2237,6 +2374,71 @@ mod tests {
             0,
             "bootstrap() should not be called for AutoSkipGap"
         );
+    }
+
+    #[tokio::test]
+    async fn startup_auto_skip_gap_handles_empty_and_saturated_bounds() {
+        let empty_query = Arc::new(MockQuery::new(42, 0));
+        let empty_query_trait: Arc<dyn crate::queries::Query> = empty_query.clone();
+        let reaction: Arc<dyn Reaction> = Arc::new(MockReaction::new("r1", vec!["q1".into()]));
+        let checkpoint = ReactionCheckpoint {
+            sequence: 0,
+            config_hash: 42,
+        };
+        let metrics = Arc::new(ReactionMetrics::new());
+        let empty = ReactionManager::replay_retained_outbox_after_gap(
+            "r1",
+            "q1",
+            &checkpoint,
+            &reaction,
+            &empty_query_trait,
+            &None,
+            &metrics,
+            &crate::queries::OutboxGap {
+                requested: 0,
+                earliest_available: 0,
+                latest_sequence: 0,
+                config_hash: 42,
+            },
+        )
+        .await
+        .expect("empty outbox bounds should not underflow");
+        assert_eq!(empty.sequence, 0);
+
+        let saturated_query = Arc::new(MockQuery::new(42, u64::MAX));
+        *saturated_query.outbox_response.write().await = Ok(OutboxResponse {
+            results: vec![Arc::new(QueryResult::new(
+                "q1".to_string(),
+                u64::MAX,
+                chrono::Utc::now(),
+                Vec::new(),
+                HashMap::new(),
+            ))],
+            latest_sequence: u64::MAX,
+            config_hash: 42,
+        });
+        let saturated_query_trait: Arc<dyn crate::queries::Query> = saturated_query;
+        let saturated = ReactionManager::replay_retained_outbox_after_gap(
+            "r1",
+            "q1",
+            &ReactionCheckpoint {
+                sequence: u64::MAX - 2,
+                config_hash: 42,
+            },
+            &reaction,
+            &saturated_query_trait,
+            &None,
+            &metrics,
+            &crate::queries::OutboxGap {
+                requested: u64::MAX - 2,
+                earliest_available: u64::MAX,
+                latest_sequence: u64::MAX,
+                config_hash: 42,
+            },
+        )
+        .await
+        .expect("saturated outbox bounds should not overflow");
+        assert_eq!(saturated.sequence, u64::MAX);
     }
 
     #[tokio::test]

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -1143,6 +1143,32 @@ impl ReactionManager {
                     loop {
                         match receiver.recv().await {
                             Ok(query_result) => {
+                                if query_result.sequence == 0
+                                    && query_result
+                                        .metadata
+                                        .get("control_signal")
+                                        .and_then(serde_json::Value::as_str)
+                                        .is_some_and(|signal| {
+                                            matches!(
+                                                signal,
+                                                "bootstrapStarted" | "bootstrapCompleted"
+                                            )
+                                        })
+                                {
+                                    let result = Arc::try_unwrap(query_result)
+                                        .unwrap_or_else(|arc| (*arc).clone());
+                                    if let Err(error) =
+                                        reaction.enqueue_query_result(result).await
+                                    {
+                                        log::error!(
+                                            "[{reaction_id_owned}] Failed to enqueue bootstrap control \
+                                             from query '{query_id_clone}': {error}"
+                                        );
+                                        break;
+                                    }
+                                    continue;
+                                }
+
                                 // Skip events already covered by the bootstrap snapshot/outbox catchup.
                                 if query_result.sequence <= last_forwarded_seq {
                                     forwarder_metrics.record_dedup_skip();

--- a/lib/tests/bootstrap_failure_e2e.rs
+++ b/lib/tests/bootstrap_failure_e2e.rs
@@ -21,14 +21,20 @@ mod mock_source;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use drasi_core::models::{
+    Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange,
+};
 use drasi_lib::bootstrap::{
     BootstrapContext, BootstrapProvider, BootstrapRequest, BootstrapResult,
 };
-use drasi_lib::channels::{BootstrapEventSender, ComponentStatus};
+use drasi_lib::channels::{BootstrapEvent, BootstrapEventSender, ComponentStatus};
 use drasi_lib::config::SourceSubscriptionSettings;
 use drasi_lib::{DrasiLib, Query, Source};
 use mock_source::MockSource;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
 /// A bootstrap provider that always fails.
@@ -47,12 +53,77 @@ impl BootstrapProvider for FailingBootstrapProvider {
     }
 }
 
+struct FailOnceAfterEventBootstrapProvider {
+    attempts: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl BootstrapProvider for FailOnceAfterEventBootstrapProvider {
+    async fn bootstrap(
+        &self,
+        _request: BootstrapRequest,
+        context: &BootstrapContext,
+        event_tx: BootstrapEventSender,
+        _settings: Option<&SourceSubscriptionSettings>,
+    ) -> Result<BootstrapResult> {
+        let attempt = self.attempts.fetch_add(1, Ordering::AcqRel);
+        event_tx
+            .send(BootstrapEvent {
+                source_id: context.source_id.clone(),
+                change: SourceChange::Insert {
+                    element: Element::Node {
+                        metadata: ElementMetadata {
+                            reference: ElementReference::new(
+                                &context.source_id,
+                                "bootstrap-person",
+                            ),
+                            labels: vec![Arc::from("Person")].into(),
+                            effective_from: 1_000,
+                        },
+                        properties: ElementPropertyMap::from(serde_json::json!({
+                            "name": "Recovered"
+                        })),
+                    },
+                },
+                timestamp: chrono::Utc::now(),
+                sequence: context.next_sequence(),
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("bootstrap receiver closed"))?;
+
+        if attempt == 0 {
+            anyhow::bail!("simulated failure after a bootstrap event");
+        }
+        Ok(BootstrapResult {
+            event_count: 1,
+            source_position: None,
+        })
+    }
+}
+
 /// Poll a query's status until it reaches `Error` or a 5 second deadline elapses.
 async fn wait_for_error_status(core: &DrasiLib, query_id: &str) -> Result<ComponentStatus> {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     let mut status = core.get_query_status(query_id).await?;
     while tokio::time::Instant::now() < deadline {
         if status == ComponentStatus::Error {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        status = core.get_query_status(query_id).await?;
+    }
+    Ok(status)
+}
+
+async fn wait_for_status(
+    core: &DrasiLib,
+    query_id: &str,
+    expected: ComponentStatus,
+) -> Result<ComponentStatus> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut status = core.get_query_status(query_id).await?;
+    while tokio::time::Instant::now() < deadline {
+        if status == expected {
             break;
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -142,5 +213,54 @@ async fn query_enters_error_state_when_multiple_bootstraps_fail() -> Result<()> 
         "Query should transition to Error state when multiple bootstraps fail, got {status:?}"
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn failed_bootstrap_can_stop_and_rebootstrap_without_partial_results() -> Result<()> {
+    let (mock_source, _handle) = MockSource::new("retry-source")?;
+    let attempts = Arc::new(AtomicUsize::new(0));
+    mock_source
+        .set_bootstrap_provider(Box::new(FailOnceAfterEventBootstrapProvider {
+            attempts: attempts.clone(),
+        }))
+        .await;
+    let query = Query::cypher("retry-query")
+        .query("MATCH (p:Person) RETURN p.name AS name")
+        .from_source("retry-source")
+        .auto_start(true)
+        .build();
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("bootstrap-retry-test")
+            .with_source(mock_source)
+            .with_query(query)
+            .build()
+            .await?,
+    );
+
+    core.start().await?;
+    assert_eq!(
+        wait_for_error_status(&core, "retry-query").await?,
+        ComponentStatus::Error
+    );
+    core.stop_query("retry-query").await?;
+    assert_eq!(
+        wait_for_status(&core, "retry-query", ComponentStatus::Stopped).await?,
+        ComponentStatus::Stopped
+    );
+    core.start_query("retry-query").await?;
+    assert_eq!(
+        wait_for_status(&core, "retry-query", ComponentStatus::Running).await?,
+        ComponentStatus::Running
+    );
+    assert_eq!(attempts.load(Ordering::Acquire), 2);
+    assert_eq!(
+        core.get_query_results("retry-query").await?.len(),
+        1,
+        "retry must replace partial volatile bootstrap output"
+    );
+
+    core.stop().await?;
     Ok(())
 }

--- a/lib/tests/reaction_recovery_e2e.rs
+++ b/lib/tests/reaction_recovery_e2e.rs
@@ -24,7 +24,9 @@ use anyhow::Result;
 use drasi_lib::channels::{ComponentStatus, QueryResult};
 use drasi_lib::context::ReactionRuntimeContext;
 use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
+use drasi_lib::reactions::ReactionCheckpoint;
 use drasi_lib::recovery::ReactionRecoveryPolicy;
+use drasi_lib::state_store::StateStoreProvider;
 use drasi_lib::{DispatchMode, DrasiLib, MemoryStateStoreProvider, Query, Reaction};
 use mock_source::{MockSource, MockSourceHandle, PropertyMapBuilder};
 use std::collections::HashMap;
@@ -289,6 +291,27 @@ async fn insert_person(handle: &MockSourceHandle, id: &str, name: &str, age: i64
     handle.send_node_insert(id, vec!["Person"], props).await
 }
 
+async fn persist_reaction_checkpoint(
+    store: &dyn StateStoreProvider,
+    reaction_id: &str,
+    query_id: &str,
+    sequence: u64,
+    config_hash: u64,
+) -> Result<()> {
+    let checkpoint = ReactionCheckpoint {
+        sequence,
+        config_hash,
+    };
+    store
+        .set(
+            reaction_id,
+            &format!("checkpoint:{query_id}"),
+            bincode::serialize(&checkpoint)?,
+        )
+        .await?;
+    Ok(())
+}
+
 /// Wait for the reaction to finish stopping before trying to restart.
 async fn stop_reaction_and_wait(core: &DrasiLib, id: &str) -> Result<()> {
     core.stop_reaction(id).await?;
@@ -337,7 +360,7 @@ async fn test_reaction_outbox_catchup_on_restart() -> Result<()> {
             .with_source(mock_source)
             .with_query(query)
             .with_reaction(reaction)
-            .with_state_store_provider(state_store)
+            .with_state_store_provider(state_store.clone())
             .build()
             .await?,
     );
@@ -349,6 +372,8 @@ async fn test_reaction_outbox_catchup_on_restart() -> Result<()> {
     insert_person(&handle, "p2", "Bob", 25).await?;
     let initial = receiver.wait_for_count(2, Duration::from_secs(5)).await;
     assert_eq!(initial.len(), 2, "Should receive 2 initial events");
+    let config_hash = drasi_lib::queries::compute_config_hash(&core.get_query_config("q1").await?);
+    persist_reaction_checkpoint(state_store.as_ref(), "rec", "q1", 2, config_hash).await?;
 
     // Stop the reaction — query keeps running, outbox accumulates
     stop_reaction_and_wait(&core, "rec").await?;
@@ -367,8 +392,8 @@ async fn test_reaction_outbox_catchup_on_restart() -> Result<()> {
     // Wait for the 3 missed events to arrive
     let replayed = receiver.wait_for_count(3, Duration::from_secs(5)).await;
     assert!(
-        replayed.len() >= 3,
-        "Should receive at least 3 replayed events, got {}",
+        replayed.len() == 3,
+        "Should receive exactly 3 replayed events, got {}",
         replayed.len()
     );
 
@@ -413,7 +438,7 @@ async fn test_reaction_restart_no_missed_events() -> Result<()> {
             .with_source(mock_source)
             .with_query(query)
             .with_reaction(reaction)
-            .with_state_store_provider(state_store)
+            .with_state_store_provider(state_store.clone())
             .build()
             .await?,
     );
@@ -425,21 +450,25 @@ async fn test_reaction_restart_no_missed_events() -> Result<()> {
     insert_person(&handle, "p2", "Bob", 25).await?;
     let initial = receiver.wait_for_count(2, Duration::from_secs(5)).await;
     assert_eq!(initial.len(), 2);
+    let config_hash = drasi_lib::queries::compute_config_hash(&core.get_query_config("q1").await?);
+    persist_reaction_checkpoint(state_store.as_ref(), "rec", "q1", 2, config_hash).await?;
 
     // Stop and immediately restart — no events in between
     stop_reaction_and_wait(&core, "rec").await?;
     core.start_reaction("rec").await?;
 
-    // Drain any spurious replays (there should be none beyond what's in the outbox)
+    // A checkpoint already at the durable sequence must suppress replay.
     tokio::time::sleep(Duration::from_millis(500)).await;
     let spurious = receiver.drain_available();
+    assert!(
+        spurious.is_empty(),
+        "checkpointed reaction received unnecessary replay: {spurious:?}"
+    );
 
     // Insert a new event to verify live delivery works
     insert_person(&handle, "p3", "Charlie", 35).await?;
     let live = receiver.wait_for_count(1, Duration::from_secs(5)).await;
     assert_eq!(live.len(), 1, "Should receive 1 live event after restart");
-
-    eprintln!("Spurious replays after clean restart: {}", spurious.len());
 
     core.stop().await?;
     Ok(())

--- a/lib/tests/reaction_recovery_e2e.rs
+++ b/lib/tests/reaction_recovery_e2e.rs
@@ -22,9 +22,13 @@ mod mock_source;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use drasi_core::interface::{
+    CheckpointStore, CreatedIndexes, IndexBackendPlugin, IndexError, OutboxWriter, SessionControl,
+};
 use drasi_core::models::{
     Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange,
 };
+use drasi_index_rocksdb::RocksDbIndexProvider;
 use drasi_lib::bootstrap::{
     BootstrapContext as SourceBootstrapContext, BootstrapProvider, BootstrapRequest,
     BootstrapResult,
@@ -36,7 +40,10 @@ use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
 use drasi_lib::reactions::{BootstrapContext as ReactionBootstrapContext, ReactionCheckpoint};
 use drasi_lib::recovery::ReactionRecoveryPolicy;
 use drasi_lib::state_store::StateStoreProvider;
-use drasi_lib::{DispatchMode, DrasiLib, MemoryStateStoreProvider, Query, Reaction, Source};
+use drasi_lib::{
+    DispatchMode, DrasiLib, MemoryStateStoreProvider, Query, Reaction, RecoveryPolicy, Source,
+    StorageBackendRef,
+};
 use mock_source::{MockSource, MockSourceHandle, PropertyMapBuilder};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -162,6 +169,28 @@ struct RecordingReaction {
 
 struct StableSnapshotBootstrapProvider {
     attempts: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+struct CapturingRocksProvider {
+    inner: RocksDbIndexProvider,
+    outbox: Arc<tokio::sync::RwLock<Option<Arc<dyn OutboxWriter>>>>,
+    checkpoint_store: Arc<tokio::sync::RwLock<Option<Arc<dyn CheckpointStore>>>>,
+    session_control: Arc<tokio::sync::RwLock<Option<Arc<dyn SessionControl>>>>,
+}
+
+#[async_trait]
+impl IndexBackendPlugin for CapturingRocksProvider {
+    async fn create_indexes(&self, query_id: &str) -> Result<CreatedIndexes, IndexError> {
+        let created = self.inner.create_indexes(query_id).await?;
+        *self.outbox.write().await = created.outbox_writer.clone();
+        *self.checkpoint_store.write().await = created.checkpoint_store.clone();
+        *self.session_control.write().await = Some(created.set.session_control.clone());
+        Ok(created)
+    }
+
+    fn is_volatile(&self) -> bool {
+        false
+    }
 }
 
 #[async_trait]
@@ -315,6 +344,19 @@ impl RecordingReceiver {
             results.push(r);
         }
         results
+    }
+
+    async fn wait_for_live(&mut self, dur: Duration) -> (Vec<QueryResult>, Option<QueryResult>) {
+        let deadline = tokio::time::Instant::now() + dur;
+        let mut controls = Vec::new();
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match timeout(remaining, self.rx.recv()).await {
+                Ok(Some(result)) if result.sequence == 0 => controls.push(result),
+                Ok(Some(result)) => return (controls, Some(result)),
+                Ok(None) | Err(_) => return (controls, None),
+            }
+        }
     }
 }
 
@@ -522,9 +564,8 @@ async fn volatile_query_rebootstrap_preserves_reaction_sequence_and_current_snap
     wait_for_query_status(&core, "volatile-query", ComponentStatus::Running).await?;
 
     insert_person(&handle, "live-before-restart", "Before", 30).await?;
-    let first = receiver.wait_for_count(1, Duration::from_secs(5)).await;
-    assert_eq!(first.len(), 1);
-    assert_eq!(first[0].sequence, 1);
+    let (_, first) = receiver.wait_for_live(Duration::from_secs(5)).await;
+    assert_eq!(first.expect("first live result").sequence, 1);
     let config_hash =
         drasi_lib::queries::compute_config_hash(&core.get_query_config("volatile-query").await?);
     persist_reaction_checkpoint(
@@ -546,13 +587,21 @@ async fn volatile_query_rebootstrap_preserves_reaction_sequence_and_current_snap
     );
 
     insert_person(&handle, "live-after-restart", "After", 31).await?;
-    let after_restart = receiver.wait_for_count(1, Duration::from_secs(5)).await;
+    let (controls, live) = receiver.wait_for_live(Duration::from_secs(5)).await;
+    let controls: Vec<_> = controls
+        .iter()
+        .filter_map(|result| {
+            (result.sequence == 0)
+                .then(|| result.metadata["control_signal"].as_str())
+                .flatten()
+        })
+        .collect();
+    assert_eq!(controls, vec!["bootstrapStarted", "bootstrapCompleted"]);
     assert_eq!(
-        after_restart.len(),
-        1,
-        "surviving reaction silently dropped the first post-rebootstrap result"
+        live.expect("surviving reaction dropped post-rebootstrap output")
+            .sequence,
+        2
     );
-    assert_eq!(after_restart[0].sequence, 2);
 
     let (snapshot_reaction, snapshot_rx) =
         SnapshotRecordingReaction::new("new-snapshot-reaction", "volatile-query");
@@ -572,6 +621,284 @@ async fn volatile_query_rebootstrap_preserves_reaction_sequence_and_current_snap
     assert!(!names.contains(&"Before"));
 
     core.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn persistent_auto_reset_preserves_reaction_high_water_across_process_restart() -> Result<()>
+{
+    let data_dir = tempfile::TempDir::new()?;
+    let state_store = Arc::new(DurableMemoryStateStoreProvider::new());
+    let captured_outbox: Arc<tokio::sync::RwLock<Option<Arc<dyn OutboxWriter>>>> =
+        Arc::new(tokio::sync::RwLock::new(None));
+    let captured_checkpoints: Arc<tokio::sync::RwLock<Option<Arc<dyn CheckpointStore>>>> =
+        Arc::new(tokio::sync::RwLock::new(None));
+    let captured_session: Arc<tokio::sync::RwLock<Option<Arc<dyn SessionControl>>>> =
+        Arc::new(tokio::sync::RwLock::new(None));
+    let provider1: Arc<dyn IndexBackendPlugin> = Arc::new(CapturingRocksProvider {
+        inner: RocksDbIndexProvider::new(data_dir.path(), true, false),
+        outbox: captured_outbox.clone(),
+        checkpoint_store: captured_checkpoints.clone(),
+        session_control: captured_session.clone(),
+    });
+    let (source1, handle1) = MockSource::new("persistent-reset-source")?;
+    let query_config = || {
+        Query::cypher("persistent-reset-query")
+            .query("MATCH (p:Person) RETURN p.name AS name, p.age AS age")
+            .from_source("persistent-reset-source")
+            .enable_bootstrap(false)
+            .with_storage_backend(StorageBackendRef::Named("rocks".to_string()))
+            .with_recovery_policy(RecoveryPolicy::AutoReset)
+            .with_outbox_capacity(16)
+            .auto_start(true)
+            .build()
+    };
+    let (reaction1, mut receiver1) = recording_reaction(
+        "persistent-reset-reaction",
+        vec!["persistent-reset-query".into()],
+        ReactionRecoveryPolicy::Strict,
+        true,
+        false,
+    );
+    let core1 = Arc::new(
+        DrasiLib::builder()
+            .with_id("persistent-reset-1")
+            .with_index_provider("rocks", provider1)
+            .with_source(source1)
+            .with_query(query_config())
+            .with_reaction(reaction1)
+            .with_state_store_provider(state_store.clone())
+            .build()
+            .await?,
+    );
+    core1.start().await?;
+    wait_for_query_status(&core1, "persistent-reset-query", ComponentStatus::Running).await?;
+    insert_person(&handle1, "p1", "BeforeReset", 30).await?;
+    let first = receiver1.wait_for_count(1, Duration::from_secs(5)).await;
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0].sequence, 1);
+    let config_hash = drasi_lib::queries::compute_config_hash(
+        &core1.get_query_config("persistent-reset-query").await?,
+    );
+    persist_reaction_checkpoint(
+        state_store.as_ref(),
+        "persistent-reset-reaction",
+        "persistent-reset-query",
+        1,
+        config_hash,
+    )
+    .await?;
+
+    core1.stop_query("persistent-reset-query").await?;
+    wait_for_query_status(&core1, "persistent-reset-query", ComponentStatus::Stopped).await?;
+    captured_outbox
+        .read()
+        .await
+        .as_ref()
+        .expect("captured RocksDB outbox")
+        .clear("persistent-reset-query")
+        .await?;
+    *captured_outbox.write().await = None;
+    *captured_checkpoints.write().await = None;
+    *captured_session.write().await = None;
+    core1.start_query("persistent-reset-query").await?;
+    wait_for_query_status(&core1, "persistent-reset-query", ComponentStatus::Running).await?;
+
+    insert_person(&handle1, "p2", "AfterReset", 31).await?;
+    let after_reset = receiver1.wait_for_count(1, Duration::from_secs(5)).await;
+    assert_eq!(after_reset.len(), 1);
+    assert_eq!(
+        after_reset[0].sequence, 2,
+        "AutoReset rewound the public output sequence"
+    );
+    persist_reaction_checkpoint(
+        state_store.as_ref(),
+        "persistent-reset-reaction",
+        "persistent-reset-query",
+        2,
+        config_hash,
+    )
+    .await?;
+
+    core1.stop_query("persistent-reset-query").await?;
+    wait_for_query_status(&core1, "persistent-reset-query", ComponentStatus::Stopped).await?;
+    let checkpoint_store = captured_checkpoints
+        .read()
+        .await
+        .as_ref()
+        .expect("captured RocksDB checkpoint store")
+        .clone();
+    let session_control = captured_session
+        .read()
+        .await
+        .as_ref()
+        .expect("captured RocksDB session control")
+        .clone();
+    session_control.begin().await?;
+    checkpoint_store
+        .stage_checkpoint("\0drasi:query-bootstrap:v1", 0, None)
+        .await?;
+    session_control.commit().await?;
+    drop(checkpoint_store);
+    drop(session_control);
+    *captured_outbox.write().await = None;
+    *captured_checkpoints.write().await = None;
+    *captured_session.write().await = None;
+    core1.start_query("persistent-reset-query").await?;
+    wait_for_query_status(&core1, "persistent-reset-query", ComponentStatus::Running).await?;
+    insert_person(&handle1, "p3", "AfterIncompleteBootstrap", 32).await?;
+    let after_incomplete = receiver1.wait_for_count(1, Duration::from_secs(5)).await;
+    assert_eq!(after_incomplete.len(), 1);
+    assert_eq!(
+        after_incomplete[0].sequence, 3,
+        "incomplete-bootstrap reset rewound the public sequence"
+    );
+    persist_reaction_checkpoint(
+        state_store.as_ref(),
+        "persistent-reset-reaction",
+        "persistent-reset-query",
+        3,
+        config_hash,
+    )
+    .await?;
+
+    let (snapshot_reaction, snapshot_rx) =
+        SnapshotRecordingReaction::new("persistent-reset-snapshot", "persistent-reset-query");
+    core1.add_reaction(snapshot_reaction).await?;
+    let (snapshot_sequence, snapshot_rows) = timeout(Duration::from_secs(5), snapshot_rx)
+        .await
+        .expect("persistent reset snapshot timed out")
+        .expect("persistent reset snapshot channel closed");
+    assert_eq!(snapshot_sequence, 3);
+    assert_eq!(snapshot_rows.len(), 1);
+    assert_eq!(snapshot_rows[0]["name"], "AfterIncompleteBootstrap");
+
+    core1.shutdown().await?;
+    *captured_outbox.write().await = None;
+    *captured_checkpoints.write().await = None;
+    *captured_session.write().await = None;
+    drop(core1);
+
+    let provider2: Arc<dyn IndexBackendPlugin> =
+        Arc::new(RocksDbIndexProvider::new(data_dir.path(), true, false));
+    let (source2, handle2) = MockSource::new("persistent-reset-source")?;
+    let (reaction2, mut receiver2) = recording_reaction(
+        "persistent-reset-reaction",
+        vec!["persistent-reset-query".into()],
+        ReactionRecoveryPolicy::Strict,
+        true,
+        false,
+    );
+    let core2 = Arc::new(
+        DrasiLib::builder()
+            .with_id("persistent-reset-2")
+            .with_index_provider("rocks", provider2)
+            .with_source(source2)
+            .with_query(query_config())
+            .with_reaction(reaction2)
+            .with_state_store_provider(state_store)
+            .build()
+            .await?,
+    );
+    core2.start().await?;
+    wait_for_query_status(&core2, "persistent-reset-query", ComponentStatus::Running).await?;
+    assert!(
+        receiver2.drain_available().is_empty(),
+        "checkpointed reaction replayed reset history on process restart"
+    );
+    insert_person(&handle2, "p3", "AfterProcessRestart", 32).await?;
+    let after_process_restart = receiver2.wait_for_count(1, Duration::from_secs(5)).await;
+    assert_eq!(after_process_restart.len(), 1);
+    assert_eq!(after_process_restart[0].sequence, 4);
+
+    core2.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn config_reset_preserves_reaction_high_water() -> Result<()> {
+    let data_dir = tempfile::TempDir::new()?;
+    let state_store = Arc::new(DurableMemoryStateStoreProvider::new());
+    let provider: Arc<dyn IndexBackendPlugin> =
+        Arc::new(RocksDbIndexProvider::new(data_dir.path(), true, false));
+    let (source, handle) = MockSource::new("config-reset-source")?;
+    let query = Query::cypher("config-reset-query")
+        .query("MATCH (p:Person) RETURN p.name AS name")
+        .from_source("config-reset-source")
+        .enable_bootstrap(false)
+        .with_storage_backend(StorageBackendRef::Named("rocks".to_string()))
+        .with_recovery_policy(RecoveryPolicy::AutoReset)
+        .auto_start(true)
+        .build();
+    let (reaction, mut receiver) = recording_reaction(
+        "config-reset-reaction",
+        vec!["config-reset-query".into()],
+        ReactionRecoveryPolicy::AutoReset,
+        true,
+        true,
+    );
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("config-reset-test")
+            .with_index_provider("rocks", provider)
+            .with_source(source)
+            .with_query(query)
+            .with_reaction(reaction)
+            .with_state_store_provider(state_store.clone())
+            .build()
+            .await?,
+    );
+    core.start().await?;
+    insert_person(&handle, "p1", "BeforeConfigReset", 30).await?;
+    let (_, first) = receiver.wait_for_live(Duration::from_secs(5)).await;
+    assert_eq!(first.expect("first config-reset output").sequence, 1);
+    let old_hash = drasi_lib::queries::compute_config_hash(
+        &core.get_query_config("config-reset-query").await?,
+    );
+    persist_reaction_checkpoint(
+        state_store.as_ref(),
+        "config-reset-reaction",
+        "config-reset-query",
+        1,
+        old_hash,
+    )
+    .await?;
+    stop_reaction_and_wait(&core, "config-reset-reaction").await?;
+
+    let changed_query = Query::cypher("config-reset-query")
+        .query("MATCH (p:Person) RETURN p.name AS name, p.age AS age")
+        .from_source("config-reset-source")
+        .enable_bootstrap(false)
+        .with_storage_backend(StorageBackendRef::Named("rocks".to_string()))
+        .with_recovery_policy(RecoveryPolicy::AutoReset)
+        .auto_start(true)
+        .build();
+    core.update_query("config-reset-query", changed_query)
+        .await?;
+    wait_for_query_status(&core, "config-reset-query", ComponentStatus::Running).await?;
+    core.start_reaction("config-reset-reaction").await?;
+
+    insert_person(&handle, "p2", "AfterConfigReset", 31).await?;
+    let (_, after_reset) = receiver.wait_for_live(Duration::from_secs(5)).await;
+    assert_eq!(
+        after_reset
+            .expect("post-config-reset output was silently dropped")
+            .sequence,
+        2
+    );
+
+    let (snapshot_reaction, snapshot_rx) =
+        SnapshotRecordingReaction::new("config-reset-snapshot", "config-reset-query");
+    core.add_reaction(snapshot_reaction).await?;
+    let (snapshot_sequence, snapshot_rows) = timeout(Duration::from_secs(5), snapshot_rx)
+        .await
+        .expect("config reset snapshot timed out")
+        .expect("config reset snapshot channel closed");
+    assert_eq!(snapshot_sequence, 2);
+    assert_eq!(snapshot_rows.len(), 1);
+    assert_eq!(snapshot_rows[0]["name"], "AfterConfigReset");
+
+    core.shutdown().await?;
     Ok(())
 }
 

--- a/lib/tests/reaction_recovery_e2e.rs
+++ b/lib/tests/reaction_recovery_e2e.rs
@@ -21,18 +21,27 @@
 mod mock_source;
 
 use anyhow::Result;
-use drasi_lib::channels::{ComponentStatus, QueryResult};
+use async_trait::async_trait;
+use drasi_core::models::{
+    Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange,
+};
+use drasi_lib::bootstrap::{
+    BootstrapContext as SourceBootstrapContext, BootstrapProvider, BootstrapRequest,
+    BootstrapResult,
+};
+use drasi_lib::channels::{BootstrapEvent, BootstrapEventSender, ComponentStatus, QueryResult};
+use drasi_lib::config::SourceSubscriptionSettings;
 use drasi_lib::context::ReactionRuntimeContext;
 use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
-use drasi_lib::reactions::ReactionCheckpoint;
+use drasi_lib::reactions::{BootstrapContext as ReactionBootstrapContext, ReactionCheckpoint};
 use drasi_lib::recovery::ReactionRecoveryPolicy;
 use drasi_lib::state_store::StateStoreProvider;
-use drasi_lib::{DispatchMode, DrasiLib, MemoryStateStoreProvider, Query, Reaction};
+use drasi_lib::{DispatchMode, DrasiLib, MemoryStateStoreProvider, Query, Reaction, Source};
 use mock_source::{MockSource, MockSourceHandle, PropertyMapBuilder};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::time::timeout;
 
 // ============================================================================
@@ -149,6 +158,134 @@ struct RecordingReaction {
     recovery_policy: ReactionRecoveryPolicy,
     durable: bool,
     snapshot_on_fresh: bool,
+}
+
+struct StableSnapshotBootstrapProvider {
+    attempts: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[async_trait]
+impl BootstrapProvider for StableSnapshotBootstrapProvider {
+    async fn bootstrap(
+        &self,
+        _request: BootstrapRequest,
+        context: &SourceBootstrapContext,
+        event_tx: BootstrapEventSender,
+        _settings: Option<&SourceSubscriptionSettings>,
+    ) -> Result<BootstrapResult> {
+        self.attempts
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        event_tx
+            .send(BootstrapEvent {
+                source_id: context.source_id.clone(),
+                change: SourceChange::Insert {
+                    element: Element::Node {
+                        metadata: ElementMetadata {
+                            reference: ElementReference::new(
+                                &context.source_id,
+                                "bootstrap-person",
+                            ),
+                            labels: vec![Arc::from("Person")].into(),
+                            effective_from: 1_000,
+                        },
+                        properties: ElementPropertyMap::from(serde_json::json!({
+                            "name": "Bootstrap",
+                            "age": 40
+                        })),
+                    },
+                },
+                timestamp: chrono::Utc::now(),
+                sequence: context.next_sequence(),
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("bootstrap receiver closed"))?;
+        Ok(BootstrapResult {
+            event_count: 1,
+            source_position: None,
+        })
+    }
+}
+
+struct SnapshotRecordingReaction {
+    base: ReactionBase,
+    snapshot_tx: Mutex<Option<oneshot::Sender<(u64, Vec<serde_json::Value>)>>>,
+}
+
+impl SnapshotRecordingReaction {
+    fn new(id: &str, query_id: &str) -> (Self, oneshot::Receiver<(u64, Vec<serde_json::Value>)>) {
+        let (snapshot_tx, snapshot_rx) = oneshot::channel();
+        (
+            Self {
+                base: ReactionBase::new(ReactionBaseParams::new(id, vec![query_id.to_string()])),
+                snapshot_tx: Mutex::new(Some(snapshot_tx)),
+            },
+            snapshot_rx,
+        )
+    }
+}
+
+#[async_trait]
+impl Reaction for SnapshotRecordingReaction {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "snapshot-recording"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+
+    fn query_ids(&self) -> Vec<String> {
+        self.base.queries.clone()
+    }
+
+    async fn initialize(&self, context: ReactionRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.base
+            .set_status(
+                ComponentStatus::Running,
+                Some("Snapshot reaction started".into()),
+            )
+            .await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base
+            .set_status(
+                ComponentStatus::Stopped,
+                Some("Snapshot reaction stopped".into()),
+            )
+            .await;
+        Ok(())
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    fn needs_snapshot_on_fresh_start(&self) -> bool {
+        true
+    }
+
+    async fn bootstrap(&self, context: ReactionBootstrapContext) -> Result<()> {
+        let snapshot = context
+            .fetch_snapshot()
+            .await
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+        let as_of_sequence = snapshot.as_of_sequence;
+        let rows = snapshot.collect_vec().await;
+        if let Some(sender) = self.snapshot_tx.lock().await.take() {
+            let _ = sender.send((as_of_sequence, rows));
+        }
+        Ok(())
+    }
 }
 
 /// Receiver side of the recording reaction.
@@ -328,9 +465,115 @@ async fn stop_reaction_and_wait(core: &DrasiLib, id: &str) -> Result<()> {
     anyhow::bail!("Reaction {id} did not reach Stopped state within timeout");
 }
 
+async fn wait_for_query_status(
+    core: &DrasiLib,
+    query_id: &str,
+    expected: ComponentStatus,
+) -> Result<()> {
+    for _ in 0..100 {
+        if core.get_query_status(query_id).await? == expected {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    anyhow::bail!("Query {query_id} did not reach {expected:?} within timeout");
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
+
+#[tokio::test]
+async fn volatile_query_rebootstrap_preserves_reaction_sequence_and_current_snapshot() -> Result<()>
+{
+    let (mock_source, handle) = MockSource::new("volatile-bootstrap-source")?;
+    let bootstrap_attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    mock_source
+        .set_bootstrap_provider(Box::new(StableSnapshotBootstrapProvider {
+            attempts: bootstrap_attempts.clone(),
+        }))
+        .await;
+    let query = Query::cypher("volatile-query")
+        .query("MATCH (p:Person) RETURN p.name AS name, p.age AS age")
+        .from_source("volatile-bootstrap-source")
+        .enable_bootstrap(true)
+        .with_outbox_capacity(16)
+        .auto_start(true)
+        .build();
+    let state_store = Arc::new(DurableMemoryStateStoreProvider::new());
+    let (reaction, mut receiver) = recording_reaction(
+        "surviving-reaction",
+        vec!["volatile-query".into()],
+        ReactionRecoveryPolicy::Strict,
+        true,
+        false,
+    );
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("volatile-rebootstrap-test")
+            .with_source(mock_source)
+            .with_query(query)
+            .with_reaction(reaction)
+            .with_state_store_provider(state_store.clone())
+            .build()
+            .await?,
+    );
+    core.start().await?;
+    wait_for_query_status(&core, "volatile-query", ComponentStatus::Running).await?;
+
+    insert_person(&handle, "live-before-restart", "Before", 30).await?;
+    let first = receiver.wait_for_count(1, Duration::from_secs(5)).await;
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0].sequence, 1);
+    let config_hash =
+        drasi_lib::queries::compute_config_hash(&core.get_query_config("volatile-query").await?);
+    persist_reaction_checkpoint(
+        state_store.as_ref(),
+        "surviving-reaction",
+        "volatile-query",
+        1,
+        config_hash,
+    )
+    .await?;
+
+    core.stop_query("volatile-query").await?;
+    wait_for_query_status(&core, "volatile-query", ComponentStatus::Stopped).await?;
+    core.start_query("volatile-query").await?;
+    wait_for_query_status(&core, "volatile-query", ComponentStatus::Running).await?;
+    assert_eq!(
+        bootstrap_attempts.load(std::sync::atomic::Ordering::Acquire),
+        2
+    );
+
+    insert_person(&handle, "live-after-restart", "After", 31).await?;
+    let after_restart = receiver.wait_for_count(1, Duration::from_secs(5)).await;
+    assert_eq!(
+        after_restart.len(),
+        1,
+        "surviving reaction silently dropped the first post-rebootstrap result"
+    );
+    assert_eq!(after_restart[0].sequence, 2);
+
+    let (snapshot_reaction, snapshot_rx) =
+        SnapshotRecordingReaction::new("new-snapshot-reaction", "volatile-query");
+    core.add_reaction(snapshot_reaction).await?;
+    let (as_of_sequence, snapshot) = timeout(Duration::from_secs(5), snapshot_rx)
+        .await
+        .expect("new reaction snapshot timed out")
+        .expect("new reaction snapshot channel closed");
+    assert_eq!(as_of_sequence, 2);
+    assert_eq!(snapshot.len(), 2);
+    let names: Vec<_> = snapshot
+        .iter()
+        .filter_map(|row| row["name"].as_str())
+        .collect();
+    assert!(names.contains(&"Bootstrap"));
+    assert!(names.contains(&"After"));
+    assert!(!names.contains(&"Before"));
+
+    core.stop().await?;
+    Ok(())
+}
 
 /// Test 1: Reaction replays missed events from outbox after restart.
 #[tokio::test]

--- a/lib/tests/reaction_recovery_e2e.rs
+++ b/lib/tests/reaction_recovery_e2e.rs
@@ -33,7 +33,9 @@ use drasi_lib::bootstrap::{
     BootstrapContext as SourceBootstrapContext, BootstrapProvider, BootstrapRequest,
     BootstrapResult,
 };
-use drasi_lib::channels::{BootstrapEvent, BootstrapEventSender, ComponentStatus, QueryResult};
+use drasi_lib::channels::{
+    BootstrapEvent, BootstrapEventSender, ComponentStatus, QueryResult, ResultDiff,
+};
 use drasi_lib::config::SourceSubscriptionSettings;
 use drasi_lib::context::ReactionRuntimeContext;
 use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
@@ -355,6 +357,31 @@ impl RecordingReceiver {
                 Ok(Some(result)) if result.sequence == 0 => controls.push(result),
                 Ok(Some(result)) => return (controls, Some(result)),
                 Ok(None) | Err(_) => return (controls, None),
+            }
+        }
+    }
+
+    async fn wait_through_name(&mut self, name: &str, dur: Duration) -> Vec<QueryResult> {
+        let deadline = tokio::time::Instant::now() + dur;
+        let mut results = Vec::new();
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match timeout(remaining, self.rx.recv()).await {
+                Ok(Some(result)) => {
+                    let found = result.results.iter().any(|diff| match diff {
+                        ResultDiff::Add { data, .. } | ResultDiff::Delete { data, .. } => {
+                            data["name"] == name
+                        }
+                        ResultDiff::Update { after, .. }
+                        | ResultDiff::Aggregation { after, .. } => after["name"] == name,
+                        ResultDiff::Noop => false,
+                    });
+                    results.push(result);
+                    if found {
+                        return results;
+                    }
+                }
+                Ok(None) | Err(_) => return results,
             }
         }
     }
@@ -1306,15 +1333,79 @@ async fn test_runtime_gap_detection_broadcast_lag() -> Result<()> {
         insert_person(&handle, &format!("p-flood-{i}"), &format!("Flood-{i}"), i).await?;
     }
 
-    // Verify that live delivery still works after the gap.
-    // With AutoSkipGap, the forwarder skips the gap and resumes.
-    // wait_for_count has its own timeout — no bare sleep needed.
+    // The newest retained event must remain deliverable even though the query's
+    // moving latest sequence already includes it.
     insert_person(&handle, "p-after-gap", "AfterGap", 99).await?;
-    let after = receiver.wait_for_count(1, Duration::from_secs(5)).await;
+    let first_episode = receiver
+        .wait_through_name("AfterGap", Duration::from_secs(5))
+        .await;
     assert_eq!(
-        after.len(),
+        first_episode
+            .iter()
+            .filter(|result| result.results.iter().any(|diff| matches!(
+                diff,
+                ResultDiff::Add { data, .. } if data["name"] == "AfterGap"
+            )))
+            .count(),
         1,
-        "Should receive live event after gap recovery"
+        "the newest post-gap event must be delivered exactly once"
+    );
+
+    // Repeat the lag episode, then send one event after the burst has gone idle.
+    for i in 0..20 {
+        insert_person(
+            &handle,
+            &format!("p-repeat-{i}"),
+            &format!("Repeat-{i}"),
+            100 + i,
+        )
+        .await?;
+    }
+    insert_person(&handle, "p-after-gap-2", "AfterGap2", 199).await?;
+    let second_episode = receiver
+        .wait_through_name("AfterGap2", Duration::from_secs(5))
+        .await;
+    assert_eq!(
+        second_episode
+            .iter()
+            .filter(|result| result.results.iter().any(|diff| matches!(
+                diff,
+                ResultDiff::Add { data, .. } if data["name"] == "AfterGap2"
+            )))
+            .count(),
+        1
+    );
+    assert!(
+        !second_episode
+            .iter()
+            .any(|result| result.results.iter().any(|diff| matches!(
+                diff,
+                ResultDiff::Add { data, .. } if data["name"] == "AfterGap"
+            ))),
+        "the prior gap-triggering event was delivered twice"
+    );
+
+    insert_person(&handle, "p-idle", "IdleAfterGap", 299).await?;
+    let idle = receiver
+        .wait_through_name("IdleAfterGap", Duration::from_secs(5))
+        .await;
+    assert_eq!(
+        idle.iter()
+            .filter(|result| result.results.iter().any(|diff| matches!(
+                diff,
+                ResultDiff::Add { data, .. } if data["name"] == "IdleAfterGap"
+            )))
+            .count(),
+        1
+    );
+    assert!(
+        !idle
+            .iter()
+            .any(|result| result.results.iter().any(|diff| matches!(
+                diff,
+                ResultDiff::Add { data, .. } if data["name"] == "AfterGap2"
+            ))),
+        "the second gap-triggering event was delivered twice"
     );
 
     core.stop().await?;

--- a/lib/tests/reaction_recovery_e2e.rs
+++ b/lib/tests/reaction_recovery_e2e.rs
@@ -242,6 +242,175 @@ struct SnapshotRecordingReaction {
     snapshot_tx: Mutex<Option<oneshot::Sender<(u64, Vec<serde_json::Value>)>>>,
 }
 
+#[derive(Default)]
+struct ReplayControl {
+    fail_sequence: std::sync::atomic::AtomicU64,
+    block_sequence: std::sync::atomic::AtomicU64,
+    block_entered: Mutex<Option<oneshot::Sender<()>>>,
+    block_release: Mutex<Option<oneshot::Receiver<()>>>,
+}
+
+impl ReplayControl {
+    fn fail_once(&self, sequence: u64) {
+        self.fail_sequence
+            .store(sequence, std::sync::atomic::Ordering::Release);
+    }
+
+    async fn block_once(&self, sequence: u64) -> (oneshot::Receiver<()>, oneshot::Sender<()>) {
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        *self.block_entered.lock().await = Some(entered_tx);
+        *self.block_release.lock().await = Some(release_rx);
+        self.block_sequence
+            .store(sequence, std::sync::atomic::Ordering::Release);
+        (entered_rx, release_tx)
+    }
+}
+
+struct ControlledRecordingReaction {
+    base: ReactionBase,
+    tx: mpsc::UnboundedSender<QueryResult>,
+    control: Arc<ReplayControl>,
+    config_hash: Arc<std::sync::atomic::AtomicU64>,
+}
+
+fn controlled_recording_reaction(
+    id: &str,
+    query_id: &str,
+) -> (
+    ControlledRecordingReaction,
+    RecordingReceiver,
+    Arc<ReplayControl>,
+    Arc<std::sync::atomic::AtomicU64>,
+) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let control = Arc::new(ReplayControl::default());
+    let config_hash = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    (
+        ControlledRecordingReaction {
+            base: ReactionBase::new(
+                ReactionBaseParams::new(id, vec![query_id.to_string()])
+                    .with_recovery_policy(ReactionRecoveryPolicy::AutoSkipGap),
+            ),
+            tx,
+            control: control.clone(),
+            config_hash: config_hash.clone(),
+        },
+        RecordingReceiver { rx },
+        control,
+        config_hash,
+    )
+}
+
+#[async_trait]
+impl Reaction for ControlledRecordingReaction {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
+
+    fn type_name(&self) -> &str {
+        "controlled-recording"
+    }
+
+    fn properties(&self) -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+
+    fn query_ids(&self) -> Vec<String> {
+        self.base.queries.clone()
+    }
+
+    async fn initialize(&self, context: ReactionRuntimeContext) {
+        self.base.initialize(context).await;
+    }
+
+    async fn start(&self) -> Result<()> {
+        self.base
+            .set_status(
+                ComponentStatus::Running,
+                Some("Controlled reaction started".into()),
+            )
+            .await;
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.base
+            .set_status(
+                ComponentStatus::Stopped,
+                Some("Controlled reaction stopped".into()),
+            )
+            .await;
+        Ok(())
+    }
+
+    async fn status(&self) -> ComponentStatus {
+        self.base.get_status().await
+    }
+
+    async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+        let sequence = result.sequence;
+        if self
+            .control
+            .block_sequence
+            .compare_exchange(
+                sequence,
+                0,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            if let Some(entered) = self.control.block_entered.lock().await.take() {
+                let _ = entered.send(());
+            }
+            self.control
+                .block_release
+                .lock()
+                .await
+                .take()
+                .expect("configured replay release receiver")
+                .await
+                .map_err(|_| anyhow::anyhow!("replay release sender dropped"))?;
+        }
+        if self
+            .control
+            .fail_sequence
+            .compare_exchange(
+                sequence,
+                0,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            anyhow::bail!("injected retained replay failure at sequence {sequence}");
+        }
+
+        self.tx
+            .send(result)
+            .map_err(|_| anyhow::anyhow!("controlled recording receiver dropped"))?;
+        if sequence > 0 {
+            let checkpoint = ReactionCheckpoint {
+                sequence,
+                config_hash: self.config_hash.load(std::sync::atomic::Ordering::Acquire),
+            };
+            self.base
+                .write_checkpoint(&self.base.queries[0], &checkpoint)
+                .await?;
+        }
+        Ok(())
+    }
+
+    fn is_durable(&self) -> bool {
+        true
+    }
+
+    fn default_recovery_policy(&self) -> ReactionRecoveryPolicy {
+        ReactionRecoveryPolicy::AutoSkipGap
+    }
+}
+
 impl SnapshotRecordingReaction {
     fn new(id: &str, query_id: &str) -> (Self, oneshot::Receiver<(u64, Vec<serde_json::Value>)>) {
         let (snapshot_tx, snapshot_rx) = oneshot::channel();
@@ -518,6 +687,18 @@ async fn persist_reaction_checkpoint(
     Ok(())
 }
 
+async fn read_reaction_checkpoint(
+    store: &dyn StateStoreProvider,
+    reaction_id: &str,
+    query_id: &str,
+) -> Result<Option<ReactionCheckpoint>> {
+    store
+        .get(reaction_id, &format!("checkpoint:{query_id}"))
+        .await?
+        .map(|bytes| bincode::deserialize(&bytes).map_err(anyhow::Error::from))
+        .transpose()
+}
+
 /// Wait for the reaction to finish stopping before trying to restart.
 async fn stop_reaction_and_wait(core: &DrasiLib, id: &str) -> Result<()> {
     core.stop_reaction(id).await?;
@@ -546,6 +727,26 @@ async fn wait_for_query_status(
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
     anyhow::bail!("Query {query_id} did not reach {expected:?} within timeout");
+}
+
+async fn wait_for_query_rows(core: &DrasiLib, query_id: &str, expected: usize) -> Result<()> {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if core
+                .get_query_results(query_id)
+                .await
+                .map_err(anyhow::Error::from)?
+                .len()
+                >= expected
+            {
+                return Ok::<(), anyhow::Error>(());
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .map_err(|_| anyhow::anyhow!("Query {query_id} did not reach {expected} rows"))??;
+    Ok(())
 }
 
 // ============================================================================
@@ -1073,7 +1274,8 @@ async fn test_reaction_restart_no_missed_events() -> Result<()> {
 
 /// Test 3: Outbox gap with AutoSkipGap — skips missed events, resumes live.
 #[tokio::test]
-async fn test_reaction_outbox_gap_auto_skip() -> Result<()> {
+async fn test_reaction_outbox_gap_auto_skip_replays_retained_suffix_and_orders_live() -> Result<()>
+{
     let (mock_source, handle) = MockSource::new("test-source")?;
 
     // Small outbox capacity so it overflows
@@ -1086,13 +1288,7 @@ async fn test_reaction_outbox_gap_auto_skip() -> Result<()> {
 
     let state_store = Arc::new(DurableMemoryStateStoreProvider::new());
 
-    let (reaction, mut receiver) = recording_reaction(
-        "rec",
-        vec!["q1".into()],
-        ReactionRecoveryPolicy::AutoSkipGap,
-        true,
-        false,
-    );
+    let (reaction, mut receiver, control, config_hash) = controlled_recording_reaction("rec", "q1");
 
     let core = Arc::new(
         DrasiLib::builder()
@@ -1100,17 +1296,21 @@ async fn test_reaction_outbox_gap_auto_skip() -> Result<()> {
             .with_source(mock_source)
             .with_query(query)
             .with_reaction(reaction)
-            .with_state_store_provider(state_store)
+            .with_state_store_provider(state_store.clone())
             .build()
             .await?,
     );
 
     core.start().await?;
+    config_hash.store(
+        drasi_lib::queries::compute_config_hash(&core.get_query_config("q1").await?),
+        std::sync::atomic::Ordering::Release,
+    );
 
     // Insert 1 row to establish checkpoint
     insert_person(&handle, "p1", "Alice", 30).await?;
-    let initial = receiver.wait_for_count(1, Duration::from_secs(5)).await;
-    assert_eq!(initial.len(), 1);
+    let (_, initial) = receiver.wait_for_live(Duration::from_secs(5)).await;
+    assert_eq!(initial.expect("initial controlled result").sequence, 1);
 
     // Stop reaction
     stop_reaction_and_wait(&core, "rec").await?;
@@ -1125,23 +1325,143 @@ async fn test_reaction_outbox_gap_auto_skip() -> Result<()> {
         )
         .await?;
     }
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_for_query_rows(&core, "q1", 6).await?;
 
-    // Restart — AutoSkipGap should jump to current sequence
-    core.start_reaction("rec").await?;
+    // Block the first retained replay (seq 5). A live seq 7 arrives while the
+    // reaction gate is still closed and must follow retained seqs 5 and 6.
+    let (replay_entered, replay_release) = control.block_once(5).await;
+    let start_core = core.clone();
+    let start = tokio::spawn(async move { start_core.start_reaction("rec").await });
+    replay_entered
+        .await
+        .expect("retained replay should reach sequence 5");
+    insert_person(&handle, "p-live", "LivePerson", 99).await?;
+    wait_for_query_rows(&core, "q1", 7).await?;
+    replay_release
+        .send(())
+        .expect("release retained replay sequence 5");
+    start
+        .await
+        .expect("reaction start task should join")
+        .expect("reaction catch-up should succeed");
 
-    // Drain any replayed events (should be minimal — gap was skipped)
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    let after_restart = receiver.drain_available();
-    eprintln!(
-        "Events after AutoSkipGap restart: {} (gap events were skipped)",
-        after_restart.len()
+    let delivered = receiver.wait_for_count(3, Duration::from_secs(5)).await;
+    assert_eq!(
+        delivered
+            .iter()
+            .map(|result| result.sequence)
+            .collect::<Vec<_>>(),
+        vec![5, 6, 7],
+        "missing prefix 2..=4 should be skipped while retained/live results stay ordered"
+    );
+    assert_eq!(
+        delivered
+            .iter()
+            .flat_map(|result| result.results.iter())
+            .filter_map(|diff| match diff {
+                ResultDiff::Add { data, .. } => data["name"].as_str(),
+                _ => None,
+            })
+            .collect::<Vec<_>>(),
+        vec!["Person-3", "Person-4", "LivePerson"]
+    );
+    assert!(receiver.drain_available().is_empty());
+    let final_checkpoint = read_reaction_checkpoint(state_store.as_ref(), "rec", "q1")
+        .await?
+        .expect("controlled reaction checkpoint");
+    assert_eq!(final_checkpoint.sequence, 7);
+
+    core.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_reaction_outbox_gap_auto_skip_resumes_first_failed_retained_entry() -> Result<()> {
+    let (mock_source, handle) = MockSource::new("test-source")?;
+    let query = Query::cypher("q1")
+        .query("MATCH (p:Person) RETURN p.name AS name")
+        .from_source("test-source")
+        .with_outbox_capacity(2)
+        .auto_start(true)
+        .build();
+    let state_store = Arc::new(DurableMemoryStateStoreProvider::new());
+    let (reaction, mut receiver, control, config_hash) = controlled_recording_reaction("rec", "q1");
+    let core = Arc::new(
+        DrasiLib::builder()
+            .with_id("skip-gap-failure-test")
+            .with_source(mock_source)
+            .with_query(query)
+            .with_reaction(reaction)
+            .with_state_store_provider(state_store.clone())
+            .build()
+            .await?,
+    );
+    core.start().await?;
+    config_hash.store(
+        drasi_lib::queries::compute_config_hash(&core.get_query_config("q1").await?),
+        std::sync::atomic::Ordering::Release,
+    );
+    insert_person(&handle, "p1", "Alice", 30).await?;
+    let (_, initial) = receiver.wait_for_live(Duration::from_secs(5)).await;
+    assert_eq!(initial.expect("initial controlled result").sequence, 1);
+    stop_reaction_and_wait(&core, "rec").await?;
+
+    for i in 0..5 {
+        insert_person(
+            &handle,
+            &format!("p{}", i + 10),
+            &format!("Person-{i}"),
+            20 + i,
+        )
+        .await?;
+    }
+    wait_for_query_rows(&core, "q1", 6).await?;
+    control.fail_once(5);
+    let error = core
+        .start_reaction("rec")
+        .await
+        .expect_err("first retained replay should fail");
+    assert!(error.to_string().contains("sequence 5"));
+    assert!(receiver.drain_available().is_empty());
+    assert_eq!(
+        read_reaction_checkpoint(state_store.as_ref(), "rec", "q1")
+            .await?
+            .expect("skipped-floor checkpoint")
+            .sequence,
+        4,
+        "failure at sequence 5 must leave the checkpoint at 4"
     );
 
-    // Verify live delivery works after skip
-    insert_person(&handle, "p-live", "LivePerson", 99).await?;
+    stop_reaction_and_wait(&core, "rec").await?;
+    core.start_reaction("rec").await?;
+    let replayed = receiver.wait_for_count(2, Duration::from_secs(5)).await;
+    assert_eq!(
+        replayed
+            .iter()
+            .map(|result| result.sequence)
+            .collect::<Vec<_>>(),
+        vec![5, 6]
+    );
+    assert!(receiver.drain_available().is_empty());
+    assert_eq!(
+        read_reaction_checkpoint(state_store.as_ref(), "rec", "q1")
+            .await?
+            .expect("retained replay checkpoint")
+            .sequence,
+        6
+    );
+
+    insert_person(&handle, "p-live", "LiveAfterRetry", 99).await?;
     let live = receiver.wait_for_count(1, Duration::from_secs(5)).await;
-    assert_eq!(live.len(), 1, "Should receive live event after gap skip");
+    assert_eq!(live.len(), 1);
+    assert_eq!(live[0].sequence, 7);
+    assert_eq!(
+        read_reaction_checkpoint(state_store.as_ref(), "rec", "q1")
+            .await?
+            .expect("final live checkpoint")
+            .sequence,
+        7
+    );
 
     core.stop().await?;
     Ok(())


### PR DESCRIPTION
## Stack

Stack A layer 7 of 7.

Depends on #870. Base: `agentofreality-atomic-query-processing-scope`.

This completes the compatibility-first Query Composite tranche. External Drasi Server, Source, Query, Reaction, plugin, and persisted `QueryResult` wire contracts remain unchanged.

## Summary

- moves source bootstrap task supervision, bounded per-envelope evaluation, final all-source handoff, gate opening, and sequence-0 bootstrap control output into a private host-owned `QueryBootstrapScope`
- persists private versioned bootstrap, reset-baseline, and Legacy pending-publication checkpoint markers
- hydrates `QueryOutputState` from committed result sequence, durable outbox, and live-result rows before source forwarders are installed
- validates durable artifact consistency and applies existing Strict/AutoReset policy instead of guessing or overwriting sequences
- recovers the exact fenced `QueryResult` allocation after commit-before-apply/dispatch and replays only that pending sequence to existing subscribers
- preserves monotonic sequence/outbox history across volatile re-bootstrap while rebuilding only the current row projection
- preserves the maximum authoritative public output high-water across every same-identity destructive reset; the first new output is high-water + 1
- stages a load-bearing persistent Legacy pending marker in the same source/future transaction before progress commits, and clears it only after required output or confirmed Noop completion
- applies Strict/AutoReset policy to malformed, unknown-version, or incomplete Legacy pending markers without trusting corrupt marker data during reset high-water derivation
- rejects persistent Legacy bundles whose checkpoint store cannot join the core transaction before evaluation begins
- makes configured persistent Legacy outbox/live/result-sequence/marker failures fail closed immediately, while retaining best-effort behavior for optional volatile writers
- centralizes destructive recovery reset so persistent state, process-local output, reset baseline, and the publication fence are reconciled together only after durable clearing succeeds
- makes live AutoSkipGap checkpoint only the actually missing floor before the retained triggering event; current and buffered results remain deliverable and advance only after successful enqueue
- makes startup AutoSkipGap persist `earliest_available - 1`, replay every retained outbox entry in order, and checkpoint after each successful enqueue; failure leaves the first undelivered sequence recoverable on restart
- keeps the live forwarder gated during retained replay so buffered live results are ordered after catch-up and deduped against the published checkpoint
- forwards sequence-0 bootstrap controls independently of reaction result high-water while retaining checkpoint-aware result dedup

## Persistence compatibility

No existing record or wire format changes. `QueryResult::profiling` only gains backward-compatible default deserialization. Recovery uses additive private NUL-prefixed checkpoint records; marker absence remains compatible with pre-A7 state. Deprovision clears the identity; same-identity resets retain their monotonic output baseline.

## Retained Legacy limitations

Legacy mode still does not claim atomic core+output publication when backend output writers cannot join the core transaction. The pending marker makes source/future progress detectably recoverable when checkpoint/session domains match. Configured persistent write or marker failures fence immediately and require verified reconciliation or AutoReset. A backend whose persistent checkpoint store cannot share the core transaction is rejected rather than receiving a false fail-closed guarantee. Optional non-persistent writers retain their documented best-effort behavior. Garnet remains Legacy for result publication because its outbox/live-result writers do not advertise the core transaction domain.

## Validation

- `cargo fmt -- --check`
- strict default-feature clippy (`-D warnings`) for drasi-lib, core, RocksDB, and Garnet across all targets
- deterministic full drasi-lib suite excluding only the unrelated pre-existing `reactions::common::base::tests::test_run_standard_loop_dedup_and_checkpoint` race; targeted rerun passed
- full drasi-core suite: 755 passed
- full RocksDB suite: 121 passed
- Garnet non-Docker tests: 14 passed; Docker-backed Garnet session tests could not start because Docker is unavailable
- source-query-reaction, deprovision/reconfigure, and static RocksDB restart/reopen integration suites: 25 passed
- real ReactionManager capacity-trimmed startup replay: missing prefix skipped, retained suffix delivered exactly once, live event ordered after replay, final checkpoint at latest
- real ReactionManager mid-replay enqueue failure: checkpoint remains S-1, restart resumes S, no duplicate, subsequent live checkpoint advances
- deterministic startup bounds, repeated live lag, moving-query-latest, enqueue-failure, corrupt-marker, reset-high-water, Legacy marker/future/Noop, and bootstrap/reconciliation matrices

All-feature clippy remains blocked before Rust linting by the existing `jq-sys 0.2.2` bundled oniguruma C build on current macOS Clang.