### PR TITLE
Forward source subscription completion through plugin ABI

### DIFF
--- a/components/host-sdk/src/loader.rs
+++ b/components/host-sdk/src/loader.rs
@@ -350,9 +350,7 @@ pub fn load_plugin_from_path(
     // safely read the trailing fields.
     let identity_provider_vtables: Option<
         Vec<drasi_plugin_sdk::ffi::IdentityProviderPluginVtable>,
-    > = if plugin_sdk_version
-        .as_deref()
-        .and_then(parse_semver)
+    > = if parse_semver(&plugin_sdk_version)
         .map(|v| v >= MIN_SDK_VERSION_WITH_IDENTITY_PROVIDERS)
         .unwrap_or(false)
         && !registration.identity_provider_plugins.is_null()
@@ -387,16 +385,15 @@ pub fn load_plugin_from_path(
     // NOTE: `set_log_level` is a trailing field appended for SDK 0.12.0; gate
     // access on the plugin's reported `sdk_version` like the identity fields
     // above, since reading it from an older (smaller) layout is UB.
-    let set_log_level_fn: Option<extern "C" fn(FfiLogLevelFilter)> = if plugin_sdk_version
-        .as_deref()
-        .and_then(parse_semver)
-        .map(|v| v >= MIN_SDK_VERSION_WITH_SET_LOG_LEVEL)
-        .unwrap_or(false)
-    {
-        Some(registration.set_log_level)
-    } else {
-        None
-    };
+    let set_log_level_fn: Option<extern "C" fn(FfiLogLevelFilter)> =
+        if parse_semver(&plugin_sdk_version)
+            .map(|v| v >= MIN_SDK_VERSION_WITH_SET_LOG_LEVEL)
+            .unwrap_or(false)
+        {
+            Some(registration.set_log_level)
+        } else {
+            None
+        };
 
     // Report the host's effective log level so the plugin can drop
     // filtered-out records before formatting or crossing the FFI.
@@ -497,67 +494,59 @@ fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
     Some((v.major as u32, v.minor as u32, v.patch as u32))
 }
 
+fn validate_sdk_compatibility(plugin_version: &str, host_version: &str) -> anyhow::Result<()> {
+    let plugin = parse_semver(plugin_version)
+        .ok_or_else(|| anyhow::anyhow!("invalid plugin SDK version '{plugin_version}'"))?;
+    let host = parse_semver(host_version)
+        .ok_or_else(|| anyhow::anyhow!("invalid host SDK version '{host_version}'"))?;
+
+    if (plugin.0, plugin.1) != (host.0, host.1) {
+        anyhow::bail!(
+            "SDK version mismatch: plugin={plugin_version}, host={host_version}. \
+             Major.minor versions must match ({}.{} != {}.{}).",
+            plugin.0,
+            plugin.1,
+            host.0,
+            host.1,
+        );
+    }
+
+    Ok(())
+}
+
 /// Validate plugin metadata against the host SDK version.
 ///
 /// Checks that the plugin's SDK version is compatible with the host.
 /// For cdylib plugins, we check major.minor compatibility (patch differences are OK).
 ///
-/// On success returns the plugin's reported `sdk_version` string (if metadata
-/// was present), so callers can gate access to ABI fields introduced in a
-/// later SDK revision.
-fn validate_plugin_metadata(lib: &Library, path: &Path) -> anyhow::Result<Option<String>> {
+/// On success returns the plugin's reported `sdk_version` string so callers can
+/// gate access to ABI fields introduced in a later SDK revision.
+fn validate_plugin_metadata(lib: &Library, path: &Path) -> anyhow::Result<String> {
     let meta_fn = unsafe {
-        match lib.get::<unsafe extern "C" fn() -> *const PluginMetadata>(b"drasi_plugin_metadata") {
-            Ok(f) => f,
-            Err(_) => {
-                log::warn!(
-                    "Plugin '{}' does not export drasi_plugin_metadata — skipping version check",
+        lib.get::<unsafe extern "C" fn() -> *const PluginMetadata>(b"drasi_plugin_metadata")
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "Plugin '{}' does not export drasi_plugin_metadata; \
+                     ABI compatibility cannot be verified",
                     path.display()
-                );
-                return Ok(None);
-            }
-        }
+                )
+            })?
     };
 
     let meta_ptr = unsafe { meta_fn() };
     if meta_ptr.is_null() {
-        log::warn!(
-            "Plugin '{}' returned null metadata — skipping version check",
+        anyhow::bail!(
+            "Plugin '{}' returned null metadata; ABI compatibility cannot be verified",
             path.display()
         );
-        return Ok(None);
     }
 
     let meta = unsafe { &*meta_ptr };
     let plugin_sdk_version = unsafe { meta.sdk_version.to_string() };
     let host_sdk_version = drasi_plugin_sdk::ffi::metadata::FFI_SDK_VERSION;
 
-    // Check major.minor compatibility
-    let plugin_parts: Vec<&str> = plugin_sdk_version.split('.').collect();
-    let host_parts: Vec<&str> = host_sdk_version.split('.').collect();
-
-    let plugin_major_minor = format!(
-        "{}.{}",
-        plugin_parts.first().unwrap_or(&"0"),
-        plugin_parts.get(1).unwrap_or(&"0")
-    );
-    let host_major_minor = format!(
-        "{}.{}",
-        host_parts.first().unwrap_or(&"0"),
-        host_parts.get(1).unwrap_or(&"0")
-    );
-
-    if plugin_major_minor != host_major_minor {
-        anyhow::bail!(
-            "Plugin '{}' SDK version mismatch: plugin={}, host={}. \
-             Major.minor versions must match ({} != {}).",
-            path.display(),
-            plugin_sdk_version,
-            host_sdk_version,
-            plugin_major_minor,
-            host_major_minor,
-        );
-    }
+    validate_sdk_compatibility(&plugin_sdk_version, host_sdk_version)
+        .map_err(|error| anyhow::anyhow!("Plugin '{}': {error}", path.display()))?;
 
     // Check target triple compatibility
     let plugin_target = unsafe { meta.target_triple.to_string() };
@@ -579,7 +568,7 @@ fn validate_plugin_metadata(lib: &Library, path: &Path) -> anyhow::Result<Option
         plugin_target
     );
 
-    Ok(Some(plugin_sdk_version))
+    Ok(plugin_sdk_version)
 }
 
 /// Scan the plugin directory and group files by plugin base name.
@@ -1183,5 +1172,22 @@ mod tests {
         // Above the threshold
         assert!(parse_semver("0.6.1").unwrap() > MIN_SDK_VERSION_WITH_IDENTITY_PROVIDERS);
         assert!(parse_semver("1.0.0").unwrap() > MIN_SDK_VERSION_WITH_IDENTITY_PROVIDERS);
+    }
+
+    #[test]
+    fn test_sdk_compatibility_rejects_pre_callback_vtable() {
+        let error = validate_sdk_compatibility("0.14.9", "0.15.0").unwrap_err();
+        assert!(error.to_string().contains("0.14 != 0.15"));
+    }
+
+    #[test]
+    fn test_sdk_compatibility_accepts_patch_difference() {
+        validate_sdk_compatibility("0.15.9", "0.15.0").unwrap();
+    }
+
+    #[test]
+    fn test_sdk_compatibility_rejects_malformed_version() {
+        let error = validate_sdk_compatibility("legacy", "0.15.0").unwrap_err();
+        assert!(error.to_string().contains("invalid plugin SDK version"));
     }
 }

--- a/components/host-sdk/src/proxies/source.rs
+++ b/components/host-sdk/src/proxies/source.rs
@@ -438,6 +438,14 @@ impl Source for SourceProxy {
         }
     }
 
+    async fn on_subscriptions_complete(&self) -> anyhow::Result<()> {
+        call_on_subscriptions_complete_slot(
+            self.vtable.state,
+            self.vtable.on_subscriptions_complete_fn,
+        )
+        .map_err(anyhow::Error::msg)
+    }
+
     async fn deprovision(&self) -> anyhow::Result<()> {
         let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
         let deprovision_fn = self.vtable.deprovision_fn;
@@ -593,6 +601,17 @@ impl Drop for SourceProxy {
     }
 }
 
+fn call_on_subscriptions_complete_slot(
+    state: *mut c_void,
+    complete_fn: extern "C" fn(*mut c_void) -> drasi_plugin_sdk::ffi::FfiResult,
+) -> Result<(), String> {
+    let state = drasi_plugin_sdk::ffi::SendMutPtr(state);
+    std::thread::spawn(move || (complete_fn)(state.as_ptr()))
+        .join()
+        .map_err(|_| "on_subscriptions_complete thread panicked".to_string())
+        .and_then(|result| unsafe { result.into_result() })
+}
+
 // ============================================================================
 // SourcePluginProxy — wraps SourcePluginVtable into SourcePluginDescriptor
 // ============================================================================
@@ -696,5 +715,40 @@ impl Drop for SourcePluginProxy {
         let drop_fn = self.vtable.drop_fn;
         let state = drasi_plugin_sdk::ffi::SendMutPtr(self.vtable.state);
         super::drop_worker::execute_drop_fn(drop_fn, state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static CALLBACK_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    extern "C" fn successful_callback(_state: *mut c_void) -> drasi_plugin_sdk::ffi::FfiResult {
+        CALLBACK_CALLS.fetch_add(1, Ordering::SeqCst);
+        drasi_plugin_sdk::ffi::FfiResult::ok()
+    }
+
+    extern "C" fn failing_callback(_state: *mut c_void) -> drasi_plugin_sdk::ffi::FfiResult {
+        drasi_plugin_sdk::ffi::FfiResult::err("plugin callback failed".to_string())
+    }
+
+    #[test]
+    fn subscriptions_complete_slot_is_invoked_once() {
+        CALLBACK_CALLS.store(0, Ordering::SeqCst);
+
+        let result = call_on_subscriptions_complete_slot(std::ptr::null_mut(), successful_callback);
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(CALLBACK_CALLS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn subscriptions_complete_slot_preserves_error() {
+        let error = call_on_subscriptions_complete_slot(std::ptr::null_mut(), failing_callback)
+            .unwrap_err();
+
+        assert_eq!(error, "plugin callback failed");
     }
 }

--- a/components/host-sdk/tests/abi_compatibility_test.rs
+++ b/components/host-sdk/tests/abi_compatibility_test.rs
@@ -1,0 +1,127 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use drasi_host_sdk::callbacks;
+use drasi_host_sdk::loader::load_plugin_from_path;
+use libloading::{Library, Symbol};
+
+fn fixture_library_path(directory: &Path) -> PathBuf {
+    if cfg!(target_os = "windows") {
+        directory.join("source_vtable_0_14.dll")
+    } else if cfg!(target_os = "macos") {
+        directory.join("libsource_vtable_0_14.dylib")
+    } else {
+        directory.join("libsource_vtable_0_14.so")
+    }
+}
+
+fn compile_fixture(configuration: Option<&str>) -> (tempfile::TempDir, PathBuf) {
+    let fixture_source =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/source_vtable_0_14.rs");
+    let output_dir = tempfile::tempdir().expect("fixture output directory");
+    let fixture_library = fixture_library_path(output_dir.path());
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let mut command = Command::new(rustc);
+    command
+        .arg("--crate-type=cdylib")
+        .arg("--edition=2021")
+        .arg(&fixture_source)
+        .arg("-o")
+        .arg(&fixture_library);
+    if let Some(configuration) = configuration {
+        command.arg("--cfg").arg(configuration);
+    }
+    let status = command.status().expect("compile old ABI fixture");
+    assert!(status.success(), "old ABI fixture should compile");
+    (output_dir, fixture_library)
+}
+
+#[test]
+fn loader_rejects_smaller_source_vtable_before_plugin_init() {
+    let (_output_dir, fixture_library) = compile_fixture(None);
+    let fixture_handle =
+        unsafe { Library::new(&fixture_library) }.expect("load old ABI fixture tripwire");
+    let init_called: Symbol<unsafe extern "C" fn() -> bool> = unsafe {
+        fixture_handle
+            .get(b"old_abi_fixture_init_called")
+            .expect("resolve fixture tripwire")
+    };
+    let source_vtable_size: Symbol<unsafe extern "C" fn() -> usize> = unsafe {
+        fixture_handle
+            .get(b"old_abi_fixture_source_vtable_size")
+            .expect("resolve old vtable size")
+    };
+    assert!(
+        unsafe { source_vtable_size() }
+            < std::mem::size_of::<drasi_plugin_sdk::ffi::SourceVtable>(),
+        "fixture must represent the physically smaller pre-0.15 source vtable"
+    );
+
+    let error = match load_plugin_from_path(
+        &fixture_library,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    ) {
+        Ok(_) => panic!("0.14 plugin must be rejected before its smaller vtable is read"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error.to_string().contains("SDK version mismatch"),
+        "expected explicit ABI rejection, got: {error:#}"
+    );
+    assert!(
+        !unsafe { init_called() },
+        "loader must reject incompatible metadata before drasi_plugin_init"
+    );
+}
+
+#[test]
+fn loader_rejects_missing_metadata_before_plugin_init() {
+    let (_output_dir, fixture_library) = compile_fixture(Some("omit_metadata"));
+    let fixture_handle =
+        unsafe { Library::new(&fixture_library) }.expect("load metadata-free fixture tripwire");
+    let init_called: Symbol<unsafe extern "C" fn() -> bool> = unsafe {
+        fixture_handle
+            .get(b"old_abi_fixture_init_called")
+            .expect("resolve fixture tripwire")
+    };
+
+    let error = match load_plugin_from_path(
+        &fixture_library,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    ) {
+        Ok(_) => panic!("plugin without metadata must be rejected before initialization"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error
+            .to_string()
+            .contains("does not export drasi_plugin_metadata"),
+        "expected explicit missing-metadata rejection, got: {error:#}"
+    );
+    assert!(
+        !unsafe { init_called() },
+        "loader must reject missing metadata before drasi_plugin_init"
+    );
+}

--- a/components/host-sdk/tests/fixtures/source_vtable_0_14.rs
+++ b/components/host-sdk/tests/fixtures/source_vtable_0_14.rs
@@ -1,0 +1,105 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(dead_code)]
+
+use std::ffi::{c_char, c_void};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[repr(C)]
+struct FfiStr {
+    ptr: *const c_char,
+    len: usize,
+}
+
+unsafe impl Sync for FfiStr {}
+
+const fn ffi_str(value: &'static [u8]) -> FfiStr {
+    FfiStr {
+        ptr: value.as_ptr().cast(),
+        len: value.len(),
+    }
+}
+
+#[repr(C)]
+struct PluginMetadata {
+    sdk_version: FfiStr,
+    core_version: FfiStr,
+    lib_version: FfiStr,
+    plugin_version: FfiStr,
+    target_triple: FfiStr,
+    git_commit: FfiStr,
+    build_timestamp: FfiStr,
+}
+
+unsafe impl Sync for PluginMetadata {}
+
+static METADATA: PluginMetadata = PluginMetadata {
+    sdk_version: ffi_str(b"0.14.0"),
+    core_version: ffi_str(b"0.0.0"),
+    lib_version: ffi_str(b"0.0.0"),
+    plugin_version: ffi_str(b"0.0.0"),
+    target_triple: ffi_str(b"old-abi-fixture"),
+    git_commit: ffi_str(b"fixture"),
+    build_timestamp: ffi_str(b"1970-01-01T00:00:00Z"),
+};
+
+static INIT_CALLED: AtomicBool = AtomicBool::new(false);
+
+// This is the physical 0.14 shape: drop_fn immediately follows
+// remove_position_handle_fn, with no on_subscriptions_complete_fn slot.
+#[allow(dead_code)]
+#[repr(C)]
+struct SourceVtableV014 {
+    state: *mut c_void,
+    executor: usize,
+    id_fn: usize,
+    type_name_fn: usize,
+    auto_start_fn: usize,
+    dispatch_mode_fn: usize,
+    properties_fn: usize,
+    describe_schema_fn: usize,
+    start_fn: usize,
+    stop_fn: usize,
+    status_fn: usize,
+    deprovision_fn: usize,
+    initialize_fn: usize,
+    subscribe_fn: usize,
+    set_bootstrap_provider_fn: usize,
+    supports_replay_fn: usize,
+    remove_position_handle_fn: usize,
+    drop_fn: usize,
+}
+
+#[cfg(not(omit_metadata))]
+#[unsafe(no_mangle)]
+extern "C" fn drasi_plugin_metadata() -> *const PluginMetadata {
+    &METADATA
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn drasi_plugin_init() -> *mut c_void {
+    INIT_CALLED.store(true, Ordering::SeqCst);
+    std::ptr::null_mut()
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn old_abi_fixture_init_called() -> bool {
+    INIT_CALLED.load(Ordering::SeqCst)
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn old_abi_fixture_source_vtable_size() -> usize {
+    std::mem::size_of::<SourceVtableV014>()
+}

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -537,6 +537,74 @@ async fn test_mock_source_start_stop_lifecycle() {
     );
 }
 
+#[tokio::test]
+#[serial]
+async fn test_dynamic_source_receives_one_subscriptions_complete_callback() {
+    if !plugin_exists("drasi-source-mock") {
+        panic!("SKIP: drasi-source-mock not built as cdylib");
+    }
+    test_capture::clear();
+
+    let path = require_plugin("drasi-source-mock");
+    let plugin = load_plugin_from_path(
+        &path,
+        std::ptr::null_mut(),
+        test_capture::log_callback,
+        std::ptr::null_mut(),
+        test_capture::lifecycle_callback,
+    )
+    .expect("Should load mock source plugin");
+    let source_id = "subscriptions-complete-ffi-source";
+    let source = plugin.source_plugins[0]
+        .create_source(
+            source_id,
+            &serde_json::json!({
+                "dataType": { "type": "generic" },
+                "intervalMs": 60000
+            }),
+            true,
+        )
+        .await
+        .expect("Should create mock source");
+
+    let core = drasi_lib::DrasiLib::builder()
+        .with_id("subscriptions-complete-ffi-test")
+        .with_source(source)
+        .with_query(
+            drasi_lib::Query::cypher("subscriptions-complete-query-1")
+                .query("MATCH (n) RETURN n")
+                .from_source(source_id)
+                .enable_bootstrap(false)
+                .build(),
+        )
+        .with_query(
+            drasi_lib::Query::cypher("subscriptions-complete-query-2")
+                .query("MATCH (n) RETURN n")
+                .from_source(source_id)
+                .enable_bootstrap(false)
+                .build(),
+        )
+        .build()
+        .await
+        .expect("Should build DrasiLib");
+
+    core.start().await.expect("Should start DrasiLib");
+
+    let marker = format!("[MOCK-SUBSCRIPTIONS-COMPLETE] source={source_id}");
+    let callback_count = test_capture::logs()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .iter()
+        .filter(|entry| entry.message == marker)
+        .count();
+    assert_eq!(
+        callback_count, 1,
+        "dynamic source callback must run exactly once after both queries subscribe"
+    );
+
+    core.stop().await.expect("Should stop DrasiLib");
+}
+
 // ============================================================================
 // Multiple Instance Tests
 // ============================================================================

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -543,15 +543,26 @@ async fn test_dynamic_source_receives_one_subscriptions_complete_callback() {
     if !plugin_exists("drasi-source-mock") {
         panic!("SKIP: drasi-source-mock not built as cdylib");
     }
-    test_capture::clear();
+
+    struct EnvGuard(&'static str);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(self.0);
+        }
+    }
+
+    const MARKER_ENV: &str = "DRASI_MOCK_SUBSCRIPTIONS_COMPLETE_MARKER";
+    let marker = tempfile::NamedTempFile::new().expect("callback marker file");
+    std::env::set_var(MARKER_ENV, marker.path());
+    let _env_guard = EnvGuard(MARKER_ENV);
 
     let path = require_plugin("drasi-source-mock");
     let plugin = load_plugin_from_path(
         &path,
         std::ptr::null_mut(),
-        test_capture::log_callback,
+        callbacks::default_log_callback_fn(),
         std::ptr::null_mut(),
-        test_capture::lifecycle_callback,
+        callbacks::default_lifecycle_callback_fn(),
     )
     .expect("Should load mock source plugin");
     let source_id = "subscriptions-complete-ffi-source";
@@ -590,15 +601,12 @@ async fn test_dynamic_source_receives_one_subscriptions_complete_callback() {
 
     core.start().await.expect("Should start DrasiLib");
 
-    let marker = format!("[MOCK-SUBSCRIPTIONS-COMPLETE] source={source_id}");
-    let callback_count = test_capture::logs()
-        .lock()
-        .unwrap_or_else(|error| error.into_inner())
-        .iter()
-        .filter(|entry| entry.message == marker)
-        .count();
+    let marker_contents =
+        std::fs::read_to_string(marker.path()).expect("read callback marker file");
+    let callbacks: Vec<_> = marker_contents.lines().collect();
     assert_eq!(
-        callback_count, 1,
+        callbacks,
+        vec![source_id],
         "dynamic source callback must run exactly once after both queries subscribe"
     );
 

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -50,7 +50,11 @@ use super::types::FfiStr;
 ///   which raise their sequence counter above it for restart monotonicity
 ///   (#827). This changes the subscribe call contract, so old plugins must be
 ///   rejected by the loader's major.minor check.
-pub const FFI_SDK_VERSION: &str = "0.14.0";
+/// - `0.15.0`: `SourceVtable` gained `on_subscriptions_complete_fn` so the host
+///   lifecycle can notify dynamic sources after startup query subscriptions
+///   have registered. The callback returns `FfiResult`, preserving source
+///   failures across the ABI boundary (#774).
+pub const FFI_SDK_VERSION: &str = "0.15.0";
 
 /// The target triple this crate was compiled for.
 pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -933,6 +933,23 @@ pub fn build_source_vtable<T: Source + 'static>(
         })
     }
 
+    extern "C" fn on_subscriptions_complete_fn<T: Source + 'static>(
+        state: *mut c_void,
+    ) -> FfiResult {
+        catch_panic_ffi(|| {
+            let w = unsafe { &*(state as *const SourceWrapper<T>) };
+            let handle = (w.runtime_handle)().handle().clone();
+            let ptr = SendPtr(state as *const SourceWrapper<T>);
+            match dispatch_to_runtime(&handle, async move {
+                let inner = unsafe { ptr.as_ref() };
+                inner.inner.on_subscriptions_complete().await
+            }) {
+                Ok(()) => FfiResult::ok(),
+                Err(e) => FfiResult::err(e.to_string()),
+            }
+        })
+    }
+
     let cached_id = source.id().to_string();
     let cached_type_name = source.type_name().to_string();
 
@@ -969,6 +986,7 @@ pub fn build_source_vtable<T: Source + 'static>(
         set_bootstrap_provider_fn: set_bootstrap_provider_fn::<T>,
         supports_replay_fn: supports_replay_fn::<T>,
         remove_position_handle_fn: remove_position_handle_fn::<T>,
+        on_subscriptions_complete_fn: on_subscriptions_complete_fn::<T>,
         drop_fn: drop_fn::<T>,
     }
 }
@@ -1324,6 +1342,21 @@ pub fn build_source_vtable_from_boxed(
         })
     }
 
+    extern "C" fn on_subscriptions_complete_fn(state: *mut c_void) -> FfiResult {
+        catch_panic_ffi(|| {
+            let w = unsafe { &*(state as *const DynSourceWrapper) };
+            let handle = (w.runtime_handle)().handle().clone();
+            let inner_ptr = SendPtr(state as *const DynSourceWrapper);
+            match dispatch_to_runtime(&handle, async move {
+                let inner = unsafe { inner_ptr.as_ref() };
+                inner.inner.on_subscriptions_complete().await
+            }) {
+                Ok(()) => FfiResult::ok(),
+                Err(e) => FfiResult::err(e.to_string()),
+            }
+        })
+    }
+
     let cached_id = source.id().to_string();
     let cached_type_name = source.type_name().to_string();
 
@@ -1360,6 +1393,7 @@ pub fn build_source_vtable_from_boxed(
         set_bootstrap_provider_fn,
         supports_replay_fn,
         remove_position_handle_fn,
+        on_subscriptions_complete_fn,
         drop_fn,
     }
 }
@@ -3843,7 +3877,7 @@ pub fn build_secret_store_plugin_vtable<T: SecretStorePluginDescriptor + 'static
 }
 
 #[cfg(test)]
-mod snapshot_stream_tests {
+mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -3866,6 +3900,183 @@ mod snapshot_stream_tests {
     extern "C" fn test_drop(ctx: *mut c_void) {
         if !ctx.is_null() {
             unsafe { drop(Box::from_raw(ctx as *mut TestIter)) };
+        }
+    }
+
+    mod source_subscriptions_complete_vtable_tests {
+        use super::*;
+        use std::any::Any;
+        use std::collections::HashMap;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, OnceLock};
+
+        #[derive(Clone, Copy)]
+        enum Completion {
+            Success,
+            Error,
+            Panic,
+        }
+
+        struct LifecycleSource {
+            calls: Arc<AtomicUsize>,
+            completion: Completion,
+        }
+
+        #[async_trait::async_trait]
+        impl Source for LifecycleSource {
+            fn id(&self) -> &str {
+                "lifecycle-source"
+            }
+
+            fn type_name(&self) -> &str {
+                "lifecycle"
+            }
+
+            fn properties(&self) -> HashMap<String, serde_json::Value> {
+                HashMap::new()
+            }
+
+            async fn start(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            async fn stop(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            async fn status(&self) -> ComponentStatus {
+                ComponentStatus::Running
+            }
+
+            async fn subscribe(
+                &self,
+                _settings: SourceSubscriptionSettings,
+            ) -> anyhow::Result<drasi_lib::channels::SubscriptionResponse> {
+                unreachable!("subscription is not used by lifecycle vtable tests")
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+
+            async fn initialize(&self, _context: SourceRuntimeContext) {}
+
+            async fn on_subscriptions_complete(&self) -> anyhow::Result<()> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                match self.completion {
+                    Completion::Success => Ok(()),
+                    Completion::Error => Err(anyhow::anyhow!("source fence release failed")),
+                    Completion::Panic => panic!("source lifecycle callback panicked"),
+                }
+            }
+        }
+
+        fn test_runtime() -> &'static tokio::runtime::Runtime {
+            static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+            RUNTIME.get_or_init(|| {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .enable_all()
+                    .build()
+                    .expect("test runtime")
+            })
+        }
+
+        extern "C" fn noop_executor(_future: *mut c_void) -> *mut c_void {
+            std::ptr::null_mut()
+        }
+
+        fn noop_lifecycle(_id: &str, _event: FfiLifecycleEventType, _message: &str) {}
+
+        fn invoke(vtable: SourceVtable) -> Result<(), String> {
+            let state = SendMutPtr(vtable.state);
+            let callback = vtable.on_subscriptions_complete_fn;
+            let result = std::thread::spawn(move || callback(state.as_ptr()))
+                .join()
+                .expect("FFI callback thread should not panic");
+            (vtable.drop_fn)(vtable.state);
+            unsafe { result.into_result() }
+        }
+
+        fn source(completion: Completion) -> (LifecycleSource, Arc<AtomicUsize>) {
+            let calls = Arc::new(AtomicUsize::new(0));
+            (
+                LifecycleSource {
+                    calls: Arc::clone(&calls),
+                    completion,
+                },
+                calls,
+            )
+        }
+
+        #[test]
+        fn typed_vtable_invokes_callback_once() {
+            let (source, calls) = source(Completion::Success);
+            let result = invoke(build_source_vtable(
+                source,
+                noop_executor,
+                noop_lifecycle,
+                test_runtime,
+            ));
+
+            assert_eq!(result, Ok(()));
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+        }
+
+        #[test]
+        fn boxed_vtable_invokes_callback_once() {
+            let (source, calls) = source(Completion::Success);
+            let result = invoke(build_source_vtable_from_boxed(
+                Box::new(source),
+                noop_executor,
+                noop_lifecycle,
+                test_runtime,
+            ));
+
+            assert_eq!(result, Ok(()));
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+        }
+
+        #[test]
+        fn typed_vtable_preserves_callback_error() {
+            let (source, _) = source(Completion::Error);
+            let error = invoke(build_source_vtable(
+                source,
+                noop_executor,
+                noop_lifecycle,
+                test_runtime,
+            ))
+            .unwrap_err();
+
+            assert_eq!(error, "source fence release failed");
+        }
+
+        #[test]
+        fn boxed_vtable_preserves_callback_error() {
+            let (source, _) = source(Completion::Error);
+            let error = invoke(build_source_vtable_from_boxed(
+                Box::new(source),
+                noop_executor,
+                noop_lifecycle,
+                test_runtime,
+            ))
+            .unwrap_err();
+
+            assert_eq!(error, "source fence release failed");
+        }
+
+        #[test]
+        fn callback_panic_becomes_ffi_error() {
+            let (source, _) = source(Completion::Panic);
+            let error = invoke(build_source_vtable(
+                source,
+                noop_executor,
+                noop_lifecycle,
+                test_runtime,
+            ))
+            .unwrap_err();
+
+            assert!(error.contains("plugin panic"));
         }
     }
 

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -374,6 +374,11 @@ drasi_ffi_primitives::ffi_vtable! {
         /// handle. The source can stop tracking the resume position for this
         /// query.
         fn remove_position_handle_fn(state: *mut, query_id: FfiStr) -> FfiResult,
+
+        /// Called by the host lifecycle once all startup queries have
+        /// subscribed. Sources that hold back feedback during the subscription
+        /// window can release those guards here.
+        fn on_subscriptions_complete_fn(state: *mut) -> FfiResult,
     }
 }
 

--- a/components/sources/mock/src/mock.rs
+++ b/components/sources/mock/src/mock.rs
@@ -617,6 +617,22 @@ impl Source for MockSource {
     }
 
     async fn on_subscriptions_complete(&self) -> Result<()> {
+        if let Ok(path) = std::env::var("DRASI_MOCK_SUBSCRIPTIONS_COMPLETE_MARKER") {
+            use std::io::Write;
+
+            let mut marker = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "failed to open subscriptions-complete marker '{path}': {error}"
+                    )
+                })?;
+            writeln!(marker, "{}", self.base.id).map_err(|error| {
+                anyhow::anyhow!("failed to write subscriptions-complete marker '{path}': {error}")
+            })?;
+        }
         log::info!("[MOCK-SUBSCRIPTIONS-COMPLETE] source={}", self.base.id);
         Ok(())
     }

--- a/components/sources/mock/src/mock.rs
+++ b/components/sources/mock/src/mock.rs
@@ -616,6 +616,11 @@ impl Source for MockSource {
         self.base.initialize(context).await;
     }
 
+    async fn on_subscriptions_complete(&self) -> Result<()> {
+        log::info!("[MOCK-SUBSCRIPTIONS-COMPLETE] source={}", self.base.id);
+        Ok(())
+    }
+
     async fn set_bootstrap_provider(
         &self,
         provider: Box<dyn drasi_lib::bootstrap::BootstrapProvider + 'static>,

--- a/components/sources/postgres/src/lib.rs
+++ b/components/sources/postgres/src/lib.rs
@@ -226,7 +226,7 @@ pub(crate) struct ReplayState {
 /// Duration (in seconds) after which the flush fence auto-clears.
 ///
 /// This is a safety fallback for deployments where no explicit
-/// `on_subscriptions_complete()` signal arrives (e.g., FFI plugin usage).
+/// `on_subscriptions_complete()` signal arrives.
 /// During normal startup all queries subscribe within a few seconds; the
 /// timeout must be generous enough to cover slow-starting deployments.
 const FENCE_TIMEOUT_SECS: u64 = 60;
@@ -1048,10 +1048,11 @@ impl Source for PostgresReplicationSource {
         self.base.remove_position_handle(query_id).await;
     }
 
-    async fn on_subscriptions_complete(&self) {
+    async fn on_subscriptions_complete(&self) -> anyhow::Result<()> {
         // Release the flush fence so that send_feedback() can advance flush_lsn
         // based on the natural min-watermark of all registered position handles.
         self.replay_state.clear_flush_fence();
+        Ok(())
     }
 
     async fn set_bootstrap_provider(

--- a/lib/src/lifecycle.rs
+++ b/lib/src/lifecycle.rs
@@ -132,7 +132,7 @@ impl LifecycleManager {
         // Notify sources that all initial subscriptions are done. Sources that
         // held back upstream feedback (e.g., Postgres flush-fence) can now
         // resume normal advancement based on the min-watermark of all handles.
-        self.source_manager.subscriptions_complete().await;
+        self.source_manager.subscriptions_complete().await?;
 
         // Start reactions last — queries are running so snapshot fetching works.
         // The reaction subscribes to the query outbox and catches up on any
@@ -244,11 +244,13 @@ impl LifecycleManager {
 
 #[cfg(test)]
 mod tests {
+    use crate::builder::Query;
     use crate::channels::ComponentStatus;
     use crate::lib_core::DrasiLib;
     use crate::sources::tests::TestMockSource;
     use crate::sources::COMPONENT_GRAPH_SOURCE_ID;
     use crate::test_helpers::wait_for_component_status;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     /// Helper: build a DrasiLib with the given sources (not yet started).
@@ -294,6 +296,60 @@ mod tests {
         // Non-autostart source should remain Added
         let status = core.get_source_status("manual-src").await.unwrap();
         assert_eq!(status, ComponentStatus::Added);
+    }
+
+    #[tokio::test]
+    async fn start_components_notifies_source_once_after_all_query_subscriptions() {
+        let source = TestMockSource::new("subscription-source".to_string()).unwrap();
+        let subscription_count = source.subscription_count();
+        let completion_count = source.subscriptions_complete_count();
+        let subscriptions_at_completion = source.subscriptions_at_completion();
+        let core = DrasiLib::builder()
+            .with_id("subscription-lifecycle-test")
+            .with_source(source)
+            .with_query(
+                Query::cypher("subscription-query-1")
+                    .query("MATCH (n) RETURN n")
+                    .from_source("subscription-source")
+                    .build(),
+            )
+            .with_query(
+                Query::cypher("subscription-query-2")
+                    .query("MATCH (n) RETURN n")
+                    .from_source("subscription-source")
+                    .build(),
+            )
+            .build()
+            .await
+            .unwrap();
+
+        core.start().await.unwrap();
+
+        assert_eq!(subscription_count.load(Ordering::SeqCst), 2);
+        assert_eq!(subscriptions_at_completion.load(Ordering::SeqCst), 2);
+        assert_eq!(completion_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn start_components_propagates_subscriptions_complete_error() {
+        let source = TestMockSource::new("failing-subscription-source".to_string())
+            .unwrap()
+            .with_subscriptions_complete_error("startup fence release failed");
+        let completion_count = source.subscriptions_complete_count();
+        let core = DrasiLib::builder()
+            .with_id("failing-subscription-lifecycle-test")
+            .with_source(source)
+            .build()
+            .await
+            .unwrap();
+
+        let error = core.start().await.unwrap_err();
+
+        assert_eq!(completion_count.load(Ordering::SeqCst), 1);
+        assert!(
+            error.to_string().contains("startup fence release failed"),
+            "callback error should reach DrasiLib::start(): {error:#}"
+        );
     }
 
     // ========================================================================
@@ -353,8 +409,6 @@ mod tests {
 
     #[tokio::test]
     async fn load_configuration_creates_queries_from_config() {
-        use crate::builder::Query;
-
         // Build with a source and a query that references it
         let source = TestMockSource::with_auto_start("cfg-src".to_string(), true).unwrap();
         let core = DrasiLib::builder()

--- a/lib/src/sources/manager.rs
+++ b/lib/src/sources/manager.rs
@@ -400,22 +400,37 @@ impl SourceManager {
     /// Called by the lifecycle after all auto-start queries have subscribed.
     /// Sources that hold back feedback during the subscription window (e.g.,
     /// Postgres flush-fence) release those guards here.
-    pub async fn subscriptions_complete(&self) {
+    pub async fn subscriptions_complete(&self) -> Result<()> {
         let sources: Vec<Arc<dyn Source>> = {
             let g = self.graph.read().await;
             g.list_by_kind(&ComponentKind::Source)
                 .iter()
                 .filter_map(|(id, status)| {
-                    if *status == ComponentStatus::Running {
-                        g.get_runtime::<Arc<dyn Source>>(id).cloned()
-                    } else {
-                        None
-                    }
+                    let source = g.get_runtime::<Arc<dyn Source>>(id)?;
+                    // start_all() completed successfully before this call, but
+                    // graph status updates emitted by a source can still be in
+                    // flight. Include auto-start sources based on the same
+                    // predicate used to start them instead of racing that
+                    // asynchronous status update.
+                    (source.auto_start() || *status == ComponentStatus::Running)
+                        .then(|| Arc::clone(source))
                 })
                 .collect()
         };
+        let mut failures = Vec::new();
         for source in sources {
-            source.on_subscriptions_complete().await;
+            if let Err(error) = source.on_subscriptions_complete().await {
+                failures.push(format!("{}: {error}", source.id()));
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "on_subscriptions_complete failed for sources: {}",
+                failures.join("; ")
+            ))
         }
     }
 

--- a/lib/src/sources/tests.rs
+++ b/lib/src/sources/tests.rs
@@ -26,6 +26,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use drasi_core::models::SourceChange;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -40,6 +41,10 @@ pub struct TestMockSource {
     status_handle: crate::component_graph::ComponentStatusHandle,
     /// Dispatchers for sending events to subscribed queries
     dispatchers: Arc<RwLock<Vec<Box<dyn ChangeDispatcher<SourceEventWrapper>>>>>,
+    subscription_count: Arc<AtomicUsize>,
+    subscriptions_complete_count: Arc<AtomicUsize>,
+    subscriptions_at_completion: Arc<AtomicUsize>,
+    subscriptions_complete_error: Option<String>,
 }
 
 impl TestMockSource {
@@ -50,6 +55,10 @@ impl TestMockSource {
             auto_start: true,
             status_handle,
             dispatchers: Arc::new(RwLock::new(Vec::new())),
+            subscription_count: Arc::new(AtomicUsize::new(0)),
+            subscriptions_complete_count: Arc::new(AtomicUsize::new(0)),
+            subscriptions_at_completion: Arc::new(AtomicUsize::new(0)),
+            subscriptions_complete_error: None,
         })
     }
 
@@ -61,7 +70,28 @@ impl TestMockSource {
             auto_start,
             status_handle,
             dispatchers: Arc::new(RwLock::new(Vec::new())),
+            subscription_count: Arc::new(AtomicUsize::new(0)),
+            subscriptions_complete_count: Arc::new(AtomicUsize::new(0)),
+            subscriptions_at_completion: Arc::new(AtomicUsize::new(0)),
+            subscriptions_complete_error: None,
         })
+    }
+
+    pub fn with_subscriptions_complete_error(mut self, error: impl Into<String>) -> Self {
+        self.subscriptions_complete_error = Some(error.into());
+        self
+    }
+
+    pub fn subscription_count(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.subscription_count)
+    }
+
+    pub fn subscriptions_complete_count(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.subscriptions_complete_count)
+    }
+
+    pub fn subscriptions_at_completion(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.subscriptions_at_completion)
     }
 
     /// Inject an event into all subscribed queries.
@@ -132,6 +162,7 @@ impl Source for TestMockSource {
         &self,
         settings: crate::config::SourceSubscriptionSettings,
     ) -> Result<SubscriptionResponse> {
+        self.subscription_count.fetch_add(1, Ordering::SeqCst);
         let dispatcher = ChannelChangeDispatcher::<SourceEventWrapper>::new(100);
         let receiver = dispatcher.create_receiver().await?;
 
@@ -153,6 +184,19 @@ impl Source for TestMockSource {
 
     async fn initialize(&self, context: crate::context::SourceRuntimeContext) {
         self.status_handle.wire(context.update_tx.clone()).await;
+    }
+
+    async fn on_subscriptions_complete(&self) -> Result<()> {
+        self.subscriptions_at_completion.store(
+            self.subscription_count.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
+        self.subscriptions_complete_count
+            .fetch_add(1, Ordering::SeqCst);
+        match &self.subscriptions_complete_error {
+            Some(error) => Err(anyhow::anyhow!(error.clone())),
+            None => Ok(()),
+        }
     }
 }
 

--- a/lib/src/sources/traits.rs
+++ b/lib/src/sources/traits.rs
@@ -333,7 +333,10 @@ pub trait Source: Send + Sync {
     /// window (e.g., Postgres flush-fence) should release those guards here.
     ///
     /// The default is a no-op for sources that do not need startup fencing.
-    async fn on_subscriptions_complete(&self) {}
+    async fn on_subscriptions_complete(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// Set the identity provider for this source.
     ///
     /// This method allows attaching a per-source identity provider after
@@ -433,7 +436,7 @@ impl Source for Box<dyn Source + 'static> {
         (**self).remove_position_handle(query_id).await
     }
 
-    async fn on_subscriptions_complete(&self) {
+    async fn on_subscriptions_complete(&self) -> Result<()> {
         (**self).on_subscriptions_complete().await
     }
 


### PR DESCRIPTION
# Description

Dynamic source plugins now receive `Source::on_subscriptions_complete` after all auto-start query subscriptions have registered. Previously, `SourceProxy` inherited the trait's no-op default because `SourceVtable` had no callback slot, so replay/pruning fences could remain active until a timing fallback.

This change:

- adds a fallible `on_subscriptions_complete_fn` to `SourceVtable` and wires both typed and boxed plugin adapters through the existing panic/error bridge;
- forwards the callback through `SourceProxy`, `SourceManager`, and `LifecycleManager`, preserving source errors at the host boundary;
- invokes each successfully auto-started source once without racing asynchronous graph status updates;
- bumps the FFI contract to `0.15.0` and requires valid plugin metadata before initialization, ensuring pre-0.15 plugins with physically smaller source vtables are rejected before any trailing slot is read;
- adds unit, lifecycle, real-cdylib, old-vtable, and missing-metadata regressions using generic counting/failing mock sources and two startup query subscriptions.

**Reproduction:** load a dynamic source that uses `on_subscriptions_complete` as a startup fence, configure multiple auto-start queries, and start Drasi. Before this change the dynamic source never observed the callback; after this change it observes exactly one callback after both subscriptions are registered, and callback errors fail startup instead of being swallowed.

**Source provenance:** selectively ported the generic lifecycle callback design from retained commit `1bd669a389924cc264ef071f5f97624b5618ef08`, verified against retained branch state `fb5d2bda2cbce4284fecbce40cae2a2d74116249`, and adapted to current `main` APIs and ABI conventions. No WorkGraph-specific code, SourceBase FIFO changes, or Reaction acknowledgement changes are included.

**Validation:** `cargo fmt --all -- --check`; targeted Clippy for `drasi-plugin-sdk`, `drasi-host-sdk`, `drasi-lib`, `drasi-source-mock`, and `drasi-source-postgres`; typed/boxed vtable tests; proxy slot tests; loader tests; real cdylib lifecycle test; old/missing-metadata ABI tests; and lifecycle ordering/error propagation tests.

## Type of change

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).

Fixes #774
Fixes #902