### PR TITLE
fix(core): propagate VariableValue serialization failures

### DIFF
--- a/core/src/evaluation/variable_value/ser.rs
+++ b/core/src/evaluation/variable_value/ser.rs
@@ -38,22 +38,38 @@ impl Serialize for VariableValue {
                 use serde::ser::SerializeMap;
                 let mut map = serializer.serialize_map(Some(m.len()))?;
                 for (k, v) in m {
-                    let _ = map.serialize_entry(k, v);
+                    map.serialize_entry(k, v)?;
                 }
                 map.end()
             }
             VariableValue::Date(v) => v.serialize(serializer),
             VariableValue::LocalTime(v) => v.serialize(serializer),
-            VariableValue::ZonedTime(_v) => todo!(),
+            VariableValue::ZonedTime(_) => Err(serde::ser::Error::custom(
+                "Cannot serialize VariableValue::ZonedTime",
+            )),
             VariableValue::LocalDateTime(v) => v.serialize(serializer),
             VariableValue::ZonedDateTime(v) => v.serialize(serializer),
-            VariableValue::Duration(_v) => todo!(),
-            VariableValue::Expression(_v) => todo!(),
-            VariableValue::ListRange(_v) => todo!(),
-            VariableValue::Element(_) => todo!(),
-            VariableValue::ElementMetadata(_m) => todo!(),
-            VariableValue::ElementReference(_) => todo!(),
-            VariableValue::Awaiting => todo!(),
+            VariableValue::Duration(_) => Err(serde::ser::Error::custom(
+                "Cannot serialize VariableValue::Duration",
+            )),
+            VariableValue::Expression(_) => Err(serde::ser::Error::custom(
+                "Cannot serialize VariableValue::Expression",
+            )),
+            VariableValue::ListRange(_) => Err(serde::ser::Error::custom(
+                "Cannot serialize VariableValue::ListRange",
+            )),
+            VariableValue::Element(_) => Err(serde::ser::Error::custom(
+                "Cannot serialize VariableValue::Element",
+            )),
+            VariableValue::ElementMetadata(_) => Err(serde::ser::Error::custom(
+                "Cannot serialize VariableValue::ElementMetadata",
+            )),
+            VariableValue::ElementReference(_) => Err(serde::ser::Error::custom(
+                "Cannot serialize VariableValue::ElementReference",
+            )),
+            VariableValue::Awaiting => Err(serde::ser::Error::custom(
+                "Cannot serialize VariableValue::Awaiting",
+            )),
         }
     }
 }

--- a/core/src/evaluation/variable_value/tests/ser_test.rs
+++ b/core/src/evaluation/variable_value/tests/ser_test.rs
@@ -12,9 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::evaluation::variable_value::VariableValue;
+use crate::{
+    evaluation::variable_value::{
+        duration::Duration, zoned_datetime::ZonedDateTime, zoned_time::ZonedTime, ListRange,
+        RangeBound, VariableValue,
+    },
+    models::{Element, ElementMetadata, ElementReference},
+};
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveTime};
+use drasi_query_ast::ast::UnaryExpression;
 use serde_json::json;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, io, sync::Arc};
 
 #[test]
 fn test_serializing_integer() {
@@ -80,4 +88,291 @@ fn test_serializing_object() {
     };
 
     assert_eq!(ser_value, json!(expected));
+}
+
+fn object_with_value(value: VariableValue) -> VariableValue {
+    VariableValue::Object(BTreeMap::from([
+        ("a_before".to_owned(), VariableValue::Bool(true)),
+        ("b_value".to_owned(), value),
+        ("c_after".to_owned(), VariableValue::Bool(false)),
+    ]))
+}
+
+fn assert_serialization_error(value: &VariableValue, expected: &str) {
+    assert_eq!(
+        serde_json::to_value(value)
+            .expect_err("JSON value serialization must fail")
+            .to_string(),
+        expected
+    );
+    assert_eq!(
+        serde_json::to_string(value)
+            .expect_err("JSON string serialization must fail")
+            .to_string(),
+        expected
+    );
+    assert_eq!(
+        rmp_serde::to_vec(value)
+            .expect_err("MessagePack serialization must fail")
+            .to_string(),
+        expected
+    );
+    assert_eq!(
+        rmp_serde::to_vec_named(value)
+            .expect_err("named MessagePack serialization must fail")
+            .to_string(),
+        expected
+    );
+}
+
+fn assert_nested_serialization_error(value: VariableValue, expected: &str) {
+    let list = VariableValue::List(vec![
+        VariableValue::Null,
+        value.clone(),
+        VariableValue::Null,
+    ]);
+    let object = object_with_value(value.clone());
+    for value in [
+        value,
+        list.clone(),
+        object.clone(),
+        VariableValue::List(vec![object.clone()]),
+        object_with_value(list),
+        object_with_value(object),
+    ] {
+        assert_serialization_error(&value, expected);
+    }
+}
+
+#[test]
+fn test_serializing_awaiting_returns_error() {
+    let outcome = std::panic::catch_unwind(|| serde_json::to_value(VariableValue::Awaiting));
+    assert!(outcome.is_ok(), "unsupported values must not panic");
+    assert_eq!(
+        outcome.unwrap().unwrap_err().to_string(),
+        "Cannot serialize VariableValue::Awaiting"
+    );
+    assert_nested_serialization_error(
+        VariableValue::Awaiting,
+        "Cannot serialize VariableValue::Awaiting",
+    );
+}
+
+#[test]
+fn test_serializing_unsupported_variants_returns_error() {
+    let metadata = ElementMetadata {
+        reference: ElementReference::new("private-source", "private-element"),
+        labels: vec!["private-label".into()].into(),
+        effective_from: 42,
+    };
+    let cases = [
+        (
+            "ZonedTime",
+            VariableValue::ZonedTime(ZonedTime::new(
+                NaiveTime::from_hms_opt(12, 34, 56).unwrap(),
+                FixedOffset::east_opt(3600).unwrap(),
+            )),
+        ),
+        (
+            "Duration",
+            VariableValue::Duration(Duration::new(chrono::Duration::seconds(42), 1, 2)),
+        ),
+        (
+            "Expression",
+            VariableValue::Expression(UnaryExpression::ident("private-expression")),
+        ),
+        (
+            "ListRange",
+            VariableValue::ListRange(ListRange {
+                start: RangeBound::Index(1),
+                end: RangeBound::Unbounded,
+            }),
+        ),
+        (
+            "Element",
+            VariableValue::Element(Arc::new(Element::Node {
+                metadata: metadata.clone(),
+                properties: Default::default(),
+            })),
+        ),
+        (
+            "ElementMetadata",
+            VariableValue::ElementMetadata(metadata.clone()),
+        ),
+        (
+            "ElementReference",
+            VariableValue::ElementReference(metadata.reference),
+        ),
+    ];
+    for (variant, value) in cases {
+        assert_nested_serialization_error(
+            value,
+            &format!("Cannot serialize VariableValue::{variant}"),
+        );
+    }
+}
+
+#[test]
+fn test_serializing_integer_overflow_returns_error() {
+    assert_serialization_error(&VariableValue::Integer(u64::MAX.into()), "Integer overflow");
+}
+
+#[test]
+fn test_serializing_object_with_only_failing_field_returns_error() {
+    let value = VariableValue::Object(BTreeMap::from([(
+        "value".to_owned(),
+        VariableValue::Integer(u64::MAX.into()),
+    )]));
+    assert_serialization_error(&value, "Integer overflow");
+}
+
+#[test]
+fn test_serializing_object_with_surrounding_fields_returns_error() {
+    let value = object_with_value(VariableValue::Integer(u64::MAX.into()));
+    assert_serialization_error(&value, "Integer overflow");
+}
+
+#[test]
+fn test_serializing_object_with_failing_list_returns_error() {
+    let value = object_with_value(VariableValue::List(vec![
+        VariableValue::Null,
+        VariableValue::Integer(u64::MAX.into()),
+        VariableValue::Null,
+    ]));
+    assert_serialization_error(&value, "Integer overflow");
+}
+
+#[test]
+fn test_serializing_list_with_failing_object_returns_error() {
+    let value = VariableValue::List(vec![
+        VariableValue::Null,
+        object_with_value(VariableValue::Integer(u64::MAX.into())),
+        VariableValue::Null,
+    ]);
+    assert_serialization_error(&value, "Integer overflow");
+}
+
+#[test]
+fn test_serializing_object_with_failing_object_returns_error() {
+    let value = object_with_value(object_with_value(VariableValue::Integer(u64::MAX.into())));
+    assert_serialization_error(&value, "Integer overflow");
+}
+
+#[test]
+fn test_serializing_non_finite_float_returns_error() {
+    for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        assert_nested_serialization_error(VariableValue::Float(value.into()), "Float overflow");
+    }
+}
+
+#[test]
+fn test_serializing_object_propagates_serializer_entry_error() {
+    #[derive(Default)]
+    struct FailOnceWriter {
+        bytes: Vec<u8>,
+        failed: bool,
+    }
+
+    impl io::Write for FailOnceWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            // Fail during serialize_entry, but allow later writes (including map.end).
+            if bytes == b"b_value" && !self.failed {
+                self.failed = true;
+                return Err(io::Error::other("injected map entry failure"));
+            }
+            self.bytes.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut writer = FailOnceWriter::default();
+    let result = serde_json::to_writer(
+        &mut writer,
+        &object_with_value(VariableValue::Integer(42.into())),
+    );
+    assert!(
+        result.is_err(),
+        "expected entry error, got {result:?} with output {:?}",
+        String::from_utf8_lossy(&writer.bytes)
+    );
+    let error = result.unwrap_err();
+    assert!(error.is_io());
+    assert_eq!(error.to_string(), "injected map entry failure");
+    assert!(writer.failed);
+    assert_eq!(writer.bytes, b"{\"a_before\":true,\"");
+}
+
+#[test]
+fn test_serializing_supported_representations() {
+    let date = NaiveDate::from_ymd_opt(2026, 9, 12).unwrap();
+    let time = NaiveTime::from_hms_milli_opt(12, 34, 56, 123).unwrap();
+    let datetime = DateTime::parse_from_rfc3339("2026-09-12T12:34:56.123+05:30").unwrap();
+    let cases = [
+        (VariableValue::Null, json!(null)),
+        (VariableValue::Bool(false), json!(false)),
+        (VariableValue::Bool(true), json!(true)),
+        (VariableValue::Integer(0.into()), json!(0)),
+        (VariableValue::Integer(i64::MIN.into()), json!(i64::MIN)),
+        (VariableValue::Integer(i64::MAX.into()), json!(i64::MAX)),
+        (VariableValue::Float(42.5.into()), json!(42.5)),
+        (VariableValue::Float((-0.0).into()), json!(-0.0)),
+        (
+            VariableValue::String("Drasi \"query\"\n".into()),
+            json!("Drasi \"query\"\n"),
+        ),
+        (VariableValue::Date(date), json!("2026-09-12")),
+        (VariableValue::LocalTime(time), json!("12:34:56.123")),
+        (
+            VariableValue::LocalDateTime(date.and_time(time)),
+            json!("2026-09-12T12:34:56.123"),
+        ),
+        (
+            VariableValue::ZonedDateTime(ZonedDateTime::new(datetime, Some("Asia/Kolkata".into()))),
+            json!({
+                "datetime": "2026-09-12T12:34:56.123+05:30",
+                "timezone_name": "Asia/Kolkata",
+            }),
+        ),
+        (
+            VariableValue::ZonedDateTime(ZonedDateTime::new(datetime, None)),
+            json!({
+                "datetime": "2026-09-12T12:34:56.123+05:30",
+                "timezone_name": null,
+            }),
+        ),
+        (VariableValue::List(vec![]), json!([])),
+        (VariableValue::Object(BTreeMap::new()), json!({})),
+        (
+            VariableValue::List(vec![object_with_value(VariableValue::List(vec![
+                VariableValue::Integer(42.into()),
+                VariableValue::Null,
+            ]))]),
+            json!([{"a_before": true, "b_value": [42, null], "c_after": false}]),
+        ),
+    ];
+    for (value, expected) in cases {
+        assert_eq!(serde_json::to_value(&value).unwrap(), expected);
+        assert_eq!(
+            serde_json::to_string(&value).unwrap(),
+            serde_json::to_string(&expected).unwrap()
+        );
+        assert_eq!(
+            rmp_serde::to_vec_named(&value).unwrap(),
+            rmp_serde::to_vec_named(&expected).unwrap()
+        );
+        let compact_expected = match &value {
+            VariableValue::ZonedDateTime(_) => {
+                json!([expected["datetime"], expected["timezone_name"]])
+            }
+            _ => expected,
+        };
+        assert_eq!(
+            rmp_serde::to_vec(&value).unwrap(),
+            rmp_serde::to_vec(&compact_expected).unwrap()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #882
Fixes #883

Make the legacy `Serialize for VariableValue` use its existing error channel consistently:

- Return `serde::ser::Error::custom("Cannot serialize VariableValue::<Variant>")` for the eight previously panicking variants: `ZonedTime`, `Duration`, `Expression`, `ListRange`, `Element`, `ElementMetadata`, `ElementReference`, and `Awaiting`. Messages identify only the variant, never its payload.
- Propagate the first `map.serialize_entry(k, v)` error with `?`; call `map.end()` only after every entry succeeds.

All previously successful scalar, list, object, date/time, and zoned-datetime encodings remain unchanged. Existing `Integer overflow` and `Float overflow` errors remain unchanged. This does not add an encoding, dependency, fallback, or ComputationGraph feature; it does not change `From<VariableValue> for serde_json::Value`.

## Baseline and actual reproduction

Independent branch based directly on freshly fetched `main` commit `e759606fa065bee0ef9e60017e263f0f85dd0e44` (the parent of this fix). The untouched [production serializer](https://github.com/drasi-project/drasi-core/blob/e759606fa065bee0ef9e60017e263f0f85dd0e44/core/src/evaluation/variable_value/ser.rs#L24-L56) was verified as blob `d83aa18c194041ff31e6749c4c80b97a5cdef474` before running the new regressions.

The committed regressions were run against that unchanged production file first: **8 passed, 9 failed**. These are observed results, not only proposed reproductions (Rust 1.95.0 on macOS; `serde_json` 1.0.151, `rmp-serde` 1.3.1).

| Input / backend | Observed on untouched main | After this fix |
| --- | --- | --- |
| `serde_json::to_value(VariableValue::Awaiting)` inside `catch_unwind` | Panic: `not yet implemented` at `ser.rs:56` | `Err("Cannot serialize VariableValue::Awaiting")`, no panic |
| Direct `Integer(u64::MAX.into())` | `Err("Integer overflow")` | Same error |
| Object containing only that failing integer field | Successful `{}` | `Err("Integer overflow")` |
| Object with `a_before=true`, `b_value=overflowing_integer`, `c_after=false` | Successful `{"a_before":true,"c_after":false}` | `Err("Integer overflow")` |
| Object containing a failing List, List containing a failing Object, and Object containing a failing Object | Successful partial containers | Original error propagates |
| Valid Object with one injected I/O failure during `serialize_entry` (writer permits subsequent writes) | `Ok(())` with malformed output `{"a_before":true,","c_after":false}` | Original I/O error `injected map entry failure`; no later entry or map end is written |

`ZonedTime` also reproduced the original `todo!()` panic at `ser.rs:47`. The unchanged successful-format fixture passed before and after the production fix.

## Regression coverage and validation

Focused tests cover all eight unsupported variants directly and through List/Object nesting, including valid fields before and after the failing field. Error propagation is exercised through JSON value/string serializers and compact/named MessagePack serializers. The one-shot failing JSON writer independently exercises a serializer-generated map-entry error and confirms early termination. Supported representations include signed integer boundaries, finite floats and signed zero, strings, empty/nested containers, dates, local times/datetimes, and zoned datetimes with and without a timezone name.

After the fix, the same focused test selection passes **17/17**:

```sh
cargo test -p drasi-core --lib -- \
  evaluation::variable_value::tests::ser_test \
  evaluation::variable_value::tests::serde_json_test
cargo clippy -p drasi-core --all-targets --all-features -- -D warnings
rustup run nightly rustfmt --check --edition 2021 \
  core/src/evaluation/variable_value/ser.rs \
  core/src/evaluation/variable_value/tests/ser_test.rs
```

All commands passed. Read-only review of the final two-file delta found no significant issues. Existing LF-header/CRLF-body formatting is retained to avoid unrelated newline churn. No workspace-wide, Docker, or JQ validation was needed.

Only changed files: `core/src/evaluation/variable_value/ser.rs` and its existing `tests/ser_test.rs`. Commit includes the actual git author's DCO sign-off and the Copilot co-author trailer.