### PR TITLE
fix(lib): preserve reaction result sequence order

### DIFF
--- a/components/reactions/profiler/src/profiler.rs
+++ b/components/reactions/profiler/src/profiler.rs
@@ -505,6 +505,7 @@ impl Reaction for ProfilerReaction {
         let stats = self.stats.clone();
         let report_interval = self.report_interval_secs;
         let priority_queue = self.base.priority_queue.clone();
+        let mut shutdown_rx = self.base.create_shutdown_channel().await;
 
         let processing_task = tokio::spawn(async move {
             let mut report_timer =
@@ -513,6 +514,10 @@ impl Reaction for ProfilerReaction {
 
             loop {
                 tokio::select! {
+                    biased;
+                    _ = &mut shutdown_rx => {
+                        break;
+                    }
                     query_result = priority_queue.dequeue() => {
                         // Extract and store profiling data
                         if let Some(profiling) = query_result.profiling.clone() {

--- a/components/reactions/profiler/src/profiler/tests.rs
+++ b/components/reactions/profiler/src/profiler/tests.rs
@@ -12,8 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(test)]
-mod tests {
-    // Tests for profiler reaction module
-    // Currently empty - tests will be added as needed
+use super::*;
+use drasi_lib::Reaction;
+
+#[tokio::test]
+async fn profiler_accepts_results_after_stop_and_restart() {
+    let reaction = ProfilerReaction::new(
+        "restart-profiler",
+        vec!["q1".to_string()],
+        ProfilerReactionConfig {
+            window_size: 10,
+            report_interval_secs: 60,
+        },
+    );
+
+    reaction.start().await.unwrap();
+    reaction.stop().await.unwrap();
+    reaction.start().await.unwrap();
+    reaction
+        .enqueue_query_result(drasi_lib::channels::QueryResult::with_profiling(
+            "q1".to_string(),
+            1,
+            chrono::Utc::now(),
+            Vec::new(),
+            HashMap::new(),
+            ProfilingMetadata {
+                source_send_ns: Some(1),
+                query_receive_ns: Some(2),
+                query_core_call_ns: Some(3),
+                query_core_return_ns: Some(4),
+                query_send_ns: Some(5),
+                reaction_receive_ns: Some(6),
+                reaction_complete_ns: Some(7),
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect("restarted profiler queue should be open");
+
+    tokio::time::timeout(tokio::time::Duration::from_secs(1), async {
+        while reaction.stats.read().await.count == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("restarted profiler did not process the result");
+    reaction.stop().await.unwrap();
 }

--- a/lib/src/channels/priority_queue.rs
+++ b/lib/src/channels/priority_queue.rs
@@ -21,21 +21,27 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
 
-/// Wrapper for priority queue events with timestamp-based ordering
+/// Wrapper for priority queue events with stable timestamp-based ordering.
 #[derive(Clone)]
 struct PriorityQueueEvent<T>
 where
     T: Timestamped + Clone + Send + Sync + 'static,
 {
     event: Arc<T>,
+    ordering_timestamp: chrono::DateTime<chrono::Utc>,
+    ordinal: u64,
 }
 
 impl<T> PriorityQueueEvent<T>
 where
     T: Timestamped + Clone + Send + Sync + 'static,
 {
-    fn new(event: Arc<T>) -> Self {
-        Self { event }
+    fn new(event: Arc<T>, ordering_timestamp: chrono::DateTime<chrono::Utc>, ordinal: u64) -> Self {
+        Self {
+            event,
+            ordering_timestamp,
+            ordinal,
+        }
     }
 }
 
@@ -45,7 +51,7 @@ where
     T: Timestamped + Clone + Send + Sync + 'static,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.event.timestamp() == other.event.timestamp()
+        self.ordering_timestamp == other.ordering_timestamp && self.ordinal == other.ordinal
     }
 }
 
@@ -65,8 +71,12 @@ where
     T: Timestamped + Clone + Send + Sync + 'static,
 {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Reverse ordering for min-heap behavior (oldest first)
-        other.event.timestamp().cmp(&self.event.timestamp())
+        // Reverse the lexicographic key for min-heap behavior. The ordinal
+        // keeps equal timestamps stable and makes this a total order.
+        other
+            .ordering_timestamp
+            .cmp(&self.ordering_timestamp)
+            .then_with(|| other.ordinal.cmp(&self.ordinal))
     }
 }
 
@@ -162,6 +172,8 @@ where
     notify: Arc<Notify>,
     /// Maximum queue capacity (for backpressure)
     max_capacity: usize,
+    /// Stable insertion order for events with the same ordering timestamp.
+    next_ordinal: Arc<AtomicU64>,
     /// Metrics (using atomic operations for lock-free updates)
     metrics: Arc<PriorityQueueMetrics>,
 }
@@ -176,6 +188,7 @@ where
             heap: Arc::new(Mutex::new(BinaryHeap::new())),
             notify: Arc::new(Notify::new()),
             max_capacity,
+            next_ordinal: Arc::new(AtomicU64::new(0)),
             metrics: Arc::new(PriorityQueueMetrics::default()),
         }
     }
@@ -183,6 +196,17 @@ where
     /// Enqueue an event into the priority queue
     /// Returns true if enqueued, false if queue is at capacity
     pub async fn enqueue(&self, event: Arc<T>) -> bool {
+        let ordering_timestamp = event.timestamp();
+        self.enqueue_with_ordering_timestamp(event, ordering_timestamp)
+            .await
+    }
+
+    /// Enqueue using an internal ordering timestamp without changing the event.
+    pub(crate) async fn enqueue_with_ordering_timestamp(
+        &self,
+        event: Arc<T>,
+        ordering_timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> bool {
         let mut heap = self.heap.lock().await;
 
         // Check capacity
@@ -210,7 +234,8 @@ where
         }
 
         // Enqueue event
-        heap.push(PriorityQueueEvent::new(event));
+        let ordinal = self.next_ordinal.fetch_add(1, AtomicOrdering::Relaxed);
+        heap.push(PriorityQueueEvent::new(event, ordering_timestamp, ordinal));
 
         // Update metrics using atomic operations (lock-free)
         self.metrics
@@ -251,6 +276,17 @@ where
     /// WARNING: Do NOT use with Broadcast dispatch mode - will cause deadlock!
     /// In broadcast mode, use the non-blocking `enqueue()` method instead.
     pub async fn enqueue_wait(&self, event: Arc<T>) {
+        let ordering_timestamp = event.timestamp();
+        self.enqueue_wait_with_ordering_timestamp(event, ordering_timestamp)
+            .await;
+    }
+
+    /// Enqueue with backpressure using an internal ordering timestamp.
+    pub(crate) async fn enqueue_wait_with_ordering_timestamp(
+        &self,
+        event: Arc<T>,
+        ordering_timestamp: chrono::DateTime<chrono::Utc>,
+    ) {
         loop {
             // Register notified future BEFORE acquiring lock to avoid race
             let notified = self.notify.notified();
@@ -261,7 +297,8 @@ where
             // Check if there's capacity
             if heap.len() < self.max_capacity {
                 // Space available - enqueue the event
-                heap.push(PriorityQueueEvent::new(event));
+                let ordinal = self.next_ordinal.fetch_add(1, AtomicOrdering::Relaxed);
+                heap.push(PriorityQueueEvent::new(event, ordering_timestamp, ordinal));
 
                 // Update metrics using atomic operations (lock-free)
                 self.metrics
@@ -433,6 +470,7 @@ where
             heap: Arc::clone(&self.heap),
             notify: Arc::clone(&self.notify),
             max_capacity: self.max_capacity,
+            next_ordinal: Arc::clone(&self.next_ordinal),
             metrics: Arc::clone(&self.metrics),
         }
     }
@@ -486,6 +524,20 @@ mod tests {
 
         let dequeued3 = pq.try_dequeue().await.unwrap();
         assert_eq!(dequeued3.id, "event3"); // Newest
+    }
+
+    #[tokio::test]
+    async fn test_equal_timestamps_preserve_enqueue_order() {
+        let pq = PriorityQueue::new(100);
+        let timestamp = Utc::now();
+
+        for id in ["event1", "event2", "event3"] {
+            assert!(pq.enqueue(create_test_event(id, timestamp)).await);
+        }
+
+        for expected in ["event1", "event2", "event3"] {
+            assert_eq!(pq.try_dequeue().await.unwrap().id, expected);
+        }
     }
 
     #[tokio::test]

--- a/lib/src/channels/priority_queue.rs
+++ b/lib/src/channels/priority_queue.rs
@@ -17,7 +17,7 @@ use log::{debug, trace};
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::fmt::Debug;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering as AtomicOrdering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
 
@@ -131,6 +131,10 @@ impl Default for PriorityQueueMetrics {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("priority queue is closed")]
+pub(crate) struct PriorityQueueClosed;
+
 /// Thread-safe generic priority queue for ordering events by timestamp
 ///
 /// # Backpressure and Dispatch Modes
@@ -172,6 +176,8 @@ where
     notify: Arc<Notify>,
     /// Maximum queue capacity (for backpressure)
     max_capacity: usize,
+    /// Closed queues reject new events and wake blocked enqueuers.
+    closed: Arc<AtomicBool>,
     /// Stable insertion order for events with the same ordering timestamp.
     next_ordinal: Arc<AtomicU64>,
     /// Metrics (using atomic operations for lock-free updates)
@@ -188,6 +194,7 @@ where
             heap: Arc::new(Mutex::new(BinaryHeap::new())),
             notify: Arc::new(Notify::new()),
             max_capacity,
+            closed: Arc::new(AtomicBool::new(false)),
             next_ordinal: Arc::new(AtomicU64::new(0)),
             metrics: Arc::new(PriorityQueueMetrics::default()),
         }
@@ -208,6 +215,10 @@ where
         ordering_timestamp: chrono::DateTime<chrono::Utc>,
     ) -> bool {
         let mut heap = self.heap.lock().await;
+
+        if self.closed.load(AtomicOrdering::Acquire) {
+            return false;
+        }
 
         // Check capacity
         if heap.len() >= self.max_capacity {
@@ -277,8 +288,13 @@ where
     /// In broadcast mode, use the non-blocking `enqueue()` method instead.
     pub async fn enqueue_wait(&self, event: Arc<T>) {
         let ordering_timestamp = event.timestamp();
-        self.enqueue_wait_with_ordering_timestamp(event, ordering_timestamp)
-            .await;
+        if self
+            .enqueue_wait_with_ordering_timestamp(event, ordering_timestamp)
+            .await
+            .is_err()
+        {
+            debug!("Priority queue closed while enqueue was waiting");
+        }
     }
 
     /// Enqueue with backpressure using an internal ordering timestamp.
@@ -286,13 +302,17 @@ where
         &self,
         event: Arc<T>,
         ordering_timestamp: chrono::DateTime<chrono::Utc>,
-    ) {
+    ) -> Result<(), PriorityQueueClosed> {
         loop {
             // Register notified future BEFORE acquiring lock to avoid race
             let notified = self.notify.notified();
             tokio::pin!(notified);
 
             let mut heap = self.heap.lock().await;
+
+            if self.closed.load(AtomicOrdering::Acquire) {
+                return Err(PriorityQueueClosed);
+            }
 
             // Check if there's capacity
             if heap.len() < self.max_capacity {
@@ -328,7 +348,7 @@ where
                 // Notify waiting dequeuers
                 self.notify.notify_one();
 
-                return;
+                return Ok(());
             }
 
             // Queue is full - increment blocked count and wait
@@ -353,6 +373,21 @@ where
             // Wait for dequeue to create space
             notified.await;
         }
+    }
+
+    /// Close the queue and wake every producer blocked on capacity.
+    pub(crate) async fn close(&self) {
+        let heap = self.heap.lock().await;
+        self.closed.store(true, AtomicOrdering::Release);
+        drop(heap);
+        self.notify.notify_waiters();
+    }
+
+    /// Reopen a closed queue for a new producer generation.
+    pub(crate) async fn reopen(&self) {
+        let heap = self.heap.lock().await;
+        self.closed.store(false, AtomicOrdering::Release);
+        drop(heap);
     }
 
     /// Dequeue the oldest event from the priority queue (non-blocking)
@@ -455,6 +490,8 @@ where
         let events: Vec<Arc<T>> = heap.drain().map(|pq_event| pq_event.event).collect();
 
         self.metrics.current_depth.store(0, AtomicOrdering::Relaxed);
+        drop(heap);
+        self.notify.notify_waiters();
 
         debug!("Drained {} events from priority queue", events.len());
         events
@@ -470,6 +507,7 @@ where
             heap: Arc::clone(&self.heap),
             notify: Arc::clone(&self.notify),
             max_capacity: self.max_capacity,
+            closed: Arc::clone(&self.closed),
             next_ordinal: Arc::clone(&self.next_ordinal),
             metrics: Arc::clone(&self.metrics),
         }
@@ -531,11 +569,13 @@ mod tests {
         let pq = PriorityQueue::new(100);
         let timestamp = Utc::now();
 
-        for id in ["event1", "event2", "event3"] {
+        for id in ["event1", "event2", "event3", "event4", "event5", "event6", "event7", "event8"] {
             assert!(pq.enqueue(create_test_event(id, timestamp)).await);
         }
 
-        for expected in ["event1", "event2", "event3"] {
+        for expected in
+            ["event1", "event2", "event3", "event4", "event5", "event6", "event7", "event8"]
+        {
             assert_eq!(pq.try_dequeue().await.unwrap().id, expected);
         }
     }
@@ -678,6 +718,43 @@ mod tests {
 
         assert!(result.is_ok(), "enqueue_wait should have been notified");
         assert_eq!(pq.depth().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_close_cancels_blocked_enqueue_and_reopen_accepts_new_events() {
+        let pq = PriorityQueue::new(1);
+        let timestamp = Utc::now();
+        pq.enqueue_wait(create_test_event("event1", timestamp))
+            .await;
+
+        let blocked_queue = pq.clone();
+        let blocked = tokio::spawn(async move {
+            blocked_queue
+                .enqueue_wait_with_ordering_timestamp(
+                    create_test_event("event2", timestamp),
+                    timestamp,
+                )
+                .await
+        });
+        while pq.metrics().await.blocked_enqueue_count == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        pq.close().await;
+        let result = tokio::time::timeout(tokio::time::Duration::from_secs(1), blocked)
+            .await
+            .expect("closed queue did not wake blocked enqueue")
+            .expect("blocked enqueue task panicked");
+        assert_eq!(result, Err(PriorityQueueClosed));
+        assert_eq!(pq.depth().await, 1);
+
+        pq.drain().await;
+        pq.reopen().await;
+        assert!(
+            pq.enqueue(create_test_event("event3", timestamp)).await,
+            "reopened queue should accept new events"
+        );
+        assert_eq!(pq.try_dequeue().await.unwrap().id, "event3");
     }
 
     #[tokio::test]

--- a/lib/src/component_graph/graph.rs
+++ b/lib/src/component_graph/graph.rs
@@ -1225,6 +1225,7 @@ pub(super) fn is_valid_relationship(
 /// Reconfiguring ──→ Stopped | Starting | Error
 ///
 /// Error ──→ Starting (retry) | Stopping (cleanup) | Stopped (reset)
+/// Stopped ──→ Error (failed-start cleanup)
 ///
 /// Note: Added and Removed are set by the graph on add/remove_component()
 /// and are NOT valid targets for validate_and_transition().
@@ -1250,6 +1251,7 @@ pub(super) fn is_valid_transition(from: &ComponentStatus, to: &ComponentStatus) 
             | (Error, Starting) // retry
             | (Error, Stopping) // operator cleanup
             | (Error, Stopped) // reset
+            | (Stopped, Error) // failed-start cleanup completed
             // Reconfiguration (from any stable state)
             | (Added, Reconfiguring)
             | (Stopped, Reconfiguring)

--- a/lib/src/component_graph/tests.rs
+++ b/lib/src/component_graph/tests.rs
@@ -528,6 +528,10 @@ fn test_valid_state_transitions() {
         &ComponentStatus::Error,
         &ComponentStatus::Stopped
     ));
+    assert!(is_valid_transition(
+        &ComponentStatus::Stopped,
+        &ComponentStatus::Error
+    ));
 }
 
 #[test]

--- a/lib/src/managers/lifecycle_helpers.rs
+++ b/lib/src/managers/lifecycle_helpers.rs
@@ -143,15 +143,35 @@ pub async fn start_component<R: ComponentRuntime>(
     component_type: &str,
     runtime: &R,
 ) -> Result<()> {
-    // Validate and apply Starting transition atomically through the graph
-    {
-        let mut g = graph.write().await;
-        g.validate_and_transition(
-            id,
-            ComponentStatus::Starting,
-            Some(format!("Starting {component_type}")),
-        )?
-    };
+    claim_component_start(graph, id, component_type).await?;
+    start_claimed_component(graph, id, runtime).await
+}
+
+/// Atomically validate and claim a component start, returning its prior status.
+pub(crate) async fn claim_component_start(
+    graph: &Arc<RwLock<ComponentGraph>>,
+    id: &str,
+    component_type: &str,
+) -> Result<ComponentStatus> {
+    let mut graph = graph.write().await;
+    let prior_status = graph
+        .get_component(id)
+        .map(|node| node.status)
+        .ok_or_else(|| anyhow::anyhow!("{component_type} '{id}' not found"))?;
+    graph.validate_and_transition(
+        id,
+        ComponentStatus::Starting,
+        Some(format!("Starting {component_type}")),
+    )?;
+    Ok(prior_status)
+}
+
+/// Start a runtime after its `Starting` transition has already been claimed.
+pub(crate) async fn start_claimed_component<R: ComponentRuntime>(
+    graph: &Arc<RwLock<ComponentGraph>>,
+    id: &str,
+    runtime: &R,
+) -> Result<()> {
     if let Err(e) = runtime.start().await {
         // Revert graph status so the component isn't stuck at Starting
         let mut g = graph.write().await;

--- a/lib/src/reactions/common/base.rs
+++ b/lib/src/reactions/common/base.rs
@@ -31,8 +31,9 @@
 
 use anyhow::Result;
 use log::{debug, error, info, warn};
+use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::Instrument;
 
 use crate::channels::priority_queue::PriorityQueue;
@@ -43,6 +44,22 @@ use crate::identity::IdentityProvider;
 use crate::reactions::checkpoint::ReactionCheckpoint;
 use crate::recovery::ReactionRecoveryPolicy;
 use crate::state_store::StateStoreProvider;
+
+#[derive(Debug, Default)]
+struct QueryOrderingCursor {
+    last_sequence: Option<u64>,
+    last_ordering_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "query result sequence inversion for query '{query_id}': received sequence {received} after {last_enqueued}"
+)]
+struct QueryResultSequenceInversion {
+    query_id: String,
+    received: u64,
+    last_enqueued: u64,
+}
 
 /// Parameters for creating a ReactionBase instance.
 ///
@@ -121,8 +138,10 @@ pub struct ReactionBase {
     context: Arc<RwLock<Option<ReactionRuntimeContext>>>,
     /// State store provider (extracted from context for convenience)
     state_store: Arc<RwLock<Option<Arc<dyn StateStoreProvider>>>>,
-    /// Priority queue for timestamp-ordered result processing
+    /// Priority queue for result processing
     pub priority_queue: PriorityQueue<QueryResult>,
+    /// Per-query cursor used to derive monotonic internal ordering keys.
+    result_ordering: Arc<Mutex<HashMap<String, QueryOrderingCursor>>>,
     /// Handles to subscription forwarder tasks
     pub subscription_tasks: Arc<RwLock<Vec<tokio::task::JoinHandle<()>>>>,
     /// Handle to the main processing task
@@ -146,6 +165,7 @@ impl ReactionBase {
     pub fn new(params: ReactionBaseParams) -> Self {
         Self {
             priority_queue: PriorityQueue::new(params.priority_queue_capacity.unwrap_or(10000)),
+            result_ordering: Arc::new(Mutex::new(HashMap::new())),
             id: params.id.clone(),
             queries: params.queries,
             auto_start: params.auto_start,
@@ -272,6 +292,7 @@ impl ReactionBase {
             context: self.context.clone(),
             state_store: self.state_store.clone(),
             priority_queue: self.priority_queue.clone(),
+            result_ordering: self.result_ordering.clone(),
             subscription_tasks: self.subscription_tasks.clone(),
             processing_task: self.processing_task.clone(),
             shutdown_tx: self.shutdown_tx.clone(),
@@ -325,9 +346,42 @@ impl ReactionBase {
     /// Enqueue a query result for processing.
     ///
     /// The host calls this to forward query results to the reaction's priority queue.
-    /// Results are processed in timestamp order by the reaction's processing task.
+    /// Each query retains FIFO sequence order. Across queries, wall-clock timestamps
+    /// remain the primary ordering key.
     pub async fn enqueue_query_result(&self, result: QueryResult) -> anyhow::Result<()> {
-        self.priority_queue.enqueue_wait(Arc::new(result)).await;
+        let query_id = result.query_id.clone();
+        let sequence = result.sequence;
+        let timestamp = result.timestamp;
+        let mut ordering = self.result_ordering.lock().await;
+        let cursor = ordering.entry(query_id.clone()).or_default();
+
+        if sequence != 0 {
+            if let Some(last_enqueued) = cursor.last_sequence {
+                if sequence < last_enqueued {
+                    return Err(QueryResultSequenceInversion {
+                        query_id,
+                        received: sequence,
+                        last_enqueued,
+                    }
+                    .into());
+                }
+            }
+        }
+
+        // Clamping each partition's timestamp makes its ordering key monotonic.
+        // The queue adds a stable ordinal, so (timestamp, ordinal) is a
+        // transitive total order while preserving FIFO within this query.
+        let ordering_timestamp = cursor
+            .last_ordering_timestamp
+            .map_or(timestamp, |last| last.max(timestamp));
+        self.priority_queue
+            .enqueue_wait_with_ordering_timestamp(Arc::new(result), ordering_timestamp)
+            .await;
+
+        cursor.last_ordering_timestamp = Some(ordering_timestamp);
+        if sequence != 0 {
+            cursor.last_sequence = Some(sequence);
+        }
         Ok(())
     }
 
@@ -447,6 +501,7 @@ impl ReactionBase {
                 drained_events.len()
             );
         }
+        self.result_ordering.lock().await.clear();
 
         self.set_status(
             ComponentStatus::Stopped,
@@ -580,6 +635,20 @@ mod tests {
     use std::time::Duration;
     use tokio::sync::mpsc;
 
+    fn query_result(
+        query_id: &str,
+        sequence: u64,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> QueryResult {
+        QueryResult::new(
+            query_id.to_string(),
+            sequence,
+            timestamp,
+            vec![],
+            Default::default(),
+        )
+    }
+
     #[tokio::test]
     async fn test_reaction_base_creation() {
         let params = ReactionBaseParams::new("test-reaction", vec!["query1".to_string()])
@@ -644,6 +713,131 @@ mod tests {
         // Drain queue
         let drained = base.priority_queue.drain().await;
         assert_eq!(drained.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn same_query_equal_timestamps_preserve_sequence_order() {
+        let base = ReactionBase::new(ReactionBaseParams::new(
+            "equal-timestamps",
+            vec!["q1".to_string()],
+        ));
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+
+        base.enqueue_query_result(query_result("q1", 6, timestamp))
+            .await
+            .unwrap();
+        base.enqueue_query_result(query_result("q1", 7, timestamp))
+            .await
+            .unwrap();
+
+        assert_eq!(base.priority_queue.dequeue().await.sequence, 6);
+        assert_eq!(base.priority_queue.dequeue().await.sequence, 7);
+    }
+
+    #[tokio::test]
+    async fn same_query_backwards_timestamps_preserve_sequence_order() {
+        let base = ReactionBase::new(ReactionBaseParams::new(
+            "backwards-timestamps",
+            vec!["q1".to_string()],
+        ));
+        let later = chrono::DateTime::from_timestamp(1_700_000_010, 0).unwrap();
+        let earlier = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+
+        base.enqueue_query_result(query_result("q1", 6, later))
+            .await
+            .unwrap();
+        base.enqueue_query_result(query_result("q1", 7, earlier))
+            .await
+            .unwrap();
+
+        assert_eq!(base.priority_queue.dequeue().await.sequence, 6);
+        assert_eq!(base.priority_queue.dequeue().await.sequence, 7);
+    }
+
+    #[tokio::test]
+    async fn multiple_queries_merge_deterministically_without_sequence_inversion() {
+        let base = ReactionBase::new(ReactionBaseParams::new(
+            "multiple-queries",
+            vec!["q1".to_string(), "q2".to_string(), "q3".to_string()],
+        ));
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+
+        base.enqueue_query_result(query_result(
+            "q1",
+            1,
+            timestamp + chrono::Duration::seconds(30),
+        ))
+        .await
+        .unwrap();
+        base.enqueue_query_result(query_result(
+            "q2",
+            1,
+            timestamp + chrono::Duration::seconds(20),
+        ))
+        .await
+        .unwrap();
+        base.enqueue_query_result(query_result(
+            "q1",
+            2,
+            timestamp + chrono::Duration::seconds(10),
+        ))
+        .await
+        .unwrap();
+        base.enqueue_query_result(query_result(
+            "q2",
+            2,
+            timestamp + chrono::Duration::seconds(30),
+        ))
+        .await
+        .unwrap();
+        base.enqueue_query_result(query_result(
+            "q3",
+            1,
+            timestamp + chrono::Duration::seconds(30),
+        ))
+        .await
+        .unwrap();
+
+        let mut actual = Vec::new();
+        for _ in 0..5 {
+            let result = base.priority_queue.dequeue().await;
+            actual.push((result.query_id.clone(), result.sequence));
+        }
+        assert_eq!(
+            actual,
+            vec![
+                ("q2".to_string(), 1),
+                ("q1".to_string(), 1),
+                ("q1".to_string(), 2),
+                ("q2".to_string(), 2),
+                ("q3".to_string(), 1),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_rejects_same_query_sequence_inversion() {
+        let base = ReactionBase::new(ReactionBaseParams::new(
+            "sequence-inversion",
+            vec!["q1".to_string()],
+        ));
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+
+        base.enqueue_query_result(query_result("q1", 7, timestamp))
+            .await
+            .unwrap();
+        let error = base
+            .enqueue_query_result(query_result("q1", 6, timestamp))
+            .await
+            .expect_err("a newly arriving sequence inversion must be surfaced");
+
+        assert!(
+            error
+                .downcast_ref::<QueryResultSequenceInversion>()
+                .is_some(),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(base.priority_queue.depth().await, 1);
     }
 
     #[tokio::test]
@@ -1029,94 +1223,81 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_standard_loop_dedup_and_checkpoint() {
-        use std::sync::atomic::{AtomicU64, Ordering};
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-        let (graph, _rx) = crate::component_graph::ComponentGraph::new("test-instance");
-        let update_tx = graph.update_sender();
+        for iteration in 0..100 {
+            let reaction_id = format!("loop-reaction-{iteration}");
+            let (graph, _rx) = crate::component_graph::ComponentGraph::new("test-instance");
+            let base = ReactionBase::new(ReactionBaseParams::new(
+                reaction_id.clone(),
+                vec!["q1".to_string()],
+            ));
 
-        let params = ReactionBaseParams::new("loop-reaction", vec!["q1".to_string()]);
-        let base = ReactionBase::new(params);
+            let store: Arc<dyn StateStoreProvider> =
+                Arc::new(crate::state_store::MemoryStateStoreProvider::new());
+            let context = crate::context::ReactionRuntimeContext::new(
+                "test-instance",
+                reaction_id,
+                Some(store),
+                graph.update_sender(),
+                None,
+            );
+            base.initialize(context).await;
 
-        let store: Arc<dyn StateStoreProvider> =
-            Arc::new(crate::state_store::MemoryStateStoreProvider::new());
-        let context = crate::context::ReactionRuntimeContext::new(
-            "test-instance",
-            "loop-reaction",
-            Some(store),
-            update_tx,
-            None,
-        );
-        base.initialize(context).await;
-
-        // Initial checkpoints: seq=5 with config_hash=42
-        let initial_checkpoints = {
-            let mut m = std::collections::HashMap::new();
-            m.insert(
+            let initial_checkpoints = HashMap::from([(
                 "q1".to_string(),
                 ReactionCheckpoint {
                     sequence: 5,
                     config_hash: 42,
                 },
-            );
-            m
-        };
+            )]);
 
-        // Enqueue events: seq 3 (dup), seq 5 (dup), seq 6, seq 7
-        for seq in [3u64, 5, 6, 7] {
-            let result = crate::channels::QueryResult {
-                query_id: "q1".to_string(),
-                sequence: seq,
-                timestamp: chrono::Utc::now(),
-                results: vec![],
-                metadata: Default::default(),
-                profiling: None,
-            };
-            base.enqueue_query_result(result).await.unwrap();
-        }
-
-        // Track which sequences the handler actually processes
-        let processed = Arc::new(tokio::sync::Mutex::new(Vec::<u64>::new()));
-        let processed_clone = processed.clone();
-        let handler_count = Arc::new(AtomicU64::new(0));
-        let handler_count_clone = handler_count.clone();
-
-        let shutdown_rx = base.create_shutdown_channel().await;
-        let base_clone = base.clone_shared();
-
-        let loop_handle = tokio::spawn(async move {
-            base_clone
-                .run_standard_loop(shutdown_rx, initial_checkpoints, |event| {
-                    let processed = processed_clone.clone();
-                    let count = handler_count_clone.clone();
-                    async move {
-                        processed.lock().await.push(event.sequence);
-                        count.fetch_add(1, Ordering::SeqCst);
-                        Ok(())
-                    }
-                })
-                .await
-                .unwrap();
-        });
-
-        // Wait for all non-dup events to be processed (seq 6 and 7)
-        for _ in 0..50 {
-            if handler_count.load(Ordering::SeqCst) >= 2 {
-                break;
+            // Equal timestamps exercise the old heap tie that could put 7 before 6.
+            // Sequences 3 and 5 are legitimate replay duplicates.
+            for sequence in [3, 5, 6, 7] {
+                base.enqueue_query_result(query_result("q1", sequence, timestamp))
+                    .await
+                    .unwrap();
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            let processed = Arc::new(tokio::sync::Mutex::new(Vec::<u64>::new()));
+            let completed = Arc::new(tokio::sync::Notify::new());
+            let processed_clone = processed.clone();
+            let completed_clone = completed.clone();
+            let shutdown_rx = base.create_shutdown_channel().await;
+            let base_clone = base.clone_shared();
+
+            let loop_handle = tokio::spawn(async move {
+                base_clone
+                    .run_standard_loop(shutdown_rx, initial_checkpoints, |event| {
+                        let processed = processed_clone.clone();
+                        let completed = completed_clone.clone();
+                        async move {
+                            let mut processed = processed.lock().await;
+                            processed.push(event.sequence);
+                            if processed.len() == 2 {
+                                completed.notify_one();
+                            }
+                            Ok(())
+                        }
+                    })
+                    .await
+                    .unwrap();
+            });
+
+            tokio::time::timeout(Duration::from_secs(2), completed.notified())
+                .await
+                .expect("standard loop did not process both new results");
+            base.stop_common().await.unwrap();
+            tokio::time::timeout(Duration::from_secs(2), loop_handle)
+                .await
+                .expect("standard loop did not stop")
+                .expect("standard loop task panicked");
+
+            assert_eq!(*processed.lock().await, vec![6, 7]);
+            let checkpoint = base.read_checkpoint("q1").await.unwrap().unwrap();
+            assert_eq!(checkpoint.sequence, 7);
+            assert_eq!(checkpoint.config_hash, 42);
         }
-
-        // Signal shutdown via stop_common (the standard path)
-        let _ = base.stop_common().await;
-        let _ = tokio::time::timeout(Duration::from_secs(2), loop_handle).await;
-
-        // Verify only seq 6 and 7 were processed (3 and 5 were deduped)
-        let processed = processed.lock().await;
-        assert_eq!(*processed, vec![6, 7]);
-
-        // Checkpoint should now be at seq=7, preserving config_hash=42
-        let cp = base.read_checkpoint("q1").await.unwrap().unwrap();
-        assert_eq!(cp.sequence, 7);
-        assert_eq!(cp.config_hash, 42);
     }
 }

--- a/lib/src/reactions/common/base.rs
+++ b/lib/src/reactions/common/base.rs
@@ -308,6 +308,20 @@ impl ReactionBase {
     ///
     /// This should be called before spawning the processing task.
     pub async fn create_shutdown_channel(&self) -> tokio::sync::oneshot::Receiver<()> {
+        // Every start owns a fresh queue generation. Closing first prevents a
+        // producer from crossing the drain/reopen boundary.
+        self.priority_queue.close().await;
+        let stale_events = self.priority_queue.drain().await;
+        if !stale_events.is_empty() {
+            warn!(
+                "[{}] Discarded {} stale results before starting a new generation",
+                self.id,
+                stale_events.len()
+            );
+        }
+        self.result_ordering.lock().await.clear();
+        self.priority_queue.reopen().await;
+
         let (tx, rx) = tokio::sync::oneshot::channel();
         *self.shutdown_tx.write().await = Some(tx);
         rx
@@ -376,7 +390,7 @@ impl ReactionBase {
             .map_or(timestamp, |last| last.max(timestamp));
         self.priority_queue
             .enqueue_wait_with_ordering_timestamp(Arc::new(result), ordering_timestamp)
-            .await;
+            .await?;
 
         cursor.last_ordering_timestamp = Some(ordering_timestamp);
         if sequence != 0 {
@@ -455,6 +469,10 @@ impl ReactionBase {
     /// 4. Draining the priority queue
     pub async fn stop_common(&self) -> Result<()> {
         info!("Stopping reaction: {}", self.id);
+
+        // Reject and wake producers before stopping the consumer. A producer
+        // may hold the per-query ordering lock while waiting for queue space.
+        self.priority_queue.close().await;
 
         // Send shutdown signal to processing task (if it's using tokio::select!)
         if let Some(tx) = self.shutdown_tx.write().await.take() {
@@ -723,15 +741,15 @@ mod tests {
         ));
         let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-        base.enqueue_query_result(query_result("q1", 6, timestamp))
-            .await
-            .unwrap();
-        base.enqueue_query_result(query_result("q1", 7, timestamp))
-            .await
-            .unwrap();
+        for sequence in 1..=8 {
+            base.enqueue_query_result(query_result("q1", sequence, timestamp))
+                .await
+                .unwrap();
+        }
 
-        assert_eq!(base.priority_queue.dequeue().await.sequence, 6);
-        assert_eq!(base.priority_queue.dequeue().await.sequence, 7);
+        for expected in 1..=8 {
+            assert_eq!(base.priority_queue.dequeue().await.sequence, expected);
+        }
     }
 
     #[tokio::test]
@@ -838,6 +856,52 @@ mod tests {
             "unexpected error: {error:#}"
         );
         assert_eq!(base.priority_queue.depth().await, 1);
+    }
+
+    #[tokio::test]
+    async fn stop_cancels_blocked_enqueue_and_next_start_reopens_queue() {
+        let base = ReactionBase::new(
+            ReactionBaseParams::new("stop-blocked-enqueue", vec!["q1".to_string()])
+                .with_priority_queue_capacity(1),
+        );
+        let _shutdown_rx = base.create_shutdown_channel().await;
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        base.enqueue_query_result(query_result("q1", 1, timestamp))
+            .await
+            .unwrap();
+
+        let producer_base = base.clone_shared();
+        let producer = tokio::spawn(async move {
+            producer_base
+                .enqueue_query_result(query_result("q1", 2, timestamp))
+                .await
+        });
+        while base.priority_queue.metrics().await.blocked_enqueue_count == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        tokio::time::timeout(Duration::from_secs(1), base.stop_common())
+            .await
+            .expect("stop deadlocked behind blocked producer")
+            .expect("stop failed");
+        let error = tokio::time::timeout(Duration::from_secs(1), producer)
+            .await
+            .expect("producer did not exit after stop")
+            .expect("producer task panicked")
+            .expect_err("closed queue must reject the blocked result");
+        assert!(
+            error
+                .downcast_ref::<crate::channels::priority_queue::PriorityQueueClosed>()
+                .is_some(),
+            "unexpected producer error: {error:#}"
+        );
+        assert_eq!(base.priority_queue.depth().await, 0);
+
+        let _next_shutdown_rx = base.create_shutdown_channel().await;
+        base.enqueue_query_result(query_result("q1", 1, timestamp))
+            .await
+            .expect("new start generation should accept results");
+        assert_eq!(base.priority_queue.dequeue().await.sequence, 1);
     }
 
     #[tokio::test]
@@ -1251,6 +1315,7 @@ mod tests {
                     config_hash: 42,
                 },
             )]);
+            let shutdown_rx = base.create_shutdown_channel().await;
 
             // Equal timestamps exercise the old heap tie that could put 7 before 6.
             // Sequences 3 and 5 are legitimate replay duplicates.
@@ -1264,7 +1329,6 @@ mod tests {
             let completed = Arc::new(tokio::sync::Notify::new());
             let processed_clone = processed.clone();
             let completed_clone = completed.clone();
-            let shutdown_rx = base.create_shutdown_channel().await;
             let base_clone = base.clone_shared();
 
             let loop_handle = tokio::spawn(async move {

--- a/lib/src/reactions/common/checkpoint_state.rs
+++ b/lib/src/reactions/common/checkpoint_state.rs
@@ -22,11 +22,10 @@
 //! loop: advance a per-query `(sequence, config_hash)` checkpoint **only after a
 //! batch of results has been successfully delivered (acked)**.
 //!
-//! Deduplication of replayed events is **not** done here — the host
-//! `ReactionManager` forwarder already filters events with
-//! `sequence <= checkpoint.sequence` (seeded from the persisted checkpoint at
-//! startup) before they reach a reaction's priority queue. These helpers only
-//! persist checkpoints, which the forwarder deliberately does not do.
+//! Deduplication of replay/live overlap is **not** done here — the host
+//! `ReactionManager` tracks a generation-local forwarded high-water separately
+//! from the durable checkpoint. These helpers persist only successfully
+//! delivered progress.
 //!
 //! Reactions that follow the simple per-event pattern can use
 //! [`ReactionBase::run_standard_loop`](crate::reactions::common::base::ReactionBase::run_standard_loop)
@@ -43,12 +42,10 @@ use crate::recovery::ReactionRecoveryPolicy;
 /// advances move forward monotonically and preserve `config_hash`.
 ///
 /// The `config_hash` is read **lazily on the first advance for a query**, not at
-/// construction. The host persists the startup-seed checkpoint (carrying the
-/// real `config_hash`) *after* the reaction's `start()` runs, so reading it
-/// eagerly would capture a stale `config_hash` of `0` and a subsequent write
-/// would clobber the seed — causing a false `config_hash` mismatch (and
-/// recovery) on the next restart. Seeding lazily, after the bootstrap gate has
-/// opened, picks up the correct value.
+/// construction. The host establishes the startup baseline carrying the real
+/// `config_hash` before replay, while snapshot/bootstrap checkpoints are
+/// committed after successful bootstrap. Lazy seeding observes whichever
+/// authoritative baseline applies without treating enqueue as acknowledgement.
 ///
 /// Checkpoints are persisted only when a state store is configured. A
 /// non-durable reaction (`is_durable() == false`) without a store advances its

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -1892,6 +1892,64 @@ mod tests {
         }
     }
 
+    struct QueueBackedReaction {
+        base: crate::reactions::common::base::ReactionBase,
+    }
+
+    impl QueueBackedReaction {
+        fn new(id: &str, queries: Vec<String>) -> Self {
+            Self {
+                base: crate::reactions::common::base::ReactionBase::new(
+                    crate::reactions::common::base::ReactionBaseParams::new(id, queries),
+                ),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Reaction for QueueBackedReaction {
+        fn id(&self) -> &str {
+            self.base.get_id()
+        }
+
+        fn type_name(&self) -> &str {
+            "queue-backed-test"
+        }
+
+        fn properties(&self) -> HashMap<String, serde_json::Value> {
+            HashMap::new()
+        }
+
+        fn query_ids(&self) -> Vec<String> {
+            self.base.get_queries().to_vec()
+        }
+
+        fn auto_start(&self) -> bool {
+            false
+        }
+
+        async fn initialize(&self, context: crate::context::ReactionRuntimeContext) {
+            self.base.initialize(context).await;
+        }
+
+        async fn start(&self) -> Result<()> {
+            self.base.set_status(ComponentStatus::Running, None).await;
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<()> {
+            self.base.stop_common().await
+        }
+
+        async fn status(&self) -> ComponentStatus {
+            self.base.get_status().await
+        }
+
+        async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+            self.base.enqueue_query_result(result).await
+        }
+    }
+
     // ========================================================================
     // Test helpers
     // ========================================================================
@@ -2439,6 +2497,82 @@ mod tests {
         .await
         .expect("saturated outbox bounds should not overflow");
         assert_eq!(saturated.sequence, u64::MAX);
+    }
+
+    #[tokio::test]
+    async fn retained_outbox_then_live_is_ordered_by_reaction_base() {
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let query = Arc::new(MockQuery::new(42, 6));
+        *query.outbox_response.write().await = Ok(OutboxResponse {
+            results: vec![
+                Arc::new(QueryResult::new(
+                    "q1".to_string(),
+                    5,
+                    timestamp + chrono::Duration::seconds(10),
+                    Vec::new(),
+                    HashMap::new(),
+                )),
+                Arc::new(QueryResult::new(
+                    "q1".to_string(),
+                    6,
+                    timestamp,
+                    Vec::new(),
+                    HashMap::new(),
+                )),
+            ],
+            latest_sequence: 6,
+            config_hash: 42,
+        });
+        let query_trait: Arc<dyn crate::queries::Query> = query;
+        let reaction = Arc::new(QueueBackedReaction::new("r1", vec!["q1".to_string()]));
+        let reaction_trait: Arc<dyn Reaction> = reaction.clone();
+        let metrics = Arc::new(ReactionMetrics::new());
+
+        let recovered = ReactionManager::replay_retained_outbox_after_gap(
+            "r1",
+            "q1",
+            &ReactionCheckpoint {
+                sequence: 4,
+                config_hash: 42,
+            },
+            &reaction_trait,
+            &query_trait,
+            &None,
+            &metrics,
+            &crate::queries::OutboxGap {
+                requested: 4,
+                earliest_available: 5,
+                latest_sequence: 6,
+                config_hash: 42,
+            },
+        )
+        .await
+        .expect("retained outbox replay should enqueue sequences 5 and 6");
+        assert_eq!(recovered.sequence, 6);
+
+        let checkpoints = Arc::new(RwLock::new(HashMap::from([("q1".to_string(), recovered)])));
+        ReactionManager::enqueue_forwarded_result(
+            &reaction_trait,
+            &query_trait,
+            "q1",
+            &checkpoints,
+            &metrics,
+            Arc::new(QueryResult::new(
+                "q1".to_string(),
+                7,
+                timestamp - chrono::Duration::seconds(10),
+                Vec::new(),
+                HashMap::new(),
+            )),
+        )
+        .await
+        .expect("buffered live result should enqueue after retained replay");
+
+        let mut sequences = Vec::new();
+        for _ in 0..3 {
+            sequences.push(reaction.base.priority_queue.dequeue().await.sequence);
+        }
+        assert_eq!(sequences, vec![5, 6, 7]);
     }
 
     #[tokio::test]

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -14,7 +14,7 @@
 
 use anyhow::{Context, Result};
 use log::{error, info, warn};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::Instrument;
@@ -62,14 +62,51 @@ struct BroadcastGapContext<'a> {
     checkpoints: &'a Arc<RwLock<HashMap<String, ReactionCheckpoint>>>,
     bootstrap_mutex: &'a Arc<tokio::sync::Mutex<()>>,
     metrics: &'a Arc<ReactionMetrics>,
+    /// Highest sequence already enqueued in this query's current generation.
+    last_forwarded_sequence: u64,
     /// The live event that exposed a sequence gap. `None` when the receiver
     /// reported lag before yielding the next retained event.
     received_sequence: Option<u64>,
 }
 
+#[derive(Clone)]
+struct StartupQueryProgress {
+    checkpoint: ReactionCheckpoint,
+    forwarded_sequence: u64,
+    persist_after_bootstrap: bool,
+}
+
+impl StartupQueryProgress {
+    fn new(
+        checkpoint: ReactionCheckpoint,
+        forwarded_sequence: u64,
+        persist_after_bootstrap: bool,
+    ) -> Self {
+        Self {
+            checkpoint,
+            forwarded_sequence,
+            persist_after_bootstrap,
+        }
+    }
+}
+
 struct ReactionSubscriptionTasks {
     forwarder_abort_handles: Vec<tokio::task::AbortHandle>,
     supervisor: tokio::task::JoinHandle<()>,
+}
+
+struct ReactionStartReservation {
+    reaction_id: String,
+    active_starts: Arc<std::sync::Mutex<HashSet<String>>>,
+}
+
+impl Drop for ReactionStartReservation {
+    fn drop(&mut self) {
+        self.active_starts
+            .lock()
+            .expect("reaction start reservation lock poisoned")
+            .remove(&self.reaction_id);
+    }
 }
 
 pub struct ReactionManager {
@@ -95,6 +132,9 @@ pub struct ReactionManager {
     reaction_metrics: Arc<RwLock<HashMap<MetricsKey, Arc<ReactionMetrics>>>>,
     /// Global lifecycle metrics shared across all reactions.
     lifecycle_metrics: Arc<LifecycleMetrics>,
+    /// Prevents concurrent starts from observing an Error retry's intermediate
+    /// cleanup states.
+    active_starts: Arc<std::sync::Mutex<HashSet<String>>>,
 }
 
 impl ReactionManager {
@@ -121,6 +161,7 @@ impl ReactionManager {
             update_tx,
             reaction_metrics: Arc::new(RwLock::new(HashMap::new())),
             lifecycle_metrics: Arc::new(LifecycleMetrics::new()),
+            active_starts: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
     }
 
@@ -208,6 +249,7 @@ impl ReactionManager {
     /// # Parameters
     /// - `id`: The reaction ID to start
     pub async fn start_reaction(&self, id: String) -> Result<()> {
+        let _reservation = self.reserve_start(&id)?;
         let reaction =
             crate::managers::lifecycle_helpers::get_runtime::<Arc<dyn Reaction>>(&self.graph, &id)
                 .await
@@ -220,15 +262,38 @@ impl ReactionManager {
         // --- §3 Startup validation ---
         self.validate_startup_config(&reaction).await?;
 
-        self.prepare_start_generation(&id, &reaction).await?;
+        let prior_status =
+            crate::managers::lifecycle_helpers::claim_component_start(&self.graph, &id, "reaction")
+                .await?;
+        anyhow::ensure!(
+            prior_status != ComponentStatus::Starting,
+            "Component '{id}' is already starting"
+        );
 
-        if let Err(error) = crate::managers::lifecycle_helpers::start_component(
-            &self.graph,
-            &id,
-            "reaction",
-            &reaction,
-        )
-        .await
+        if let Err(error) = self
+            .prepare_start_generation(&id, &reaction, prior_status)
+            .await
+        {
+            self.cleanup_failed_start(&id, &reaction, format!("Start failed: {error}"))
+                .await;
+            return Err(error);
+        }
+
+        let existing_checkpoints = match self
+            .capture_and_seed_start_checkpoints(&id, &reaction)
+            .await
+        {
+            Ok(checkpoints) => checkpoints,
+            Err(error) => {
+                self.cleanup_failed_start(&id, &reaction, format!("Start failed: {error}"))
+                    .await;
+                return Err(error);
+            }
+        };
+
+        if let Err(error) =
+            crate::managers::lifecycle_helpers::start_claimed_component(&self.graph, &id, &reaction)
+                .await
         {
             self.cleanup_failed_start(&id, &reaction, format!("Start failed: {error}"))
                 .await;
@@ -241,7 +306,7 @@ impl ReactionManager {
         let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
 
         if let Err(error) = self
-            .subscribe_and_bootstrap(&id, reaction.clone(), gate_rx)
+            .subscribe_and_bootstrap(&id, reaction.clone(), existing_checkpoints, gate_rx)
             .await
         {
             self.cleanup_failed_start(&id, &reaction, format!("Bootstrap failed: {error}"))
@@ -255,21 +320,74 @@ impl ReactionManager {
         Ok(())
     }
 
+    async fn capture_and_seed_start_checkpoints(
+        &self,
+        reaction_id: &str,
+        reaction: &Arc<dyn Reaction>,
+    ) -> Result<HashMap<String, ReactionCheckpoint>> {
+        let query_ids = reaction.query_ids();
+        let Some(store) = self.state_store.read().await.clone() else {
+            return Ok(HashMap::new());
+        };
+        let existing = crate::reactions::checkpoint::read_checkpoints_batch(
+            store.as_ref(),
+            reaction_id,
+            &query_ids,
+        )
+        .await?;
+
+        if !reaction.needs_snapshot_on_fresh_start() {
+            let query_provider = self.query_provider.read().await.clone().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "QueryProvider not injected - was ReactionManager initialized properly?"
+                )
+            })?;
+            for query_id in &query_ids {
+                if existing.contains_key(query_id) {
+                    continue;
+                }
+                let query = query_provider.get_query_instance(query_id).await?;
+                crate::reactions::checkpoint::write_checkpoint(
+                    store.as_ref(),
+                    reaction_id,
+                    query_id,
+                    &ReactionCheckpoint {
+                        sequence: 0,
+                        config_hash: crate::queries::compute_config_hash(query.get_config()),
+                    },
+                )
+                .await?;
+            }
+        }
+
+        Ok(existing)
+    }
+
+    fn reserve_start(&self, reaction_id: &str) -> Result<ReactionStartReservation> {
+        let mut active_starts = self
+            .active_starts
+            .lock()
+            .expect("reaction start reservation lock poisoned");
+        anyhow::ensure!(
+            active_starts.insert(reaction_id.to_string()),
+            "Component '{reaction_id}' is already starting"
+        );
+        drop(active_starts);
+        Ok(ReactionStartReservation {
+            reaction_id: reaction_id.to_string(),
+            active_starts: self.active_starts.clone(),
+        })
+    }
+
     async fn prepare_start_generation(
         &self,
         reaction_id: &str,
         reaction: &Arc<dyn Reaction>,
+        prior_status: ComponentStatus,
     ) -> Result<()> {
         Self::abort_subscription_tasks_static(&self.subscription_tasks, reaction_id).await;
 
-        let status = self
-            .graph
-            .read()
-            .await
-            .get_component(reaction_id)
-            .map(|node| node.status)
-            .ok_or_else(|| anyhow::anyhow!("Reaction '{reaction_id}' not found"))?;
-        if status != ComponentStatus::Error {
+        if prior_status != ComponentStatus::Error {
             return Ok(());
         }
 
@@ -287,6 +405,12 @@ impl ReactionManager {
         .with_context(|| {
             format!("Reaction '{reaction_id}' did not stop before retrying its start")
         })?;
+        crate::managers::lifecycle_helpers::claim_component_start(
+            &self.graph,
+            reaction_id,
+            "reaction",
+        )
+        .await?;
         Ok(())
     }
 
@@ -403,6 +527,7 @@ impl ReactionManager {
         &self,
         reaction_id: &str,
         reaction: Arc<dyn Reaction>,
+        existing_checkpoints: HashMap<String, ReactionCheckpoint>,
         gate: tokio::sync::watch::Receiver<bool>,
     ) -> Result<()> {
         let query_ids = reaction.query_ids();
@@ -420,8 +545,11 @@ impl ReactionManager {
         let state_store = self.state_store.read().await.clone();
         let policy = reaction.default_recovery_policy();
 
-        // Shared checkpoint map — populated during bootstrap, read by forwarders after gate opens.
+        // Authoritative handled/bootstrap checkpoints and generation-local
+        // enqueued high-water are intentionally separate.
         let shared_checkpoints: Arc<RwLock<HashMap<String, ReactionCheckpoint>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        let shared_forwarded_sequences: Arc<RwLock<HashMap<String, u64>>> =
             Arc::new(RwLock::new(HashMap::new()));
 
         // 1. Wire subscriptions FIRST so events buffer in broadcast channels
@@ -432,26 +560,15 @@ impl ReactionManager {
             &query_provider,
             &query_ids,
             shared_checkpoints.clone(),
+            shared_forwarded_sequences.clone(),
             gate,
         )
         .await?;
 
-        // 2. Read existing checkpoints from the state store (batch).
-        let existing_checkpoints = match state_store.as_ref() {
-            Some(store) => {
-                crate::reactions::checkpoint::read_checkpoints_batch(
-                    store.as_ref(),
-                    reaction_id,
-                    &query_ids,
-                )
-                .await?
-            }
-            None => HashMap::new(),
-        };
-
-        // 3. Per-query bootstrap: build the initial checkpoint map and collect
+        // 2. Per-query bootstrap: stage authoritative checkpoint baselines and
+        // generation-local replay high-water separately.
         //    any queries that need a full bootstrap hook call.
-        let mut initial_checkpoints: HashMap<String, ReactionCheckpoint> = HashMap::new();
+        let mut startup_progress: HashMap<String, StartupQueryProgress> = HashMap::new();
         let mut bootstrap_queries: Vec<(String, Arc<dyn Query>)> = Vec::new();
 
         for query_id in &query_ids {
@@ -471,18 +588,17 @@ impl ReactionManager {
             match existing_checkpoints.get(query_id) {
                 None => {
                     // No checkpoint — fresh start for this query.
-                    let cp = self
+                    let progress = self
                         .handle_fresh_start(
                             reaction_id,
                             query_id,
                             &reaction,
                             &query,
-                            &state_store,
                             &mut bootstrap_queries,
                             &per_query_metrics,
                         )
                         .await?;
-                    initial_checkpoints.insert(query_id.clone(), cp);
+                    startup_progress.insert(query_id.clone(), progress);
                 }
                 Some(cp) => {
                     // Checkpoint exists — check config hash.
@@ -496,22 +612,20 @@ impl ReactionManager {
                              checkpoint={}, current={}",
                             cp.config_hash, current_config_hash
                         );
-                        let new_cp = self
+                        let progress = self
                             .apply_recovery_policy(
                                 reaction_id,
                                 query_id,
-                                &reaction,
                                 &query,
                                 policy,
-                                &state_store,
                                 &mut bootstrap_queries,
                                 &per_query_metrics,
                             )
                             .await?;
-                        initial_checkpoints.insert(query_id.clone(), new_cp);
+                        startup_progress.insert(query_id.clone(), progress);
                     } else {
                         // Hash matches — try to catch up via outbox.
-                        let new_cp = self
+                        let progress = self
                             .handle_outbox_catchup(
                                 reaction_id,
                                 query_id,
@@ -524,13 +638,13 @@ impl ReactionManager {
                                 &per_query_metrics,
                             )
                             .await?;
-                        initial_checkpoints.insert(query_id.clone(), new_cp);
+                        startup_progress.insert(query_id.clone(), progress);
                     }
                 }
             }
         }
 
-        // 4. Invoke the bootstrap hook if any queries triggered a reset.
+        // 3. Invoke the bootstrap hook if any queries triggered a reset.
         if !bootstrap_queries.is_empty() {
             for (query_id, query) in &bootstrap_queries {
                 let is_reset = existing_checkpoints.contains_key(query_id);
@@ -545,29 +659,53 @@ impl ReactionManager {
             }
         }
 
-        // 5. Persist checkpoints AFTER bootstrap succeeds — a crash before this
-        //    point will re-trigger bootstrap on next start (safe).
+        // 4. Persist only baselines established by delivered snapshots or
+        // explicit recovery skips. Replayed QueryResults advance exclusively in
+        // the reaction's successful handler/ack path.
         if let Some(store) = state_store.as_ref() {
-            for (query_id, cp) in &initial_checkpoints {
-                if let Err(e) = crate::reactions::checkpoint::write_checkpoint(
+            for (query_id, progress) in &startup_progress {
+                if !progress.persist_after_bootstrap {
+                    continue;
+                }
+                crate::reactions::checkpoint::write_checkpoint(
                     store.as_ref(),
                     reaction_id,
                     query_id,
-                    cp,
+                    &progress.checkpoint,
                 )
                 .await
-                {
-                    log::warn!(
-                        "[{reaction_id}] Failed to persist checkpoint for query '{query_id}' \
-                         at seq={}: {e}",
-                        cp.sequence
-                    );
-                }
+                .with_context(|| {
+                    format!(
+                        "[{reaction_id}] failed to persist startup checkpoint for query \
+                         '{query_id}' at sequence {}",
+                        progress.checkpoint.sequence
+                    )
+                })?;
             }
         }
 
-        // Publish the computed checkpoints so forwarders can filter stale events.
-        *shared_checkpoints.write().await = initial_checkpoints;
+        let mut authoritative_checkpoints = startup_progress
+            .iter()
+            .map(|(query_id, progress)| (query_id.clone(), progress.checkpoint.clone()))
+            .collect::<HashMap<_, _>>();
+        if let Some(store) = state_store.as_ref() {
+            let durable = crate::reactions::checkpoint::read_checkpoints_batch(
+                store.as_ref(),
+                reaction_id,
+                &query_ids,
+            )
+            .await?;
+            for (query_id, checkpoint) in durable {
+                authoritative_checkpoints.insert(query_id, checkpoint);
+            }
+        }
+        let forwarded_sequences = startup_progress
+            .into_iter()
+            .map(|(query_id, progress)| (query_id, progress.forwarded_sequence))
+            .collect();
+
+        *shared_checkpoints.write().await = authoritative_checkpoints;
+        *shared_forwarded_sequences.write().await = forwarded_sequences;
 
         Ok(())
     }
@@ -582,10 +720,9 @@ impl ReactionManager {
         query_id: &str,
         reaction: &Arc<dyn Reaction>,
         query: &Arc<dyn Query>,
-        state_store: &Option<Arc<dyn StateStoreProvider>>,
         bootstrap_queries: &mut Vec<(String, Arc<dyn Query>)>,
         metrics: &Arc<ReactionMetrics>,
-    ) -> Result<ReactionCheckpoint> {
+    ) -> Result<StartupQueryProgress> {
         let config_hash = crate::queries::compute_config_hash(query.get_config());
 
         if reaction.needs_snapshot_on_fresh_start() {
@@ -601,15 +738,19 @@ impl ReactionManager {
             };
 
             bootstrap_queries.push((query_id.to_string(), query.clone()));
-            Ok(cp)
+            Ok(StartupQueryProgress::new(cp.clone(), cp.sequence, true))
         } else {
-            // No snapshot needed — replay any outbox entries produced during this
-            // startup cycle (e.g., from source replay) and record the checkpoint.
-            // Without this replay, results produced before the reaction subscribes
-            // to the broadcast channel would be silently skipped.
+            // Seed the config hash at sequence zero before replay so a handler
+            // cannot persist a replayed sequence with an unknown hash.
             metrics.record_fetch_outbox();
-            let seq = match query.fetch_outbox(0).await {
+            match query.fetch_outbox(0).await {
                 Ok(resp) => {
+                    let checkpoint = ReactionCheckpoint {
+                        sequence: 0,
+                        config_hash,
+                    };
+
+                    let mut forwarded_sequence = checkpoint.sequence;
                     if resp.results.is_empty() {
                         info!(
                             "[{reaction_id}] Fresh start for query '{query_id}' — fetch_outbox(0) returned latest_seq={}",
@@ -633,42 +774,42 @@ impl ReactionManager {
                                         entry.sequence
                                     )
                                 })?;
+                            forwarded_sequence = entry.sequence;
                         }
                     }
-                    resp.latest_sequence
+                    Ok(StartupQueryProgress::new(
+                        checkpoint,
+                        forwarded_sequence,
+                        false,
+                    ))
                 }
                 Err(FetchError::OutboxGap(gap)) => {
                     info!(
                         "[{reaction_id}] Fresh start for query '{query_id}' — outbox gap, latest_seq={}",
                         gap.latest_sequence
                     );
-                    gap.latest_sequence
+                    let checkpoint = ReactionCheckpoint {
+                        sequence: gap.latest_sequence,
+                        config_hash,
+                    };
+                    Ok(StartupQueryProgress::new(
+                        checkpoint.clone(),
+                        checkpoint.sequence,
+                        true,
+                    ))
                 }
                 Err(FetchError::NotRunning { .. } | FetchError::TimedOut) => {
                     info!(
                         "[{reaction_id}] Fresh start for query '{query_id}' — \
                          query not yet running, starting from sequence 0"
                     );
-                    0
+                    let checkpoint = ReactionCheckpoint {
+                        sequence: 0,
+                        config_hash,
+                    };
+                    Ok(StartupQueryProgress::new(checkpoint, 0, false))
                 }
-            };
-
-            let cp = ReactionCheckpoint {
-                sequence: seq,
-                config_hash,
-            };
-
-            if let Some(store) = state_store.as_ref() {
-                crate::reactions::checkpoint::write_checkpoint(
-                    store.as_ref(),
-                    reaction_id,
-                    query_id,
-                    &cp,
-                )
-                .await?;
             }
-
-            Ok(cp)
         }
     }
 
@@ -688,14 +829,11 @@ impl ReactionManager {
         state_store: &Option<Arc<dyn StateStoreProvider>>,
         bootstrap_queries: &mut Vec<(String, Arc<dyn Query>)>,
         metrics: &Arc<ReactionMetrics>,
-    ) -> Result<ReactionCheckpoint> {
+    ) -> Result<StartupQueryProgress> {
         metrics.record_fetch_outbox();
         match query.fetch_outbox(checkpoint.sequence).await {
             Ok(outbox_resp) => {
-                // Replay outbox entries by enqueuing them.
-                // Track the last successfully enqueued sequence to avoid
-                // advancing the checkpoint past failed entries.
-                let mut last_ok_seq = checkpoint.sequence;
+                let mut forwarded_sequence = checkpoint.sequence;
                 for entry in &outbox_resp.results {
                     let result = (*entry).as_ref().clone();
                     reaction
@@ -708,30 +846,14 @@ impl ReactionManager {
                                 entry.sequence
                             )
                         })?;
-                    last_ok_seq = entry.sequence;
+                    forwarded_sequence = entry.sequence;
                 }
 
-                // Update checkpoint to the latest SUCCESSFULLY replayed sequence.
-                let new_seq = last_ok_seq;
-
-                let cp = ReactionCheckpoint {
-                    sequence: new_seq,
-                    config_hash: checkpoint.config_hash,
-                };
-
-                if new_seq != checkpoint.sequence {
-                    if let Some(store) = state_store.as_ref() {
-                        crate::reactions::checkpoint::write_checkpoint(
-                            store.as_ref(),
-                            reaction_id,
-                            query_id,
-                            &cp,
-                        )
-                        .await?;
-                    }
-                }
-
-                Ok(cp)
+                Ok(StartupQueryProgress::new(
+                    checkpoint.clone(),
+                    forwarded_sequence,
+                    false,
+                ))
             }
             Err(FetchError::OutboxGap(gap)) => {
                 info!(
@@ -755,10 +877,8 @@ impl ReactionManager {
                         self.apply_recovery_policy(
                             reaction_id,
                             query_id,
-                            reaction,
                             query,
                             policy,
-                            state_store,
                             bootstrap_queries,
                             metrics,
                         )
@@ -774,7 +894,11 @@ impl ReactionManager {
                      keeping existing checkpoint at seq={}",
                     checkpoint.sequence
                 );
-                Ok(checkpoint.clone())
+                Ok(StartupQueryProgress::new(
+                    checkpoint.clone(),
+                    checkpoint.sequence,
+                    false,
+                ))
             }
         }
     }
@@ -789,12 +913,12 @@ impl ReactionManager {
         state_store: &Option<Arc<dyn StateStoreProvider>>,
         metrics: &Arc<ReactionMetrics>,
         gap: &crate::queries::OutboxGap,
-    ) -> Result<ReactionCheckpoint> {
+    ) -> Result<StartupQueryProgress> {
         let mut skipped_floor = gap
             .earliest_available
             .saturating_sub(1)
             .max(checkpoint.sequence);
-        let mut current = ReactionCheckpoint {
+        let mut authoritative_checkpoint = ReactionCheckpoint {
             sequence: skipped_floor,
             config_hash: checkpoint.config_hash,
         };
@@ -806,10 +930,10 @@ impl ReactionManager {
                 reaction_id,
                 query_id,
                 previous_sequence,
-                &current,
+                &authoritative_checkpoint,
             )
             .await?;
-            previous_sequence = current.sequence;
+            previous_sequence = authoritative_checkpoint.sequence;
 
             metrics.record_fetch_outbox();
             match query.fetch_outbox(skipped_floor).await {
@@ -818,14 +942,14 @@ impl ReactionManager {
                     let next_floor = next_gap
                         .earliest_available
                         .saturating_sub(1)
-                        .max(current.sequence);
+                        .max(authoritative_checkpoint.sequence);
                     anyhow::ensure!(
                         next_floor > skipped_floor,
                         "[{reaction_id}] query '{query_id}' returned a non-advancing \
                              outbox gap at floor {skipped_floor}"
                     );
                     skipped_floor = next_floor;
-                    current.sequence = next_floor;
+                    authoritative_checkpoint.sequence = next_floor;
                 }
                 Err(error) => {
                     return Err(anyhow::anyhow!(
@@ -837,6 +961,7 @@ impl ReactionManager {
         };
 
         let mut expected = skipped_floor.saturating_add(1);
+        let mut forwarded_sequence = authoritative_checkpoint.sequence;
         for entry in retained.results {
             anyhow::ensure!(
                 entry.sequence == expected,
@@ -854,27 +979,22 @@ impl ReactionManager {
                         entry.sequence
                     )
                 })?;
-            current.sequence = entry.sequence;
-            Self::persist_reaction_checkpoint(
-                state_store,
-                reaction_id,
-                query_id,
-                previous_sequence,
-                &current,
-            )
-            .await?;
-            previous_sequence = current.sequence;
+            forwarded_sequence = entry.sequence;
             expected = entry.sequence.saturating_add(1);
         }
         anyhow::ensure!(
-            current.sequence == retained.latest_sequence,
+            forwarded_sequence == retained.latest_sequence,
             "[{reaction_id}] retained outbox replay for query '{query_id}' ended at {}, \
                  expected latest {}",
-            current.sequence,
+            forwarded_sequence,
             retained.latest_sequence
         );
 
-        Ok(current)
+        Ok(StartupQueryProgress::new(
+            authoritative_checkpoint,
+            forwarded_sequence,
+            false,
+        ))
     }
 
     async fn persist_reaction_checkpoint(
@@ -905,13 +1025,11 @@ impl ReactionManager {
         &self,
         reaction_id: &str,
         query_id: &str,
-        _reaction: &Arc<dyn Reaction>,
         query: &Arc<dyn Query>,
         policy: ReactionRecoveryPolicy,
-        state_store: &Option<Arc<dyn StateStoreProvider>>,
         bootstrap_queries: &mut Vec<(String, Arc<dyn Query>)>,
         metrics: &Arc<ReactionMetrics>,
-    ) -> Result<ReactionCheckpoint> {
+    ) -> Result<StartupQueryProgress> {
         let config_hash = crate::queries::compute_config_hash(query.get_config());
 
         match policy {
@@ -940,7 +1058,7 @@ impl ReactionManager {
                 self.lifecycle_metrics.record_auto_reset_completion();
 
                 bootstrap_queries.push((query_id.to_string(), query.clone()));
-                Ok(cp)
+                Ok(StartupQueryProgress::new(cp.clone(), cp.sequence, true))
             }
             ReactionRecoveryPolicy::AutoSkipGap => {
                 info!(
@@ -966,17 +1084,7 @@ impl ReactionManager {
                     config_hash,
                 };
 
-                if let Some(store) = state_store.as_ref() {
-                    crate::reactions::checkpoint::write_checkpoint(
-                        store.as_ref(),
-                        reaction_id,
-                        query_id,
-                        &cp,
-                    )
-                    .await?;
-                }
-
-                Ok(cp)
+                Ok(StartupQueryProgress::new(cp.clone(), cp.sequence, true))
             }
         }
     }
@@ -1286,6 +1394,7 @@ impl ReactionManager {
         query_provider: &Arc<dyn QueryProvider>,
         query_ids: &[String],
         shared_checkpoints: Arc<RwLock<HashMap<String, ReactionCheckpoint>>>,
+        shared_forwarded_sequences: Arc<RwLock<HashMap<String, u64>>>,
         gate: tokio::sync::watch::Receiver<bool>,
     ) -> Result<()> {
         let instance_id = self.instance_id.clone();
@@ -1332,6 +1441,7 @@ impl ReactionManager {
             let query_clone = query.clone();
             let state_store_clone = state_store.clone();
             let checkpoints = shared_checkpoints.clone();
+            let forwarded_sequences = shared_forwarded_sequences.clone();
             let bootstrap_mutex = bootstrap_mutex.clone();
             let lifecycle_metrics = self.lifecycle_metrics.clone();
 
@@ -1355,11 +1465,11 @@ impl ReactionManager {
                         return;
                     }
 
-                    // Read the initial checkpoint sequence so we can skip stale events
-                    // that were buffered in the broadcast channel during bootstrap.
+                    // The generation-local high-water includes replayed results
+                    // that have been enqueued but not necessarily handled yet.
                     let initial_seq = {
-                        let cps = checkpoints.read().await;
-                        cps.get(&query_id_clone).map(|cp| cp.sequence).unwrap_or(0)
+                        let forwarded = forwarded_sequences.read().await;
+                        forwarded.get(&query_id_clone).copied().unwrap_or(0)
                     };
 
                     // Track the last forwarded sequence for gap detection.
@@ -1423,6 +1533,20 @@ impl ReactionManager {
                                         last_forwarded_seq.saturating_add(1),
                                         query_result.sequence
                                     );
+                                    if let Err(error) = Self::refresh_shared_checkpoint(
+                                        &state_store_clone,
+                                        &reaction_id_owned,
+                                        &query_id_clone,
+                                        &checkpoints,
+                                    )
+                                    .await
+                                    {
+                                        log::error!(
+                                            "[{reaction_id_owned}] Failed to refresh checkpoint for \
+                                             query '{query_id_clone}' before gap recovery: {error}"
+                                        );
+                                        break;
+                                    }
                                     let gap_ctx = BroadcastGapContext {
                                         reaction_id: &reaction_id_owned,
                                         query_id: &query_id_clone,
@@ -1433,6 +1557,7 @@ impl ReactionManager {
                                         checkpoints: &checkpoints,
                                         bootstrap_mutex: &bootstrap_mutex,
                                         metrics: &forwarder_metrics,
+                                        last_forwarded_sequence: last_forwarded_seq,
                                         received_sequence: Some(query_result.sequence),
                                     };
                                     match Self::handle_broadcast_gap(&gap_ctx)
@@ -1442,10 +1567,12 @@ impl ReactionManager {
                                             // After gap recovery, update checkpoint from the shared map
                                             // (handle_broadcast_gap updates it).
                                             let cps = checkpoints.read().await;
-                                            last_forwarded_seq = cps
+                                            last_forwarded_seq = last_forwarded_seq.max(
+                                                cps
                                                 .get(&query_id_clone)
                                                 .map(|cp| cp.sequence)
-                                                .unwrap_or(last_forwarded_seq);
+                                                .unwrap_or(0),
+                                            );
                                             // Re-evaluate this event against the updated checkpoint.
                                             if query_result.sequence <= last_forwarded_seq {
                                                 continue;
@@ -1471,7 +1598,9 @@ impl ReactionManager {
                                 )
                                 .await
                                 {
-                                    Ok(sequence) => last_forwarded_seq = sequence,
+                                   Ok(sequence) => {
+                                       last_forwarded_seq = sequence;
+                                   }
                                     Err(error) => {
                                         log::error!(
                                             "[{reaction_id_owned}] Failed to enqueue result from query \
@@ -1490,6 +1619,20 @@ impl ReactionManager {
                                     log::warn!(
                                         "[{reaction_id_owned}] Broadcast lag for query '{query_id_clone}': {error_str}"
                                     );
+                                    if let Err(error) = Self::refresh_shared_checkpoint(
+                                        &state_store_clone,
+                                        &reaction_id_owned,
+                                        &query_id_clone,
+                                        &checkpoints,
+                                    )
+                                    .await
+                                    {
+                                        log::error!(
+                                            "[{reaction_id_owned}] Failed to refresh checkpoint for \
+                                             query '{query_id_clone}' before lag recovery: {error}"
+                                        );
+                                        break;
+                                    }
                                     let gap_ctx = BroadcastGapContext {
                                         reaction_id: &reaction_id_owned,
                                         query_id: &query_id_clone,
@@ -1500,6 +1643,7 @@ impl ReactionManager {
                                         checkpoints: &checkpoints,
                                         bootstrap_mutex: &bootstrap_mutex,
                                         metrics: &forwarder_metrics,
+                                        last_forwarded_sequence: last_forwarded_seq,
                                         received_sequence: None,
                                     };
                                     match Self::handle_broadcast_gap(&gap_ctx)
@@ -1592,27 +1736,39 @@ impl ReactionManager {
         let result = Arc::try_unwrap(query_result).unwrap_or_else(|result| (*result).clone());
         reaction.enqueue_query_result(result).await?;
 
-        // This checkpoint is process-local. Durable reactions persist their
-        // checkpoint only after successful handling of the enqueued result.
-        let config_hash = checkpoints
+        let checkpoint_sequence = checkpoints
             .read()
             .await
             .get(query_id)
-            .map(|checkpoint| checkpoint.config_hash)
+            .map(|checkpoint| checkpoint.sequence)
             .unwrap_or(0);
-        checkpoints.write().await.insert(
-            query_id.to_string(),
-            ReactionCheckpoint {
-                sequence,
-                config_hash,
-            },
-        );
         let query_latest = query
             .output_metrics()
             .map(|metrics| metrics.load_outbox_latest_seq())
             .unwrap_or(sequence);
-        metrics.record_checkpoint(sequence, query_latest);
+        metrics.record_checkpoint(checkpoint_sequence, query_latest);
         Ok(sequence)
+    }
+
+    async fn refresh_shared_checkpoint(
+        state_store: &Option<Arc<dyn StateStoreProvider>>,
+        reaction_id: &str,
+        query_id: &str,
+        checkpoints: &Arc<RwLock<HashMap<String, ReactionCheckpoint>>>,
+    ) -> Result<()> {
+        let Some(store) = state_store.as_ref() else {
+            return Ok(());
+        };
+        if let Some(checkpoint) =
+            crate::reactions::checkpoint::read_checkpoint(store.as_ref(), reaction_id, query_id)
+                .await?
+        {
+            checkpoints
+                .write()
+                .await
+                .insert(query_id.to_string(), checkpoint);
+        }
+        Ok(())
     }
 
     /// Handle a broadcast gap (§6): `RecvError::Lagged` in the forwarder loop.
@@ -1704,6 +1860,17 @@ impl ReactionManager {
                     .get(ctx.query_id)
                     .map(|checkpoint| checkpoint.sequence)
                     .unwrap_or(0);
+                if existing_sequence < ctx.last_forwarded_sequence {
+                    log::debug!(
+                        "[{}] Deferring AutoSkipGap checkpoint for query '{}' because \
+                         sequences {}..={} are forwarded but not yet acknowledged",
+                        ctx.reaction_id,
+                        ctx.query_id,
+                        existing_sequence.saturating_add(1),
+                        ctx.last_forwarded_sequence
+                    );
+                    return Ok(());
+                }
                 let skipped_floor = skipped_floor.max(existing_sequence);
 
                 let cp = ReactionCheckpoint {
@@ -1785,12 +1952,42 @@ impl ReactionManager {
         }
         drop(graph);
 
-        let metrics = self.reaction_metrics.read().await;
-        Ok(metrics
+        let metrics = self
+            .reaction_metrics
+            .read()
+            .await
             .iter()
             .filter(|((rid, _), _)| rid == reaction_id)
-            .map(|((_, qid), m)| (qid.clone(), m.snapshot()))
-            .collect())
+            .map(|((_, qid), metrics)| (qid.clone(), metrics.clone()))
+            .collect::<Vec<_>>();
+        let state_store = self.state_store.read().await.clone();
+        let query_provider = self.query_provider.read().await.clone();
+        let mut snapshots = HashMap::with_capacity(metrics.len());
+        for (query_id, metrics) in metrics {
+            if let Some(store) = state_store.as_ref() {
+                if let Some(checkpoint) = crate::reactions::checkpoint::read_checkpoint(
+                    store.as_ref(),
+                    reaction_id,
+                    &query_id,
+                )
+                .await?
+                {
+                    let query_latest = if let Some(provider) = query_provider.as_ref() {
+                        provider
+                            .get_query_instance(&query_id)
+                            .await?
+                            .output_metrics()
+                            .map(|query_metrics| query_metrics.load_outbox_latest_seq())
+                            .unwrap_or(checkpoint.sequence)
+                    } else {
+                        checkpoint.sequence
+                    };
+                    metrics.record_checkpoint(checkpoint.sequence, query_latest);
+                }
+            }
+            snapshots.insert(query_id, metrics.snapshot());
+        }
+        Ok(snapshots)
     }
 
     /// Get the global lifecycle metrics.
@@ -1809,7 +2006,7 @@ mod tests {
     use crate::sources::tests::TestMockSource;
     use async_trait::async_trait;
     use drasi_core::models::{Element, ElementMetadata, ElementPropertyMap, ElementReference};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use tokio::sync::Mutex;
 
     // ========================================================================
@@ -1859,6 +2056,17 @@ mod tests {
                 })),
                 subscriptions: Mutex::new(Vec::new()),
             }
+        }
+
+        async fn send(&self, result: QueryResult) {
+            let senders = self.subscriptions.lock().await.clone();
+            for sender in senders {
+                let _ = sender.send(Arc::new(result.clone())).await;
+            }
+        }
+
+        async fn subscription_count(&self) -> usize {
+            self.subscriptions.lock().await.len()
         }
     }
 
@@ -2148,6 +2356,210 @@ mod tests {
 
     struct QueueBackedReaction {
         base: crate::reactions::common::base::ReactionBase,
+        auto_start: bool,
+    }
+
+    struct ProcessingQueueReaction {
+        base: crate::reactions::common::base::ReactionBase,
+        processing_enabled: Arc<AtomicBool>,
+        block_handler: Arc<AtomicBool>,
+        handler_released: Arc<AtomicBool>,
+        handler_gate: Arc<tokio::sync::Notify>,
+        handler_started: Arc<tokio::sync::Notify>,
+        processed: Arc<Mutex<Vec<(String, u64)>>>,
+        processed_notify: Arc<tokio::sync::Notify>,
+    }
+
+    impl ProcessingQueueReaction {
+        fn new(id: &str, queries: Vec<String>) -> Self {
+            Self {
+                base: crate::reactions::common::base::ReactionBase::new(
+                    crate::reactions::common::base::ReactionBaseParams::new(id, queries),
+                ),
+                processing_enabled: Arc::new(AtomicBool::new(false)),
+                block_handler: Arc::new(AtomicBool::new(true)),
+                handler_released: Arc::new(AtomicBool::new(false)),
+                handler_gate: Arc::new(tokio::sync::Notify::new()),
+                handler_started: Arc::new(tokio::sync::Notify::new()),
+                processed: Arc::new(Mutex::new(Vec::new())),
+                processed_notify: Arc::new(tokio::sync::Notify::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Reaction for ProcessingQueueReaction {
+        fn id(&self) -> &str {
+            self.base.get_id()
+        }
+
+        fn type_name(&self) -> &str {
+            "processing-queue-test"
+        }
+
+        fn properties(&self) -> HashMap<String, serde_json::Value> {
+            HashMap::new()
+        }
+
+        fn query_ids(&self) -> Vec<String> {
+            self.base.get_queries().to_vec()
+        }
+
+        fn auto_start(&self) -> bool {
+            false
+        }
+
+        async fn initialize(&self, context: crate::context::ReactionRuntimeContext) {
+            self.base.initialize(context).await;
+        }
+
+        async fn start(&self) -> Result<()> {
+            let shutdown_rx = self.base.create_shutdown_channel().await;
+            if self.processing_enabled.load(Ordering::Acquire) {
+                self.handler_released.store(
+                    !self.block_handler.load(Ordering::Acquire),
+                    Ordering::Release,
+                );
+                let checkpoints = self.base.read_all_checkpoints().await?;
+                let base = self.base.clone_shared();
+                let status_handle = self.base.status_handle();
+                let handler_released = self.handler_released.clone();
+                let handler_gate = self.handler_gate.clone();
+                let handler_started = self.handler_started.clone();
+                let processed = self.processed.clone();
+                let processed_notify = self.processed_notify.clone();
+                let task = tokio::spawn(async move {
+                    let result = base
+                        .run_standard_loop(shutdown_rx, checkpoints, move |result| {
+                            let handler_released = handler_released.clone();
+                            let handler_gate = handler_gate.clone();
+                            let handler_started = handler_started.clone();
+                            let processed = processed.clone();
+                            let processed_notify = processed_notify.clone();
+                            async move {
+                                handler_started.notify_one();
+                                while !handler_released.load(Ordering::Acquire) {
+                                    let notified = handler_gate.notified();
+                                    if handler_released.load(Ordering::Acquire) {
+                                        break;
+                                    }
+                                    notified.await;
+                                }
+                                processed
+                                    .lock()
+                                    .await
+                                    .push((result.query_id.clone(), result.sequence));
+                                processed_notify.notify_waiters();
+                                Ok(())
+                            }
+                        })
+                        .await;
+                    if let Err(error) = result {
+                        status_handle
+                            .set_status(
+                                ComponentStatus::Error,
+                                Some(format!("processing failed: {error:#}")),
+                            )
+                            .await;
+                    }
+                });
+                self.base.set_processing_task(task).await;
+            }
+            self.base.set_status(ComponentStatus::Running, None).await;
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<()> {
+            self.handler_released.store(true, Ordering::Release);
+            self.handler_gate.notify_waiters();
+            self.base.stop_common().await
+        }
+
+        async fn status(&self) -> ComponentStatus {
+            self.base.get_status().await
+        }
+
+        async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+            self.base.enqueue_query_result(result).await
+        }
+    }
+
+    struct BlockingStartReaction {
+        base: crate::reactions::common::base::ReactionBase,
+        start_entered: Arc<tokio::sync::Notify>,
+        release_start: Arc<AtomicBool>,
+        start_gate: Arc<tokio::sync::Notify>,
+        report_running: bool,
+    }
+
+    impl BlockingStartReaction {
+        fn new(id: &str, queries: Vec<String>) -> Self {
+            Self {
+                base: crate::reactions::common::base::ReactionBase::new(
+                    crate::reactions::common::base::ReactionBaseParams::new(id, queries),
+                ),
+                start_entered: Arc::new(tokio::sync::Notify::new()),
+                release_start: Arc::new(AtomicBool::new(false)),
+                start_gate: Arc::new(tokio::sync::Notify::new()),
+                report_running: true,
+            }
+        }
+
+        fn without_running_update(mut self) -> Self {
+            self.report_running = false;
+            self
+        }
+    }
+
+    #[async_trait]
+    impl Reaction for BlockingStartReaction {
+        fn id(&self) -> &str {
+            self.base.get_id()
+        }
+
+        fn type_name(&self) -> &str {
+            "blocking-start-test"
+        }
+
+        fn properties(&self) -> HashMap<String, serde_json::Value> {
+            HashMap::new()
+        }
+
+        fn query_ids(&self) -> Vec<String> {
+            self.base.get_queries().to_vec()
+        }
+
+        async fn initialize(&self, context: crate::context::ReactionRuntimeContext) {
+            self.base.initialize(context).await;
+        }
+
+        async fn start(&self) -> Result<()> {
+            self.start_entered.notify_one();
+            while !self.release_start.load(Ordering::Acquire) {
+                let notified = self.start_gate.notified();
+                if self.release_start.load(Ordering::Acquire) {
+                    break;
+                }
+                notified.await;
+            }
+            let _shutdown_rx = self.base.create_shutdown_channel().await;
+            if self.report_running {
+                self.base.set_status(ComponentStatus::Running, None).await;
+            }
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<()> {
+            self.base.stop_common().await
+        }
+
+        async fn status(&self) -> ComponentStatus {
+            self.base.get_status().await
+        }
+
+        async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+            self.base.enqueue_query_result(result).await
+        }
     }
 
     impl QueueBackedReaction {
@@ -2161,7 +2573,13 @@ mod tests {
                     crate::reactions::common::base::ReactionBaseParams::new(id, queries)
                         .with_priority_queue_capacity(capacity),
                 ),
+                auto_start: false,
             }
+        }
+
+        fn with_auto_start(mut self) -> Self {
+            self.auto_start = true;
+            self
         }
     }
 
@@ -2184,7 +2602,7 @@ mod tests {
         }
 
         fn auto_start(&self) -> bool {
-            false
+            self.auto_start
         }
 
         async fn initialize(&self, context: crate::context::ReactionRuntimeContext) {
@@ -2294,7 +2712,7 @@ mod tests {
     async fn provision_queue_backed_manager(
         queries: HashMap<String, Arc<dyn crate::queries::Query>>,
         state_store: Arc<dyn StateStoreProvider>,
-        reaction: QueueBackedReaction,
+        reaction: impl Reaction + 'static,
     ) -> (
         Arc<ReactionManager>,
         Arc<RwLock<crate::component_graph::ComponentGraph>>,
@@ -2329,6 +2747,308 @@ mod tests {
         manager.inject_state_store(state_store).await;
         manager.provision_reaction(reaction).await.unwrap();
         (manager, graph)
+    }
+
+    #[tokio::test]
+    async fn duplicate_start_does_not_disturb_running_reaction() {
+        let reaction_id = "duplicate-start";
+        let store = Arc::new(crate::state_store::MemoryStateStoreProvider::new());
+        let query = Arc::new(MockQuery::with_id("q1", 0, 0));
+        let reaction =
+            QueueBackedReaction::new(reaction_id, vec!["q1".to_string()]).with_auto_start();
+        let base = reaction.base.clone_shared();
+        let queries: HashMap<String, Arc<dyn crate::queries::Query>> = HashMap::from([(
+            "q1".to_string(),
+            query.clone() as Arc<dyn crate::queries::Query>,
+        )]);
+        let (manager, graph) =
+            provision_queue_backed_manager(queries, store.clone(), reaction).await;
+
+        manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .unwrap();
+        crate::component_graph::wait_for_status(
+            &graph,
+            reaction_id,
+            &[ComponentStatus::Running],
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        query
+            .send(QueryResult::new(
+                "q1".to_string(),
+                1,
+                chrono::Utc::now(),
+                Vec::new(),
+                HashMap::new(),
+            ))
+            .await;
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while base.priority_queue.depth().await != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("original forwarder did not enqueue a result");
+        let checkpoint_before =
+            crate::reactions::checkpoint::read_checkpoint(store.as_ref(), reaction_id, "q1")
+                .await
+                .unwrap();
+
+        let duplicate_error = manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .expect_err("a running reaction cannot be started again");
+        assert!(format!("{duplicate_error:#}").contains("already running"));
+        assert_eq!(
+            graph
+                .read()
+                .await
+                .get_component(reaction_id)
+                .unwrap()
+                .status,
+            ComponentStatus::Running
+        );
+        assert_eq!(query.subscription_count().await, 1);
+        assert_eq!(base.priority_queue.depth().await, 1);
+        assert_eq!(
+            crate::reactions::checkpoint::read_checkpoint(store.as_ref(), reaction_id, "q1")
+                .await
+                .unwrap(),
+            checkpoint_before
+        );
+
+        let start_all_error = manager
+            .start_all()
+            .await
+            .expect_err("start_all should preserve the existing duplicate-start error");
+        assert!(format!("{start_all_error:#}").contains("already running"));
+        assert_eq!(query.subscription_count().await, 1);
+        assert_eq!(base.priority_queue.depth().await, 1);
+
+        query
+            .send(QueryResult::new(
+                "q1".to_string(),
+                2,
+                chrono::Utc::now(),
+                Vec::new(),
+                HashMap::new(),
+            ))
+            .await;
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while base.priority_queue.depth().await != 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("original forwarder stopped after duplicate start");
+        assert_eq!(base.priority_queue.try_dequeue().await.unwrap().sequence, 1);
+        assert_eq!(base.priority_queue.try_dequeue().await.unwrap().sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_start_rejection_leaves_starting_generation_intact() {
+        let reaction_id = "concurrent-start";
+        let store = Arc::new(crate::state_store::MemoryStateStoreProvider::new());
+        let query = Arc::new(MockQuery::with_id("q1", 0, 0));
+        let reaction = BlockingStartReaction::new(reaction_id, vec!["q1".to_string()]);
+        let base = reaction.base.clone_shared();
+        let start_entered = reaction.start_entered.clone();
+        let release_start = reaction.release_start.clone();
+        let start_gate = reaction.start_gate.clone();
+        let queries: HashMap<String, Arc<dyn crate::queries::Query>> = HashMap::from([(
+            "q1".to_string(),
+            query.clone() as Arc<dyn crate::queries::Query>,
+        )]);
+        let (manager, graph) = provision_queue_backed_manager(queries, store, reaction).await;
+
+        let first_manager = manager.clone();
+        let first_start =
+            tokio::spawn(
+                async move { first_manager.start_reaction(reaction_id.to_string()).await },
+            );
+        tokio::time::timeout(std::time::Duration::from_secs(1), start_entered.notified())
+            .await
+            .expect("first start did not enter the runtime");
+        assert_eq!(
+            graph
+                .read()
+                .await
+                .get_component(reaction_id)
+                .unwrap()
+                .status,
+            ComponentStatus::Starting
+        );
+
+        let second_error = manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .expect_err("concurrent start must be rejected");
+        assert!(format!("{second_error:#}").contains("already starting"));
+        assert_eq!(
+            graph
+                .read()
+                .await
+                .get_component(reaction_id)
+                .unwrap()
+                .status,
+            ComponentStatus::Starting
+        );
+        assert_eq!(query.subscription_count().await, 0);
+
+        release_start.store(true, Ordering::Release);
+        start_gate.notify_waiters();
+        first_start
+            .await
+            .expect("first start task panicked")
+            .expect("first start failed");
+        query
+            .send(QueryResult::new(
+                "q1".to_string(),
+                1,
+                chrono::Utc::now(),
+                Vec::new(),
+                HashMap::new(),
+            ))
+            .await;
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while base.priority_queue.depth().await != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first generation forwarder was not preserved");
+        assert_eq!(
+            graph
+                .read()
+                .await
+                .get_component(reaction_id)
+                .unwrap()
+                .status,
+            ComponentStatus::Running
+        );
+        assert_eq!(query.subscription_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn duplicate_start_after_runtime_returns_starting_is_non_destructive() {
+        let reaction_id = "still-starting";
+        let store = Arc::new(crate::state_store::MemoryStateStoreProvider::new());
+        let query = Arc::new(MockQuery::with_id("q1", 0, 0));
+        let reaction = BlockingStartReaction::new(reaction_id, vec!["q1".to_string()])
+            .without_running_update();
+        reaction.release_start.store(true, Ordering::Release);
+        let base = reaction.base.clone_shared();
+        let queries: HashMap<String, Arc<dyn crate::queries::Query>> = HashMap::from([(
+            "q1".to_string(),
+            query.clone() as Arc<dyn crate::queries::Query>,
+        )]);
+        let (manager, graph) = provision_queue_backed_manager(queries, store, reaction).await;
+
+        manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .expect("first start should complete while runtime remains Starting");
+        assert_eq!(
+            graph
+                .read()
+                .await
+                .get_component(reaction_id)
+                .unwrap()
+                .status,
+            ComponentStatus::Starting
+        );
+        query
+            .send(QueryResult::new(
+                "q1".to_string(),
+                1,
+                chrono::Utc::now(),
+                Vec::new(),
+                HashMap::new(),
+            ))
+            .await;
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while base.priority_queue.depth().await != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first generation did not retain its live forwarder");
+
+        let error = manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .expect_err("a Starting reaction cannot be started twice");
+        assert!(format!("{error:#}").contains("already starting"));
+        assert_eq!(query.subscription_count().await, 1);
+        assert_eq!(base.priority_queue.depth().await, 1);
+        assert_eq!(
+            graph
+                .read()
+                .await
+                .get_component(reaction_id)
+                .unwrap()
+                .status,
+            ComponentStatus::Starting
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_replay_seeds_config_before_eager_handler_start() {
+        let reaction_id = "fresh-eager-handler";
+        let store = Arc::new(crate::state_store::MemoryStateStoreProvider::new());
+        let query = Arc::new(MockQuery::with_id("q1", 0, 1));
+        let config_hash = crate::queries::compute_config_hash(query.get_config());
+        *query.outbox_response.write().await = Ok(OutboxResponse {
+            results: vec![Arc::new(QueryResult::new(
+                "q1".to_string(),
+                1,
+                chrono::Utc::now(),
+                Vec::new(),
+                HashMap::new(),
+            ))],
+            latest_sequence: 1,
+            config_hash,
+        });
+        let reaction = ProcessingQueueReaction::new(reaction_id, vec!["q1".to_string()]);
+        reaction.processing_enabled.store(true, Ordering::Release);
+        reaction.block_handler.store(false, Ordering::Release);
+        let processed = reaction.processed.clone();
+        let processed_notify = reaction.processed_notify.clone();
+        let queries: HashMap<String, Arc<dyn crate::queries::Query>> =
+            HashMap::from([("q1".to_string(), query as Arc<dyn crate::queries::Query>)]);
+        let (manager, _graph) =
+            provision_queue_backed_manager(queries, store.clone(), reaction).await;
+
+        manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while processed.lock().await.is_empty() {
+                processed_notify.notified().await;
+            }
+        })
+        .await
+        .expect("fresh replay was not handled");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if crate::reactions::checkpoint::read_checkpoint(store.as_ref(), reaction_id, "q1")
+                    .await
+                    .unwrap()
+                    .is_some_and(|checkpoint| {
+                        checkpoint.sequence == 1 && checkpoint.config_hash == config_hash
+                    })
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("eager checkpoint cache did not retain the seeded config hash");
     }
 
     // ========================================================================
@@ -2591,16 +3311,12 @@ mod tests {
             results.len()
         );
 
-        // Verify: checkpoint should have advanced.
+        // Enqueue alone must not claim durable handling progress.
         let cp = crate::reactions::checkpoint::read_checkpoint(store.as_ref(), "r_catchup", "q1")
             .await
             .unwrap()
             .expect("Checkpoint should exist");
-        assert!(
-            cp.sequence > 0,
-            "Checkpoint sequence should have advanced from 0, got {}",
-            cp.sequence
-        );
+        assert_eq!(cp.sequence, 0);
     }
 
     // ========================================================================
@@ -2624,6 +3340,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            last_forwarded_sequence: 0,
             received_sequence: None,
         })
         .await;
@@ -2659,6 +3376,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            last_forwarded_sequence: 0,
             received_sequence: None,
         })
         .await;
@@ -2710,6 +3428,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            last_forwarded_sequence: 0,
             received_sequence: Some(42),
         })
         .await;
@@ -2761,7 +3480,8 @@ mod tests {
         )
         .await
         .expect("empty outbox bounds should not underflow");
-        assert_eq!(empty.sequence, 0);
+        assert_eq!(empty.checkpoint.sequence, 0);
+        assert_eq!(empty.forwarded_sequence, 0);
 
         let saturated_query = Arc::new(MockQuery::new(42, u64::MAX));
         *saturated_query.outbox_response.write().await = Ok(OutboxResponse {
@@ -2796,7 +3516,8 @@ mod tests {
         )
         .await
         .expect("saturated outbox bounds should not overflow");
-        assert_eq!(saturated.sequence, u64::MAX);
+        assert_eq!(saturated.checkpoint.sequence, u64::MAX - 1);
+        assert_eq!(saturated.forwarded_sequence, u64::MAX);
     }
 
     #[tokio::test]
@@ -2848,9 +3569,13 @@ mod tests {
         )
         .await
         .expect("retained outbox replay should enqueue sequences 5 and 6");
-        assert_eq!(recovered.sequence, 6);
+        assert_eq!(recovered.checkpoint.sequence, 4);
+        assert_eq!(recovered.forwarded_sequence, 6);
 
-        let checkpoints = Arc::new(RwLock::new(HashMap::from([("q1".to_string(), recovered)])));
+        let checkpoints = Arc::new(RwLock::new(HashMap::from([(
+            "q1".to_string(),
+            recovered.checkpoint,
+        )])));
         ReactionManager::enqueue_forwarded_result(
             &reaction_trait,
             &query_trait,
@@ -2878,7 +3603,7 @@ mod tests {
     #[tokio::test]
     async fn failed_catchup_generations_are_clean_and_retryable() {
         let reaction_id = "retry-ordering";
-        let store = Arc::new(FailingCheckpointStore::new(reaction_id, "q1", 10, 2));
+        let store = Arc::new(crate::state_store::MemoryStateStoreProvider::new());
         let q1 = Arc::new(MockQuery::with_id("q1", 0, 10));
         let q2 = Arc::new(MockQuery::with_id("q2", 0, 4));
         let q1_hash = crate::queries::compute_config_hash(q1.get_config());
@@ -2932,15 +3657,21 @@ mod tests {
             "q2",
             &ReactionCheckpoint {
                 sequence: 0,
-                config_hash: q2_hash,
+                config_hash: q2_hash.wrapping_add(1),
             },
         )
         .await
         .unwrap();
 
         let reaction =
-            QueueBackedReaction::new(reaction_id, vec!["q1".to_string(), "q2".to_string()]);
+            ProcessingQueueReaction::new(reaction_id, vec!["q1".to_string(), "q2".to_string()]);
         let base = reaction.base.clone_shared();
+        let processing_enabled = reaction.processing_enabled.clone();
+        let handler_released = reaction.handler_released.clone();
+        let handler_gate = reaction.handler_gate.clone();
+        let handler_started = reaction.handler_started.clone();
+        let processed = reaction.processed.clone();
+        let processed_notify = reaction.processed_notify.clone();
         let queries: HashMap<String, Arc<dyn crate::queries::Query>> = HashMap::from([
             ("q1".to_string(), q1 as Arc<dyn crate::queries::Query>),
             ("q2".to_string(), q2 as Arc<dyn crate::queries::Query>),
@@ -2952,9 +3683,9 @@ mod tests {
             let error = manager
                 .start_reaction(reaction_id.to_string())
                 .await
-                .expect_err("injected checkpoint write should fail startup");
+                .expect_err("q2 config mismatch should fail after q1 replay");
             assert!(
-                format!("{error:#}").contains("injected checkpoint write failure"),
+                format!("{error:#}").contains("Strict recovery policy"),
                 "unexpected startup error: {error:#}"
             );
             assert_eq!(
@@ -2976,25 +3707,187 @@ mod tests {
                 4,
                 "failed generation must not advance the durable checkpoint"
             );
+            assert!(
+                processed.lock().await.is_empty(),
+                "the disabled handler must not consume failed-generation replay"
+            );
         }
+
+        crate::reactions::checkpoint::write_checkpoint(
+            store.as_ref(),
+            reaction_id,
+            "q2",
+            &ReactionCheckpoint {
+                sequence: 0,
+                config_hash: q2_hash,
+            },
+        )
+        .await
+        .unwrap();
+        processing_enabled.store(true, Ordering::Release);
 
         manager
             .start_reaction(reaction_id.to_string())
             .await
-            .expect("third generation should replay from checkpoint 4");
+            .expect("retry should replay from the original durable checkpoints");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            if processed.lock().await.is_empty() {
+                handler_started.notified().await;
+            }
+        })
+        .await
+        .expect("slow handler never received the replay");
+        assert_eq!(
+            crate::reactions::checkpoint::read_checkpoint(store.as_ref(), reaction_id, "q1")
+                .await
+                .unwrap()
+                .unwrap()
+                .sequence,
+            4,
+            "dequeued but unhandled replay must not advance the checkpoint"
+        );
+        handler_released.store(true, Ordering::Release);
+        handler_gate.notify_waiters();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while processed.lock().await.len() < 10 {
+                processed_notify.notified().await;
+            }
+        })
+        .await
+        .expect("handler did not consume the complete multi-query replay");
 
-        let depth = base.priority_queue.depth().await;
-        assert_eq!(depth, 10);
         let mut by_query: HashMap<String, Vec<u64>> = HashMap::new();
-        for _ in 0..depth {
-            let result = base.priority_queue.try_dequeue().await.unwrap();
+        for (query_id, sequence) in processed.lock().await.iter() {
             by_query
-                .entry(result.query_id.clone())
+                .entry(query_id.clone())
                 .or_default()
-                .push(result.sequence);
+                .push(*sequence);
         }
         assert_eq!(by_query["q1"], vec![5, 6, 7, 8, 9, 10]);
         assert_eq!(by_query["q2"], vec![1, 2, 3, 4]);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let checkpoints = crate::reactions::checkpoint::read_checkpoints_batch(
+                    store.as_ref(),
+                    reaction_id,
+                    &["q1".to_string(), "q2".to_string()],
+                )
+                .await
+                .unwrap();
+                if checkpoints.get("q1").map(|cp| cp.sequence) == Some(10)
+                    && checkpoints.get("q2").map(|cp| cp.sequence) == Some(4)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("successful handlers did not persist final checkpoints");
+        assert_eq!(base.priority_queue.depth().await, 0);
+    }
+
+    #[tokio::test]
+    async fn handler_checkpoint_failure_replays_from_last_acknowledged_sequence() {
+        let reaction_id = "handler-checkpoint-failure";
+        let store = Arc::new(FailingCheckpointStore::new(reaction_id, "q1", 7, 1));
+        let query = Arc::new(MockQuery::with_id("q1", 0, 10));
+        let config_hash = crate::queries::compute_config_hash(query.get_config());
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        *query.outbox_response.write().await = Ok(OutboxResponse {
+            results: (5..=10)
+                .map(|sequence| {
+                    Arc::new(QueryResult::new(
+                        "q1".to_string(),
+                        sequence,
+                        timestamp,
+                        Vec::new(),
+                        HashMap::new(),
+                    ))
+                })
+                .collect(),
+            latest_sequence: 10,
+            config_hash,
+        });
+        crate::reactions::checkpoint::write_checkpoint(
+            store.as_ref(),
+            reaction_id,
+            "q1",
+            &ReactionCheckpoint {
+                sequence: 4,
+                config_hash,
+            },
+        )
+        .await
+        .unwrap();
+
+        let reaction = ProcessingQueueReaction::new(reaction_id, vec!["q1".to_string()]);
+        reaction.processing_enabled.store(true, Ordering::Release);
+        reaction.block_handler.store(false, Ordering::Release);
+        let processed = reaction.processed.clone();
+        let processed_notify = reaction.processed_notify.clone();
+        let queries: HashMap<String, Arc<dyn crate::queries::Query>> =
+            HashMap::from([("q1".to_string(), query as Arc<dyn crate::queries::Query>)]);
+        let (manager, graph) =
+            provision_queue_backed_manager(queries, store.clone(), reaction).await;
+
+        manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .expect("startup replay should enqueue before the handler checkpoint fails");
+        crate::component_graph::wait_for_status(
+            &graph,
+            reaction_id,
+            &[ComponentStatus::Error],
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect("checkpoint failure did not fail the processing generation");
+        assert_eq!(
+            crate::reactions::checkpoint::read_checkpoint(store.as_ref(), reaction_id, "q1")
+                .await
+                .unwrap()
+                .unwrap()
+                .sequence,
+            6
+        );
+
+        manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .expect("retry should replay from the last acknowledged sequence");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while processed.lock().await.len() < 7 {
+                processed_notify.notified().await;
+            }
+        })
+        .await
+        .expect("retry did not finish replay after checkpoint recovery");
+        assert_eq!(
+            processed
+                .lock()
+                .await
+                .iter()
+                .map(|(_, sequence)| *sequence)
+                .collect::<Vec<_>>(),
+            vec![5, 6, 7, 7, 8, 9, 10],
+            "only the unacknowledged sequence may be delivered again"
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if crate::reactions::checkpoint::read_checkpoint(store.as_ref(), reaction_id, "q1")
+                    .await
+                    .unwrap()
+                    .is_some_and(|checkpoint| checkpoint.sequence == 10)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("retry did not persist the final acknowledged checkpoint");
     }
 
     #[tokio::test]
@@ -3132,6 +4025,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            last_forwarded_sequence: 10,
             received_sequence: Some(42),
         })
         .await
@@ -3175,6 +4069,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            last_forwarded_sequence: 10,
             received_sequence: None,
         })
         .await
@@ -3211,6 +4106,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &metrics,
+            last_forwarded_sequence: 10,
             received_sequence: Some(42),
         })
         .await
@@ -3250,12 +4146,16 @@ mod tests {
         )
         .await
         .expect("restart/retry should deliver the current event");
-        assert_eq!(checkpoints.read().await["q1"].sequence, 42);
+        assert_eq!(
+            checkpoints.read().await["q1"].sequence,
+            41,
+            "successful enqueue is not a handler acknowledgement"
+        );
         assert_eq!(reaction.enqueued.lock().await.len(), 1);
     }
 
     #[tokio::test]
-    async fn auto_skip_gap_repeated_episodes_advance_only_after_delivery() {
+    async fn auto_skip_gap_does_not_skip_past_unacknowledged_forwarded_results() {
         let query: Arc<dyn crate::queries::Query> = Arc::new(MockQuery::new(42, 100));
         let reaction = Arc::new(
             MockReaction::new("r1", vec!["q1".into()])
@@ -3283,13 +4183,16 @@ mod tests {
                 checkpoints: &checkpoints,
                 bootstrap_mutex: &bootstrap_mutex,
                 metrics: &metrics,
+                last_forwarded_sequence: if received_sequence == 10 { 1 } else { 10 },
                 received_sequence: Some(received_sequence),
             })
             .await
             .expect("skip one missing range");
+            let expected_checkpoint = 9;
             assert_eq!(
                 checkpoints.read().await["q1"].sequence,
-                received_sequence - 1
+                expected_checkpoint,
+                "a later gap must not checkpoint past the unacknowledged sequence 10"
             );
             ReactionManager::enqueue_forwarded_result(
                 &reaction_trait,
@@ -3307,7 +4210,11 @@ mod tests {
             )
             .await
             .expect("deliver retained gap-triggering event");
-            assert_eq!(checkpoints.read().await["q1"].sequence, received_sequence);
+            assert_eq!(
+                checkpoints.read().await["q1"].sequence,
+                expected_checkpoint,
+                "forwarding must not advance the authoritative checkpoint"
+            );
         }
         assert_eq!(
             reaction
@@ -3469,6 +4376,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            last_forwarded_sequence: 0,
             received_sequence: None,
         })
         .await;
@@ -3598,6 +4506,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &Arc::new(ReactionMetrics::new()),
+            last_forwarded_sequence: 0,
             received_sequence: None,
         })
         .await;
@@ -3651,6 +4560,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &metrics_q1,
+            last_forwarded_sequence: 0,
             received_sequence: None,
         };
         let ctx_q2 = BroadcastGapContext {
@@ -3663,6 +4573,7 @@ mod tests {
             checkpoints: &checkpoints,
             bootstrap_mutex: &bootstrap_mutex,
             metrics: &metrics_q2,
+            last_forwarded_sequence: 0,
             received_sequence: None,
         };
         let (r1, r2) = tokio::join!(

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -67,6 +67,11 @@ struct BroadcastGapContext<'a> {
     received_sequence: Option<u64>,
 }
 
+struct ReactionSubscriptionTasks {
+    forwarder_abort_handles: Vec<tokio::task::AbortHandle>,
+    supervisor: tokio::task::JoinHandle<()>,
+}
+
 pub struct ReactionManager {
     instance_id: String,
     /// Query provider for reactions to access queries (injected after DrasiLib is constructed)
@@ -77,8 +82,8 @@ pub struct ReactionManager {
     identity_provider: Arc<RwLock<Option<Arc<dyn IdentityProvider>>>>,
     /// Log registry for component log streaming
     log_registry: Arc<ComponentLogRegistry>,
-    /// Abort handles to subscription forwarder + supervisor tasks per reaction
-    subscription_tasks: Arc<RwLock<HashMap<String, Vec<tokio::task::AbortHandle>>>>,
+    /// Subscription forwarders and their reaping supervisor per reaction.
+    subscription_tasks: Arc<RwLock<HashMap<String, ReactionSubscriptionTasks>>>,
     /// Shared component graph — the single source of truth for component metadata,
     /// state, relationships, runtime instances, AND event history.
     graph: Arc<RwLock<ComponentGraph>>,
@@ -215,40 +220,113 @@ impl ReactionManager {
         // --- §3 Startup validation ---
         self.validate_startup_config(&reaction).await?;
 
-        crate::managers::lifecycle_helpers::start_component(
+        self.prepare_start_generation(&id, &reaction).await?;
+
+        if let Err(error) = crate::managers::lifecycle_helpers::start_component(
             &self.graph,
             &id,
             "reaction",
             &reaction,
         )
-        .await?;
+        .await
+        {
+            self.cleanup_failed_start(&id, &reaction, format!("Start failed: {error}"))
+                .await;
+            return Err(error);
+        }
 
         // Create the bootstrap gate — forwarders wait on this before processing.
         // Using a watch channel (not Notify) so late subscribers see the current value
         // and cannot miss the notification.
         let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
 
-        if let Err(e) = self
+        if let Err(error) = self
             .subscribe_and_bootstrap(&id, reaction.clone(), gate_rx)
             .await
         {
-            // Abort any forwarder/supervisor tasks spawned during wire_subscriptions.
-            Self::abort_subscription_tasks_static(&self.subscription_tasks, &id).await;
-
-            // Revert to Error since the reaction can't receive data without subscriptions
-            let mut graph = self.graph.write().await;
-            let _ = graph.validate_and_transition(
-                &id,
-                ComponentStatus::Error,
-                Some(format!("Bootstrap failed: {e}")),
-            );
-            return Err(e);
+            self.cleanup_failed_start(&id, &reaction, format!("Bootstrap failed: {error}"))
+                .await;
+            return Err(error);
         }
 
         // Open the gate — forwarders begin draining buffered events.
         let _ = gate_tx.send(true);
 
         Ok(())
+    }
+
+    async fn prepare_start_generation(
+        &self,
+        reaction_id: &str,
+        reaction: &Arc<dyn Reaction>,
+    ) -> Result<()> {
+        Self::abort_subscription_tasks_static(&self.subscription_tasks, reaction_id).await;
+
+        let status = self
+            .graph
+            .read()
+            .await
+            .get_component(reaction_id)
+            .map(|node| node.status)
+            .ok_or_else(|| anyhow::anyhow!("Reaction '{reaction_id}' not found"))?;
+        if status != ComponentStatus::Error {
+            return Ok(());
+        }
+
+        reaction
+            .stop()
+            .await
+            .with_context(|| format!("Failed to clean prior generation for '{reaction_id}'"))?;
+        crate::component_graph::wait_for_status(
+            &self.graph,
+            reaction_id,
+            &[ComponentStatus::Stopped],
+            std::time::Duration::from_secs(2),
+        )
+        .await
+        .with_context(|| {
+            format!("Reaction '{reaction_id}' did not stop before retrying its start")
+        })?;
+        Ok(())
+    }
+
+    async fn cleanup_failed_start(
+        &self,
+        reaction_id: &str,
+        reaction: &Arc<dyn Reaction>,
+        message: String,
+    ) {
+        {
+            let mut graph = self.graph.write().await;
+            let _ = graph.validate_and_transition(
+                reaction_id,
+                ComponentStatus::Error,
+                Some(message.clone()),
+            );
+        }
+
+        Self::abort_subscription_tasks_static(&self.subscription_tasks, reaction_id).await;
+        if let Err(cleanup_error) = reaction.stop().await {
+            log::error!(
+                "[{reaction_id}] Failed to clean reaction after start failure: {cleanup_error}"
+            );
+            return;
+        }
+
+        if let Err(wait_error) = crate::component_graph::wait_for_status(
+            &self.graph,
+            reaction_id,
+            &[ComponentStatus::Stopped],
+            std::time::Duration::from_secs(2),
+        )
+        .await
+        {
+            log::error!("[{reaction_id}] Failed-start cleanup did not reach Stopped: {wait_error}");
+            return;
+        }
+
+        let mut graph = self.graph.write().await;
+        let _ = graph.validate_and_transition(reaction_id, ComponentStatus::Error, Some(message));
     }
 
     /// Validate the reaction's startup configuration (§3 compatibility rules).
@@ -1220,9 +1298,21 @@ impl ReactionManager {
         let bootstrap_mutex = Arc::new(tokio::sync::Mutex::new(()));
 
         for query_id in query_ids {
-            let query = query_provider.get_query_instance(query_id).await?;
+            let query = match query_provider.get_query_instance(query_id).await {
+                Ok(query) => query,
+                Err(error) => {
+                    Self::abort_and_reap_forwarders(abort_handles, join_handles).await;
+                    return Err(error);
+                }
+            };
 
-            let subscription = query.subscribe(reaction_id.to_string()).await?;
+            let subscription = match query.subscribe(reaction_id.to_string()).await {
+                Ok(subscription) => subscription,
+                Err(error) => {
+                    Self::abort_and_reap_forwarders(abort_handles, join_handles).await;
+                    return Err(error);
+                }
+            };
             let mut receiver = subscription.receiver;
 
             // Create or retrieve per-(reaction, query) metrics
@@ -1478,13 +1568,14 @@ impl ReactionManager {
             }
         });
 
-        abort_handles.push(supervisor.abort_handle());
-
-        // Store abort handles so stop_reaction/teardown can cancel everything.
-        self.subscription_tasks
-            .write()
-            .await
-            .insert(reaction_id.to_string(), abort_handles);
+        // Store the forwarder abort handles with the supervisor that reaps them.
+        self.subscription_tasks.write().await.insert(
+            reaction_id.to_string(),
+            ReactionSubscriptionTasks {
+                forwarder_abort_handles: abort_handles,
+                supervisor,
+            },
+        );
 
         Ok(())
     }
@@ -1646,13 +1737,31 @@ impl ReactionManager {
     }
 
     async fn abort_subscription_tasks_static(
-        tasks: &Arc<RwLock<HashMap<String, Vec<tokio::task::AbortHandle>>>>,
+        tasks: &Arc<RwLock<HashMap<String, ReactionSubscriptionTasks>>>,
         reaction_id: &str,
     ) {
-        if let Some(handles) = tasks.write().await.remove(reaction_id) {
-            for handle in handles {
+        let task_set = { tasks.write().await.remove(reaction_id) };
+        if let Some(task_set) = task_set {
+            for handle in task_set.forwarder_abort_handles {
                 handle.abort();
             }
+            if let Err(error) = task_set.supervisor.await {
+                log::debug!(
+                    "[{reaction_id}] Subscription supervisor ended during cleanup: {error}"
+                );
+            }
+        }
+    }
+
+    async fn abort_and_reap_forwarders(
+        abort_handles: Vec<tokio::task::AbortHandle>,
+        join_handles: Vec<tokio::task::JoinHandle<()>>,
+    ) {
+        for handle in abort_handles {
+            handle.abort();
+        }
+        for handle in join_handles {
+            let _ = handle.await;
         }
     }
 
@@ -1712,12 +1821,17 @@ mod tests {
         config: QueryConfig,
         snapshot: tokio::sync::RwLock<SnapshotResponse>,
         outbox_response: tokio::sync::RwLock<Result<OutboxResponse, FetchError>>,
+        subscriptions: Mutex<Vec<tokio::sync::mpsc::Sender<Arc<QueryResult>>>>,
     }
 
     impl MockQuery {
         fn new(config_hash: u64, snapshot_seq: u64) -> Self {
+            Self::with_id("q1", config_hash, snapshot_seq)
+        }
+
+        fn with_id(id: &str, config_hash: u64, snapshot_seq: u64) -> Self {
             let config = QueryConfig {
-                id: "q1".to_string(),
+                id: id.to_string(),
                 query: "MATCH (n) RETURN n".to_string(),
                 query_language: crate::config::schema::QueryLanguage::Cypher,
                 middleware: vec![],
@@ -1743,6 +1857,7 @@ mod tests {
                     latest_sequence: snapshot_seq,
                     config_hash,
                 })),
+                subscriptions: Mutex::new(Vec::new()),
             }
         }
     }
@@ -1765,13 +1880,152 @@ mod tests {
             self
         }
         async fn subscribe(&self, _reaction_id: String) -> Result<QuerySubscriptionResponse> {
-            Err(anyhow::anyhow!("MockQuery does not support subscribe"))
+            let (sender, receiver) = tokio::sync::mpsc::channel(16);
+            self.subscriptions.lock().await.push(sender);
+            Ok(QuerySubscriptionResponse {
+                query_id: self.config.id.clone(),
+                receiver: Box::new(crate::channels::ChannelChangeReceiver::new(receiver)),
+            })
         }
         async fn fetch_snapshot(&self) -> Result<SnapshotResponse, FetchError> {
             Ok(self.snapshot.read().await.clone())
         }
         async fn fetch_outbox(&self, _after_sequence: u64) -> Result<OutboxResponse, FetchError> {
             self.outbox_response.read().await.clone()
+        }
+    }
+
+    struct MockQueryProvider {
+        queries: HashMap<String, Arc<dyn crate::queries::Query>>,
+    }
+
+    #[async_trait]
+    impl QueryProvider for MockQueryProvider {
+        async fn get_query_instance(&self, id: &str) -> Result<Arc<dyn crate::queries::Query>> {
+            self.queries
+                .get(id)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Query '{id}' not found"))
+        }
+    }
+
+    struct FailingCheckpointStore {
+        inner: crate::state_store::MemoryStateStoreProvider,
+        target_reaction: String,
+        target_query: String,
+        target_sequence: u64,
+        remaining_failures: AtomicUsize,
+    }
+
+    impl FailingCheckpointStore {
+        fn new(
+            target_reaction: &str,
+            target_query: &str,
+            target_sequence: u64,
+            failures: usize,
+        ) -> Self {
+            Self {
+                inner: crate::state_store::MemoryStateStoreProvider::new(),
+                target_reaction: target_reaction.to_string(),
+                target_query: target_query.to_string(),
+                target_sequence,
+                remaining_failures: AtomicUsize::new(failures),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl StateStoreProvider for FailingCheckpointStore {
+        async fn get(
+            &self,
+            store_id: &str,
+            key: &str,
+        ) -> crate::state_store::StateStoreResult<Option<Vec<u8>>> {
+            self.inner.get(store_id, key).await
+        }
+
+        async fn set(
+            &self,
+            store_id: &str,
+            key: &str,
+            value: Vec<u8>,
+        ) -> crate::state_store::StateStoreResult<()> {
+            let target_key = format!("checkpoint:{}", self.target_query);
+            let should_fail = store_id == self.target_reaction
+                && key == target_key
+                && bincode::deserialize::<ReactionCheckpoint>(&value)
+                    .is_ok_and(|checkpoint| checkpoint.sequence == self.target_sequence)
+                && self
+                    .remaining_failures
+                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok();
+            if should_fail {
+                return Err(crate::state_store::StateStoreError::StorageError(
+                    "injected checkpoint write failure".to_string(),
+                ));
+            }
+            self.inner.set(store_id, key, value).await
+        }
+
+        async fn delete(
+            &self,
+            store_id: &str,
+            key: &str,
+        ) -> crate::state_store::StateStoreResult<bool> {
+            self.inner.delete(store_id, key).await
+        }
+
+        async fn contains_key(
+            &self,
+            store_id: &str,
+            key: &str,
+        ) -> crate::state_store::StateStoreResult<bool> {
+            self.inner.contains_key(store_id, key).await
+        }
+
+        async fn get_many(
+            &self,
+            store_id: &str,
+            keys: &[&str],
+        ) -> crate::state_store::StateStoreResult<HashMap<String, Vec<u8>>> {
+            self.inner.get_many(store_id, keys).await
+        }
+
+        async fn set_many(
+            &self,
+            store_id: &str,
+            entries: &[(&str, &[u8])],
+        ) -> crate::state_store::StateStoreResult<()> {
+            self.inner.set_many(store_id, entries).await
+        }
+
+        async fn delete_many(
+            &self,
+            store_id: &str,
+            keys: &[&str],
+        ) -> crate::state_store::StateStoreResult<usize> {
+            self.inner.delete_many(store_id, keys).await
+        }
+
+        async fn clear_store(&self, store_id: &str) -> crate::state_store::StateStoreResult<usize> {
+            self.inner.clear_store(store_id).await
+        }
+
+        async fn list_keys(
+            &self,
+            store_id: &str,
+        ) -> crate::state_store::StateStoreResult<Vec<String>> {
+            self.inner.list_keys(store_id).await
+        }
+
+        async fn store_exists(&self, store_id: &str) -> crate::state_store::StateStoreResult<bool> {
+            self.inner.store_exists(store_id).await
+        }
+
+        async fn key_count(&self, store_id: &str) -> crate::state_store::StateStoreResult<usize> {
+            self.inner.key_count(store_id).await
         }
     }
 
@@ -1898,9 +2152,14 @@ mod tests {
 
     impl QueueBackedReaction {
         fn new(id: &str, queries: Vec<String>) -> Self {
+            Self::with_capacity(id, queries, 10_000)
+        }
+
+        fn with_capacity(id: &str, queries: Vec<String>, capacity: usize) -> Self {
             Self {
                 base: crate::reactions::common::base::ReactionBase::new(
-                    crate::reactions::common::base::ReactionBaseParams::new(id, queries),
+                    crate::reactions::common::base::ReactionBaseParams::new(id, queries)
+                        .with_priority_queue_capacity(capacity),
                 ),
             }
         }
@@ -1933,6 +2192,7 @@ mod tests {
         }
 
         async fn start(&self) -> Result<()> {
+            let _shutdown_rx = self.base.create_shutdown_channel().await;
             self.base.set_status(ComponentStatus::Running, None).await;
             Ok(())
         }
@@ -2029,6 +2289,46 @@ mod tests {
         }
         // Give the query time to process events.
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    }
+
+    async fn provision_queue_backed_manager(
+        queries: HashMap<String, Arc<dyn crate::queries::Query>>,
+        state_store: Arc<dyn StateStoreProvider>,
+        reaction: QueueBackedReaction,
+    ) -> (
+        Arc<ReactionManager>,
+        Arc<RwLock<crate::component_graph::ComponentGraph>>,
+    ) {
+        let log_registry = crate::managers::get_or_init_global_registry();
+        let (mut graph, mut update_rx) =
+            crate::component_graph::ComponentGraph::new("ordering-tests");
+        let update_tx = graph.update_sender();
+        for query_id in queries.keys() {
+            graph.register_query(query_id, HashMap::new(), &[]).unwrap();
+        }
+        graph
+            .register_reaction(reaction.id(), HashMap::new(), &reaction.query_ids())
+            .unwrap();
+        let graph = Arc::new(RwLock::new(graph));
+        let update_graph = graph.clone();
+        tokio::spawn(async move {
+            while let Some(update) = update_rx.recv().await {
+                update_graph.write().await.apply_update(update);
+            }
+        });
+
+        let manager = Arc::new(ReactionManager::new(
+            "ordering-tests",
+            log_registry,
+            graph.clone(),
+            update_tx,
+        ));
+        manager
+            .inject_query_provider(Arc::new(MockQueryProvider { queries }))
+            .await;
+        manager.inject_state_store(state_store).await;
+        manager.provision_reaction(reaction).await.unwrap();
+        (manager, graph)
     }
 
     // ========================================================================
@@ -2573,6 +2873,234 @@ mod tests {
             sequences.push(reaction.base.priority_queue.dequeue().await.sequence);
         }
         assert_eq!(sequences, vec![5, 6, 7]);
+    }
+
+    #[tokio::test]
+    async fn failed_catchup_generations_are_clean_and_retryable() {
+        let reaction_id = "retry-ordering";
+        let store = Arc::new(FailingCheckpointStore::new(reaction_id, "q1", 10, 2));
+        let q1 = Arc::new(MockQuery::with_id("q1", 0, 10));
+        let q2 = Arc::new(MockQuery::with_id("q2", 0, 4));
+        let q1_hash = crate::queries::compute_config_hash(q1.get_config());
+        let q2_hash = crate::queries::compute_config_hash(q2.get_config());
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+
+        *q1.outbox_response.write().await = Ok(OutboxResponse {
+            results: (5..=10)
+                .map(|sequence| {
+                    Arc::new(QueryResult::new(
+                        "q1".to_string(),
+                        sequence,
+                        timestamp - chrono::Duration::seconds(sequence as i64),
+                        Vec::new(),
+                        HashMap::new(),
+                    ))
+                })
+                .collect(),
+            latest_sequence: 10,
+            config_hash: q1_hash,
+        });
+        *q2.outbox_response.write().await = Ok(OutboxResponse {
+            results: (1..=4)
+                .map(|sequence| {
+                    Arc::new(QueryResult::new(
+                        "q2".to_string(),
+                        sequence,
+                        timestamp + chrono::Duration::seconds(sequence as i64),
+                        Vec::new(),
+                        HashMap::new(),
+                    ))
+                })
+                .collect(),
+            latest_sequence: 4,
+            config_hash: q2_hash,
+        });
+        crate::reactions::checkpoint::write_checkpoint(
+            store.as_ref(),
+            reaction_id,
+            "q1",
+            &ReactionCheckpoint {
+                sequence: 4,
+                config_hash: q1_hash,
+            },
+        )
+        .await
+        .unwrap();
+        crate::reactions::checkpoint::write_checkpoint(
+            store.as_ref(),
+            reaction_id,
+            "q2",
+            &ReactionCheckpoint {
+                sequence: 0,
+                config_hash: q2_hash,
+            },
+        )
+        .await
+        .unwrap();
+
+        let reaction =
+            QueueBackedReaction::new(reaction_id, vec!["q1".to_string(), "q2".to_string()]);
+        let base = reaction.base.clone_shared();
+        let queries: HashMap<String, Arc<dyn crate::queries::Query>> = HashMap::from([
+            ("q1".to_string(), q1 as Arc<dyn crate::queries::Query>),
+            ("q2".to_string(), q2 as Arc<dyn crate::queries::Query>),
+        ]);
+        let (manager, graph) =
+            provision_queue_backed_manager(queries, store.clone(), reaction).await;
+
+        for _ in 0..2 {
+            let error = manager
+                .start_reaction(reaction_id.to_string())
+                .await
+                .expect_err("injected checkpoint write should fail startup");
+            assert!(
+                format!("{error:#}").contains("injected checkpoint write failure"),
+                "unexpected startup error: {error:#}"
+            );
+            assert_eq!(
+                graph
+                    .read()
+                    .await
+                    .get_component(reaction_id)
+                    .unwrap()
+                    .status,
+                ComponentStatus::Error
+            );
+            assert_eq!(base.priority_queue.depth().await, 0);
+            assert_eq!(
+                crate::reactions::checkpoint::read_checkpoint(store.as_ref(), reaction_id, "q1")
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .sequence,
+                4,
+                "failed generation must not advance the durable checkpoint"
+            );
+        }
+
+        manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .expect("third generation should replay from checkpoint 4");
+
+        let depth = base.priority_queue.depth().await;
+        assert_eq!(depth, 10);
+        let mut by_query: HashMap<String, Vec<u64>> = HashMap::new();
+        for _ in 0..depth {
+            let result = base.priority_queue.try_dequeue().await.unwrap();
+            by_query
+                .entry(result.query_id.clone())
+                .or_default()
+                .push(result.sequence);
+        }
+        assert_eq!(by_query["q1"], vec![5, 6, 7, 8, 9, 10]);
+        assert_eq!(by_query["q2"], vec![1, 2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn stop_cancels_full_queue_bootstrap_and_restart_succeeds() {
+        let reaction_id = "stop-full-bootstrap";
+        let store = Arc::new(crate::state_store::MemoryStateStoreProvider::new());
+        let query = Arc::new(MockQuery::with_id("q1", 0, 6));
+        let config_hash = crate::queries::compute_config_hash(query.get_config());
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        *query.outbox_response.write().await = Ok(OutboxResponse {
+            results: vec![
+                Arc::new(QueryResult::new(
+                    "q1".to_string(),
+                    5,
+                    timestamp,
+                    Vec::new(),
+                    HashMap::new(),
+                )),
+                Arc::new(QueryResult::new(
+                    "q1".to_string(),
+                    6,
+                    timestamp,
+                    Vec::new(),
+                    HashMap::new(),
+                )),
+            ],
+            latest_sequence: 6,
+            config_hash,
+        });
+        crate::reactions::checkpoint::write_checkpoint(
+            store.as_ref(),
+            reaction_id,
+            "q1",
+            &ReactionCheckpoint {
+                sequence: 4,
+                config_hash,
+            },
+        )
+        .await
+        .unwrap();
+
+        let reaction = QueueBackedReaction::with_capacity(reaction_id, vec!["q1".to_string()], 1);
+        let base = reaction.base.clone_shared();
+        let queries: HashMap<String, Arc<dyn crate::queries::Query>> = HashMap::from([(
+            "q1".to_string(),
+            query.clone() as Arc<dyn crate::queries::Query>,
+        )]);
+        let (manager, _graph) =
+            provision_queue_backed_manager(queries, store.clone(), reaction).await;
+
+        let start_manager = manager.clone();
+        let start_task =
+            tokio::spawn(
+                async move { start_manager.start_reaction(reaction_id.to_string()).await },
+            );
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while base.priority_queue.metrics().await.blocked_enqueue_count == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("bootstrap did not block on the full reaction queue");
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            manager.stop_reaction(reaction_id.to_string()),
+        )
+        .await
+        .expect("stop deadlocked with a blocked bootstrap enqueue")
+        .expect("stop failed");
+        let start_error = tokio::time::timeout(std::time::Duration::from_secs(1), start_task)
+            .await
+            .expect("bootstrap producer did not exit after stop")
+            .expect("start task panicked")
+            .expect_err("stopped bootstrap generation must not report success");
+        assert!(
+            format!("{start_error:#}").contains("priority queue is closed"),
+            "unexpected start error: {start_error:#}"
+        );
+        assert_eq!(base.priority_queue.depth().await, 0);
+        assert_eq!(
+            crate::reactions::checkpoint::read_checkpoint(store.as_ref(), reaction_id, "q1")
+                .await
+                .unwrap()
+                .unwrap()
+                .sequence,
+            4
+        );
+
+        *query.outbox_response.write().await = Ok(OutboxResponse {
+            results: vec![Arc::new(QueryResult::new(
+                "q1".to_string(),
+                5,
+                timestamp,
+                Vec::new(),
+                HashMap::new(),
+            ))],
+            latest_sequence: 5,
+            config_hash,
+        });
+        manager
+            .start_reaction(reaction_id.to_string())
+            .await
+            .expect("restart should reopen a clean reaction queue generation");
+        assert_eq!(base.priority_queue.depth().await, 1);
+        assert_eq!(base.priority_queue.try_dequeue().await.unwrap().sequence, 5);
     }
 
     #[tokio::test]

--- a/lib/tests/metrics_e2e.rs
+++ b/lib/tests/metrics_e2e.rs
@@ -22,6 +22,7 @@ mod mock_source;
 use anyhow::Result;
 use drasi_lib::channels::{ComponentStatus, QueryResult};
 use drasi_lib::context::ReactionRuntimeContext;
+use drasi_lib::reactions::checkpoint::ReactionCheckpoint;
 use drasi_lib::reactions::common::base::{ReactionBase, ReactionBaseParams};
 use drasi_lib::recovery::ReactionRecoveryPolicy;
 use drasi_lib::{DrasiLib, MemoryStateStoreProvider, Query, Reaction};
@@ -247,7 +248,26 @@ impl Reaction for RecordingReaction {
     }
 
     async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
-        let _ = self.tx.send(result);
+        let checkpoint = self
+            .base
+            .read_checkpoint(&result.query_id)
+            .await?
+            .unwrap_or(ReactionCheckpoint {
+                sequence: 0,
+                config_hash: 0,
+            });
+        self.tx
+            .send(result.clone())
+            .map_err(|_| anyhow::anyhow!("recording receiver closed"))?;
+        self.base
+            .write_checkpoint(
+                &result.query_id,
+                &ReactionCheckpoint {
+                    sequence: result.sequence,
+                    config_hash: checkpoint.config_hash,
+                },
+            )
+            .await?;
         Ok(())
     }
 


### PR DESCRIPTION
Stack A follow-up layer 8.

Depends on #871.

Base: `agentofreality-query-bootstrap-recovery`.

This isolated fix closes the pre-existing reaction priority-queue ordering bug exposed by A7 retained-outbox recovery. `ReactionBase` derives monotonic per-query internal ordering timestamps and the heap uses a stable insertion ordinal, producing a transitive total order without changing serialized `QueryResult` data or external contracts.

Lifecycle and checkpoint invariants:
- Reaction start admission is claimed before any generation cleanup. Duplicate Running/Starting starts and `start_all` retries are rejected without touching the healthy generation's subscriptions, queue, cursor, status, or checkpoint.
- Each admitted generation closes/drains/resets/reopens its queue; failed starts cancel and reap forwarders. Queue close wakes capacity-blocked producers with a typed error and prevents post-stop enqueue.
- Authoritative checkpoints represent only handled/acknowledged results, delivered snapshots, or explicit recovery skips. Outbox replay enqueue progress is generation-local and is used only to suppress replay/live overlap.
- Non-snapshot sequence-zero/config-hash baselines are established before eager reaction processing loops start. Snapshot checkpoints commit only after successful bootstrap.
- AutoSkipGap never checkpoints past results already forwarded but not yet acknowledged. Reaction metrics refresh from the authoritative durable checkpoint.

Tests cover eight equal-timestamp entries, backwards timestamps, deterministic multi-query merging, sequence inversion errors, duplicate suppression, 100 deterministic former-flaky iterations, retained replay followed by buffered live delivery, repeated failed multi-query generations, slow-handler retry, handler checkpoint-write failure, duplicate/concurrent/public start admission, `start_all` on a running reaction, full-capacity concurrent stop/restart, eager checkpoint cache seeding, AutoSkip protection for outstanding results, and profiler stop/restart.