### PR TITLE
fix(lib): preserve reaction result order and guard startup

### DIFF
--- a/components/reactions/profiler/src/profiler.rs
+++ b/components/reactions/profiler/src/profiler.rs
@@ -505,6 +505,7 @@ impl Reaction for ProfilerReaction {
         let stats = self.stats.clone();
         let report_interval = self.report_interval_secs;
         let priority_queue = self.base.priority_queue.clone();
+        let mut shutdown_rx = self.base.create_shutdown_channel().await;
 
         let processing_task = tokio::spawn(async move {
             let mut report_timer =
@@ -513,6 +514,10 @@ impl Reaction for ProfilerReaction {
 
             loop {
                 tokio::select! {
+                    biased;
+                    _ = &mut shutdown_rx => {
+                        break;
+                    }
                     query_result = priority_queue.dequeue() => {
                         // Extract and store profiling data
                         if let Some(profiling) = query_result.profiling.clone() {

--- a/components/reactions/profiler/src/profiler.rs
+++ b/components/reactions/profiler/src/profiler.rs
@@ -518,12 +518,7 @@ impl Reaction for ProfilerReaction {
                     _ = &mut shutdown_rx => {
                         break;
                     }
-                    query_result = priority_queue.dequeue() => {
-                        // Extract and store profiling data
-                        if let Some(profiling) = query_result.profiling.clone() {
-                            stats.write().await.add_sample(profiling);
-                        }
-                    }
+                    // Service a due report even when the result queue stays backlogged.
                     _ = report_timer.tick() => {
                         // Generate periodic report
                         let stats_guard = stats.read().await;
@@ -551,6 +546,12 @@ impl Reaction for ProfilerReaction {
                         info!("[{}] {}", reaction_name, Self::format_stats("Total End-to-End", &total));
 
                         info!("[{reaction_name}] ======================================");
+                    }
+                    query_result = priority_queue.dequeue() => {
+                        // Extract and store profiling data
+                        if let Some(profiling) = query_result.profiling.clone() {
+                            stats.write().await.add_sample(profiling);
+                        }
                     }
                 }
             }

--- a/components/reactions/profiler/src/profiler/tests.rs
+++ b/components/reactions/profiler/src/profiler/tests.rs
@@ -16,6 +16,92 @@ use super::*;
 use drasi_lib::channels::QueryResult;
 use std::time::Duration;
 
+struct ReportLogger {
+    first_report: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<String>>>,
+}
+
+impl log::Log for ReportLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.level() <= log::Level::Info
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        let message = record.args().to_string();
+        if message.starts_with("[profiler-report-fairness] Source") {
+            if let Some(tx) = self.first_report.lock().unwrap().take() {
+                tx.send(message).unwrap();
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+#[tokio::test]
+async fn a_due_report_is_not_starved_by_queued_results() {
+    static LOGGER: ReportLogger = ReportLogger {
+        first_report: std::sync::Mutex::new(None),
+    };
+    let (report_tx, report_rx) = tokio::sync::oneshot::channel();
+    *LOGGER.first_report.lock().unwrap() = Some(report_tx);
+    log::set_logger(&LOGGER).unwrap();
+    log::set_max_level(log::LevelFilter::Info);
+
+    let reaction = ProfilerReaction::new(
+        "profiler-report-fairness",
+        vec!["q1".to_string()],
+        ProfilerReactionConfig {
+            report_interval_secs: 1,
+            ..Default::default()
+        },
+    );
+    reaction.start().await.unwrap();
+    let held_stats = reaction.stats.write().await;
+    let mut result = QueryResult::new(
+        "q1".to_string(),
+        1,
+        chrono::Utc::now(),
+        vec![],
+        Default::default(),
+    );
+    result.profiling = Some(ProfilingMetadata::default());
+    reaction.enqueue_query_result(result.clone()).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while reaction.base.priority_queue.metrics().await.total_dequeued == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    for sequence in 2..=65 {
+        result.sequence = sequence;
+        reaction.enqueue_query_result(result.clone()).await.unwrap();
+    }
+    // The consumer is gated on its first sample. Let its real timer become due
+    // with a full backlog, then verify the report runs before another dequeue.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    drop(held_stats);
+    let report = tokio::time::timeout(Duration::from_secs(30), report_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while reaction.stats.read().await.count < 65 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), reaction.stop())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        report.ends_with("(n=1)"),
+        "report was delayed by backlog: {report}"
+    );
+}
+
 #[tokio::test]
 async fn stop_and_restart_reopens_the_result_queue() {
     let reaction = ProfilerReaction::new(

--- a/components/reactions/profiler/src/profiler/tests.rs
+++ b/components/reactions/profiler/src/profiler/tests.rs
@@ -12,8 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(test)]
-mod tests {
-    // Tests for profiler reaction module
-    // Currently empty - tests will be added as needed
+use super::*;
+use drasi_lib::channels::QueryResult;
+use std::time::Duration;
+
+#[tokio::test]
+async fn stop_and_restart_reopens_the_result_queue() {
+    let reaction = ProfilerReaction::new(
+        "profiler-restart",
+        vec!["q1".to_string()],
+        ProfilerReactionConfig::default(),
+    );
+    for sequence in [100, 1] {
+        reaction.start().await.unwrap();
+        reaction
+            .enqueue_query_result(QueryResult::new(
+                "q1".to_string(),
+                sequence,
+                chrono::Utc::now(),
+                vec![],
+                Default::default(),
+            ))
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !reaction.base.priority_queue.is_empty().await {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), reaction.stop())
+            .await
+            .expect("profiler must use graceful shutdown, not the two-second abort timeout")
+            .unwrap();
+        assert!(reaction.base.processing_task.read().await.is_none());
+        assert_eq!(reaction.status().await, ComponentStatus::Stopped);
+    }
 }

--- a/lib/src/channels/priority_queue.rs
+++ b/lib/src/channels/priority_queue.rs
@@ -583,6 +583,7 @@ mod tests {
     fn test_ordering_key_is_a_transitive_total_order() {
         let timestamp = Utc::now();
         let events: Vec<_> = (0..8)
+            .chain([u64::MAX - 1, u64::MAX])
             .map(|ordinal| {
                 PriorityQueueEvent::new(
                     create_test_event("same-payload", timestamp),

--- a/lib/src/channels/priority_queue.rs
+++ b/lib/src/channels/priority_queue.rs
@@ -21,21 +21,27 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
 
-/// Wrapper for priority queue events with timestamp-based ordering
+/// Wrapper for priority queue events with stable timestamp-based ordering
 #[derive(Clone)]
 struct PriorityQueueEvent<T>
 where
     T: Timestamped + Clone + Send + Sync + 'static,
 {
     event: Arc<T>,
+    ordering_timestamp: chrono::DateTime<chrono::Utc>,
+    ordinal: u64,
 }
 
 impl<T> PriorityQueueEvent<T>
 where
     T: Timestamped + Clone + Send + Sync + 'static,
 {
-    fn new(event: Arc<T>) -> Self {
-        Self { event }
+    fn new(event: Arc<T>, ordering_timestamp: chrono::DateTime<chrono::Utc>, ordinal: u64) -> Self {
+        Self {
+            event,
+            ordering_timestamp,
+            ordinal,
+        }
     }
 }
 
@@ -45,7 +51,7 @@ where
     T: Timestamped + Clone + Send + Sync + 'static,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.event.timestamp() == other.event.timestamp()
+        self.ordering_timestamp == other.ordering_timestamp && self.ordinal == other.ordinal
     }
 }
 
@@ -65,8 +71,11 @@ where
     T: Timestamped + Clone + Send + Sync + 'static,
 {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Reverse ordering for min-heap behavior (oldest first)
-        other.event.timestamp().cmp(&self.event.timestamp())
+        // Reverse a lexicographic key: equal timestamps retain insertion order.
+        other
+            .ordering_timestamp
+            .cmp(&self.ordering_timestamp)
+            .then_with(|| other.ordinal.cmp(&self.ordinal))
     }
 }
 
@@ -121,6 +130,10 @@ impl Default for PriorityQueueMetrics {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("priority queue generation is closed")]
+pub(crate) struct PriorityQueueClosed;
+
 /// Thread-safe generic priority queue for ordering events by timestamp
 ///
 /// # Backpressure and Dispatch Modes
@@ -162,6 +175,10 @@ where
     notify: Arc<Notify>,
     /// Maximum queue capacity (for backpressure)
     max_capacity: usize,
+    /// Even generations are open; odd generations are closed.
+    generation: Arc<AtomicU64>,
+    /// Stable insertion order, independent of resettable metrics.
+    next_ordinal: Arc<AtomicU64>,
     /// Metrics (using atomic operations for lock-free updates)
     metrics: Arc<PriorityQueueMetrics>,
 }
@@ -176,6 +193,8 @@ where
             heap: Arc::new(Mutex::new(BinaryHeap::new())),
             notify: Arc::new(Notify::new()),
             max_capacity,
+            generation: Arc::new(AtomicU64::new(0)),
+            next_ordinal: Arc::new(AtomicU64::new(0)),
             metrics: Arc::new(PriorityQueueMetrics::default()),
         }
     }
@@ -184,6 +203,10 @@ where
     /// Returns true if enqueued, false if queue is at capacity
     pub async fn enqueue(&self, event: Arc<T>) -> bool {
         let mut heap = self.heap.lock().await;
+
+        if self.generation() % 2 != 0 {
+            return false;
+        }
 
         // Check capacity
         if heap.len() >= self.max_capacity {
@@ -210,7 +233,9 @@ where
         }
 
         // Enqueue event
-        heap.push(PriorityQueueEvent::new(event));
+        let ordering_timestamp = event.timestamp();
+        let ordinal = self.next_ordinal.fetch_add(1, AtomicOrdering::Relaxed);
+        heap.push(PriorityQueueEvent::new(event, ordering_timestamp, ordinal));
 
         // Update metrics using atomic operations (lock-free)
         self.metrics
@@ -251,6 +276,23 @@ where
     /// WARNING: Do NOT use with Broadcast dispatch mode - will cause deadlock!
     /// In broadcast mode, use the non-blocking `enqueue()` method instead.
     pub async fn enqueue_wait(&self, event: Arc<T>) {
+        let ordering_timestamp = event.timestamp();
+        if self
+            .enqueue_wait_with_ordering_timestamp(event, ordering_timestamp, self.generation())
+            .await
+            .is_err()
+        {
+            debug!("Priority queue closed while enqueue was waiting");
+        }
+    }
+
+    /// Enqueue without changing the event's timestamp or serialized payload.
+    pub(crate) async fn enqueue_wait_with_ordering_timestamp(
+        &self,
+        event: Arc<T>,
+        ordering_timestamp: chrono::DateTime<chrono::Utc>,
+        generation: u64,
+    ) -> Result<(), PriorityQueueClosed> {
         loop {
             // Register notified future BEFORE acquiring lock to avoid race
             let notified = self.notify.notified();
@@ -258,10 +300,15 @@ where
 
             let mut heap = self.heap.lock().await;
 
+            if generation % 2 != 0 || self.generation() != generation {
+                return Err(PriorityQueueClosed);
+            }
+
             // Check if there's capacity
             if heap.len() < self.max_capacity {
                 // Space available - enqueue the event
-                heap.push(PriorityQueueEvent::new(event));
+                let ordinal = self.next_ordinal.fetch_add(1, AtomicOrdering::Relaxed);
+                heap.push(PriorityQueueEvent::new(event, ordering_timestamp, ordinal));
 
                 // Update metrics using atomic operations (lock-free)
                 self.metrics
@@ -291,7 +338,7 @@ where
                 // Notify waiting dequeuers
                 self.notify.notify_one();
 
-                return;
+                return Ok(());
             }
 
             // Queue is full - increment blocked count and wait
@@ -315,6 +362,26 @@ where
 
             // Wait for dequeue to create space
             notified.await;
+        }
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation.load(AtomicOrdering::Acquire)
+    }
+
+    /// Wake all blocked producers before waiting for a consumer or ordering lock.
+    pub(crate) async fn close(&self) {
+        let heap = self.heap.lock().await;
+        self.generation.fetch_or(1, AtomicOrdering::Release);
+        drop(heap);
+        self.notify.notify_waiters();
+    }
+
+    /// A new generation cannot accept sends that were waiting before closure.
+    pub(crate) async fn reopen(&self) {
+        let _heap = self.heap.lock().await;
+        if self.generation() % 2 != 0 {
+            self.generation.fetch_add(1, AtomicOrdering::Release);
         }
     }
 
@@ -418,6 +485,8 @@ where
         let events: Vec<Arc<T>> = heap.drain().map(|pq_event| pq_event.event).collect();
 
         self.metrics.current_depth.store(0, AtomicOrdering::Relaxed);
+        drop(heap);
+        self.notify.notify_waiters();
 
         debug!("Drained {} events from priority queue", events.len());
         events
@@ -433,6 +502,8 @@ where
             heap: Arc::clone(&self.heap),
             notify: Arc::clone(&self.notify),
             max_capacity: self.max_capacity,
+            generation: Arc::clone(&self.generation),
+            next_ordinal: Arc::clone(&self.next_ordinal),
             metrics: Arc::clone(&self.metrics),
         }
     }
@@ -486,6 +557,129 @@ mod tests {
 
         let dequeued3 = pq.try_dequeue().await.unwrap();
         assert_eq!(dequeued3.id, "event3"); // Newest
+    }
+
+    #[tokio::test]
+    async fn test_equal_timestamps_are_stable_across_enqueue_modes_and_metric_reset() {
+        let pq = PriorityQueue::new(10);
+        let timestamp = Utc::now();
+        for id in 0..8 {
+            let event = create_test_event(&id.to_string(), timestamp);
+            if id % 2 == 0 {
+                assert!(pq.enqueue(event).await);
+            } else {
+                pq.enqueue_wait(event).await;
+            }
+            if id == 3 {
+                pq.reset_metrics().await;
+            }
+        }
+        for id in 0..8 {
+            assert_eq!(pq.dequeue().await.id, id.to_string());
+        }
+    }
+
+    #[test]
+    fn test_ordering_key_is_a_transitive_total_order() {
+        let timestamp = Utc::now();
+        let events: Vec<_> = (0..8)
+            .map(|ordinal| {
+                PriorityQueueEvent::new(
+                    create_test_event("same-payload", timestamp),
+                    timestamp + chrono::Duration::milliseconds((ordinal % 3) as i64),
+                    ordinal,
+                )
+            })
+            .collect();
+        for a in &events {
+            for b in &events {
+                assert_eq!(a == b, a.cmp(b) == Ordering::Equal);
+                assert_eq!(a.partial_cmp(b), Some(a.cmp(b)));
+                assert_eq!(a.cmp(b), b.cmp(a).reverse());
+                for c in &events {
+                    if a <= b && b <= c {
+                        assert!(a <= c);
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_close_wakes_all_blocked_producers() {
+        let pq = PriorityQueue::new(1);
+        let timestamp = Utc::now();
+        pq.enqueue_wait(create_test_event("first", timestamp)).await;
+        let generation = pq.generation();
+        let mut senders = Vec::new();
+        for id in 0..4 {
+            let queue = pq.clone();
+            senders.push(tokio::spawn(async move {
+                queue
+                    .enqueue_wait_with_ordering_timestamp(
+                        create_test_event(&id.to_string(), timestamp),
+                        timestamp,
+                        generation,
+                    )
+                    .await
+            }));
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while pq.metrics().await.blocked_enqueue_count < 4 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        pq.close().await;
+        for sender in senders {
+            assert_eq!(
+                tokio::time::timeout(std::time::Duration::from_secs(1), sender)
+                    .await
+                    .unwrap()
+                    .unwrap(),
+                Err(PriorityQueueClosed)
+            );
+        }
+        assert!(!pq.enqueue(create_test_event("closed", timestamp)).await);
+        assert_eq!(pq.depth().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_reopen_rejects_an_old_waiter_before_it_observes_closure() {
+        let pq = PriorityQueue::new(1);
+        let timestamp = Utc::now();
+        pq.enqueue_wait(create_test_event("first", timestamp)).await;
+        let blocked = pq.enqueue_wait_with_ordering_timestamp(
+            create_test_event("stale", timestamp),
+            timestamp,
+            pq.generation(),
+        );
+        tokio::pin!(blocked);
+        assert!(futures::poll!(blocked.as_mut()).is_pending());
+
+        pq.close().await;
+        pq.drain().await;
+        pq.reopen().await;
+        assert_eq!(blocked.await, Err(PriorityQueueClosed));
+        assert!(pq.is_empty().await);
+        assert!(pq.enqueue(create_test_event("new", timestamp)).await);
+        assert_eq!(pq.dequeue().await.id, "new");
+    }
+
+    #[tokio::test]
+    async fn test_drain_wakes_blocked_producers_without_closing() {
+        let pq = PriorityQueue::new(1);
+        let timestamp = Utc::now();
+        pq.enqueue_wait(create_test_event("first", timestamp)).await;
+        let blocked = pq.enqueue_wait(create_test_event("second", timestamp));
+        tokio::pin!(blocked);
+        assert!(futures::poll!(blocked.as_mut()).is_pending());
+        pq.drain().await;
+        tokio::time::timeout(std::time::Duration::from_secs(1), blocked)
+            .await
+            .unwrap();
+        assert_eq!(pq.dequeue().await.id, "second");
     }
 
     #[tokio::test]

--- a/lib/src/queries/priority_queue.rs
+++ b/lib/src/queries/priority_queue.rs
@@ -83,6 +83,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_source_timestamps_remain_authoritative_with_stable_ties() {
+        let pq = PriorityQueue::new(10);
+        let timestamp = Utc::now();
+        let events = [
+            create_test_event("source1", timestamp + chrono::Duration::seconds(30)),
+            create_test_event("source2", timestamp + chrono::Duration::seconds(20)),
+            create_test_event("source1", timestamp + chrono::Duration::seconds(10)),
+            create_test_event("source3", timestamp + chrono::Duration::seconds(20)),
+        ];
+        for event in &events {
+            pq.enqueue_wait(event.clone()).await;
+        }
+        // Source queues still merge by the actual timestamp, even when a single
+        // source's clock goes backwards; only reaction queues clamp their keys.
+        for index in [2, 1, 3, 0] {
+            assert!(Arc::ptr_eq(&pq.dequeue().await, &events[index]));
+        }
+    }
+
+    #[tokio::test]
     async fn test_priority_queue_capacity() {
         let pq = PriorityQueue::new(2);
 

--- a/lib/src/reactions/common/base.rs
+++ b/lib/src/reactions/common/base.rs
@@ -57,6 +57,9 @@ struct QueryResultSequenceInversion {
 
 struct QuerySequenceCursor {
     last_observed: u64,
+    // Retained for this loop generation to distinguish unseen inversions from
+    // old duplicates. Space is O(disjoint forward gaps), not the gap widths or
+    // contiguous event count; evicting a gap would silently accept an inversion.
     missing: Vec<std::ops::Range<u64>>,
 }
 
@@ -599,8 +602,10 @@ impl ReactionBase {
     ///    (or 0 if no prior checkpoint exists for that query).
     /// 5. Breaks when `shutdown_rx` fires.
     ///
-    /// Previously unseen sequence regressions return an error rather than being
-    /// mistaken for replay duplicates. Ordered gaps remain valid.
+    /// Previously unseen sequence regressions close the queue generation, wake
+    /// blocked producers, publish `Error`, and return the inversion error rather
+    /// than treating it as a replay duplicate. This fences ingress but does not
+    /// abort host-owned subscription tasks. Ordered gaps remain valid.
     ///
     /// # Arguments
     /// * `shutdown_rx` — receiver created via [`create_shutdown_channel`].
@@ -635,12 +640,24 @@ impl ReactionBase {
             let query_id = &event.query_id;
             let seq = event.sequence;
 
-            sequences
+            if let Err(e) = sequences
                 .entry(query_id.clone())
                 .or_insert_with(|| {
                     QuerySequenceCursor::new(checkpoints.get(query_id).map_or(0, |cp| cp.sequence))
                 })
-                .observe(query_id, seq)?;
+                .observe(query_id, seq)
+            {
+                // Fence producers before reporting failure; do not join this
+                // processing task from itself through stop_common().
+                self.priority_queue.close().await;
+                error!("[{}] Stopping result processing: {e}", self.id);
+                self.set_status(
+                    ComponentStatus::Error,
+                    Some(format!("Result processing stopped: {e}")),
+                )
+                .await;
+                return Err(e);
+            }
 
             // Dedup: skip events at or before the checkpoint.
             if let Some(cp) = checkpoints.get(query_id) {
@@ -736,23 +753,37 @@ mod tests {
                 })
                 .await
         });
-        tokio::time::timeout(Duration::from_secs(2), async {
+        finish_queued_loop(base, expected_dequeued, task).await;
+        let results = processed.lock().await.clone();
+        results
+    }
+
+    async fn finish_queued_loop(
+        base: &ReactionBase,
+        expected_dequeued: u64,
+        mut task: tokio::task::JoinHandle<Result<()>>,
+    ) {
+        // Dequeue completion includes skipped replay inputs. Joining the actual
+        // loop also waits for the final handler and checkpoint, not just its pop.
+        let completed = tokio::time::timeout(Duration::from_secs(30), async {
             while base.priority_queue.metrics().await.total_dequeued < expected_dequeued
                 && !task.is_finished()
             {
                 tokio::task::yield_now().await;
             }
+            base.stop_common().await.unwrap();
+            (&mut task).await.unwrap().unwrap();
         })
-        .await
-        .unwrap();
-        base.stop_common().await.unwrap();
-        tokio::time::timeout(Duration::from_secs(2), task)
-            .await
-            .unwrap()
-            .unwrap()
-            .unwrap();
-        let results = processed.lock().await.clone();
-        results
+        .await;
+        if completed.is_err() {
+            task.abort();
+            let _ = task.await;
+            panic!(
+                "queue/handler/checkpoint completion timed out: expected {expected_dequeued} \
+                 dequeued inputs, metrics={:?}",
+                base.priority_queue.metrics().await
+            );
+        }
     }
 
     #[tokio::test]
@@ -902,48 +933,178 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unseen_sequence_inversion_returns_typed_error_without_skipping_ahead() {
-        let base = store_backed_base("inversion").await;
+    async fn test_unseen_inversion_fences_running_generation_and_allows_cleanup_restart() {
+        use crate::channels::priority_queue::PriorityQueueClosed;
+        use crate::component_graph::{ComponentGraph, ComponentUpdate};
+
+        let (mut graph, mut updates) = ComponentGraph::new("test-instance");
+        graph.register_query("q1", HashMap::new(), &[]).unwrap();
+        graph
+            .register_reaction("inversion", HashMap::new(), &["q1".to_string()])
+            .unwrap();
+        let base = ReactionBase::new(
+            ReactionBaseParams::new("inversion", vec!["q1".to_string()])
+                .with_priority_queue_capacity(2),
+        );
+        base.initialize(ReactionRuntimeContext::new(
+            "test-instance",
+            "inversion",
+            Some(Arc::new(crate::state_store::MemoryStateStoreProvider::new())),
+            graph.update_sender(),
+            None,
+        ))
+        .await;
+        for status in [ComponentStatus::Starting, ComponentStatus::Running] {
+            base.set_status(status, None).await;
+            graph.apply_update(updates.recv().await.unwrap());
+        }
+        assert_eq!(base.get_status().await, ComponentStatus::Running);
+        assert_eq!(
+            graph.get_component("inversion").unwrap().status,
+            ComponentStatus::Running
+        );
+
+        base.write_checkpoint(
+            "q1",
+            &ReactionCheckpoint {
+                sequence: 5,
+                config_hash: 42,
+            },
+        )
+        .await
+        .unwrap();
+        let checkpoints = base.read_all_checkpoints().await.unwrap();
         let shutdown_rx = base.create_shutdown_channel().await;
-        for (sequence, timestamp) in [(7, 10), (6, 20), (8, 30)] {
+        for (sequence, timestamp) in [(7, 10), (6, 20)] {
             base.enqueue_query_result(query_result("q1", sequence, timestamp))
                 .await
                 .unwrap();
         }
-        let checkpoints = HashMap::from([(
-            "q1".to_string(),
-            ReactionCheckpoint {
-                sequence: 5,
-                config_hash: 42,
-            },
-        )]);
-        let processed = Mutex::new(Vec::new());
-        let error = tokio::time::timeout(
-            Duration::from_secs(2),
-            base.run_standard_loop(shutdown_rx, checkpoints, |event| {
-                let processed = &processed;
-                async move {
-                    processed.lock().await.push(event.sequence);
-                    Ok(())
-                }
-            }),
-        )
-        .await
-        .unwrap()
-        .unwrap_err();
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let processed = Arc::new(Mutex::new(Vec::new()));
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        let loop_base = base.clone_shared();
+        let loop_entered = entered.clone();
+        let loop_release = release.clone();
+        let loop_processed = processed.clone();
+        base.set_processing_task(tokio::spawn(async move {
+            let result = loop_base
+                .run_standard_loop(shutdown_rx, checkpoints, |event| {
+                    let entered = loop_entered.clone();
+                    let release = loop_release.clone();
+                    let processed = loop_processed.clone();
+                    async move {
+                        processed.lock().await.push(event.sequence);
+                        entered.notify_one();
+                        release.notified().await;
+                        Ok(())
+                    }
+                })
+                .await;
+            result_tx.send(result).unwrap();
+        }))
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(2), entered.notified())
+            .await
+            .unwrap();
+        base.enqueue_query_result(query_result("q1", 8, 30))
+            .await
+            .unwrap();
+        // Poll both producers to Pending while the handler is gated: one owns
+        // the ordering lock and waits for capacity, the other waits for that lock.
+        let blocked = base.enqueue_query_result(query_result("q1", 9, 40));
+        tokio::pin!(blocked);
+        assert!(futures::poll!(blocked.as_mut()).is_pending());
+        let waiting = base.enqueue_query_result(query_result("q1", 10, 50));
+        tokio::pin!(waiting);
+        assert!(futures::poll!(waiting.as_mut()).is_pending());
+        assert_eq!(base.priority_queue.depth().await, 2);
+        release.notify_one();
+
+        let error = tokio::time::timeout(Duration::from_secs(2), result_rx)
+            .await
+            .expect("the registered consumer must fail without trying to join itself")
+            .unwrap()
+            .unwrap_err();
         let inversion = error
             .downcast_ref::<QueryResultSequenceInversion>()
             .unwrap();
         assert_eq!(inversion.query_id, "q1");
         assert_eq!(inversion.received, 6);
         assert_eq!(inversion.last_observed, 7);
+        assert_eq!(base.get_status().await, ComponentStatus::Error);
+        let update = tokio::time::timeout(Duration::from_secs(2), updates.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let ComponentUpdate::Status {
+            status, message, ..
+        } = &update;
+        assert_eq!(*status, ComponentStatus::Error);
+        assert!(message.as_ref().unwrap().contains(&error.to_string()));
+        graph.apply_update(update);
+        assert_eq!(
+            graph.get_component("inversion").unwrap().status,
+            ComponentStatus::Error
+        );
+        let (blocked, waiting) = tokio::time::timeout(Duration::from_secs(2), async {
+            tokio::join!(blocked, waiting)
+        })
+        .await
+        .expect("an inversion must fence capacity and ordering waiters");
+        for result in [blocked, waiting] {
+            assert!(result.unwrap_err().is::<PriorityQueueClosed>());
+        }
+        assert!(base
+            .enqueue_query_result(query_result("q1", 11, 60))
+            .await
+            .unwrap_err()
+            .is::<PriorityQueueClosed>());
         assert_eq!(*processed.lock().await, vec![7]);
         assert_eq!(
-            base.read_checkpoint("q1").await.unwrap().unwrap().sequence,
-            7
+            base.read_checkpoint("q1").await.unwrap().unwrap(),
+            ReactionCheckpoint {
+                sequence: 7,
+                config_hash: 42
+            }
         );
-        assert_eq!(base.priority_queue.dequeue().await.sequence, 8);
-        base.stop_common().await.unwrap();
+        assert_eq!(base.priority_queue.depth().await, 1);
+
+        tokio::time::timeout(Duration::from_secs(2), base.stop_common())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(base.processing_task.read().await.is_none());
+        assert!(base.priority_queue.is_empty().await);
+        assert!(base.result_ordering.lock().await.is_empty());
+        let shutdown_rx = base.create_shutdown_channel().await;
+        base.set_status(ComponentStatus::Starting, None).await;
+        base.set_status(ComponentStatus::Running, None).await;
+        let checkpoints = base.read_all_checkpoints().await.unwrap();
+        base.enqueue_query_result(query_result("q1", 7, 1))
+            .await
+            .unwrap();
+        base.enqueue_query_result(query_result("q1", 8, 0))
+            .await
+            .unwrap();
+        let restarted = collect_queued_results(&base, shutdown_rx, checkpoints).await;
+        assert_eq!(
+            restarted
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            vec![8]
+        );
+        assert_eq!(
+            base.read_checkpoint("q1").await.unwrap().unwrap(),
+            ReactionCheckpoint {
+                sequence: 8,
+                config_hash: 42
+            }
+        );
     }
 
     #[test]
@@ -958,6 +1119,36 @@ mod tests {
                 .unwrap_err()
                 .is::<QueryResultSequenceInversion>());
         }
+    }
+
+    #[test]
+    fn test_sequence_cursor_retains_one_range_per_gap_not_per_missing_sequence() {
+        let mut cursor = QuerySequenceCursor::new(0);
+        for sequence in 0..=100_000 {
+            cursor.observe("q1", sequence).unwrap();
+        }
+        assert_eq!(cursor.missing.capacity(), 0);
+
+        for sequence in (100_002..=108_192).step_by(2) {
+            cursor.observe("q1", sequence).unwrap();
+        }
+        assert_eq!(cursor.missing.len(), 4_096);
+        cursor.observe("q1", u64::MAX).unwrap();
+        assert_eq!(cursor.missing.len(), 4_097);
+        assert_eq!(cursor.missing.last().unwrap(), &(108_193..u64::MAX));
+        for sequence in [0, 100_000, 100_002, 108_192, u64::MAX] {
+            cursor.observe("q1", sequence).unwrap();
+        }
+        assert_eq!(cursor.missing.len(), 4_097);
+        for sequence in [100_001, 108_191, u64::MAX - 1] {
+            assert!(cursor.observe("q1", sequence).is_err());
+        }
+
+        let mut restarted = QuerySequenceCursor::new(u64::MAX);
+        for sequence in [0, 1, u64::MAX - 1, u64::MAX] {
+            restarted.observe("q1", sequence).unwrap();
+        }
+        assert_eq!(restarted.missing.capacity(), 0);
     }
 
     #[tokio::test]
@@ -1530,6 +1721,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_loop_completion_waits_for_the_final_handler_and_checkpoint() {
+        let base = store_backed_base("delayed-completion").await;
+        let checkpoint = ReactionCheckpoint {
+            sequence: 5,
+            config_hash: 42,
+        };
+        base.write_checkpoint("q1", &checkpoint).await.unwrap();
+        let checkpoints = HashMap::from([("q1".to_string(), checkpoint)]);
+        let shutdown_rx = base.create_shutdown_channel().await;
+        for sequence in [6, 7] {
+            base.enqueue_query_result(query_result("q1", sequence, 100))
+                .await
+                .unwrap();
+        }
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let processed = Arc::new(Mutex::new(Vec::new()));
+        let loop_base = base.clone_shared();
+        let loop_entered = entered.clone();
+        let loop_release = release.clone();
+        let loop_processed = processed.clone();
+        let task = tokio::spawn(async move {
+            loop_base
+                .run_standard_loop(shutdown_rx, checkpoints, |event| {
+                    let entered = loop_entered.clone();
+                    let release = loop_release.clone();
+                    let processed = loop_processed.clone();
+                    async move {
+                        if event.sequence == 7 {
+                            entered.notify_one();
+                            release.notified().await;
+                        }
+                        processed.lock().await.push(event.sequence);
+                        Ok(())
+                    }
+                })
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(30), entered.notified())
+            .await
+            .unwrap();
+        assert_eq!(base.priority_queue.metrics().await.total_dequeued, 2);
+        let completed = finish_queued_loop(&base, 2, task);
+        tokio::pin!(completed);
+        assert!(
+            futures::poll!(completed.as_mut()).is_pending(),
+            "completion must wait for the handler, even after every input was dequeued"
+        );
+        assert_eq!(*processed.lock().await, vec![6]);
+        assert_eq!(
+            base.read_checkpoint("q1").await.unwrap().unwrap().sequence,
+            6
+        );
+        release.notify_one();
+        completed.await;
+        assert_eq!(*processed.lock().await, vec![6, 7]);
+        assert_eq!(
+            base.read_checkpoint("q1").await.unwrap().unwrap(),
+            ReactionCheckpoint {
+                sequence: 7,
+                config_hash: 42
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn test_run_standard_loop_dedup_and_checkpoint() {
         assert_standard_loop_sequence_order([0, 1, 2, 2]).await;
     }
@@ -1546,22 +1803,8 @@ mod tests {
 
     async fn assert_standard_loop_sequence_order(timestamp_offsets: [i64; 4]) {
         for iteration in 0..100 {
-            let (graph, _rx) = crate::component_graph::ComponentGraph::new("test-instance");
-            let base = ReactionBase::new(ReactionBaseParams::new(
-                "loop-reaction",
-                vec!["q1".to_string()],
-            ));
-            let store = Arc::new(crate::state_store::MemoryStateStoreProvider::new());
-            base.initialize(ReactionRuntimeContext::new(
-                "test-instance",
-                "loop-reaction",
-                Some(store),
-                graph.update_sender(),
-                None,
-            ))
-            .await;
-
-            let initial_checkpoints = std::collections::HashMap::from([(
+            let base = store_backed_base("loop-reaction").await;
+            let initial_checkpoints = HashMap::from([(
                 "q1".to_string(),
                 ReactionCheckpoint {
                     sequence: 5,
@@ -1572,50 +1815,20 @@ mod tests {
 
             // Queue the whole batch before starting the real checkpointing loop.
             for (seq, offset) in [3u64, 5, 6, 7].into_iter().zip(timestamp_offsets) {
-                let result = QueryResult::new(
-                    "q1".to_string(),
-                    seq,
-                    chrono::DateTime::from_timestamp_millis(1_000 + offset).unwrap(),
-                    vec![],
-                    Default::default(),
-                );
-                base.enqueue_query_result(result).await.unwrap();
+                base.enqueue_query_result(query_result("q1", seq, 1_000 + offset))
+                    .await
+                    .unwrap();
             }
 
-            let processed = Arc::new(tokio::sync::Mutex::new(Vec::<u64>::new()));
-            let processed_clone = processed.clone();
-            let base_clone = base.clone_shared();
-            let loop_handle = tokio::spawn(async move {
-                base_clone
-                    .run_standard_loop(shutdown_rx, initial_checkpoints, |event| {
-                        let processed = processed_clone.clone();
-                        async move {
-                            processed.lock().await.push(event.sequence);
-                            Ok(())
-                        }
-                    })
-                    .await
-            });
-
-            tokio::time::timeout(Duration::from_secs(2), async {
-                while base.priority_queue.metrics().await.total_dequeued < 4 {
-                    tokio::task::yield_now().await;
-                }
-            })
-            .await
-            .expect("the loop must dequeue every event, including replay duplicates");
-            base.stop_common().await.unwrap();
-            tokio::time::timeout(Duration::from_secs(2), loop_handle)
-                .await
-                .unwrap()
-                .unwrap()
-                .unwrap();
-
+            let processed = collect_queued_results(&base, shutdown_rx, initial_checkpoints).await;
             let cp = base.read_checkpoint("q1").await.unwrap().unwrap();
             assert_eq!(cp.sequence, 7);
             assert_eq!(cp.config_hash, 42);
             assert_eq!(
-                *processed.lock().await,
+                processed
+                    .iter()
+                    .map(|event| event.sequence)
+                    .collect::<Vec<_>>(),
                 vec![6, 7],
                 "lost a new result on iteration {iteration} after checkpointing seq={}",
                 cp.sequence

--- a/lib/src/reactions/common/base.rs
+++ b/lib/src/reactions/common/base.rs
@@ -31,8 +31,9 @@
 
 use anyhow::Result;
 use log::{debug, error, info, warn};
+use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::Instrument;
 
 use crate::channels::priority_queue::PriorityQueue;
@@ -43,6 +44,57 @@ use crate::identity::IdentityProvider;
 use crate::reactions::checkpoint::ReactionCheckpoint;
 use crate::recovery::ReactionRecoveryPolicy;
 use crate::state_store::StateStoreProvider;
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "query result sequence inversion for query '{query_id}': received sequence {received} after {last_observed}"
+)]
+struct QueryResultSequenceInversion {
+    query_id: String,
+    received: u64,
+    last_observed: u64,
+}
+
+struct QuerySequenceCursor {
+    last_observed: u64,
+    missing: Vec<std::ops::Range<u64>>,
+}
+
+impl QuerySequenceCursor {
+    fn new(checkpoint: u64) -> Self {
+        Self {
+            last_observed: checkpoint,
+            missing: Vec::new(),
+        }
+    }
+
+    fn observe(&mut self, query_id: &str, sequence: u64) -> Result<()> {
+        if sequence > self.last_observed {
+            let next = self.last_observed + 1;
+            if sequence > next {
+                self.missing.push(next..sequence);
+            }
+            self.last_observed = sequence;
+        } else {
+            // Retain only gaps, not every delivered sequence: old checkpoint
+            // replays and previously observed duplicates must remain valid.
+            let index = self.missing.partition_point(|range| range.end <= sequence);
+            if self
+                .missing
+                .get(index)
+                .is_some_and(|range| range.contains(&sequence))
+            {
+                return Err(QueryResultSequenceInversion {
+                    query_id: query_id.to_string(),
+                    received: sequence,
+                    last_observed: self.last_observed,
+                }
+                .into());
+            }
+        }
+        Ok(())
+    }
+}
 
 /// Parameters for creating a ReactionBase instance.
 ///
@@ -121,8 +173,10 @@ pub struct ReactionBase {
     context: Arc<RwLock<Option<ReactionRuntimeContext>>>,
     /// State store provider (extracted from context for convenience)
     state_store: Arc<RwLock<Option<Arc<dyn StateStoreProvider>>>>,
-    /// Priority queue for timestamp-ordered result processing
+    /// Priority queue for result processing
     pub priority_queue: PriorityQueue<QueryResult>,
+    /// Per-query effective timestamps; never written into QueryResult payloads.
+    result_ordering: Arc<Mutex<HashMap<String, chrono::DateTime<chrono::Utc>>>>,
     /// Handles to subscription forwarder tasks
     pub subscription_tasks: Arc<RwLock<Vec<tokio::task::JoinHandle<()>>>>,
     /// Handle to the main processing task
@@ -146,6 +200,7 @@ impl ReactionBase {
     pub fn new(params: ReactionBaseParams) -> Self {
         Self {
             priority_queue: PriorityQueue::new(params.priority_queue_capacity.unwrap_or(10000)),
+            result_ordering: Arc::new(Mutex::new(HashMap::new())),
             id: params.id.clone(),
             queries: params.queries,
             auto_start: params.auto_start,
@@ -272,6 +327,7 @@ impl ReactionBase {
             context: self.context.clone(),
             state_store: self.state_store.clone(),
             priority_queue: self.priority_queue.clone(),
+            result_ordering: self.result_ordering.clone(),
             subscription_tasks: self.subscription_tasks.clone(),
             processing_task: self.processing_task.clone(),
             shutdown_tx: self.shutdown_tx.clone(),
@@ -285,10 +341,29 @@ impl ReactionBase {
     /// Returns the receiver which should be passed to the processing task.
     /// The sender is stored internally and will be triggered by `stop_common()`.
     ///
-    /// This should be called before spawning the processing task.
+    /// Call this once per start, before spawning the processing task. A previous
+    /// processing generation is stopped and its pending results are discarded.
     pub async fn create_shutdown_channel(&self) -> tokio::sync::oneshot::Receiver<()> {
+        let mut shutdown_tx = self.shutdown_tx.write().await;
+        let previous_generation = self.processing_task.read().await.is_some()
+            || shutdown_tx.as_ref().is_some_and(|tx| tx.is_closed());
+        if previous_generation {
+            self.priority_queue.close().await;
+            if let Some(tx) = shutdown_tx.take() {
+                let _ = tx.send(());
+            }
+            if let Some(task) = self.processing_task.write().await.take() {
+                task.abort();
+                if let Err(e) = task.await {
+                    debug!("[{}] Previous processing task ended: {}", self.id, e);
+                }
+            }
+            self.drain_pending_results().await;
+        }
+        self.priority_queue.reopen().await;
+
         let (tx, rx) = tokio::sync::oneshot::channel();
-        *self.shutdown_tx.write().await = Some(tx);
+        *shutdown_tx = Some(tx);
         rx
     }
 
@@ -325,9 +400,22 @@ impl ReactionBase {
     /// Enqueue a query result for processing.
     ///
     /// The host calls this to forward query results to the reaction's priority queue.
-    /// Results are processed in timestamp order by the reaction's processing task.
+    /// Each query retains its incoming sequence order. Across queries, effective
+    /// timestamps are merged, with insertion order breaking ties.
     pub async fn enqueue_query_result(&self, result: QueryResult) -> anyhow::Result<()> {
-        self.priority_queue.enqueue_wait(Arc::new(result)).await;
+        // Capture the generation before waiting for the ordering lock so a
+        // sender cannot carry an old result across a stop/restart boundary.
+        let generation = self.priority_queue.generation();
+        let mut ordering = self.result_ordering.lock().await;
+        let timestamp = result.timestamp;
+        let query_id = result.query_id.clone();
+        let ordering_timestamp = ordering
+            .get(&query_id)
+            .map_or(timestamp, |last| (*last).max(timestamp));
+        self.priority_queue
+            .enqueue_wait_with_ordering_timestamp(Arc::new(result), ordering_timestamp, generation)
+            .await?;
+        ordering.insert(query_id, ordering_timestamp);
         Ok(())
     }
 
@@ -402,6 +490,9 @@ impl ReactionBase {
     pub async fn stop_common(&self) -> Result<()> {
         info!("Stopping reaction: {}", self.id);
 
+        // A producer can hold result_ordering while waiting for queue capacity.
+        self.priority_queue.close().await;
+
         // Send shutdown signal to processing task (if it's using tokio::select!)
         if let Some(tx) = self.shutdown_tx.write().await.take() {
             let _ = tx.send(());
@@ -433,20 +524,13 @@ impl ReactionBase {
                         self.id
                     );
                     task.abort();
+                    let _ = task.await;
                 }
             }
         }
         drop(processing_task);
 
-        // Drain the priority queue
-        let drained_events = self.priority_queue.drain().await;
-        if !drained_events.is_empty() {
-            info!(
-                "[{}] Drained {} pending events from priority queue",
-                self.id,
-                drained_events.len()
-            );
-        }
+        self.drain_pending_results().await;
 
         self.set_status(
             ComponentStatus::Stopped,
@@ -456,6 +540,19 @@ impl ReactionBase {
         info!("Reaction '{}' stopped", self.id);
 
         Ok(())
+    }
+
+    async fn drain_pending_results(&self) {
+        let mut ordering = self.result_ordering.lock().await;
+        let drained_events = self.priority_queue.drain().await;
+        if !drained_events.is_empty() {
+            info!(
+                "[{}] Drained {} pending events from priority queue",
+                self.id,
+                drained_events.len()
+            );
+        }
+        ordering.clear();
     }
 
     /// Clear the reaction's state store partition.
@@ -502,6 +599,9 @@ impl ReactionBase {
     ///    (or 0 if no prior checkpoint exists for that query).
     /// 5. Breaks when `shutdown_rx` fires.
     ///
+    /// Previously unseen sequence regressions return an error rather than being
+    /// mistaken for replay duplicates. Ordered gaps remain valid.
+    ///
     /// # Arguments
     /// * `shutdown_rx` — receiver created via [`create_shutdown_channel`].
     /// * `initial_checkpoints` — pre-loaded checkpoint map (from bootstrap
@@ -521,6 +621,7 @@ impl ReactionBase {
         Fut: std::future::Future<Output = Result<()>> + Send,
     {
         let mut checkpoints = initial_checkpoints;
+        let mut sequences = HashMap::new();
 
         loop {
             let event = tokio::select! {
@@ -533,6 +634,13 @@ impl ReactionBase {
 
             let query_id = &event.query_id;
             let seq = event.sequence;
+
+            sequences
+                .entry(query_id.clone())
+                .or_insert_with(|| {
+                    QuerySequenceCursor::new(checkpoints.get(query_id).map_or(0, |cp| cp.sequence))
+                })
+                .observe(query_id, seq)?;
 
             // Dedup: skip events at or before the checkpoint.
             if let Some(cp) = checkpoints.get(query_id) {
@@ -579,6 +687,73 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
     use tokio::sync::mpsc;
+
+    fn query_result(query_id: &str, sequence: u64, timestamp: i64) -> QueryResult {
+        QueryResult::new(
+            query_id.to_string(),
+            sequence,
+            chrono::DateTime::from_timestamp_millis(timestamp).unwrap(),
+            vec![],
+            Default::default(),
+        )
+    }
+
+    async fn store_backed_base(id: &str) -> ReactionBase {
+        let (graph, _rx) = crate::component_graph::ComponentGraph::new("test-instance");
+        let base = ReactionBase::new(ReactionBaseParams::new(
+            id,
+            vec!["q1".to_string(), "q2".to_string(), "q3".to_string()],
+        ));
+        base.initialize(ReactionRuntimeContext::new(
+            "test-instance",
+            id,
+            Some(Arc::new(crate::state_store::MemoryStateStoreProvider::new())),
+            graph.update_sender(),
+            None,
+        ))
+        .await;
+        base
+    }
+
+    async fn collect_queued_results(
+        base: &ReactionBase,
+        shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+        checkpoints: HashMap<String, ReactionCheckpoint>,
+    ) -> Vec<Arc<QueryResult>> {
+        let expected_dequeued = base.priority_queue.metrics().await.total_dequeued
+            + base.priority_queue.depth().await as u64;
+        let processed = Arc::new(Mutex::new(Vec::new()));
+        let processed_clone = processed.clone();
+        let base_clone = base.clone_shared();
+        let task = tokio::spawn(async move {
+            base_clone
+                .run_standard_loop(shutdown_rx, checkpoints, |event| {
+                    let processed = processed_clone.clone();
+                    async move {
+                        processed.lock().await.push(event);
+                        Ok(())
+                    }
+                })
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while base.priority_queue.metrics().await.total_dequeued < expected_dequeued
+                && !task.is_finished()
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        base.stop_common().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let results = processed.lock().await.clone();
+        results
+    }
 
     #[tokio::test]
     async fn test_reaction_base_creation() {
@@ -647,6 +822,325 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_multi_query_order_preserves_query_result_bytes() {
+        let base = store_backed_base("multi-query").await;
+        let shutdown_rx = base.create_shutdown_channel().await;
+        let results = [
+            query_result("q1", 6, 30),
+            query_result("q2", 1, 20),
+            query_result("q1", 7, 10),
+            query_result("q3", 1, 30),
+            query_result("q2", 2, 30),
+        ];
+        let wire_bytes: Vec<_> = results
+            .iter()
+            .map(|result| rmp_serde::to_vec_named(result).unwrap())
+            .collect();
+        let persisted_bytes: Vec<_> = results
+            .iter()
+            .map(|result| bincode::serialize(result).unwrap())
+            .collect();
+        let shared = base.clone_shared();
+        for (index, result) in results.into_iter().enumerate() {
+            let producer = if index % 2 == 0 { &base } else { &shared };
+            producer.enqueue_query_result(result).await.unwrap();
+        }
+
+        let processed = collect_queued_results(&base, shutdown_rx, HashMap::new()).await;
+        assert_eq!(processed.len(), 5);
+        for (result, index) in processed.iter().zip([1, 0, 2, 3, 4]) {
+            assert_eq!(
+                rmp_serde::to_vec_named(result.as_ref()).unwrap(),
+                wire_bytes[index]
+            );
+            assert_eq!(
+                bincode::serialize(result.as_ref()).unwrap(),
+                persisted_bytes[index]
+            );
+        }
+        assert_eq!(
+            base.read_checkpoint("q1").await.unwrap().unwrap().sequence,
+            7
+        );
+        assert_eq!(
+            base.read_checkpoint("q2").await.unwrap().unwrap().sequence,
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn test_replays_below_checkpoint_and_earlier_deliveries_are_still_skipped() {
+        let base = store_backed_base("replay").await;
+        let shutdown_rx = base.create_shutdown_channel().await;
+        let checkpoints = HashMap::from([(
+            "q1".to_string(),
+            ReactionCheckpoint {
+                sequence: 5,
+                config_hash: 42,
+            },
+        )]);
+        for sequence in [5, 3, 6, 7, 6, 4, 7, 8] {
+            base.enqueue_query_result(query_result("q1", sequence, 100))
+                .await
+                .unwrap();
+        }
+        let processed = collect_queued_results(&base, shutdown_rx, checkpoints).await;
+        assert_eq!(
+            processed
+                .iter()
+                .map(|result| result.sequence)
+                .collect::<Vec<_>>(),
+            vec![6, 7, 8]
+        );
+        assert_eq!(
+            base.read_checkpoint("q1").await.unwrap().unwrap(),
+            ReactionCheckpoint {
+                sequence: 8,
+                config_hash: 42,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unseen_sequence_inversion_returns_typed_error_without_skipping_ahead() {
+        let base = store_backed_base("inversion").await;
+        let shutdown_rx = base.create_shutdown_channel().await;
+        for (sequence, timestamp) in [(7, 10), (6, 20), (8, 30)] {
+            base.enqueue_query_result(query_result("q1", sequence, timestamp))
+                .await
+                .unwrap();
+        }
+        let checkpoints = HashMap::from([(
+            "q1".to_string(),
+            ReactionCheckpoint {
+                sequence: 5,
+                config_hash: 42,
+            },
+        )]);
+        let processed = Mutex::new(Vec::new());
+        let error = tokio::time::timeout(
+            Duration::from_secs(2),
+            base.run_standard_loop(shutdown_rx, checkpoints, |event| {
+                let processed = &processed;
+                async move {
+                    processed.lock().await.push(event.sequence);
+                    Ok(())
+                }
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap_err();
+        let inversion = error
+            .downcast_ref::<QueryResultSequenceInversion>()
+            .unwrap();
+        assert_eq!(inversion.query_id, "q1");
+        assert_eq!(inversion.received, 6);
+        assert_eq!(inversion.last_observed, 7);
+        assert_eq!(*processed.lock().await, vec![7]);
+        assert_eq!(
+            base.read_checkpoint("q1").await.unwrap().unwrap().sequence,
+            7
+        );
+        assert_eq!(base.priority_queue.dequeue().await.sequence, 8);
+        base.stop_common().await.unwrap();
+    }
+
+    #[test]
+    fn test_sequence_cursor_accepts_gaps_replays_and_u64_max() {
+        let mut cursor = QuerySequenceCursor::new(5);
+        for sequence in [3, 5, 7, 9, 7, 3, u64::MAX, 9, u64::MAX] {
+            cursor.observe("q1", sequence).unwrap();
+        }
+        for sequence in [6, 8, u64::MAX - 1] {
+            assert!(cursor
+                .observe("q1", sequence)
+                .unwrap_err()
+                .is::<QueryResultSequenceInversion>());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stop_wakes_capacity_and_ordering_waiters() {
+        let base = ReactionBase::new(
+            ReactionBaseParams::new("full-queue", vec!["q1".to_string()])
+                .with_priority_queue_capacity(1),
+        );
+        let _shutdown_rx = base.create_shutdown_channel().await;
+        base.enqueue_query_result(query_result("q1", 100, 100))
+            .await
+            .unwrap();
+        let blocked = base.enqueue_query_result(query_result("q1", 101, 101));
+        tokio::pin!(blocked);
+        assert!(futures::poll!(blocked.as_mut()).is_pending());
+        let waiting = base.enqueue_query_result(query_result("q2", 1, 1));
+        tokio::pin!(waiting);
+        assert!(futures::poll!(waiting.as_mut()).is_pending());
+
+        let (stopped, blocked, waiting) = tokio::time::timeout(Duration::from_secs(1), async {
+            tokio::join!(base.stop_common(), blocked, waiting)
+        })
+        .await
+        .expect("stop must close the queue before acquiring the ordering lock");
+        stopped.unwrap();
+        for result in [blocked, waiting] {
+            assert!(result
+                .unwrap_err()
+                .is::<crate::channels::priority_queue::PriorityQueueClosed>());
+        }
+        assert!(base.priority_queue.is_empty().await);
+        assert!(base.result_ordering.lock().await.is_empty());
+        assert!(base
+            .enqueue_query_result(query_result("q1", 102, 102))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_restarting_a_full_failed_generation_wakes_old_senders() {
+        let base = ReactionBase::new(
+            ReactionBaseParams::new("full-restart", vec![]).with_priority_queue_capacity(1),
+        );
+        let shutdown = base.create_shutdown_channel().await;
+        let consumer = tokio::spawn(async move {
+            let _ = shutdown.await;
+        });
+        let old_consumer = consumer.abort_handle();
+        base.set_processing_task(consumer).await;
+        base.enqueue_query_result(query_result("q1", 100, 100))
+            .await
+            .unwrap();
+        let blocked = base.enqueue_query_result(query_result("q1", 101, 101));
+        tokio::pin!(blocked);
+        assert!(futures::poll!(blocked.as_mut()).is_pending());
+        let waiting = base.enqueue_query_result(query_result("q1", 102, 102));
+        tokio::pin!(waiting);
+        assert!(futures::poll!(waiting.as_mut()).is_pending());
+
+        let (_new_shutdown, blocked, waiting) =
+            tokio::time::timeout(Duration::from_secs(1), async {
+                tokio::join!(base.create_shutdown_channel(), blocked, waiting)
+            })
+            .await
+            .expect("restart must close the old generation before waiting for its senders");
+        for result in [blocked, waiting] {
+            assert!(result
+                .unwrap_err()
+                .is::<crate::channels::priority_queue::PriorityQueueClosed>());
+        }
+        assert!(old_consumer.is_finished());
+        assert!(base.priority_queue.is_empty().await);
+        assert!(base.result_ordering.lock().await.is_empty());
+        base.enqueue_query_result(query_result("q1", 1, 10))
+            .await
+            .unwrap();
+        assert_eq!(base.priority_queue.dequeue().await.sequence, 1);
+        base.stop_common().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_clean_restart_resets_ordering_for_fresh_lower_sequences() {
+        let base = ReactionBase::new(ReactionBaseParams::new("restart", vec![]));
+        let _first_rx = base.create_shutdown_channel().await;
+        base.enqueue_query_result(query_result("q1", 100, 100))
+            .await
+            .unwrap();
+        base.stop_common().await.unwrap();
+        let _next_rx = base.create_shutdown_channel().await;
+        base.enqueue_query_result(query_result("q2", 1, 20))
+            .await
+            .unwrap();
+        base.enqueue_query_result(query_result("q1", 1, 10))
+            .await
+            .unwrap();
+        let result = base.priority_queue.dequeue().await;
+        assert_eq!((result.query_id.as_str(), result.sequence), ("q1", 1));
+        assert_eq!(base.priority_queue.dequeue().await.query_id, "q2");
+        base.stop_common().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_failed_generation_discards_stale_results_and_ordering() {
+        let base = ReactionBase::new(ReactionBaseParams::new("failed", vec![]));
+        let first_rx = base.create_shutdown_channel().await;
+        base.enqueue_query_result(query_result("q1", 100, 100))
+            .await
+            .unwrap();
+        let task = tokio::spawn(async move {
+            drop(first_rx);
+        });
+        let aborted = task.abort_handle();
+        base.set_processing_task(task).await;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !aborted.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        base.set_status(ComponentStatus::Error, None).await;
+
+        let _next_rx = base.create_shutdown_channel().await;
+        assert!(base.processing_task.read().await.is_none());
+        assert!(base.priority_queue.is_empty().await);
+        assert!(base.result_ordering.lock().await.is_empty());
+        base.enqueue_query_result(query_result("q2", 1, 20))
+            .await
+            .unwrap();
+        base.enqueue_query_result(query_result("q1", 1, 10))
+            .await
+            .unwrap();
+        let result = base.priority_queue.dequeue().await;
+        assert_eq!((result.query_id.as_str(), result.sequence), ("q1", 1));
+        assert_eq!(base.priority_queue.dequeue().await.query_id, "q2");
+        base.stop_common().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_failed_start_before_task_registration_resets_ordering() {
+        let base = ReactionBase::new(ReactionBaseParams::new("failed-start", vec![]));
+        let first_rx = base.create_shutdown_channel().await;
+        base.enqueue_query_result(query_result("q1", 100, 100))
+            .await
+            .unwrap();
+        drop(first_rx);
+        let _next_rx = base.create_shutdown_channel().await;
+        assert!(base.priority_queue.is_empty().await);
+        assert!(base.result_ordering.lock().await.is_empty());
+        base.enqueue_query_result(query_result("q1", 1, 10))
+            .await
+            .unwrap();
+        assert_eq!(base.priority_queue.dequeue().await.sequence, 1);
+        base.stop_common().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_enqueue_does_not_advance_ordering() {
+        let base = ReactionBase::new(
+            ReactionBaseParams::new("cancelled", vec![]).with_priority_queue_capacity(2),
+        );
+        for sequence in [4, 5] {
+            base.enqueue_query_result(query_result("q1", sequence, 10))
+                .await
+                .unwrap();
+        }
+        let mut blocked = Box::pin(base.enqueue_query_result(query_result("q1", 6, 100)));
+        assert!(futures::poll!(blocked.as_mut()).is_pending());
+        drop(blocked);
+        for _ in 0..2 {
+            base.priority_queue.dequeue().await;
+        }
+        base.enqueue_query_result(query_result("q1", 6, 20))
+            .await
+            .unwrap();
+        base.enqueue_query_result(query_result("q2", 1, 30))
+            .await
+            .unwrap();
+        assert_eq!(base.priority_queue.dequeue().await.query_id, "q1");
+        assert_eq!(base.priority_queue.dequeue().await.query_id, "q2");
+    }
+
+    #[tokio::test]
     async fn test_event_without_initialization() {
         // Test that set_status works even without context initialization
         let params = ReactionBaseParams::new("test-reaction", vec![]);
@@ -703,9 +1197,17 @@ mod tests {
 
         // Create first channel
         let _rx1 = base.create_shutdown_channel().await;
+        base.enqueue_query_result(query_result("q1", 6, 30))
+            .await
+            .unwrap();
 
         // Create second channel (should replace the first)
         let mut rx2 = base.create_shutdown_channel().await;
+        assert_eq!(base.priority_queue.depth().await, 1);
+        assert_eq!(
+            base.result_ordering.lock().await["q1"].timestamp_millis(),
+            30
+        );
 
         // Send signal - should go to second channel
         if let Some(tx) = base.shutdown_tx.write().await.take() {
@@ -1029,94 +1531,95 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_standard_loop_dedup_and_checkpoint() {
-        use std::sync::atomic::{AtomicU64, Ordering};
+        assert_standard_loop_sequence_order([0, 1, 2, 2]).await;
+    }
 
-        let (graph, _rx) = crate::component_graph::ComponentGraph::new("test-instance");
-        let update_tx = graph.update_sender();
+    #[tokio::test]
+    async fn test_run_standard_loop_all_equal_timestamps() {
+        assert_standard_loop_sequence_order([0, 0, 0, 0]).await;
+    }
 
-        let params = ReactionBaseParams::new("loop-reaction", vec!["q1".to_string()]);
-        let base = ReactionBase::new(params);
+    #[tokio::test]
+    async fn test_run_standard_loop_backwards_timestamps() {
+        assert_standard_loop_sequence_order([3, 2, 1, 0]).await;
+    }
 
-        let store: Arc<dyn StateStoreProvider> =
-            Arc::new(crate::state_store::MemoryStateStoreProvider::new());
-        let context = crate::context::ReactionRuntimeContext::new(
-            "test-instance",
-            "loop-reaction",
-            Some(store),
-            update_tx,
-            None,
-        );
-        base.initialize(context).await;
+    async fn assert_standard_loop_sequence_order(timestamp_offsets: [i64; 4]) {
+        for iteration in 0..100 {
+            let (graph, _rx) = crate::component_graph::ComponentGraph::new("test-instance");
+            let base = ReactionBase::new(ReactionBaseParams::new(
+                "loop-reaction",
+                vec!["q1".to_string()],
+            ));
+            let store = Arc::new(crate::state_store::MemoryStateStoreProvider::new());
+            base.initialize(ReactionRuntimeContext::new(
+                "test-instance",
+                "loop-reaction",
+                Some(store),
+                graph.update_sender(),
+                None,
+            ))
+            .await;
 
-        // Initial checkpoints: seq=5 with config_hash=42
-        let initial_checkpoints = {
-            let mut m = std::collections::HashMap::new();
-            m.insert(
+            let initial_checkpoints = std::collections::HashMap::from([(
                 "q1".to_string(),
                 ReactionCheckpoint {
                     sequence: 5,
                     config_hash: 42,
                 },
-            );
-            m
-        };
+            )]);
+            let shutdown_rx = base.create_shutdown_channel().await;
 
-        // Enqueue events: seq 3 (dup), seq 5 (dup), seq 6, seq 7
-        for seq in [3u64, 5, 6, 7] {
-            let result = crate::channels::QueryResult {
-                query_id: "q1".to_string(),
-                sequence: seq,
-                timestamp: chrono::Utc::now(),
-                results: vec![],
-                metadata: Default::default(),
-                profiling: None,
-            };
-            base.enqueue_query_result(result).await.unwrap();
-        }
-
-        // Track which sequences the handler actually processes
-        let processed = Arc::new(tokio::sync::Mutex::new(Vec::<u64>::new()));
-        let processed_clone = processed.clone();
-        let handler_count = Arc::new(AtomicU64::new(0));
-        let handler_count_clone = handler_count.clone();
-
-        let shutdown_rx = base.create_shutdown_channel().await;
-        let base_clone = base.clone_shared();
-
-        let loop_handle = tokio::spawn(async move {
-            base_clone
-                .run_standard_loop(shutdown_rx, initial_checkpoints, |event| {
-                    let processed = processed_clone.clone();
-                    let count = handler_count_clone.clone();
-                    async move {
-                        processed.lock().await.push(event.sequence);
-                        count.fetch_add(1, Ordering::SeqCst);
-                        Ok(())
-                    }
-                })
-                .await
-                .unwrap();
-        });
-
-        // Wait for all non-dup events to be processed (seq 6 and 7)
-        for _ in 0..50 {
-            if handler_count.load(Ordering::SeqCst) >= 2 {
-                break;
+            // Queue the whole batch before starting the real checkpointing loop.
+            for (seq, offset) in [3u64, 5, 6, 7].into_iter().zip(timestamp_offsets) {
+                let result = QueryResult::new(
+                    "q1".to_string(),
+                    seq,
+                    chrono::DateTime::from_timestamp_millis(1_000 + offset).unwrap(),
+                    vec![],
+                    Default::default(),
+                );
+                base.enqueue_query_result(result).await.unwrap();
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            let processed = Arc::new(tokio::sync::Mutex::new(Vec::<u64>::new()));
+            let processed_clone = processed.clone();
+            let base_clone = base.clone_shared();
+            let loop_handle = tokio::spawn(async move {
+                base_clone
+                    .run_standard_loop(shutdown_rx, initial_checkpoints, |event| {
+                        let processed = processed_clone.clone();
+                        async move {
+                            processed.lock().await.push(event.sequence);
+                            Ok(())
+                        }
+                    })
+                    .await
+            });
+
+            tokio::time::timeout(Duration::from_secs(2), async {
+                while base.priority_queue.metrics().await.total_dequeued < 4 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("the loop must dequeue every event, including replay duplicates");
+            base.stop_common().await.unwrap();
+            tokio::time::timeout(Duration::from_secs(2), loop_handle)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+
+            let cp = base.read_checkpoint("q1").await.unwrap().unwrap();
+            assert_eq!(cp.sequence, 7);
+            assert_eq!(cp.config_hash, 42);
+            assert_eq!(
+                *processed.lock().await,
+                vec![6, 7],
+                "lost a new result on iteration {iteration} after checkpointing seq={}",
+                cp.sequence
+            );
         }
-
-        // Signal shutdown via stop_common (the standard path)
-        let _ = base.stop_common().await;
-        let _ = tokio::time::timeout(Duration::from_secs(2), loop_handle).await;
-
-        // Verify only seq 6 and 7 were processed (3 and 5 were deduped)
-        let processed = processed.lock().await;
-        assert_eq!(*processed, vec![6, 7]);
-
-        // Checkpoint should now be at seq=7, preserving config_hash=42
-        let cp = base.read_checkpoint("q1").await.unwrap().unwrap();
-        assert_eq!(cp.sequence, 7);
-        assert_eq!(cp.config_hash, 42);
     }
 }

--- a/lib/src/reactions/manager.rs
+++ b/lib/src/reactions/manager.rs
@@ -212,13 +212,33 @@ impl ReactionManager {
         // --- §3 Startup validation ---
         self.validate_startup_config(&reaction).await?;
 
-        crate::managers::lifecycle_helpers::start_component(
-            &self.graph,
-            &id,
-            "reaction",
-            &reaction,
-        )
-        .await?;
+        // A no-op Starting -> Starting graph update must not restart the runtime
+        // and discard the active result queue. Claim the generation atomically.
+        {
+            let mut graph = self.graph.write().await;
+            if graph
+                .get_component(&id)
+                .is_some_and(|node| node.status == ComponentStatus::Starting)
+            {
+                return Err(anyhow::anyhow!("Component '{id}' is already starting"));
+            }
+            graph.validate_and_transition(
+                &id,
+                ComponentStatus::Starting,
+                Some("Starting reaction".to_string()),
+            )?;
+        }
+        self.abort_subscription_tasks(&id).await;
+
+        if let Err(e) = reaction.start().await {
+            let mut graph = self.graph.write().await;
+            let _ = graph.validate_and_transition(
+                &id,
+                ComponentStatus::Error,
+                Some(format!("Start failed: {e}")),
+            );
+            return Err(e);
+        }
 
         // Create the bootstrap gate — forwarders wait on this before processing.
         // Using a watch channel (not Notify) so late subscribers see the current value
@@ -1701,6 +1721,55 @@ mod tests {
     // ========================================================================
     // Test helpers
     // ========================================================================
+
+    #[tokio::test]
+    async fn test_only_a_new_start_cancels_the_previous_subscription_generation() {
+        let (mut graph, _updates) = ComponentGraph::new("test");
+        let update_tx = graph.update_sender();
+        graph.register_reaction("r1", HashMap::new(), &[]).unwrap();
+        graph
+            .validate_and_transition("r1", ComponentStatus::Starting, None)
+            .unwrap();
+        graph
+            .validate_and_transition("r1", ComponentStatus::Error, None)
+            .unwrap();
+        let graph = Arc::new(RwLock::new(graph));
+        let manager = ReactionManager::new(
+            "test",
+            crate::managers::get_or_init_global_registry(),
+            graph,
+            update_tx,
+        );
+        manager
+            .provision_reaction(MockReaction::new("r1", vec![]))
+            .await
+            .unwrap();
+        let stale = tokio::spawn(std::future::pending::<()>());
+        manager
+            .subscription_tasks
+            .write()
+            .await
+            .insert("r1".to_string(), vec![stale.abort_handle()]);
+        manager.start_reaction("r1".to_string()).await.unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), stale)
+                .await
+                .unwrap()
+                .unwrap_err()
+                .is_cancelled()
+        );
+
+        let active = tokio::spawn(std::future::pending::<()>());
+        manager
+            .subscription_tasks
+            .write()
+            .await
+            .insert("r1".to_string(), vec![active.abort_handle()]);
+        assert!(manager.start_reaction("r1".to_string()).await.is_err());
+        assert!(!active.is_finished());
+        active.abort();
+        assert!(active.await.unwrap_err().is_cancelled());
+    }
 
     /// Build a DrasiLib with a source and one query (auto_start=false).
     async fn build_core() -> crate::DrasiLib {

--- a/lib/src/reactions/tests.rs
+++ b/lib/src/reactions/tests.rs
@@ -16,10 +16,12 @@
 pub(crate) mod manager_tests {
     use super::super::*;
     use crate::channels::*;
+    use crate::reactions::common::base::{ReactionBase, ReactionBaseParams};
     use crate::test_helpers::wait_for_component_status;
     use anyhow::Result;
     use async_trait::async_trait;
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::sync::RwLock;
@@ -132,6 +134,67 @@ pub(crate) mod manager_tests {
         async fn enqueue_query_result(&self, _result: QueryResult) -> Result<()> {
             Ok(())
         }
+    }
+
+    struct QueuedReaction {
+        base: Arc<ReactionBase>,
+        fail_start: AtomicBool,
+    }
+
+    #[async_trait]
+    impl crate::reactions::Reaction for QueuedReaction {
+        fn id(&self) -> &str {
+            &self.base.id
+        }
+        fn type_name(&self) -> &str {
+            "queued-test"
+        }
+        fn properties(&self) -> HashMap<String, serde_json::Value> {
+            HashMap::new()
+        }
+        fn query_ids(&self) -> Vec<String> {
+            self.base.queries.clone()
+        }
+        fn auto_start(&self) -> bool {
+            false
+        }
+        async fn initialize(&self, context: crate::context::ReactionRuntimeContext) {
+            self.base.initialize(context).await;
+        }
+        async fn start(&self) -> Result<()> {
+            let shutdown = self.base.create_shutdown_channel().await;
+            self.base
+                .set_processing_task(tokio::spawn(async move {
+                    let _ = shutdown.await;
+                }))
+                .await;
+            if self.fail_start.swap(false, Ordering::SeqCst) {
+                return Err(anyhow::anyhow!(
+                    "injected failure after spawning the consumer"
+                ));
+            }
+            self.base.set_status(ComponentStatus::Running, None).await;
+            Ok(())
+        }
+        async fn stop(&self) -> Result<()> {
+            self.base.stop_common().await
+        }
+        async fn status(&self) -> ComponentStatus {
+            self.base.get_status().await
+        }
+        async fn enqueue_query_result(&self, result: QueryResult) -> Result<()> {
+            self.base.enqueue_query_result(result).await
+        }
+    }
+
+    fn queued_result(sequence: u64, timestamp: i64) -> QueryResult {
+        QueryResult::new(
+            "q1".to_string(),
+            sequence,
+            chrono::DateTime::from_timestamp_millis(timestamp).unwrap(),
+            vec![],
+            Default::default(),
+        )
     }
 
     /// Helper to create a TestMockReaction instance
@@ -335,6 +398,115 @@ pub(crate) mod manager_tests {
         let status = manager.get_reaction_status("nonexistent".to_string()).await;
         assert!(status.is_err());
         assert!(status.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_or_illegal_start_preserves_pending_results() {
+        for status in
+            [ComponentStatus::Starting, ComponentStatus::Running, ComponentStatus::Stopping]
+        {
+            let (manager, graph) = create_test_manager().await;
+            let base = Arc::new(ReactionBase::new(ReactionBaseParams::new("queued", vec![])));
+            add_reaction(
+                &manager,
+                &graph,
+                QueuedReaction {
+                    base: base.clone(),
+                    fail_start: AtomicBool::new(false),
+                },
+            )
+            .await
+            .unwrap();
+            // Keep an existing consumer alive and a pending result queued.
+            let shutdown = base.create_shutdown_channel().await;
+            let task = tokio::spawn(async move {
+                let _ = shutdown.await;
+            });
+            let old_consumer = task.abort_handle();
+            base.set_processing_task(task).await;
+            base.enqueue_query_result(queued_result(6, 30))
+                .await
+                .unwrap();
+            {
+                let mut graph = graph.write().await;
+                graph
+                    .validate_and_transition("queued", ComponentStatus::Starting, None)
+                    .unwrap();
+                if status != ComponentStatus::Starting {
+                    graph
+                        .validate_and_transition("queued", ComponentStatus::Running, None)
+                        .unwrap();
+                }
+                if status == ComponentStatus::Stopping {
+                    graph
+                        .validate_and_transition("queued", ComponentStatus::Stopping, None)
+                        .unwrap();
+                }
+            }
+            let result = manager.start_reaction("queued".to_string()).await;
+            assert!(
+                result.is_err(),
+                "start from {status:?} must not start another generation"
+            );
+            assert!(!old_consumer.is_finished());
+            assert_eq!(base.priority_queue.depth().await, 1);
+            base.enqueue_query_result(queued_result(7, 10))
+                .await
+                .unwrap();
+            assert_eq!(base.priority_queue.dequeue().await.sequence, 6);
+            assert_eq!(base.priority_queue.dequeue().await.sequence, 7);
+            base.stop_common().await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retry_after_failed_start_discards_the_old_queue_generation() {
+        let (manager, graph) = create_test_manager().await;
+        let base = Arc::new(ReactionBase::new(ReactionBaseParams::new("retry", vec![])));
+        add_reaction(
+            &manager,
+            &graph,
+            QueuedReaction {
+                base: base.clone(),
+                fail_start: AtomicBool::new(true),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(manager.start_reaction("retry".to_string()).await.is_err());
+        let old_consumer = base
+            .processing_task
+            .read()
+            .await
+            .as_ref()
+            .unwrap()
+            .abort_handle();
+        base.enqueue_query_result(queued_result(100, 100))
+            .await
+            .unwrap();
+        assert_eq!(
+            manager
+                .get_reaction_status("retry".to_string())
+                .await
+                .unwrap(),
+            ComponentStatus::Error
+        );
+        let mut events = graph.read().await.subscribe();
+        manager.start_reaction("retry".to_string()).await.unwrap();
+        wait_for_component_status(
+            &mut events,
+            "retry",
+            ComponentStatus::Running,
+            Duration::from_secs(2),
+        )
+        .await;
+        assert!(old_consumer.is_finished());
+        assert!(base.priority_queue.is_empty().await);
+        base.enqueue_query_result(queued_result(1, 10))
+            .await
+            .unwrap();
+        assert_eq!(base.priority_queue.dequeue().await.sequence, 1);
+        manager.stop_reaction("retry".to_string()).await.unwrap();
     }
 
     /// Test that concurrent add_reaction calls with the same ID are handled atomically.

--- a/lib/src/reactions/tests.rs
+++ b/lib/src/reactions/tests.rs
@@ -21,7 +21,7 @@ pub(crate) mod manager_tests {
     use anyhow::Result;
     use async_trait::async_trait;
     use std::collections::HashMap;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::sync::RwLock;
@@ -139,6 +139,14 @@ pub(crate) mod manager_tests {
     struct QueuedReaction {
         base: Arc<ReactionBase>,
         fail_start: AtomicBool,
+        start_gate: Option<Arc<StartGate>>,
+    }
+
+    #[derive(Default)]
+    struct StartGate {
+        entered: tokio::sync::Notify,
+        release: tokio::sync::Notify,
+        calls: AtomicUsize,
     }
 
     #[async_trait]
@@ -162,6 +170,13 @@ pub(crate) mod manager_tests {
             self.base.initialize(context).await;
         }
         async fn start(&self) -> Result<()> {
+            if let Some(gate) = &self.start_gate {
+                let previous = gate.calls.fetch_add(1, Ordering::SeqCst);
+                gate.entered.notify_one();
+                if previous == 0 {
+                    gate.release.notified().await;
+                }
+            }
             let shutdown = self.base.create_shutdown_channel().await;
             self.base
                 .set_processing_task(tokio::spawn(async move {
@@ -401,6 +416,69 @@ pub(crate) mod manager_tests {
     }
 
     #[tokio::test]
+    async fn test_concurrent_start_invokes_the_start_hook_only_once() {
+        let (manager, graph) = create_test_manager().await;
+        let base = Arc::new(ReactionBase::new(ReactionBaseParams::new(
+            "gated-start",
+            vec![],
+        )));
+        let gate = Arc::new(StartGate::default());
+        add_reaction(
+            &manager,
+            &graph,
+            QueuedReaction {
+                base,
+                fail_start: AtomicBool::new(false),
+                start_gate: Some(gate.clone()),
+            },
+        )
+        .await
+        .unwrap();
+        let mut events = graph.read().await.subscribe();
+        let first_manager = manager.clone();
+        let first = tokio::spawn(async move {
+            first_manager
+                .start_reaction("gated-start".to_string())
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(2), gate.entered.notified())
+            .await
+            .unwrap();
+        assert_eq!(
+            manager
+                .get_reaction_status("gated-start".to_string())
+                .await
+                .unwrap(),
+            ComponentStatus::Starting
+        );
+        let second = tokio::time::timeout(
+            Duration::from_secs(2),
+            manager.start_reaction("gated-start".to_string()),
+        )
+        .await
+        .expect("a duplicate start must reject without waiting for the first hook");
+        gate.release.notify_one();
+        tokio::time::timeout(Duration::from_secs(2), first)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(second.unwrap_err().to_string().contains("already starting"));
+        assert_eq!(gate.calls.load(Ordering::SeqCst), 1);
+        wait_for_component_status(
+            &mut events,
+            "gated-start",
+            ComponentStatus::Running,
+            Duration::from_secs(2),
+        )
+        .await;
+        manager
+            .stop_reaction("gated-start".to_string())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_duplicate_or_illegal_start_preserves_pending_results() {
         for status in
             [ComponentStatus::Starting, ComponentStatus::Running, ComponentStatus::Stopping]
@@ -413,6 +491,7 @@ pub(crate) mod manager_tests {
                 QueuedReaction {
                     base: base.clone(),
                     fail_start: AtomicBool::new(false),
+                    start_gate: None,
                 },
             )
             .await
@@ -469,6 +548,7 @@ pub(crate) mod manager_tests {
             QueuedReaction {
                 base: base.clone(),
                 fail_start: AtomicBool::new(true),
+                start_gate: None,
             },
         )
         .await


### PR DESCRIPTION
# Description

Standalone bug fixes against `main` (`e759606fa065bee0ef9e60017e263f0f85dd0e44`), with no feature-stack or ComputationGraph ancestry. Prevent the reaction timestamp heap from checkpointing past an unhandled result, reject duplicate startup admission before touching the active generation, and preserve safe queue shutdown/restart and profiler reporting.

## Type of change

- This pull request fixes bugs in Drasi and has approved issues.

Fixes #877
Fixes #878
Fixes #880
Fixes #884

Related: #461, #482, #564. Source-side ordering remains separately tracked by #348 and #879 and is **not changed or claimed fixed** here.

## Changes

- **Reaction ordering:** derive an internal nondecreasing effective timestamp per query and use a stable lexicographic `(effective timestamp, insertion ordinal)` heap key. Equal or backwards clocks no longer move a later same-query result ahead of an earlier one. Cross-query merging remains deterministic; serialized `QueryResult` timestamps, MessagePack/bincode bytes, public signatures and persistence schemas are unchanged.
- **Queue generations:** close and wake blocked producers before waiting for the ordering lock or consumer. Old sends cannot cross a close/reopen boundary. Failed/cancelled enqueues do not advance the ordering cursor, and legitimate restarts clear stale queues/cursors without destructively resetting rejected starts.
- **Observable inversions:** the existing standard loop distinguishes a previously unseen older sequence from legitimate initial-checkpoint replays and already-observed duplicates. An unseen inversion closes ingress, reports `Error`, and returns the typed error without advancing the checkpoint for that event or later queued events. It does not join itself or claim to automatically cancel manager-owned subscriptions. Ordered gaps and existing handler/checkpoint-write error semantics remain unchanged.
- **Startup admission:** claim `Starting` atomically in `ReactionManager`; reject duplicate `Starting` and illegal `Running`/`Stopping` starts before replacing consumers, queues or subscriptions. No changes to generic graph transitions or shared lifecycle helpers.
- **Profiler:** participate in shutdown/reopen and prioritize shutdown, then due reporting, then dequeue. A continuous backlog cannot hide a due report.
- **Completion assertions:** replace sleep-budget polling in the original regression with whole-input dequeue completion plus an awaited real processing task/final handler/checkpoint. A gated final handler proves that completed dequeues alone cannot make the test pass. A 30-second outer guard diagnoses deadlocks; full `[6, 7]`, checkpoint and config-hash assertions remain.

## Reproduction and regression evidence

The data-loss cases were first run with **test-only changes** against `ceb2c885a3d2e1e9a9935e13e56c652fb54b3d13`. The four affected production blobs are unchanged on the current-main base above.

Initialize the real `ReactionBase::run_standard_loop` with checkpoint `{sequence: 5, config_hash: 42}`. Create its shutdown channel, enqueue all four query `q1` results before starting the consumer, and record handler sequences. Wait for all inputs to be dequeued and await the actual loop shutdown before asserting:

| Case | Arrival sequences | Timestamps, milliseconds since epoch | Before | After |
|---|---|---|---|---|
| Equal new-result timestamps | `[3, 5, 6, 7]` | `[1000, 1001, 1002, 1002]` | Handler `[7]`, persisted checkpoint 7 | Handler `[6, 7]`, checkpoint 7/hash 42 |
| Backwards timestamps | `[3, 5, 6, 7]` | `[1003, 1002, 1001, 1000]` | Handler `[7]`, persisted checkpoint 7 | Handler `[6, 7]`, checkpoint 7/hash 42 |

Both baseline cases failed on iteration 0. Each now passes **100 iterations**, alongside a 100-iteration all-equal control. Increasing sleeps or checking only checkpoint 7 would conceal the original data loss.

Additional deterministic evidence:

- A gated concurrent-start fixture proves only one start hook is invoked. Separate fixtures preserve active consumers and queued data for rejected `Starting`, `Running` and `Stopping` requests. The original coupled duplicate-start regression failed before the local manager correction.
- The new registered-consumer inversion fixture first failed with actual status `Running` instead of `Error`. It now proves local and graph `Error`, capacity/ordering waiter rejection, unchanged checkpoint after the offending input, and explicit cleanup/restart with replay suppression and newer delivery.
- The profiler candidate regression is **not a claim about unchanged main**: hold the first sample behind the stats lock, queue 64 more samples, let the real report timer become due while that backlog is held, then release. Before correcting branch priority, the first report contained `n=65`; now it reports `n=1` before draining the backlog, all 65 samples are subsequently counted, and shutdown remains prompt. The one-second wait makes the timer due under a controlled lock, rather than hoping load keeps the queue full.
- Coverage also includes true total-order comparisons, multiple-query merging with unchanged serialized bytes, actual typed source queues retaining timestamp semantics, close/reopen races, cancellation, fresh lower-sequence restart, duplicate replay, and zero/`u64::MAX` sequence edges.

## Validation

On the current-main base:

- 281 selected `drasi-lib` unit tests passed across reactions, priority queues, source lifecycle/dispatch, query dispatch, sequence deduplication and checkpoint integration.
- All 5 profiler unit tests passed, including the controlled due-report/backlog case and stop/restart.
- All 15 selected integration tests passed: `bootstrap_failure_e2e`, `reaction_recovery_e2e`, profiler `recovery_e2e`, `application_source_e2e`, and `source_query_reaction_e2e`. Profiler recovery was rerun after the final scheduling correction.
- `cargo +nightly fmt --check -p drasi-lib -p drasi-reaction-profiler` passed.
- `cargo clippy --locked --offline -p drasi-lib -p drasi-reaction-profiler --all-targets -- -D warnings` passed.
- Required read-only specialist review identified the profiler timer issue; after correction and its regression, final re-review reported **no significant issues**.

No full-workspace, Docker-backed or system-JQ/all-features claim is made. This does not claim #482's broader ten-busy-workspace-run acceptance matrix.

## Scope and limits

Production changes are confined to `lib/src/channels/priority_queue.rs`, `lib/src/reactions/common/base.rs`, `lib/src/reactions/manager.rs`, and `components/reactions/profiler/src/profiler.rs`. The other three changed files contain regression tests only. Legacy ComponentGraph, shared lifecycle helpers, Source/query engine, recovery policies and dependency manifests are untouched.

The standard-loop inversion ledger retains one range per disjoint forward gap for that loop generation: no allocation for contiguous streams and no expansion by gap width or duplicate count. Its worst-case storage grows with the number of gaps; silently evicting old gaps would lose the exact distinction between legitimate duplicates and unseen inversions. Restart discards this generation-local ledger. This PR makes no arbitrary external exactly-once or automatic subscription-supervision guarantee.