### PR TITLE
feat(lib): add opt-in computation v1 contracts (B1)

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -30,6 +30,9 @@ workspace = true
 [features]
 default = []
 
+# Experimental, additive in-process computation contracts.
+computation = []
+
 # Middleware features (passed through to drasi-middleware)
 middleware-jq = ["drasi-middleware/jq"]
 middleware-bundled-jq = ["drasi-middleware/bundled-jq"]

--- a/lib/README.md
+++ b/lib/README.md
@@ -35,6 +35,37 @@ tokio = { version = "1", features = ["full"] }
 
 **Note:** If you don't use middleware, or only use non-jq middleware, you don't need these build tools.
 
+## Experimental computation contracts
+
+The **default-off** `computation` feature exposes additive, versioned contracts at
+`drasi_lib::computation::v1`:
+
+```toml
+drasi-lib = { version = "0.9", features = ["computation"] }
+```
+
+These contracts support custom schema-validated immutable record bytes, ordered
+Adds/Updates/Deletes (explicit PATCH versus REPLACE), shared envelopes, append-only
+branch-local context, and input lineage. They also define host-owned
+`EnvelopeSource`, `Transformer`, and `EnvelopeSink` traits, named schema ports, and
+pipe capability negotiation. A transformer can emit zero, one, or many outputs,
+using its own producer stream and sequence while retaining input lineage.
+
+**This is not yet a composable graph runtime.** There is no concrete pipe, graph
+runner, legacy adapter, serialization format, server configuration, or plugin ABI
+in this feature. Enabling it does not migrate or change existing Sources, Queries,
+Reactions, or `DrasiLib` behavior. Future legacy codecs must preserve typed values;
+internal canonical identity bytes are not a proven reversible wire codec.
+
+Enqueue receipts mean **acceptance only**, not handling or acknowledgement.
+Sinks declare a fixed `Accepted` or `Handled` completion boundary; legacy reaction
+queue acceptance must never be advertised as completed handling. Local
+acknowledgement handles remain outside envelopes and contexts. The volatile bounded
+pipe descriptor advertises only per-stream FIFO and backpressure, rejecting
+requirements for durability, replay, explicit acknowledgement, transactions, or
+exactly-once. Sequence is authoritative; timestamps do not reorder a stream.
+See the v1 rustdocs for validation, lifecycle, and capability contracts.
+
 ## Identity Providers
 
 DrasiLib includes a trait-based identity provider abstraction for authenticating with databases and external services. The core trait (`IdentityProvider`) and `PasswordIdentityProvider` are built into `drasi-lib`. Cloud-specific providers are available as separate crates.

--- a/lib/src/change/mod.rs
+++ b/lib/src/change/mod.rs
@@ -20,6 +20,10 @@
 mod adapters;
 mod canonical;
 
+#[cfg(feature = "computation")]
+#[path = "../computation/a2_bridge.rs"]
+pub(crate) mod computation_bridge;
+
 pub(crate) use adapters::{
     query_evaluation_to_envelope, query_result_from_envelope, source_change_from_envelope,
     source_change_from_envelope_owned, source_event_from_envelope, source_event_parts_to_envelope,

--- a/lib/src/computation/a2_bridge.rs
+++ b/lib/src/computation/a2_bridge.rs
@@ -1,0 +1,74 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compiled as a private child of `change`, so v1 can reuse context storage
+//! without widening the visibility of any existing A2 constructor or type.
+
+use super::{ContextContribution, ContextRootId, ProcessingContext, StableIdBuilder};
+
+pub(crate) fn new_context(namespace: &str, identity: &[u8]) -> ProcessingContext {
+    let mut hash = StableIdBuilder::new("drasi.computation.context-root/v1");
+    hash.string("namespace", namespace);
+    hash.bytes("identity", identity);
+    ProcessingContext::new(ContextRootId::new(hash.finish()))
+}
+
+// The v1 caller checks length overflow before using A2's append primitive.
+pub(crate) fn append_context(
+    context: &ProcessingContext,
+    contribution: ContextContribution,
+) -> ProcessingContext {
+    context.append(contribution)
+}
+
+pub(crate) fn schema_fingerprint(id: &str, version: u32, encoding: &str, definition: &[u8]) -> u64 {
+    let mut hash = StableIdBuilder::new("drasi.computation.schema/v1");
+    hash.string("schema-id", id);
+    hash.u64("schema-version", u64::from(version));
+    hash.string("encoding", encoding);
+    hash.bytes("definition", definition);
+    hash.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::change::{ContextContributor, ContextContributorKind, ContextValue};
+    use std::sync::Arc;
+
+    #[test]
+    fn computation_reuses_a2_context_allocations() {
+        let root = new_context("example", b"event");
+        let entry = ContextContribution::new(
+            ContextContributor::new(ContextContributorKind::Runtime, "transform"),
+            "count",
+            ContextValue::Unsigned(1),
+        );
+        let first = append_context(&root, entry.clone());
+        let left = append_context(&first, entry.clone());
+        let right = append_context(&first, entry);
+        assert!(Arc::ptr_eq(root.root(), left.root()));
+        assert!(Arc::ptr_eq(
+            left.head().unwrap().parent().unwrap(),
+            first.head().unwrap()
+        ));
+        assert!(Arc::ptr_eq(
+            left.head().unwrap().parent().unwrap(),
+            right.head().unwrap().parent().unwrap()
+        ));
+        assert!(!Arc::ptr_eq(left.head().unwrap(), right.head().unwrap()));
+        assert_eq!(root.len(), 0);
+        assert_eq!(first.len(), 1);
+    }
+}

--- a/lib/src/computation/mod.rs
+++ b/lib/src/computation/mod.rs
@@ -1,0 +1,22 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Experimental computation contracts, enabled by the default-off `computation`
+//! Cargo feature. These sit beside, and do not modify, the existing
+//! [`crate::Source`], [`crate::Reaction`], or [`crate::DrasiLib`] APIs.
+//!
+//! Only versioned namespaces are public. This module provides no graph runner,
+//! concrete pipe, legacy adapter, persistence format, or plugin ABI.
+
+pub mod v1;

--- a/lib/src/computation/v1/component.rs
+++ b/lib/src/computation/v1/component.rs
@@ -1,0 +1,95 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+
+use super::{ComponentDescriptor, Envelope, PortId};
+
+/// Fixed meaning of a sink's successful handle call. This is an instance-level
+/// declaration, never a per-call downgrade or a consequence of pipe capabilities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SinkCompletion {
+    /// Accepted by the sink or a legacy queue. No claim of durable acceptance,
+    /// completed processing, or completed external effects.
+    Accepted,
+    /// Processing completed at the declared sink boundary. Not automatic
+    /// end-to-end acknowledgement, atomic external effects, or exactly-once.
+    Handled,
+}
+
+/// Input routed to a declared input port. The host validates port/schema membership.
+#[derive(Debug, Clone)]
+pub struct InputEnvelope {
+    pub port: PortId,
+    pub envelope: Envelope,
+}
+
+/// New emission on a declared output port. The producing component owns its
+/// output stream and authoritative monotonically increasing sequence.
+#[derive(Debug, Clone)]
+pub struct OutputEnvelope {
+    pub port: PortId,
+    pub envelope: Envelope,
+}
+
+/// Host-owned component lifecycle, independent of legacy Source/Reaction contexts.
+///
+/// The future DAG host owns `Box<dyn ...>` instances, validates roles/ports before
+/// starting, serializes all mutable calls, and owns cancellation and error policy.
+/// Call processing methods only after successful start; drain/cancel processing
+/// before stop. Dropping a cancelled future does not imply rollback of component
+/// state or external effects. Restart, recovery, and transactional lifecycle are
+/// not supplied by these contracts or by Drasi Server.
+///
+/// The descriptor must remain unchanged throughout the owned component's life.
+/// No default success methods conceal missing implementation.
+#[async_trait]
+pub trait ComputationComponent: Send + Sync {
+    fn descriptor(&self) -> &ComponentDescriptor;
+    async fn start(&mut self) -> anyhow::Result<()>;
+    async fn stop(&mut self) -> anyhow::Result<()>;
+}
+
+/// A producer beside legacy Source. Its descriptor has output ports only.
+#[async_trait]
+pub trait EnvelopeSource: ComputationComponent {
+    /// Wait for the next event; None means exhausted, never temporarily idle.
+    async fn next(&mut self) -> anyhow::Result<Option<OutputEnvelope>>;
+}
+
+/// A stateful transformer with declared input and output ports.
+#[async_trait]
+pub trait Transformer: ComputationComponent {
+    /// Produce zero, one, or many ordered emissions. Use Envelope::derive to
+    /// preserve input context and lineage, with this producer's output sequence.
+    ///
+    /// Success means local transformation completed, not that outputs have been
+    /// enqueued/handled or the input acknowledged. Cancellation/error can leave
+    /// component-local state changed; atomic staging/recovery is deferred.
+    async fn transform(&mut self, input: InputEnvelope) -> anyhow::Result<Vec<OutputEnvelope>>;
+}
+
+/// A consumer beside legacy Reaction. Its descriptor has input ports only.
+#[async_trait]
+pub trait EnvelopeSink: ComputationComponent {
+    /// Immutable for this component instance. A legacy Reaction enqueue adapter
+    /// must declare Accepted, never Handled. ExplicitAcknowledgement on a pipe
+    /// cannot upgrade this declaration.
+    fn completion(&self) -> SinkCompletion;
+
+    /// Success meets exactly the instance's declared completion boundary.
+    /// It does not automatically acknowledge a Delivery or establish
+    /// durability/atomicity of external effects.
+    async fn handle(&mut self, input: InputEnvelope) -> anyhow::Result<()>;
+}

--- a/lib/src/computation/v1/data.rs
+++ b/lib/src/computation/v1/data.rs
@@ -1,0 +1,560 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashSet, fmt, sync::Arc};
+
+use bytes::Bytes;
+
+use super::{ContractError, Result};
+use crate::change::computation_bridge;
+
+pub(super) fn validate_identifier(kind: &'static str, value: &str) -> Result<()> {
+    if value.is_empty() || value.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return Err(ContractError::InvalidIdentifier {
+            kind,
+            value: value.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+macro_rules! name_type {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(Arc<str>);
+
+        impl $name {
+            /// Reject empty identifiers, whitespace, and control characters.
+            pub fn try_new(value: impl Into<Arc<str>>) -> Result<Self> {
+                let value = value.into();
+                validate_identifier(stringify!($name), &value)?;
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+    };
+}
+
+name_type!(
+    SchemaId,
+    "Schema identity, scoped by its provider's naming convention."
+);
+name_type!(ComponentId, "Component identity within a graph.");
+name_type!(PortId, "Port identity within a component.");
+name_type!(
+    StreamId,
+    "Logical producer stream identity, unique to a producer/output port."
+);
+
+macro_rules! identity_type {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub struct $name {
+            namespace: Arc<str>,
+            value: Bytes,
+        }
+
+        impl $name {
+            /// Preserve opaque identity bytes exactly; empty bytes are invalid.
+            /// The caller owns uniqueness and stability within the namespace.
+            pub fn try_new(namespace: impl Into<Arc<str>>, value: Bytes) -> Result<Self> {
+                let namespace = namespace.into();
+                validate_identifier("identity namespace", &namespace)?;
+                if value.is_empty() {
+                    return Err(ContractError::EmptyIdentity {
+                        kind: stringify!($name),
+                    });
+                }
+                Ok(Self { namespace, value })
+            }
+
+            pub fn namespace(&self) -> &str {
+                &self.namespace
+            }
+
+            pub fn value(&self) -> &Bytes {
+                &self.value
+            }
+        }
+    };
+}
+
+identity_type!(
+    RecordId,
+    "Stable record identity; not a content fingerprint."
+);
+identity_type!(
+    ChangeSetId,
+    "Stable change-set identity supplied by its producer."
+);
+identity_type!(
+    EnvelopeId,
+    "Logical event identity, unchanged by branch-local context appends."
+);
+
+/// Positive schema version. No implicit upgrade or compatibility is assumed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SchemaVersion(u32);
+
+impl SchemaVersion {
+    pub fn try_new(value: u32) -> Result<Self> {
+        if value == 0 {
+            return Err(ContractError::InvalidSchemaVersion { value });
+        }
+        Ok(Self(value))
+    }
+
+    pub const fn value(self) -> u32 {
+        self.0
+    }
+}
+
+/// Advisory noncryptographic fingerprint. Collisions are possible; never use
+/// this instead of full descriptor equality or as a security/integrity guarantee.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SchemaFingerprint(u64);
+
+impl SchemaFingerprint {
+    pub const fn value(self) -> u64 {
+        self.0
+    }
+}
+
+/// Immutable schema identity and exact encoding/definition contract.
+/// Definition bytes must be canonical according to the schema provider.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SchemaDescriptor {
+    id: SchemaId,
+    version: SchemaVersion,
+    encoding: Arc<str>,
+    definition: Bytes,
+    fingerprint: SchemaFingerprint,
+}
+
+impl SchemaDescriptor {
+    pub fn try_new(
+        id: SchemaId,
+        version: SchemaVersion,
+        encoding: impl Into<Arc<str>>,
+        definition: Bytes,
+    ) -> Result<Self> {
+        let encoding = encoding.into();
+        validate_identifier("schema encoding", &encoding)?;
+        if definition.is_empty() {
+            return Err(ContractError::EmptySchemaDefinition);
+        }
+        let fingerprint = SchemaFingerprint(computation_bridge::schema_fingerprint(
+            id.as_str(),
+            version.value(),
+            &encoding,
+            &definition,
+        ));
+        Ok(Self {
+            id,
+            version,
+            encoding,
+            definition,
+            fingerprint,
+        })
+    }
+
+    pub fn id(&self) -> &SchemaId {
+        &self.id
+    }
+
+    pub const fn version(&self) -> SchemaVersion {
+        self.version
+    }
+
+    pub fn encoding(&self) -> &str {
+        &self.encoding
+    }
+
+    pub fn definition(&self) -> &Bytes {
+        &self.definition
+    }
+
+    pub const fn fingerprint(&self) -> SchemaFingerprint {
+        self.fingerprint
+    }
+}
+
+/// Completeness/meaning of a schema-defined record image.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordImage {
+    /// Complete snapshot of the record.
+    Full,
+    /// Update delta; omitted fields are unchanged, per the schema's patch rules.
+    Patch,
+    /// Known before-image projection, not a full snapshot or an update delta.
+    Partial,
+}
+
+/// Domain-specific validator error, retained as the source of ContractError.
+#[derive(Debug, thiserror::Error)]
+#[error("{code}: {message}")]
+pub struct RecordValidationError {
+    code: String,
+    message: String,
+}
+
+impl RecordValidationError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+/// Executable schema validation. Implementors must verify encoding, image-specific
+/// structure, domain constraints, and embedded record identity where applicable.
+/// Validation must be deterministic for the same descriptor/identity/image/bytes.
+/// Different providers of the same descriptor must implement identical semantics.
+pub trait RecordValidator: Send + Sync {
+    /// Validate schema-specific identity namespace/encoding, including references
+    /// without an image (identity-only deletes). No permissive default is supplied.
+    fn validate_identity(
+        &self,
+        schema: &SchemaDescriptor,
+        identity: &RecordId,
+    ) -> std::result::Result<(), RecordValidationError>;
+
+    fn validate(
+        &self,
+        schema: &SchemaDescriptor,
+        identity: &RecordId,
+        image: RecordImage,
+        payload: &[u8],
+    ) -> std::result::Result<(), RecordValidationError>;
+}
+
+/// Schema-validated record key, including when no before-image is available.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordReference {
+    schema: SchemaDescriptor,
+    identity: RecordId,
+}
+
+impl RecordReference {
+    pub fn try_new(schema: &Schema, identity: RecordId) -> Result<Self> {
+        schema
+            .validator
+            .validate_identity(&schema.descriptor, &identity)
+            .map_err(|source| ContractError::RecordValidation {
+                identity: identity.clone(),
+                source,
+            })?;
+        Ok(Self {
+            schema: schema.descriptor.clone(),
+            identity,
+        })
+    }
+
+    pub fn schema(&self) -> &SchemaDescriptor {
+        &self.schema
+    }
+
+    pub fn identity(&self) -> &RecordId {
+        &self.identity
+    }
+}
+
+/// A descriptor paired with its mandatory in-process validator.
+/// It is not a serializable schema registry entry.
+pub struct Schema {
+    descriptor: SchemaDescriptor,
+    validator: Arc<dyn RecordValidator>,
+}
+
+impl Schema {
+    pub fn new(descriptor: SchemaDescriptor, validator: Arc<dyn RecordValidator>) -> Self {
+        Self {
+            descriptor,
+            validator,
+        }
+    }
+
+    pub fn descriptor(&self) -> &SchemaDescriptor {
+        &self.descriptor
+    }
+}
+
+/// A validated immutable image. Cloning shares payload and descriptor allocations.
+/// Deserialization cannot bypass identity/image validation.
+///
+/// ```compile_fail
+/// use drasi_lib::computation::v1::Record;
+/// let _: Record = serde_json::from_str("{}").unwrap();
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Record {
+    reference: RecordReference,
+    image: RecordImage,
+    payload: Bytes,
+}
+
+impl Record {
+    pub fn try_new(
+        schema: &Schema,
+        identity: RecordId,
+        image: RecordImage,
+        payload: Bytes,
+    ) -> Result<Self> {
+        let reference = RecordReference::try_new(schema, identity)?;
+        schema
+            .validator
+            .validate(&schema.descriptor, reference.identity(), image, &payload)
+            .map_err(|source| ContractError::RecordValidation {
+                identity: reference.identity.clone(),
+                source,
+            })?;
+        Ok(Self {
+            reference,
+            image,
+            payload,
+        })
+    }
+
+    pub fn schema(&self) -> &SchemaDescriptor {
+        self.reference.schema()
+    }
+
+    pub fn identity(&self) -> &RecordId {
+        self.reference.identity()
+    }
+
+    /// Reuse this record's already validated key without decoding its image again.
+    pub fn reference(&self) -> &RecordReference {
+        &self.reference
+    }
+
+    pub const fn image(&self) -> RecordImage {
+        self.image
+    }
+
+    pub fn payload(&self) -> &Bytes {
+        &self.payload
+    }
+}
+
+/// Update semantics are explicit; there is no default interpretation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateSemantics {
+    Patch,
+    Replace,
+}
+
+/// An operation candidate. Cross-image and batch invariants are checked when
+/// constructing a ChangeSet, not when assembling this enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChangeOperation {
+    Added {
+        ordinal: u64,
+        after: Record,
+    },
+    Updated {
+        ordinal: u64,
+        before: Option<Record>,
+        after: Record,
+        semantics: UpdateSemantics,
+    },
+    Deleted {
+        ordinal: u64,
+        identity: RecordReference,
+        before: Option<Record>,
+    },
+}
+
+impl ChangeOperation {
+    pub const fn ordinal(&self) -> u64 {
+        match self {
+            Self::Added { ordinal, .. }
+            | Self::Updated { ordinal, .. }
+            | Self::Deleted { ordinal, .. } => *ordinal,
+        }
+    }
+
+    pub fn identity(&self) -> &RecordId {
+        match self {
+            Self::Added { after, .. } | Self::Updated { after, .. } => after.identity(),
+            Self::Deleted { identity, .. } => identity.identity(),
+        }
+    }
+}
+
+/// Shared immutable change-set reference.
+pub type ChangeSetRef = Arc<ChangeSet>;
+
+/// An ordered, schema-consistent batch. Stable operation identity is the pair
+/// `(change_set.id(), operation.ordinal())`; ordinals need not be contiguous.
+#[derive(Debug)]
+pub struct ChangeSet {
+    id: ChangeSetId,
+    schema: SchemaDescriptor,
+    operations: Arc<[ChangeOperation]>,
+}
+
+impl ChangeSet {
+    /// Reject invalid batches rather than sorting or repairing their contents.
+    pub fn try_new(
+        id: ChangeSetId,
+        schema: SchemaDescriptor,
+        operations: Vec<ChangeOperation>,
+    ) -> Result<ChangeSetRef> {
+        let mut ordinals = HashSet::new();
+        let mut previous = None;
+        for operation in &operations {
+            let ordinal = operation.ordinal();
+            if !ordinals.insert(ordinal) {
+                return Err(ContractError::DuplicateOrdinal { ordinal });
+            }
+            if let Some(previous) = previous {
+                if ordinal < previous {
+                    return Err(ContractError::OutOfOrderOrdinal { previous, ordinal });
+                }
+            }
+            previous = Some(ordinal);
+            let before = match operation {
+                ChangeOperation::Added { after, .. } => {
+                    validate_record(&schema, operation, after)?;
+                    require_image(ordinal, after, RecordImage::Full)?;
+                    None
+                }
+                ChangeOperation::Updated {
+                    before,
+                    after,
+                    semantics,
+                    ..
+                } => {
+                    validate_record(&schema, operation, after)?;
+                    let image = match semantics {
+                        UpdateSemantics::Patch => RecordImage::Patch,
+                        UpdateSemantics::Replace => RecordImage::Full,
+                    };
+                    require_image(ordinal, after, image)?;
+                    before.as_ref()
+                }
+                ChangeOperation::Deleted {
+                    identity, before, ..
+                } => {
+                    validate_schema(&schema, identity.schema())?;
+                    before.as_ref()
+                }
+            };
+            if let Some(before) = before {
+                validate_record(&schema, operation, before)?;
+                if before.image == RecordImage::Patch {
+                    return Err(ContractError::InvalidImage {
+                        ordinal,
+                        expected: "full or partial before-image",
+                        actual: before.image,
+                    });
+                }
+            }
+        }
+        Ok(Arc::new(Self {
+            id,
+            schema,
+            operations: operations.into(),
+        }))
+    }
+
+    pub fn id(&self) -> &ChangeSetId {
+        &self.id
+    }
+
+    pub fn schema(&self) -> &SchemaDescriptor {
+        &self.schema
+    }
+
+    pub fn operations(&self) -> &[ChangeOperation] {
+        &self.operations
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+
+    /// Empty batches are append-only vacuously. Append-only data uses Adds,
+    /// rather than a separate operation with ambiguous mutation semantics.
+    pub fn is_append_only(&self) -> bool {
+        self.operations
+            .iter()
+            .all(|operation| matches!(operation, ChangeOperation::Added { .. }))
+    }
+}
+
+pub(super) fn validate_schema(
+    expected: &SchemaDescriptor,
+    actual: &SchemaDescriptor,
+) -> Result<()> {
+    if expected != actual {
+        return Err(ContractError::SchemaMismatch {
+            expected: Box::new(expected.clone()),
+            actual: Box::new(actual.clone()),
+        });
+    }
+    Ok(())
+}
+
+fn validate_record(
+    schema: &SchemaDescriptor,
+    operation: &ChangeOperation,
+    record: &Record,
+) -> Result<()> {
+    validate_schema(schema, record.schema())?;
+    if operation.identity() != record.identity() {
+        return Err(ContractError::IdentityMismatch {
+            ordinal: operation.ordinal(),
+            expected: operation.identity().clone(),
+            actual: record.identity().clone(),
+        });
+    }
+    Ok(())
+}
+
+fn require_image(ordinal: u64, record: &Record, expected: RecordImage) -> Result<()> {
+    if record.image != expected {
+        return Err(ContractError::InvalidImage {
+            ordinal,
+            expected: match expected {
+                RecordImage::Full => "full after-image",
+                RecordImage::Patch => "patch after-image",
+                RecordImage::Partial => "partial image",
+            },
+            actual: record.image,
+        });
+    }
+    Ok(())
+}

--- a/lib/src/computation/v1/envelope.rs
+++ b/lib/src/computation/v1/envelope.rs
@@ -1,0 +1,270 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+
+use super::{
+    data::validate_identifier, ChangeSetRef, ComponentId, ContractError, EnvelopeId, Result,
+    StreamId,
+};
+use crate::change::{self, computation_bridge};
+
+/// Ordinary immutable data only. Opaque transactions, acknowledgements, and other
+/// local resource capabilities belong outside the envelope, never in context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextValue {
+    Bool(bool),
+    Signed(i64),
+    Unsigned(u64),
+    String(Arc<str>),
+    Bytes(Arc<[u8]>),
+}
+
+/// One validated append-only contribution. Repeated keys do not overwrite history.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextEntry {
+    inner: change::ContextContribution,
+}
+
+impl ContextEntry {
+    pub fn try_new(
+        contributor: ComponentId,
+        key: impl Into<Arc<str>>,
+        value: ContextValue,
+    ) -> Result<Self> {
+        let key = key.into();
+        validate_identifier("context key", &key)?;
+        let value = match value {
+            ContextValue::Bool(value) => change::ContextValue::Bool(value),
+            ContextValue::Signed(value) => change::ContextValue::Signed(value),
+            ContextValue::Unsigned(value) => change::ContextValue::Unsigned(value),
+            ContextValue::String(value) => change::ContextValue::String(value),
+            ContextValue::Bytes(value) => change::ContextValue::Bytes(value),
+        };
+        Ok(Self {
+            inner: change::ContextContribution::new(
+                change::ContextContributor::new(
+                    change::ContextContributorKind::Runtime,
+                    contributor.as_str(),
+                ),
+                key,
+                value,
+            ),
+        })
+    }
+
+    pub fn contributor(&self) -> &str {
+        self.inner.contributor().component_id()
+    }
+
+    pub fn key(&self) -> &str {
+        self.inner.key()
+    }
+
+    /// Scalars are copied; string/byte allocations remain shared.
+    pub fn value(&self) -> ContextValue {
+        match self.inner.value() {
+            change::ContextValue::Bool(value) => ContextValue::Bool(*value),
+            change::ContextValue::Signed(value) => ContextValue::Signed(*value),
+            change::ContextValue::Unsigned(value) => ContextValue::Unsigned(*value),
+            change::ContextValue::String(value) => ContextValue::String(value.clone()),
+            change::ContextValue::Bytes(value) => ContextValue::Bytes(value.clone()),
+        }
+    }
+}
+
+/// Persistent immutable context chain, sharing the A2 root and linked nodes.
+#[derive(Debug, Clone)]
+pub struct ProcessingContext {
+    inner: change::ProcessingContext,
+}
+
+impl ProcessingContext {
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Iterate newest first, retaining duplicate keys and sharing data allocations.
+    pub fn entries(&self) -> impl Iterator<Item = ContextEntry> {
+        let mut head = self.inner.head().cloned();
+        std::iter::from_fn(move || {
+            let node = head.take()?;
+            head = node.parent().cloned();
+            Some(ContextEntry {
+                inner: node.contribution().clone(),
+            })
+        })
+    }
+}
+
+/// Immutable producer metadata. Sequence, not timestamp, is authoritative.
+/// Each stream belongs to one producer/output port. Successful new emissions
+/// have strictly increasing sequences (gaps are legal); the future host enforces
+/// ownership and ordering. No order is promised across distinct streams.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemMetadata {
+    stream: StreamId,
+    sequence: u64,
+    timestamp: Option<DateTime<Utc>>,
+    source_position: Option<Bytes>,
+}
+
+impl SystemMetadata {
+    pub fn new(stream: StreamId, sequence: u64) -> Self {
+        Self {
+            stream,
+            sequence,
+            timestamp: None,
+            source_position: None,
+        }
+    }
+
+    /// Observational timestamp, never a scheduling/order key.
+    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    /// Opaque producer position, not proof of durability or a checkpoint.
+    pub fn with_source_position(mut self, position: Bytes) -> Self {
+        self.source_position = Some(position);
+        self
+    }
+
+    pub fn stream(&self) -> &StreamId {
+        &self.stream
+    }
+
+    pub const fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    pub const fn timestamp(&self) -> Option<DateTime<Utc>> {
+        self.timestamp
+    }
+
+    pub fn source_position(&self) -> Option<&Bytes> {
+        self.source_position.as_ref()
+    }
+}
+
+/// Input identity and metadata retained by a derived output, without retaining
+/// the input payload. Prior ancestry is shared. This is single-input lineage,
+/// not a multi-input transactional or causal graph.
+#[derive(Debug)]
+pub struct Lineage {
+    envelope_id: EnvelopeId,
+    system: Arc<SystemMetadata>,
+    parent: Option<Arc<Lineage>>,
+}
+
+impl Lineage {
+    pub fn envelope_id(&self) -> &EnvelopeId {
+        &self.envelope_id
+    }
+
+    pub fn system(&self) -> &Arc<SystemMetadata> {
+        &self.system
+    }
+
+    pub fn parent(&self) -> Option<&Arc<Lineage>> {
+        self.parent.as_ref()
+    }
+}
+
+/// Immutable logical event with shared data and branch-local context history.
+/// Cloning or appending context does not deep-clone records or system metadata.
+#[derive(Debug, Clone)]
+pub struct Envelope {
+    id: EnvelopeId,
+    changes: ChangeSetRef,
+    system: Arc<SystemMetadata>,
+    context: ProcessingContext,
+    lineage: Option<Arc<Lineage>>,
+}
+
+impl Envelope {
+    /// Construct a new root event. Producers must not reuse an identity for
+    /// different events. IDs are supplied identities, not content fingerprints.
+    pub fn new(id: EnvelopeId, changes: ChangeSetRef, system: SystemMetadata) -> Self {
+        let context = ProcessingContext {
+            inner: computation_bridge::new_context(id.namespace(), id.value()),
+        };
+        Self {
+            id,
+            changes,
+            system: Arc::new(system),
+            context,
+            lineage: None,
+        }
+    }
+
+    /// Extend only this branch. Logical event identity and metadata are preserved.
+    pub fn append_context(&self, entry: ContextEntry) -> Result<Self> {
+        self.context
+            .len()
+            .checked_add(1)
+            .ok_or(ContractError::ContextOverflow)?;
+        Ok(Self {
+            context: ProcessingContext {
+                inner: computation_bridge::append_context(&self.context.inner, entry.inner),
+            },
+            ..self.clone()
+        })
+    }
+
+    /// Emit a new event from this input, preserving context and input metadata
+    /// in lineage. The producer supplies its own output-stream identity/sequence.
+    /// An input sequence must not be reused as the sequence of multiple outputs.
+    pub fn derive(&self, id: EnvelopeId, changes: ChangeSetRef, system: SystemMetadata) -> Self {
+        Self {
+            id,
+            changes,
+            system: Arc::new(system),
+            context: self.context.clone(),
+            lineage: Some(Arc::new(Lineage {
+                envelope_id: self.id.clone(),
+                system: self.system.clone(),
+                parent: self.lineage.clone(),
+            })),
+        }
+    }
+
+    pub fn id(&self) -> &EnvelopeId {
+        &self.id
+    }
+
+    pub fn changes(&self) -> &ChangeSetRef {
+        &self.changes
+    }
+
+    pub fn system(&self) -> &Arc<SystemMetadata> {
+        &self.system
+    }
+
+    pub fn context(&self) -> &ProcessingContext {
+        &self.context
+    }
+
+    pub fn lineage(&self) -> Option<&Arc<Lineage>> {
+        self.lineage.as_ref()
+    }
+}

--- a/lib/src/computation/v1/error.rs
+++ b/lib/src/computation/v1/error.rs
@@ -1,0 +1,83 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{
+    PipeCapability, PortDirection, PortId, RecordId, RecordImage, RecordValidationError,
+    SchemaDescriptor, SinkCompletion,
+};
+
+/// Structured validation errors for v1 contracts, independent of legacy APIs.
+#[derive(Debug, thiserror::Error)]
+pub enum ContractError {
+    #[error("invalid {kind} identifier {value:?}: expected nonempty text without whitespace or controls")]
+    InvalidIdentifier { kind: &'static str, value: String },
+    #[error("{kind} identity must contain nonempty bytes")]
+    EmptyIdentity { kind: &'static str },
+    #[error("schema version must be nonzero, got {value}")]
+    InvalidSchemaVersion { value: u32 },
+    #[error("schema definition must not be empty")]
+    EmptySchemaDefinition,
+    #[error("record {identity:?} failed schema validation: {source}")]
+    RecordValidation {
+        identity: RecordId,
+        #[source]
+        source: RecordValidationError,
+    },
+    #[error("operation ordinal {ordinal} occurs more than once")]
+    DuplicateOrdinal { ordinal: u64 },
+    #[error("operation ordinal {ordinal} follows larger ordinal {previous}")]
+    OutOfOrderOrdinal { previous: u64, ordinal: u64 },
+    #[error("schema mismatch: expected {expected:?}, got {actual:?}")]
+    SchemaMismatch {
+        expected: Box<SchemaDescriptor>,
+        actual: Box<SchemaDescriptor>,
+    },
+    #[error("operation {ordinal} has mismatched record identities")]
+    IdentityMismatch {
+        ordinal: u64,
+        expected: RecordId,
+        actual: RecordId,
+    },
+    #[error("operation {ordinal} requires {expected}, got {actual:?}")]
+    InvalidImage {
+        ordinal: u64,
+        expected: &'static str,
+        actual: RecordImage,
+    },
+    #[error("port {port:?} occurs more than once")]
+    DuplicatePort { port: PortId },
+    #[error("port {port:?} must be {expected:?}, got {actual:?}")]
+    WrongPortDirection {
+        port: PortId,
+        expected: PortDirection,
+        actual: PortDirection,
+    },
+    #[error("pipe does not support required capability {capability:?}")]
+    UnsupportedCapability { capability: PipeCapability },
+    #[error("capability {capability:?} requires {requires:?}")]
+    InvalidCapabilities {
+        capability: PipeCapability,
+        requires: PipeCapability,
+    },
+    #[error("sink completion {actual:?} cannot satisfy {required:?}")]
+    InsufficientSinkCompletion {
+        actual: SinkCompletion,
+        required: PipeCapability,
+    },
+    #[error("processing context length overflow")]
+    ContextOverflow,
+}
+
+/// Result of validated construction or compatibility negotiation.
+pub type Result<T> = std::result::Result<T, ContractError>;

--- a/lib/src/computation/v1/mod.rs
+++ b/lib/src/computation/v1/mod.rs
@@ -1,0 +1,57 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Version 1 of the experimental, default-off computation contracts.
+//!
+//! Enable with `drasi-lib = { version = "0.9", features = ["computation"] }`.
+//! These are in-process contracts for a future acyclic graph host, not a runnable
+//! graph API. Legacy source/query/reaction execution remains unchanged.
+//!
+//! Records contain immutable, schema-defined bytes. A [`RecordValidator`] must
+//! check their encoding, domain constraints, and embedded identity where applicable.
+//! [`RecordReference`] validates schema-specific keys even for image-less deletes.
+//! The library additionally checks complete schema descriptors, operation ordering,
+//! image roles, and cross-image identity. Providers are responsible for the truth
+//! of their validators and capability declarations.
+//!
+//! None of these types implements automatic serialization. Record encoding is
+//! schema-specific, not a Drasi wire standard. Lossless legacy codecs/adapters,
+//! graph execution, durable delivery, replay, and SDK/ABI integration are separate
+//! work. Internal canonical identity bytes are not a proven reversible codec.
+//!
+//! ```
+//! use drasi_lib::computation::v1::{
+//!     PipeCapabilities, PipeCapability, PipeRequirements, SchemaVersion,
+//! };
+//! use std::num::NonZeroUsize;
+//!
+//! assert!(SchemaVersion::try_new(0).is_err());
+//! let pipe = PipeCapabilities::volatile_bounded(NonZeroUsize::new(16).unwrap());
+//! let durable = PipeRequirements::new([PipeCapability::DurableAcceptance]);
+//! assert!(pipe.validate(&durable).is_err());
+//! ```
+
+mod component;
+mod data;
+mod envelope;
+mod error;
+mod pipe;
+mod ports;
+
+pub use component::*;
+pub use data::*;
+pub use envelope::*;
+pub use error::{ContractError, Result};
+pub use pipe::*;
+pub use ports::*;

--- a/lib/src/computation/v1/pipe.rs
+++ b/lib/src/computation/v1/pipe.rs
@@ -1,0 +1,137 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::{ContractError, Envelope, EnvelopeId, PipeCapabilities};
+
+/// Enqueue acceptance ONLY. Not downstream handling, acknowledgement, checkpoint
+/// advancement, or durability (unless DurableAcceptance was explicitly negotiated).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnqueueReceipt {
+    id: EnvelopeId,
+}
+
+impl EnqueueReceipt {
+    /// Providers construct a receipt only after actually accepting the event.
+    pub fn new(id: EnvelopeId) -> Self {
+        Self { id }
+    }
+
+    pub fn envelope_id(&self) -> &EnvelopeId {
+        &self.id
+    }
+}
+
+/// Local handling outcome submitted separately to a delivery acknowledgement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HandlingOutcome {
+    Handled,
+    Failed { reason: String },
+}
+
+/// Typed in-process pipe errors; provider errors retain their source chain.
+#[derive(Debug, thiserror::Error)]
+pub enum PipeError {
+    #[error(transparent)]
+    Contract(#[from] ContractError),
+    #[error("pipe is closed")]
+    Closed,
+    #[error("pipe receiver has already been taken")]
+    ReceiverTaken,
+    #[error(transparent)]
+    Backend(#[from] anyhow::Error),
+}
+
+/// A definite nonacceptance, returning the immutable event to its caller.
+#[derive(Debug, thiserror::Error)]
+#[error("envelope was not accepted: {error}")]
+pub struct SendFailure {
+    pub envelope: Envelope,
+    #[source]
+    pub error: PipeError,
+}
+
+/// One-shot, local-only handling acknowledgement, NOT part of an Envelope.
+/// Drop is never acknowledgement. Retry, failure, replay, and transaction scope
+/// must be supplied by a future provider/host contract, not inferred here.
+#[async_trait]
+pub trait Acknowledgement: Send + Sync {
+    /// Consume this handle to report actual handling. A successful call means
+    /// the provider accepted the outcome, not an automatic end-to-end commit.
+    async fn complete(
+        self: Box<Self>,
+        outcome: HandlingOutcome,
+    ) -> std::result::Result<(), PipeError>;
+}
+
+/// Received event and optional separate local delivery capability.
+/// Intentionally not Clone or serializable. A volatile pipe uses no ack handle.
+pub struct Delivery {
+    envelope: Envelope,
+    acknowledgement: Option<Box<dyn Acknowledgement>>,
+}
+
+impl Delivery {
+    pub fn new(envelope: Envelope, acknowledgement: Option<Box<dyn Acknowledgement>>) -> Self {
+        Self {
+            envelope,
+            acknowledgement,
+        }
+    }
+
+    pub fn envelope(&self) -> &Envelope {
+        &self.envelope
+    }
+
+    /// The host retains the handle separately while invoking a sink/transformer;
+    /// neither processing success nor dropping the handle implicitly completes it.
+    pub fn into_parts(self) -> (Envelope, Option<Box<dyn Acknowledgement>>) {
+        (self.envelope, self.acknowledgement)
+    }
+}
+
+/// Enqueue boundary. Concurrent producers have no cross-stream global order.
+/// A host serializes sends for a single producer stream in sequence order.
+#[async_trait]
+pub trait EnvelopeSender: Send + Sync {
+    /// Success is acceptance only. Err means definitely not accepted. Cancellation
+    /// before a result can be ambiguous and MUST NOT be interpreted as nonacceptance.
+    /// Receiver drop or runtime closure must wake blocked capacity waiters and
+    /// return Closed with their unaccepted envelope, rather than hang indefinitely.
+    async fn send(&self, envelope: Envelope) -> std::result::Result<EnqueueReceipt, SendFailure>;
+}
+
+/// Single-consumer boundary. The negotiated FIFO guarantee follows producer
+/// sequence, never wall-clock timestamps.
+#[async_trait]
+pub trait EnvelopeReceiver: Send + Sync {
+    /// None means closed and drained, not temporarily empty. Cancellation must
+    /// not silently acknowledge or discard an event removed from a volatile queue;
+    /// durable providers retain responsibility until their negotiated completion.
+    /// Dropping all senders or runtime closure must wake a waiting receiver;
+    /// drain accepted events before returning None on a graceful close.
+    async fn receive(&mut self) -> std::result::Result<Option<Delivery>, PipeError>;
+}
+
+/// In-process pipe interface, with no concrete implementation in this phase.
+/// A future host validates capabilities/requirements before starting components.
+pub trait Pipe: Send + Sync {
+    fn capabilities(&self) -> &PipeCapabilities;
+    fn sender(&self) -> Arc<dyn EnvelopeSender>;
+    /// Transfer the single receiver to its owning task; subsequent calls fail.
+    fn take_receiver(&mut self) -> std::result::Result<Box<dyn EnvelopeReceiver>, PipeError>;
+}

--- a/lib/src/computation/v1/ports.rs
+++ b/lib/src/computation/v1/ports.rs
@@ -1,0 +1,259 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeSet, num::NonZeroUsize, sync::Arc};
+
+use super::{
+    data::validate_schema, ComponentId, ContractError, PortId, Result, SchemaDescriptor,
+    SinkCompletion,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortDirection {
+    Input,
+    Output,
+}
+
+/// Provider promises which must be negotiated before a graph starts.
+/// These descriptors implement no delivery guarantees by themselves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PipeCapability {
+    /// FIFO for each logical producer stream using authoritative sequence.
+    FifoPerStream,
+    /// Capacity pressure waits/rejects explicitly rather than silently dropping.
+    Backpressure,
+    /// Successful enqueue survives the provider's documented crash boundary.
+    DurableAcceptance,
+    /// Delivered events have an explicit, separate handling acknowledgement.
+    ExplicitAcknowledgement,
+    /// Provider can replay retained data from a supported position.
+    Replay,
+    /// Provider supports atomic delivery/ack operations in a negotiated scope.
+    Transactions,
+    /// Exactly-once within the transport's negotiated scope, NOT arbitrary
+    /// downstream effects. A future host must negotiate that scope separately.
+    ExactlyOnce,
+}
+
+/// Immutable required guarantees; unsupported requirements are errors.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PipeRequirements {
+    required: BTreeSet<PipeCapability>,
+}
+
+impl PipeRequirements {
+    pub fn new(required: impl IntoIterator<Item = PipeCapability>) -> Self {
+        Self {
+            required: required.into_iter().collect(),
+        }
+    }
+
+    pub fn required(&self) -> &BTreeSet<PipeCapability> {
+        &self.required
+    }
+}
+
+/// Immutable capability declaration, not a runtime or persistence configuration.
+/// Providers are responsible for actually honoring every advertised guarantee.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PipeCapabilities {
+    supported: BTreeSet<PipeCapability>,
+    capacity: Option<NonZeroUsize>,
+}
+
+impl PipeCapabilities {
+    /// Reject inconsistent claims. This validates the declaration's structure,
+    /// not the correctness of a pipe implementation or its failure model.
+    pub fn try_new(
+        supported: impl IntoIterator<Item = PipeCapability>,
+        capacity: Option<NonZeroUsize>,
+    ) -> Result<Self> {
+        use PipeCapability::*;
+        let supported: BTreeSet<_> = supported.into_iter().collect();
+        for (capability, requires) in [
+            (Replay, DurableAcceptance),
+            (Transactions, ExplicitAcknowledgement),
+            (ExactlyOnce, DurableAcceptance),
+            (ExactlyOnce, ExplicitAcknowledgement),
+            (ExactlyOnce, Transactions),
+        ] {
+            if supported.contains(&capability) && !supported.contains(&requires) {
+                return Err(ContractError::InvalidCapabilities {
+                    capability,
+                    requires,
+                });
+            }
+        }
+        Ok(Self {
+            supported,
+            capacity,
+        })
+    }
+
+    /// The initial bounded in-process pipe's declaration: only FIFO and
+    /// backpressure. No durability, replay, acknowledgements, or transactions.
+    /// This constructs a descriptor, not a functioning pipe.
+    pub fn volatile_bounded(capacity: NonZeroUsize) -> Self {
+        Self {
+            supported: BTreeSet::from([
+                PipeCapability::FifoPerStream,
+                PipeCapability::Backpressure,
+            ]),
+            capacity: Some(capacity),
+        }
+    }
+
+    pub fn supported(&self) -> &BTreeSet<PipeCapability> {
+        &self.supported
+    }
+
+    /// Declared maximum buffered envelopes, or no declared finite bound.
+    pub const fn capacity(&self) -> Option<NonZeroUsize> {
+        self.capacity
+    }
+
+    pub fn validate(&self, requirements: &PipeRequirements) -> Result<()> {
+        for capability in requirements.required() {
+            if !self.supported.contains(capability) {
+                return Err(ContractError::UnsupportedCapability {
+                    capability: *capability,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Named, single-schema port with required transport guarantees.
+/// Descriptors contain no resolved configuration, secrets, or runtime contexts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortDescriptor {
+    id: PortId,
+    direction: PortDirection,
+    schema: SchemaDescriptor,
+    requirements: PipeRequirements,
+}
+
+impl PortDescriptor {
+    pub fn new(
+        id: PortId,
+        direction: PortDirection,
+        schema: SchemaDescriptor,
+        requirements: PipeRequirements,
+    ) -> Self {
+        Self {
+            id,
+            direction,
+            schema,
+            requirements,
+        }
+    }
+
+    pub fn id(&self) -> &PortId {
+        &self.id
+    }
+
+    pub const fn direction(&self) -> PortDirection {
+        self.direction
+    }
+
+    pub fn schema(&self) -> &SchemaDescriptor {
+        &self.schema
+    }
+
+    pub fn requirements(&self) -> &PipeRequirements {
+        &self.requirements
+    }
+}
+
+/// Immutable descriptive component interface, not a runtime properties dump.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentDescriptor {
+    id: ComponentId,
+    ports: Arc<[PortDescriptor]>,
+}
+
+impl ComponentDescriptor {
+    pub fn try_new(id: ComponentId, ports: Vec<PortDescriptor>) -> Result<Self> {
+        let mut ids = BTreeSet::new();
+        for port in &ports {
+            if !ids.insert(port.id()) {
+                return Err(ContractError::DuplicatePort {
+                    port: port.id().clone(),
+                });
+            }
+        }
+        Ok(Self {
+            id,
+            ports: ports.into(),
+        })
+    }
+
+    pub fn id(&self) -> &ComponentId {
+        &self.id
+    }
+
+    pub fn ports(&self) -> &[PortDescriptor] {
+        &self.ports
+    }
+}
+
+/// Pure, pre-start edge negotiation: direction, exact full schema descriptor,
+/// FIFO baseline, and both endpoints' required guarantees. No hash-only matching.
+/// A future host must also validate the DAG, roles, and producer stream ownership;
+/// this function neither starts components nor proves provider behavior.
+pub fn validate_connection(
+    output: &PortDescriptor,
+    input: &PortDescriptor,
+    pipe: &PipeCapabilities,
+) -> Result<()> {
+    for (port, expected) in [(output, PortDirection::Output), (input, PortDirection::Input)] {
+        if port.direction != expected {
+            return Err(ContractError::WrongPortDirection {
+                port: port.id.clone(),
+                expected,
+                actual: port.direction,
+            });
+        }
+    }
+    validate_schema(output.schema(), input.schema())?;
+    pipe.validate(&PipeRequirements::new([PipeCapability::FifoPerStream]))?;
+    pipe.validate(output.requirements())?;
+    pipe.validate(input.requirements())
+}
+
+/// Reject handling-dependent requirements at an acceptance-only sink. A future
+/// host must call this for both endpoints' requirements (and any graph-level
+/// requirements) before starting a sink. Pipe capabilities never upgrade a sink.
+/// Handled is necessary, not sufficient, for end-to-end transactional guarantees.
+pub fn validate_sink_completion(
+    completion: SinkCompletion,
+    requirements: &PipeRequirements,
+) -> Result<()> {
+    if completion == SinkCompletion::Accepted {
+        for required in [
+            PipeCapability::ExplicitAcknowledgement,
+            PipeCapability::Transactions,
+            PipeCapability::ExactlyOnce,
+        ] {
+            if requirements.required.contains(&required) {
+                return Err(ContractError::InsufficientSinkCompletion {
+                    actual: completion,
+                    required,
+                });
+            }
+        }
+    }
+    Ok(())
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -52,6 +52,10 @@ pub mod wal;
 /// Error types for drasi-lib
 pub mod error;
 
+/// Experimental, opt-in computation contracts (not a graph runtime).
+#[cfg(feature = "computation")]
+pub mod computation;
+
 /// Identity providers for authentication credentials
 pub mod identity;
 

--- a/lib/tests/computation_contracts.rs
+++ b/lib/tests/computation_contracts.rs
@@ -1,0 +1,1177 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "computation")]
+
+use std::{
+    collections::VecDeque,
+    num::NonZeroUsize,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use drasi_lib::computation::v1::*;
+use tokio::sync::mpsc;
+
+// A custom binary schema, unrelated to graph elements or query result rows.
+// Full/patch: [record-id, unsigned value big-endian u16]; partial: [record-id].
+struct MeterValidator {
+    calls: Arc<AtomicUsize>,
+}
+
+impl RecordValidator for MeterValidator {
+    fn validate_identity(
+        &self,
+        schema: &SchemaDescriptor,
+        identity: &RecordId,
+    ) -> std::result::Result<(), RecordValidationError> {
+        if schema.encoding() != "meter-bin-v1"
+            || identity.namespace() != "meters"
+            || identity.value().len() != 1
+        {
+            return Err(RecordValidationError::new(
+                "identity",
+                "meter identity must be one byte in the meters namespace",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate(
+        &self,
+        schema: &SchemaDescriptor,
+        identity: &RecordId,
+        image: RecordImage,
+        payload: &[u8],
+    ) -> std::result::Result<(), RecordValidationError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let length = match image {
+            RecordImage::Full | RecordImage::Patch => 3,
+            RecordImage::Partial => 1,
+        };
+        if schema.encoding() != "meter-bin-v1" || payload.len() != length {
+            return Err(RecordValidationError::new(
+                "encoding",
+                "invalid meter image",
+            ));
+        }
+        if identity.namespace() != "meters" || identity.value().as_ref() != &payload[..1] {
+            return Err(RecordValidationError::new(
+                "identity",
+                "embedded identity differs",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn descriptor() -> SchemaDescriptor {
+    descriptor_with("example.meter", 1, "meter-bin-v1", b"id:u8,value:u16be")
+}
+
+fn descriptor_with(
+    id: &str,
+    version: u32,
+    encoding: &str,
+    definition: &'static [u8],
+) -> SchemaDescriptor {
+    SchemaDescriptor::try_new(
+        SchemaId::try_new(id).expect("valid fixture schema ID"),
+        SchemaVersion::try_new(version).expect("positive fixture schema version"),
+        encoding,
+        Bytes::from_static(definition),
+    )
+    .expect("valid fixture schema descriptor")
+}
+
+fn schema() -> Schema {
+    Schema::new(
+        descriptor(),
+        Arc::new(MeterValidator {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }),
+    )
+}
+
+fn record_id(id: u8) -> RecordId {
+    RecordId::try_new("meters", Bytes::copy_from_slice(&[id])).expect("valid fixture record ID")
+}
+
+fn reference(id: u8) -> RecordReference {
+    RecordReference::try_new(&schema(), record_id(id)).expect("valid fixture record reference")
+}
+
+fn record_for(schema: &Schema, id: u8, image: RecordImage) -> Record {
+    let bytes = match image {
+        RecordImage::Partial => vec![id],
+        RecordImage::Full | RecordImage::Patch => vec![id, 0xff, 0xff],
+    };
+    Record::try_new(schema, record_id(id), image, Bytes::from(bytes))
+        .expect("valid fixture record image")
+}
+
+fn record(id: u8, image: RecordImage) -> Record {
+    record_for(&schema(), id, image)
+}
+
+fn change_set_id() -> ChangeSetId {
+    ChangeSetId::try_new("test.batch", Bytes::from_static(b"batch-1"))
+        .expect("valid fixture change-set ID")
+}
+
+fn changes(operations: Vec<ChangeOperation>) -> ChangeSetRef {
+    ChangeSet::try_new(change_set_id(), descriptor(), operations).expect("valid fixture change-set")
+}
+
+fn added(ordinal: u64) -> ChangeOperation {
+    ChangeOperation::Added {
+        ordinal,
+        after: record(1, RecordImage::Full),
+    }
+}
+
+fn event_id(sequence: u64) -> EnvelopeId {
+    EnvelopeId::try_new(
+        "test.event",
+        Bytes::copy_from_slice(&sequence.to_be_bytes()),
+    )
+    .expect("valid fixture envelope ID")
+}
+
+fn stream(name: &str) -> StreamId {
+    StreamId::try_new(name).expect("valid fixture stream ID")
+}
+
+fn envelope(sequence: u64, operations: Vec<ChangeOperation>) -> Envelope {
+    Envelope::new(
+        event_id(sequence),
+        changes(operations),
+        SystemMetadata::new(stream("source/out"), sequence),
+    )
+}
+
+fn entry(key: &str, value: ContextValue) -> ContextEntry {
+    ContextEntry::try_new(
+        ComponentId::try_new("transform").expect("valid fixture contributor"),
+        key,
+        value,
+    )
+    .expect("valid fixture context entry")
+}
+
+#[test]
+fn public_identifiers_and_schema_versions_reject_invalid_inputs_without_repair() {
+    for value in ["", " ", "leading ", "a\tb", "a\nb", "a\0b", "a\u{2003}b"] {
+        assert!(matches!(
+            SchemaId::try_new(value),
+            Err(ContractError::InvalidIdentifier { .. })
+        ));
+        assert!(ComponentId::try_new(value).is_err());
+        assert!(PortId::try_new(value).is_err());
+        assert!(StreamId::try_new(value).is_err());
+        assert!(RecordId::try_new(value, Bytes::from_static(b"x")).is_err());
+        assert!(ChangeSetId::try_new(value, Bytes::from_static(b"x")).is_err());
+        assert!(EnvelopeId::try_new(value, Bytes::from_static(b"x")).is_err());
+        assert!(ContextEntry::try_new(
+            ComponentId::try_new("test").unwrap(),
+            value,
+            ContextValue::Bool(true)
+        )
+        .is_err());
+    }
+    assert!(matches!(
+        SchemaVersion::try_new(0),
+        Err(ContractError::InvalidSchemaVersion { value: 0 })
+    ));
+    assert_eq!(SchemaVersion::try_new(u32::MAX).unwrap().value(), u32::MAX);
+    assert_eq!(
+        StreamId::try_new("producer/port:0").unwrap().as_str(),
+        "producer/port:0"
+    );
+    assert!(matches!(
+        RecordId::try_new("id", Bytes::new()),
+        Err(ContractError::EmptyIdentity { .. })
+    ));
+    assert!(ChangeSetId::try_new("id", Bytes::new()).is_err());
+    assert!(EnvelopeId::try_new("id", Bytes::new()).is_err());
+    // Opaque zero u64 identities, including original A2 IDs, remain valid.
+    assert_eq!(event_id(0).value().as_ref(), &0_u64.to_be_bytes());
+    assert_ne!(
+        RecordId::try_new("left", Bytes::from_static(b"1")).unwrap(),
+        RecordId::try_new("right", Bytes::from_static(b"1")).unwrap()
+    );
+    assert!(matches!(
+        SchemaDescriptor::try_new(
+            SchemaId::try_new("meter").unwrap(),
+            SchemaVersion::try_new(1).unwrap(),
+            "binary",
+            Bytes::new(),
+        ),
+        Err(ContractError::EmptySchemaDefinition)
+    ));
+    assert!(SchemaDescriptor::try_new(
+        SchemaId::try_new("meter").unwrap(),
+        SchemaVersion::try_new(1).unwrap(),
+        " ",
+        Bytes::from_static(b"definition"),
+    )
+    .is_err());
+}
+
+#[test]
+fn full_descriptors_and_fingerprints_include_identity_version_encoding_and_definition() {
+    let base = descriptor();
+    for different in [
+        descriptor_with("example.other", 1, "meter-bin-v1", b"id:u8,value:u16be"),
+        descriptor_with("example.meter", 2, "meter-bin-v1", b"id:u8,value:u16be"),
+        descriptor_with("example.meter", 1, "meter-bin-v2", b"id:u8,value:u16be"),
+        descriptor_with("example.meter", 1, "meter-bin-v1", b"id:u8,value:u16le"),
+    ] {
+        assert_ne!(base, different);
+        assert_ne!(base.fingerprint(), different.fingerprint());
+    }
+    assert_eq!(base, descriptor());
+    assert_eq!(
+        base.fingerprint().value(),
+        descriptor().fingerprint().value()
+    );
+    // Tagged fields prevent ambiguous concatenations across identity/content.
+    assert_ne!(
+        descriptor_with("ab", 1, "c", b"d").fingerprint(),
+        descriptor_with("a", 1, "bc", b"d").fingerprint()
+    );
+}
+
+#[test]
+fn validator_runs_on_every_image_and_checks_actual_payload_identity() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let schema = Schema::new(
+        descriptor(),
+        Arc::new(MeterValidator {
+            calls: calls.clone(),
+        }),
+    );
+    for image in [RecordImage::Full, RecordImage::Patch, RecordImage::Partial] {
+        let valid = record_for(&schema, 1, image);
+        assert_eq!(valid.image(), image);
+        let invalid = Record::try_new(&schema, record_id(2), image, valid.payload().clone());
+        assert!(matches!(
+            invalid,
+            Err(ContractError::RecordValidation { source, .. }) if source.code() == "identity"
+        ));
+        assert!(matches!(
+            Record::try_new(&schema, record_id(1), image, Bytes::new()),
+            Err(ContractError::RecordValidation { source, .. }) if source.code() == "encoding"
+        ));
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 9);
+}
+
+#[test]
+fn identity_only_deletes_require_schema_validated_keys() {
+    let schema = schema();
+    for identity in [
+        RecordId::try_new("unrelated-namespace", Bytes::from_static(&[1])).unwrap(),
+        RecordId::try_new("meters", Bytes::from_static(&[1, 2])).unwrap(),
+    ] {
+        assert!(matches!(
+            RecordReference::try_new(&schema, identity.clone()),
+            Err(ContractError::RecordValidation { source, .. })
+                if source.code() == "identity"
+        ));
+        assert!(matches!(
+            Record::try_new(&schema, identity, RecordImage::Full, Bytes::from_static(&[1, 0, 1])),
+            Err(ContractError::RecordValidation { source, .. })
+                if source.code() == "identity"
+        ));
+    }
+    let identity = RecordReference::try_new(&schema, record_id(1)).unwrap();
+    let delete = ChangeOperation::Deleted {
+        ordinal: 0,
+        identity: identity.clone(),
+        before: None,
+    };
+    assert!(ChangeSet::try_new(change_set_id(), descriptor(), vec![delete.clone()]).is_ok());
+    assert!(matches!(
+        ChangeSet::try_new(
+            change_set_id(),
+            descriptor_with("example.meter", 2, "meter-bin-v1", b"id:u8,value:u16be"),
+            vec![delete],
+        ),
+        Err(ContractError::SchemaMismatch { .. })
+    ));
+    assert_eq!(identity, record(1, RecordImage::Full).reference().clone());
+}
+
+#[test]
+fn ordered_custom_changes_preserve_add_patch_replace_delete_and_before_images() {
+    let operations = vec![
+        added(0),
+        ChangeOperation::Updated {
+            ordinal: 2,
+            before: Some(record(1, RecordImage::Partial)),
+            after: record(1, RecordImage::Patch),
+            semantics: UpdateSemantics::Patch,
+        },
+        ChangeOperation::Updated {
+            ordinal: 3,
+            before: Some(record(1, RecordImage::Full)),
+            after: record(1, RecordImage::Full),
+            semantics: UpdateSemantics::Replace,
+        },
+        ChangeOperation::Deleted {
+            ordinal: u64::MAX,
+            identity: reference(1),
+            before: Some(record(1, RecordImage::Partial)),
+        },
+    ];
+    let batch = changes(operations.clone());
+    assert_eq!(batch.operations(), operations);
+    assert_eq!(batch.id(), &change_set_id());
+    assert!(!batch.is_append_only());
+    assert!(batch
+        .operations()
+        .iter()
+        .all(|op| op.identity() == &record_id(1)));
+    assert_eq!(batch.operations()[3].ordinal(), u64::MAX);
+    assert!(changes(vec![added(0), added(10)]).is_append_only());
+    assert!(changes(vec![]).is_empty());
+    assert!(changes(vec![]).is_append_only());
+    assert!(ChangeSet::try_new(
+        change_set_id(),
+        descriptor(),
+        vec![
+            ChangeOperation::Updated {
+                ordinal: 0,
+                before: None,
+                after: record(1, RecordImage::Patch),
+                semantics: UpdateSemantics::Patch,
+            },
+            ChangeOperation::Updated {
+                ordinal: 1,
+                before: None,
+                after: record(1, RecordImage::Full),
+                semantics: UpdateSemantics::Replace,
+            },
+            ChangeOperation::Deleted {
+                ordinal: 2,
+                identity: reference(1),
+                before: None,
+            },
+        ],
+    )
+    .is_ok());
+}
+
+#[test]
+fn duplicate_and_out_of_order_ordinals_are_not_sorted_or_silently_accepted() {
+    assert!(matches!(
+        ChangeSet::try_new(change_set_id(), descriptor(), vec![added(5), added(5)]),
+        Err(ContractError::DuplicateOrdinal { ordinal: 5 })
+    ));
+    assert!(matches!(
+        ChangeSet::try_new(
+            change_set_id(),
+            descriptor(),
+            vec![
+                added(5),
+                ChangeOperation::Deleted {
+                    ordinal: 5,
+                    identity: reference(1),
+                    before: None
+                }
+            ]
+        ),
+        Err(ContractError::DuplicateOrdinal { ordinal: 5 })
+    ));
+    assert!(matches!(
+        ChangeSet::try_new(change_set_id(), descriptor(), vec![added(5), added(1)]),
+        Err(ContractError::OutOfOrderOrdinal {
+            previous: 5,
+            ordinal: 1
+        })
+    ));
+}
+
+#[test]
+fn every_before_and_after_schema_must_match_the_entire_batch_descriptor() {
+    for different in [
+        descriptor_with("example.other", 1, "meter-bin-v1", b"id:u8,value:u16be"),
+        descriptor_with("example.meter", 2, "meter-bin-v1", b"id:u8,value:u16be"),
+        descriptor_with("example.meter", 1, "meter-bin-v1", b"different-definition"),
+    ] {
+        let other = Schema::new(
+            different,
+            Arc::new(MeterValidator {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+        );
+        let foreign = record_for(&other, 1, RecordImage::Full);
+        for operation in [
+            ChangeOperation::Added {
+                ordinal: 0,
+                after: foreign.clone(),
+            },
+            ChangeOperation::Updated {
+                ordinal: 0,
+                before: Some(foreign.clone()),
+                after: record(1, RecordImage::Full),
+                semantics: UpdateSemantics::Replace,
+            },
+            ChangeOperation::Updated {
+                ordinal: 0,
+                before: Some(record(1, RecordImage::Full)),
+                after: foreign.clone(),
+                semantics: UpdateSemantics::Replace,
+            },
+            ChangeOperation::Deleted {
+                ordinal: 0,
+                identity: reference(1),
+                before: Some(foreign),
+            },
+        ] {
+            assert!(matches!(
+                ChangeSet::try_new(change_set_id(), descriptor(), vec![operation]),
+                Err(ContractError::SchemaMismatch { .. })
+            ));
+        }
+    }
+}
+
+#[test]
+fn before_identity_and_image_roles_are_checked_for_updates_and_deletes() {
+    for operation in [
+        ChangeOperation::Updated {
+            ordinal: 0,
+            before: Some(record(2, RecordImage::Full)),
+            after: record(1, RecordImage::Full),
+            semantics: UpdateSemantics::Replace,
+        },
+        ChangeOperation::Deleted {
+            ordinal: 0,
+            identity: reference(1),
+            before: Some(record(2, RecordImage::Full)),
+        },
+    ] {
+        assert!(matches!(
+            ChangeSet::try_new(change_set_id(), descriptor(), vec![operation]),
+            Err(ContractError::IdentityMismatch { ordinal: 0, .. })
+        ));
+    }
+    for operation in [
+        ChangeOperation::Added {
+            ordinal: 0,
+            after: record(1, RecordImage::Patch),
+        },
+        ChangeOperation::Added {
+            ordinal: 0,
+            after: record(1, RecordImage::Partial),
+        },
+        ChangeOperation::Updated {
+            ordinal: 0,
+            before: None,
+            after: record(1, RecordImage::Patch),
+            semantics: UpdateSemantics::Replace,
+        },
+        ChangeOperation::Updated {
+            ordinal: 0,
+            before: None,
+            after: record(1, RecordImage::Full),
+            semantics: UpdateSemantics::Patch,
+        },
+        ChangeOperation::Updated {
+            ordinal: 0,
+            before: Some(record(1, RecordImage::Patch)),
+            after: record(1, RecordImage::Full),
+            semantics: UpdateSemantics::Replace,
+        },
+        ChangeOperation::Deleted {
+            ordinal: 0,
+            identity: reference(1),
+            before: Some(record(1, RecordImage::Patch)),
+        },
+    ] {
+        assert!(matches!(
+            ChangeSet::try_new(change_set_id(), descriptor(), vec![operation]),
+            Err(ContractError::InvalidImage { ordinal: 0, .. })
+        ));
+    }
+}
+
+#[test]
+fn context_branches_append_without_mutating_siblings_and_share_data() {
+    let text: Arc<str> = Arc::from("value");
+    let bytes: Arc<[u8]> = Arc::from([1, 2, 3]);
+    let root = envelope(0, vec![added(0)]);
+    let first = root
+        .append_context(entry("key", ContextValue::String(text.clone())))
+        .unwrap();
+    let left = first
+        .append_context(entry("key", ContextValue::Bytes(bytes.clone())))
+        .unwrap();
+    let right = first
+        .append_context(entry("key", ContextValue::Bool(false)))
+        .unwrap();
+    assert!(root.context().is_empty());
+    assert_eq!(first.context().len(), 1);
+    assert_eq!(left.context().len(), 2);
+    assert_eq!(right.context().len(), 2);
+    let history: Vec<_> = left.context().entries().collect();
+    assert_eq!(
+        history.iter().map(ContextEntry::key).collect::<Vec<_>>(),
+        ["key", "key"]
+    );
+    assert_eq!(history[0].contributor(), "transform");
+    assert!(
+        matches!(history[0].value(), ContextValue::Bytes(value) if Arc::ptr_eq(&value, &bytes))
+    );
+    assert!(
+        matches!(history[1].value(), ContextValue::String(value) if Arc::ptr_eq(&value, &text))
+    );
+    assert_eq!(
+        right.context().entries().next().unwrap().value(),
+        ContextValue::Bool(false)
+    );
+    assert_eq!(
+        first.context().entries().next().unwrap().value(),
+        ContextValue::String(text)
+    );
+    assert_eq!(root.id(), left.id());
+    assert!(Arc::ptr_eq(root.changes(), left.changes()));
+    assert!(Arc::ptr_eq(left.changes(), right.changes()));
+    assert!(Arc::ptr_eq(root.system(), left.system()));
+    let signed = left
+        .append_context(entry("signed", ContextValue::Signed(i64::MIN)))
+        .unwrap();
+    let unsigned = signed
+        .append_context(entry("unsigned", ContextValue::Unsigned(u64::MAX)))
+        .unwrap();
+    let values: Vec<_> = unsigned
+        .context()
+        .entries()
+        .map(|entry| entry.value())
+        .collect();
+    assert_eq!(values[0], ContextValue::Unsigned(u64::MAX));
+    assert_eq!(values[1], ContextValue::Signed(i64::MIN));
+
+    let payload = record(1, RecordImage::Full);
+    let copy = payload.clone();
+    assert_eq!(payload.payload().as_ptr(), copy.payload().as_ptr());
+    assert_eq!(
+        payload.schema().definition().as_ptr(),
+        copy.schema().definition().as_ptr()
+    );
+}
+
+#[test]
+fn derivation_preserves_input_lineage_metadata_and_branch_context() {
+    let timestamp = chrono::DateTime::from_timestamp(123, 0).unwrap();
+    let root = Envelope::new(
+        event_id(41),
+        changes(vec![added(0)]),
+        SystemMetadata::new(stream("input/out"), 41)
+            .with_timestamp(timestamp)
+            .with_source_position(Bytes::from_static(b"position")),
+    )
+    .append_context(entry("source", ContextValue::Bool(true)))
+    .unwrap();
+    let derived = root.derive(
+        EnvelopeId::try_new("transform", Bytes::from_static(b"1")).unwrap(),
+        root.changes().clone(),
+        SystemMetadata::new(stream("transform/out"), 0),
+    );
+    let next = derived.derive(
+        event_id(42),
+        derived.changes().clone(),
+        SystemMetadata::new(stream("next/out"), 7),
+    );
+    assert_eq!(derived.context().len(), 1);
+    assert_eq!(derived.system().sequence(), 0);
+    assert_eq!(derived.system().stream().as_str(), "transform/out");
+    assert_eq!(root.system().sequence(), 41);
+    assert_eq!(root.system().timestamp(), Some(timestamp));
+    assert_eq!(
+        root.system().source_position().unwrap().as_ref(),
+        b"position"
+    );
+    assert!(root.lineage().is_none());
+    assert_eq!(derived.lineage().unwrap().envelope_id(), root.id());
+    assert!(Arc::ptr_eq(
+        derived.lineage().unwrap().system(),
+        root.system()
+    ));
+    assert!(Arc::ptr_eq(
+        next.lineage().unwrap().parent().unwrap(),
+        derived.lineage().unwrap()
+    ));
+    assert!(Arc::ptr_eq(root.changes(), derived.changes()));
+}
+
+fn port(name: &str, direction: PortDirection, requirements: PipeRequirements) -> PortDescriptor {
+    PortDescriptor::new(
+        PortId::try_new(name).expect("valid fixture port ID"),
+        direction,
+        descriptor(),
+        requirements,
+    )
+}
+
+#[test]
+fn port_negotiation_checks_directions_full_schema_and_both_requirements() {
+    let fifo = PipeCapabilities::volatile_bounded(NonZeroUsize::new(1).unwrap());
+    let output = port("out", PortDirection::Output, PipeRequirements::default());
+    let input = port("in", PortDirection::Input, PipeRequirements::default());
+    assert!(validate_connection(&output, &input, &fifo).is_ok());
+    assert!(matches!(
+        validate_connection(&input, &output, &fifo),
+        Err(ContractError::WrongPortDirection { .. })
+    ));
+    let non_fifo = PipeCapabilities::try_new([], None).unwrap();
+    assert!(matches!(
+        validate_connection(&output, &input, &non_fifo),
+        Err(ContractError::UnsupportedCapability {
+            capability: PipeCapability::FifoPerStream
+        })
+    ));
+    for schema in [
+        descriptor_with("example.meter", 2, "meter-bin-v1", b"id:u8,value:u16be"),
+        descriptor_with("example.meter", 1, "other", b"id:u8,value:u16be"),
+        descriptor_with("example.meter", 1, "meter-bin-v1", b"other-definition"),
+    ] {
+        let other = PortDescriptor::new(
+            input.id().clone(),
+            PortDirection::Input,
+            schema,
+            PipeRequirements::default(),
+        );
+        assert!(matches!(
+            validate_connection(&output, &other, &fifo),
+            Err(ContractError::SchemaMismatch { .. })
+        ));
+    }
+    for capability in [
+        PipeCapability::DurableAcceptance,
+        PipeCapability::ExplicitAcknowledgement,
+        PipeCapability::Replay,
+        PipeCapability::Transactions,
+        PipeCapability::ExactlyOnce,
+    ] {
+        let requirement = PipeRequirements::new([capability]);
+        assert!(matches!(
+            fifo.validate(&requirement),
+            Err(ContractError::UnsupportedCapability { capability: actual }) if actual == capability
+        ));
+        let required_output = port("out", PortDirection::Output, requirement.clone());
+        let required_input = port("in", PortDirection::Input, requirement);
+        assert!(validate_connection(&required_output, &input, &fifo).is_err());
+        assert!(validate_connection(&output, &required_input, &fifo).is_err());
+    }
+    assert_eq!(fifo.capacity().unwrap().get(), 1);
+    assert_eq!(fifo.supported().len(), 2);
+    assert!(matches!(
+        ComponentDescriptor::try_new(
+            ComponentId::try_new("duplicate").unwrap(),
+            vec![
+                input.clone(),
+                PortDescriptor::new(
+                    input.id().clone(),
+                    PortDirection::Output,
+                    descriptor(),
+                    PipeRequirements::default()
+                )
+            ]
+        ),
+        Err(ContractError::DuplicatePort { .. })
+    ));
+}
+
+#[test]
+fn capability_claims_reject_missing_prerequisites() {
+    use PipeCapability::*;
+    for (supported, capability, requires) in [
+        (vec![Replay], Replay, DurableAcceptance),
+        (vec![Transactions], Transactions, ExplicitAcknowledgement),
+        (vec![ExactlyOnce], ExactlyOnce, DurableAcceptance),
+        (
+            vec![ExactlyOnce, DurableAcceptance],
+            ExactlyOnce,
+            ExplicitAcknowledgement,
+        ),
+        (
+            vec![ExactlyOnce, DurableAcceptance, ExplicitAcknowledgement],
+            ExactlyOnce,
+            Transactions,
+        ),
+    ] {
+        assert!(matches!(
+            PipeCapabilities::try_new(supported, None),
+            Err(ContractError::InvalidCapabilities { capability: c, requires: r })
+                if c == capability && r == requires
+        ));
+    }
+}
+
+// Consumer fixtures implement actual state transitions; no default lifecycle stubs.
+struct Lifecycle {
+    descriptor: ComponentDescriptor,
+    running: bool,
+}
+
+impl Lifecycle {
+    fn new(name: &str, ports: Vec<PortDescriptor>) -> Self {
+        Self {
+            descriptor: ComponentDescriptor::try_new(
+                ComponentId::try_new(name).expect("valid fixture component ID"),
+                ports,
+            )
+            .expect("valid fixture component descriptor"),
+            running: false,
+        }
+    }
+
+    fn start(&mut self) -> anyhow::Result<()> {
+        anyhow::ensure!(!self.running, "already running");
+        self.running = true;
+        Ok(())
+    }
+
+    fn stop(&mut self) -> anyhow::Result<()> {
+        anyhow::ensure!(self.running, "not running");
+        self.running = false;
+        Ok(())
+    }
+
+    fn require_running(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(self.running, "not running");
+        Ok(())
+    }
+}
+
+macro_rules! component_lifecycle {
+    ($component:ty) => {
+        #[async_trait]
+        impl ComputationComponent for $component {
+            fn descriptor(&self) -> &ComponentDescriptor {
+                &self.lifecycle.descriptor
+            }
+            async fn start(&mut self) -> anyhow::Result<()> {
+                self.lifecycle.start()
+            }
+            async fn stop(&mut self) -> anyhow::Result<()> {
+                self.lifecycle.stop()
+            }
+        }
+    };
+}
+
+struct CustomSource {
+    lifecycle: Lifecycle,
+    events: VecDeque<Envelope>,
+}
+component_lifecycle!(CustomSource);
+
+#[async_trait]
+impl EnvelopeSource for CustomSource {
+    async fn next(&mut self) -> anyhow::Result<Option<OutputEnvelope>> {
+        self.lifecycle.require_running()?;
+        let port = PortId::try_new("out")?;
+        Ok(self
+            .events
+            .pop_front()
+            .map(|envelope| OutputEnvelope { port, envelope }))
+    }
+}
+
+struct CustomTransformer {
+    lifecycle: Lifecycle,
+    next_sequence: u64,
+}
+component_lifecycle!(CustomTransformer);
+
+#[async_trait]
+impl Transformer for CustomTransformer {
+    async fn transform(&mut self, input: InputEnvelope) -> anyhow::Result<Vec<OutputEnvelope>> {
+        self.lifecycle.require_running()?;
+        anyhow::ensure!(input.port.as_str() == "in", "wrong port");
+        let annotated = input
+            .envelope
+            .append_context(entry("processed", ContextValue::Bool(true)))?;
+        let mut outputs = Vec::new();
+        for _ in annotated.changes().operations() {
+            let sequence = self.next_sequence;
+            self.next_sequence = sequence
+                .checked_add(1)
+                .ok_or_else(|| anyhow::anyhow!("sequence exhausted"))?;
+            outputs.push(OutputEnvelope {
+                port: PortId::try_new("out")?,
+                envelope: annotated.derive(
+                    EnvelopeId::try_new(
+                        "custom.transform",
+                        Bytes::copy_from_slice(&sequence.to_be_bytes()),
+                    )?,
+                    annotated.changes().clone(),
+                    SystemMetadata::new(stream("transform/out"), sequence),
+                ),
+            });
+        }
+        Ok(outputs)
+    }
+}
+
+struct CustomSink {
+    lifecycle: Lifecycle,
+    completion: SinkCompletion,
+    observed: Arc<AtomicUsize>,
+}
+component_lifecycle!(CustomSink);
+
+#[async_trait]
+impl EnvelopeSink for CustomSink {
+    fn completion(&self) -> SinkCompletion {
+        self.completion
+    }
+    async fn handle(&mut self, input: InputEnvelope) -> anyhow::Result<()> {
+        self.lifecycle.require_running()?;
+        anyhow::ensure!(input.port.as_str() == "in", "wrong port");
+        self.observed.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+fn custom_sink(completion: SinkCompletion, observed: Arc<AtomicUsize>) -> Box<dyn EnvelopeSink> {
+    Box::new(CustomSink {
+        lifecycle: Lifecycle::new(
+            "sink",
+            vec![port("in", PortDirection::Input, PipeRequirements::default())],
+        ),
+        completion,
+        observed,
+    })
+}
+
+#[tokio::test]
+async fn external_stateful_components_are_object_safe_and_support_zero_one_many_outputs() {
+    let mut source: Box<dyn EnvelopeSource> = Box::new(CustomSource {
+        lifecycle: Lifecycle::new(
+            "source",
+            vec![port("out", PortDirection::Output, PipeRequirements::default())],
+        ),
+        events: VecDeque::from([
+            envelope(0, vec![]),
+            envelope(1, vec![added(0)]),
+            envelope(2, vec![added(0), added(1)]),
+        ]),
+    });
+    let mut transform: Box<dyn Transformer> = Box::new(CustomTransformer {
+        lifecycle: Lifecycle::new(
+            "transform",
+            vec![
+                port("in", PortDirection::Input, PipeRequirements::default()),
+                port("out", PortDirection::Output, PipeRequirements::default()),
+            ],
+        ),
+        next_sequence: 0,
+    });
+    let observed = Arc::new(AtomicUsize::new(0));
+    let mut sink = custom_sink(SinkCompletion::Handled, observed.clone());
+    assert!(source.next().await.is_err());
+    source.start().await.unwrap();
+    transform.start().await.unwrap();
+    sink.start().await.unwrap();
+    assert_eq!(transform.descriptor().id().as_str(), "transform");
+    let mut next_sequence = 0;
+    for count in 0..3 {
+        let input = source.next().await.unwrap().unwrap();
+        let input_id = input.envelope.id().clone();
+        let outputs = transform
+            .transform(InputEnvelope {
+                port: PortId::try_new("in").unwrap(),
+                envelope: input.envelope,
+            })
+            .await
+            .unwrap();
+        assert_eq!(outputs.len(), count);
+        for output in outputs {
+            assert_eq!(output.envelope.system().stream().as_str(), "transform/out");
+            assert_eq!(output.envelope.system().sequence(), next_sequence);
+            next_sequence += 1;
+            assert_eq!(output.envelope.lineage().unwrap().envelope_id(), &input_id);
+            assert_eq!(output.envelope.context().len(), 1);
+            sink.handle(InputEnvelope {
+                port: PortId::try_new("in").unwrap(),
+                envelope: output.envelope,
+            })
+            .await
+            .unwrap();
+        }
+    }
+    assert!(source.next().await.unwrap().is_none());
+    assert_eq!(observed.load(Ordering::SeqCst), 3);
+    source.stop().await.unwrap();
+    transform.stop().await.unwrap();
+    sink.stop().await.unwrap();
+    assert!(sink
+        .handle(InputEnvelope {
+            port: PortId::try_new("in").unwrap(),
+            envelope: envelope(9, vec![])
+        })
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn accepted_sink_never_upgrades_to_handled_even_with_ack_capable_pipe() {
+    use PipeCapability::*;
+    let pipe = PipeCapabilities::try_new(
+        [
+            FifoPerStream,
+            DurableAcceptance,
+            ExplicitAcknowledgement,
+            Replay,
+            Transactions,
+            ExactlyOnce,
+        ],
+        NonZeroUsize::new(1),
+    )
+    .unwrap();
+    let accepted_count = Arc::new(AtomicUsize::new(0));
+    let handled_count = Arc::new(AtomicUsize::new(0));
+    let mut accepted = custom_sink(SinkCompletion::Accepted, accepted_count.clone());
+    let mut handled = custom_sink(SinkCompletion::Handled, handled_count.clone());
+    for required in [ExplicitAcknowledgement, Transactions, ExactlyOnce] {
+        let requirements = PipeRequirements::new([required]);
+        assert!(pipe.validate(&requirements).is_ok());
+        assert!(matches!(
+            validate_sink_completion(accepted.completion(), &requirements),
+            Err(ContractError::InsufficientSinkCompletion { actual: SinkCompletion::Accepted, required: r }) if r == required
+        ));
+        assert!(validate_sink_completion(handled.completion(), &requirements).is_ok());
+    }
+    assert!(validate_sink_completion(accepted.completion(), &PipeRequirements::default()).is_ok());
+    accepted.start().await.unwrap();
+    handled.start().await.unwrap();
+    for sink in [&mut accepted, &mut handled] {
+        sink.handle(InputEnvelope {
+            port: PortId::try_new("in").unwrap(),
+            envelope: envelope(0, vec![added(0)]),
+        })
+        .await
+        .unwrap();
+        sink.stop().await.unwrap();
+    }
+    assert_eq!(accepted.completion(), SinkCompletion::Accepted);
+    assert_eq!(handled.completion(), SinkCompletion::Handled);
+    assert_eq!(accepted_count.load(Ordering::SeqCst), 1);
+    assert_eq!(handled_count.load(Ordering::SeqCst), 1);
+}
+
+struct TestAcknowledgement(Arc<AtomicUsize>);
+
+#[async_trait]
+impl Acknowledgement for TestAcknowledgement {
+    async fn complete(
+        self: Box<Self>,
+        outcome: HandlingOutcome,
+    ) -> std::result::Result<(), PipeError> {
+        if outcome == HandlingOutcome::Handled {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+        Ok(())
+    }
+}
+
+struct TestSender(mpsc::Sender<Envelope>);
+
+#[async_trait]
+impl EnvelopeSender for TestSender {
+    async fn send(&self, envelope: Envelope) -> std::result::Result<EnqueueReceipt, SendFailure> {
+        let id = envelope.id().clone();
+        self.0.send(envelope).await.map_err(|error| SendFailure {
+            envelope: error.0,
+            error: PipeError::Closed,
+        })?;
+        Ok(EnqueueReceipt::new(id))
+    }
+}
+
+struct TestReceiver(mpsc::Receiver<Envelope>);
+
+#[async_trait]
+impl EnvelopeReceiver for TestReceiver {
+    async fn receive(&mut self) -> std::result::Result<Option<Delivery>, PipeError> {
+        Ok(self
+            .0
+            .recv()
+            .await
+            .map(|envelope| Delivery::new(envelope, None)))
+    }
+}
+
+struct TestPipe {
+    capabilities: PipeCapabilities,
+    sender: Arc<dyn EnvelopeSender>,
+    receiver: Option<Box<dyn EnvelopeReceiver>>,
+}
+
+impl Pipe for TestPipe {
+    fn capabilities(&self) -> &PipeCapabilities {
+        &self.capabilities
+    }
+    fn sender(&self) -> Arc<dyn EnvelopeSender> {
+        self.sender.clone()
+    }
+    fn take_receiver(&mut self) -> std::result::Result<Box<dyn EnvelopeReceiver>, PipeError> {
+        self.receiver.take().ok_or(PipeError::ReceiverTaken)
+    }
+}
+
+#[tokio::test]
+async fn transport_acceptance_delivery_and_handling_ack_are_separate() {
+    let (tx, rx) = mpsc::channel(2);
+    let mut pipe: Box<dyn Pipe> = Box::new(TestPipe {
+        capabilities: PipeCapabilities::volatile_bounded(NonZeroUsize::new(2).unwrap()),
+        sender: Arc::new(TestSender(tx)),
+        receiver: Some(Box::new(TestReceiver(rx))),
+    });
+    assert_eq!(pipe.capabilities().capacity().unwrap().get(), 2);
+    let mut receiver = pipe.take_receiver().unwrap();
+    assert!(matches!(
+        pipe.take_receiver(),
+        Err(PipeError::ReceiverTaken)
+    ));
+    let sender = pipe.sender();
+    let first = Envelope::new(
+        event_id(1),
+        changes(vec![]),
+        SystemMetadata::new(stream("source/out"), 1)
+            .with_timestamp(chrono::DateTime::from_timestamp(200, 0).unwrap()),
+    );
+    let second = Envelope::new(
+        event_id(2),
+        changes(vec![]),
+        SystemMetadata::new(stream("source/out"), 2)
+            .with_timestamp(chrono::DateTime::from_timestamp(100, 0).unwrap()),
+    );
+    let handled = Arc::new(AtomicUsize::new(0));
+    assert_eq!(
+        sender.send(first.clone()).await.unwrap().envelope_id(),
+        first.id()
+    );
+    sender.send(second).await.unwrap();
+    assert_eq!(handled.load(Ordering::SeqCst), 0);
+    let delivery = receiver.receive().await.unwrap().unwrap();
+    assert_eq!(delivery.envelope().system().sequence(), 1);
+    let (received, acknowledgement) = delivery.into_parts();
+    assert!(acknowledgement.is_none());
+    assert!(Arc::ptr_eq(received.changes(), first.changes()));
+    assert_eq!(
+        receiver
+            .receive()
+            .await
+            .unwrap()
+            .unwrap()
+            .envelope()
+            .system()
+            .sequence(),
+        2
+    );
+    assert_eq!(handled.load(Ordering::SeqCst), 0);
+    // An explicit local delivery handle is not an envelope/context property.
+    let explicit = Delivery::new(
+        received.clone(),
+        Some(Box::new(TestAcknowledgement(handled.clone()))),
+    );
+    drop(Delivery::new(
+        received,
+        Some(Box::new(TestAcknowledgement(handled.clone()))),
+    ));
+    assert_eq!(handled.load(Ordering::SeqCst), 0);
+    explicit
+        .into_parts()
+        .1
+        .unwrap()
+        .complete(HandlingOutcome::Handled)
+        .await
+        .unwrap();
+    assert_eq!(handled.load(Ordering::SeqCst), 1);
+    drop(pipe);
+    drop(sender);
+    assert!(receiver.receive().await.unwrap().is_none());
+
+    let (tx, rx) = mpsc::channel(1);
+    drop(rx);
+    let failure = TestSender(tx).send(first.clone()).await.unwrap_err();
+    assert!(matches!(failure.error, PipeError::Closed));
+    assert!(Arc::ptr_eq(failure.envelope.changes(), first.changes()));
+}
+
+#[tokio::test]
+async fn blocked_sender_returns_closed_with_unaccepted_event_when_receiver_drops() {
+    let (tx, rx) = mpsc::channel(1);
+    let sender: Arc<dyn EnvelopeSender> = Arc::new(TestSender(tx));
+    let receiver: Box<dyn EnvelopeReceiver> = Box::new(TestReceiver(rx));
+    sender.send(envelope(0, vec![added(0)])).await.unwrap();
+    let waiting = envelope(1, vec![added(0)]);
+    let mut send = Box::pin(sender.send(waiting.clone()));
+    assert!(futures::poll!(send.as_mut()).is_pending());
+    drop(receiver);
+    let std::task::Poll::Ready(Err(failure)) = futures::poll!(send.as_mut()) else {
+        panic!("receiver closure must release a capacity-blocked sender");
+    };
+    assert!(matches!(failure.error, PipeError::Closed));
+    assert_eq!(failure.envelope.id(), waiting.id());
+    assert!(Arc::ptr_eq(failure.envelope.changes(), waiting.changes()));
+}
+
+#[tokio::test]
+async fn cancelling_waiting_receive_keeps_the_next_volatile_event_available() {
+    let (tx, rx) = mpsc::channel(1);
+    let sender: Arc<dyn EnvelopeSender> = Arc::new(TestSender(tx));
+    let mut receiver: Box<dyn EnvelopeReceiver> = Box::new(TestReceiver(rx));
+    let mut receive = Box::pin(receiver.receive());
+    assert!(futures::poll!(receive.as_mut()).is_pending());
+    drop(receive);
+    let event = envelope(1, vec![added(0)]);
+    sender.send(event.clone()).await.unwrap();
+    let delivered = receiver.receive().await.unwrap().unwrap();
+    assert_eq!(delivered.envelope().id(), event.id());
+    assert!(Arc::ptr_eq(delivered.envelope().changes(), event.changes()));
+    let mut receive = Box::pin(receiver.receive());
+    assert!(futures::poll!(receive.as_mut()).is_pending());
+    drop(sender);
+    assert!(matches!(
+        futures::poll!(receive.as_mut()),
+        std::task::Poll::Ready(Ok(None))
+    ));
+}
+
+#[test]
+fn public_data_and_trait_objects_are_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync + ?Sized>() {}
+    assert_send_sync::<Envelope>();
+    assert_send_sync::<ChangeSet>();
+    assert_send_sync::<ProcessingContext>();
+    assert_send_sync::<dyn RecordValidator>();
+    assert_send_sync::<dyn Transformer>();
+    assert_send_sync::<dyn EnvelopeSource>();
+    assert_send_sync::<dyn EnvelopeSink>();
+    assert_send_sync::<dyn Pipe>();
+    assert_send_sync::<dyn EnvelopeSender>();
+    assert_send_sync::<dyn EnvelopeReceiver>();
+    assert_send_sync::<dyn Acknowledgement>();
+}


### PR DESCRIPTION
## Summary

Additive phase **B1: contracts only** for composable Drasi. **Depends on #872 (A8)** and is based on `agentofreality-preserve-reaction-result-order` at `444dac19cbfd98b3c3cfade227db2a4c514f3e69`.

The new `computation` Cargo feature is **default-off**, with public contracts only under `drasi_lib::computation::v1`. This does not migrate or replace the legacy Source/Query/Reaction pipeline, ComponentGraph, managers, DrasiLibConfig, persistence/wire formats, plugin SDK/ABI, or Drasi Server.

## Contracts

- Immutable custom schema/record/change-set/envelope data using shared Bytes/Arc allocations. Mandatory schema-specific identity and image validation; validated RecordReference keys also cover image-less deletes. Complete descriptor equality, ordered unique operation ordinals, explicit PATCH/REPLACE, before/after image and identity checks.
- Persistent append-only branch context and shared input lineage. Reuse A2 context storage and tagged hash primitive through a narrow private feature-gated bridge without changing A2 codecs, IDs, or legacy behavior. Fingerprints are advisory and noncryptographic, not collision-free identities.
- Object-safe Send+Sync source/transformer/sink contracts with host-owned mutable lifecycle. Transformers support zero/one/many outputs and their own producer sequences. Immutable named ports and pure schema/capability preflight validation.
- Distinct enqueue acceptance, fixed sink completion (`Accepted`/`Handled`), and opaque local-only delivery acknowledgement contracts. Acceptance-only sinks cannot satisfy handling-dependent requirements merely because a pipe advertises acknowledgements. Close/drop wakeup and volatile receive cancellation contracts are explicit.

## Deliberately deferred

No graph runtime, concrete production pipe, legacy adapter, lossless codec, general serialization format, durability/replay/transactions/exactly-once implementation, ABI, server configuration, or migration. The volatile bounded pipe *descriptor* advertises only per-stream FIFO and backpressure and rejects unsupported requirements. Context/envelope data cannot contain resource or acknowledgement handles. A2 canonical identity bytes are not claimed to be a reversible public wire codec.

Native stack metadata is intentionally unchanged; the coordinator will append this draft after review.

## Validation

- External consumer suite: **18 passed**, including custom schema validation, bare deletes, invalid identity/schema/image/ordinal cases, Arc/Bytes/context/lineage sharing, stateful dyn components, zero/one/many outputs, completion negotiation, and deterministic blocked-send/receiver-drop/cancellation cases.
- Full `cargo test -p drasi-lib --no-default-features`: **984 unit + 21 integration + 97 doctests passed**, 55 existing doctests ignored.
- Full `cargo test -p drasi-lib --no-default-features --features computation`: **985 unit + 39 integration + 99 doctests passed**, 55 existing doctests ignored. Includes private A2 sharing coverage and compile-fail coverage against unchecked Record deserialization.
- Strict `cargo clippy -p drasi-lib --all-targets --no-default-features -- -D warnings` and the same command with `--features computation`: passed.
- Existing nightly formatter check and `git diff --check`: passed.

Coordinator read-only contract review completed; both identified gaps (bare-delete identity validation and close/cancellation contract coverage) were addressed before publication.