### PR TITLE
Bridge state store durability through plugin FFI

### DIFF
--- a/components/host-sdk/Cargo.toml
+++ b/components/host-sdk/Cargo.toml
@@ -63,3 +63,4 @@ serial_test = "3"
 im = "15"
 tokio-stream = "0.1"
 async-stream = "0.3"
+drasi-state-store-redb = { path = "../state_stores/redb" }

--- a/components/host-sdk/src/loader.rs
+++ b/components/host-sdk/src/loader.rs
@@ -1175,19 +1175,19 @@ mod tests {
     }
 
     #[test]
-    fn test_sdk_compatibility_rejects_pre_callback_vtable() {
-        let error = validate_sdk_compatibility("0.14.9", "0.15.0").unwrap_err();
-        assert!(error.to_string().contains("0.14 != 0.15"));
+    fn test_sdk_compatibility_rejects_pre_current_vtable() {
+        let error = validate_sdk_compatibility("0.15.9", "0.16.0").unwrap_err();
+        assert!(error.to_string().contains("0.15 != 0.16"));
     }
 
     #[test]
     fn test_sdk_compatibility_accepts_patch_difference() {
-        validate_sdk_compatibility("0.15.9", "0.15.0").unwrap();
+        validate_sdk_compatibility("0.16.9", "0.16.0").unwrap();
     }
 
     #[test]
     fn test_sdk_compatibility_rejects_malformed_version() {
-        let error = validate_sdk_compatibility("legacy", "0.15.0").unwrap_err();
+        let error = validate_sdk_compatibility("legacy", "0.16.0").unwrap_err();
         assert!(error.to_string().contains("invalid plugin SDK version"));
     }
 }

--- a/components/host-sdk/src/state_store_bridge.rs
+++ b/components/host-sdk/src/state_store_bridge.rs
@@ -64,6 +64,7 @@ impl StateStoreVtableBuilder {
             key_count_fn: ss_key_count,
             sync_fn: ss_sync,
             drop_fn: ss_drop,
+            is_durable_fn: ss_is_durable,
         }
     }
 }
@@ -282,9 +283,73 @@ extern "C" fn ss_sync(state: *mut c_void) -> FfiResult {
     })
 }
 
+extern "C" fn ss_is_durable(state: *mut c_void) -> bool {
+    ffi_guard(false, || {
+        if state.is_null() {
+            return false;
+        }
+        provider_ref(state).is_durable()
+    })
+}
+
 extern "C" fn ss_drop(state: *mut c_void) {
     ffi_guard((), || {
         // Reconstruct the Box<Arc<...>> and drop it
         unsafe { drop(Box::from_raw(state as *mut Arc<dyn StateStoreProvider>)) };
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use drasi_lib::MemoryStateStoreProvider;
+    use drasi_plugin_sdk::ffi::FfiStateStoreProxy;
+    use drasi_state_store_redb::RedbStateStoreProvider;
+
+    fn release(vtable: StateStoreVtable) {
+        (vtable.drop_fn)(vtable.state);
+    }
+
+    #[test]
+    fn durable_provider_reports_true_through_vtable_and_proxy() {
+        let temp_dir = tempfile::tempdir().expect("temp directory");
+        let provider = Arc::new(
+            RedbStateStoreProvider::new(temp_dir.path().join("state.redb"))
+                .expect("redb state store"),
+        );
+        let vtable = StateStoreVtableBuilder::build(provider);
+
+        {
+            let proxy = unsafe { FfiStateStoreProxy::from_raw(&vtable) };
+            assert!(proxy.is_durable());
+        }
+
+        release(vtable);
+    }
+
+    #[test]
+    fn volatile_provider_reports_false_through_vtable_and_proxy() {
+        let provider = Arc::new(MemoryStateStoreProvider::new());
+        let vtable = StateStoreVtableBuilder::build(provider);
+
+        {
+            let proxy = unsafe { FfiStateStoreProxy::from_raw(&vtable) };
+            assert!(!proxy.is_durable());
+        }
+
+        release(vtable);
+    }
+
+    #[test]
+    fn durability_callback_is_versioned_and_trailing() {
+        assert_eq!(drasi_plugin_sdk::ffi::metadata::FFI_SDK_VERSION, "0.16.0");
+
+        let callback_offset = std::mem::offset_of!(StateStoreVtable, is_durable_fn);
+        let callback_size = std::mem::size_of::<extern "C" fn(state: *mut c_void) -> bool>();
+
+        assert_eq!(
+            callback_offset + callback_size,
+            std::mem::size_of::<StateStoreVtable>()
+        );
+    }
 }

--- a/components/host-sdk/tests/abi_compatibility_test.rs
+++ b/components/host-sdk/tests/abi_compatibility_test.rs
@@ -19,21 +19,25 @@ use drasi_host_sdk::callbacks;
 use drasi_host_sdk::loader::load_plugin_from_path;
 use libloading::{Library, Symbol};
 
-fn fixture_library_path(directory: &Path) -> PathBuf {
+fn fixture_library_path(directory: &Path, fixture_name: &str) -> PathBuf {
     if cfg!(target_os = "windows") {
-        directory.join("source_vtable_0_14.dll")
+        directory.join(format!("{fixture_name}.dll"))
     } else if cfg!(target_os = "macos") {
-        directory.join("libsource_vtable_0_14.dylib")
+        directory.join(format!("lib{fixture_name}.dylib"))
     } else {
-        directory.join("libsource_vtable_0_14.so")
+        directory.join(format!("lib{fixture_name}.so"))
     }
 }
 
-fn compile_fixture(configuration: Option<&str>) -> (tempfile::TempDir, PathBuf) {
-    let fixture_source =
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/source_vtable_0_14.rs");
+fn compile_fixture(
+    fixture_name: &str,
+    configuration: Option<&str>,
+) -> (tempfile::TempDir, PathBuf) {
+    let fixture_source = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(format!("{fixture_name}.rs"));
     let output_dir = tempfile::tempdir().expect("fixture output directory");
-    let fixture_library = fixture_library_path(output_dir.path());
+    let fixture_library = fixture_library_path(output_dir.path(), fixture_name);
     let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
     let mut command = Command::new(rustc);
     command
@@ -52,7 +56,7 @@ fn compile_fixture(configuration: Option<&str>) -> (tempfile::TempDir, PathBuf) 
 
 #[test]
 fn loader_rejects_smaller_source_vtable_before_plugin_init() {
-    let (_output_dir, fixture_library) = compile_fixture(None);
+    let (_output_dir, fixture_library) = compile_fixture("source_vtable_0_14", None);
     let fixture_handle =
         unsafe { Library::new(&fixture_library) }.expect("load old ABI fixture tripwire");
     let init_called: Symbol<unsafe extern "C" fn() -> bool> = unsafe {
@@ -93,8 +97,51 @@ fn loader_rejects_smaller_source_vtable_before_plugin_init() {
 }
 
 #[test]
+fn loader_rejects_smaller_state_store_vtable_before_plugin_init() {
+    let (_output_dir, fixture_library) = compile_fixture("state_store_vtable_0_15", None);
+    let fixture_handle =
+        unsafe { Library::new(&fixture_library) }.expect("load old ABI fixture tripwire");
+    let init_called: Symbol<unsafe extern "C" fn() -> bool> = unsafe {
+        fixture_handle
+            .get(b"old_abi_fixture_init_called")
+            .expect("resolve fixture tripwire")
+    };
+    let state_store_vtable_size: Symbol<unsafe extern "C" fn() -> usize> = unsafe {
+        fixture_handle
+            .get(b"old_abi_fixture_state_store_vtable_size")
+            .expect("resolve old vtable size")
+    };
+    assert!(
+        unsafe { state_store_vtable_size() }
+            < std::mem::size_of::<drasi_plugin_sdk::ffi::StateStoreVtable>(),
+        "fixture must represent the physically smaller pre-0.16 state-store vtable"
+    );
+
+    let error = match load_plugin_from_path(
+        &fixture_library,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    ) {
+        Ok(_) => panic!("0.15 plugin must be rejected before its smaller vtable is read"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error.to_string().contains("SDK version mismatch"),
+        "expected explicit ABI rejection, got: {error:#}"
+    );
+    assert!(
+        !unsafe { init_called() },
+        "loader must reject incompatible metadata before drasi_plugin_init"
+    );
+}
+
+#[test]
 fn loader_rejects_missing_metadata_before_plugin_init() {
-    let (_output_dir, fixture_library) = compile_fixture(Some("omit_metadata"));
+    let (_output_dir, fixture_library) =
+        compile_fixture("source_vtable_0_14", Some("omit_metadata"));
     let fixture_handle =
         unsafe { Library::new(&fixture_library) }.expect("load metadata-free fixture tripwire");
     let init_called: Symbol<unsafe extern "C" fn() -> bool> = unsafe {

--- a/components/host-sdk/tests/fixtures/state_store_vtable_0_15.rs
+++ b/components/host-sdk/tests/fixtures/state_store_vtable_0_15.rs
@@ -1,0 +1,98 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(dead_code)]
+
+use std::ffi::{c_char, c_void};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[repr(C)]
+struct FfiStr {
+    ptr: *const c_char,
+    len: usize,
+}
+
+unsafe impl Sync for FfiStr {}
+
+const fn ffi_str(value: &'static [u8]) -> FfiStr {
+    FfiStr {
+        ptr: value.as_ptr().cast(),
+        len: value.len(),
+    }
+}
+
+#[repr(C)]
+struct PluginMetadata {
+    sdk_version: FfiStr,
+    core_version: FfiStr,
+    lib_version: FfiStr,
+    plugin_version: FfiStr,
+    target_triple: FfiStr,
+    git_commit: FfiStr,
+    build_timestamp: FfiStr,
+}
+
+unsafe impl Sync for PluginMetadata {}
+
+static METADATA: PluginMetadata = PluginMetadata {
+    sdk_version: ffi_str(b"0.15.0"),
+    core_version: ffi_str(b"0.0.0"),
+    lib_version: ffi_str(b"0.0.0"),
+    plugin_version: ffi_str(b"0.0.0"),
+    target_triple: ffi_str(b"old-abi-fixture"),
+    git_commit: ffi_str(b"fixture"),
+    build_timestamp: ffi_str(b"1970-01-01T00:00:00Z"),
+};
+
+static INIT_CALLED: AtomicBool = AtomicBool::new(false);
+
+// This is the physical 0.15 shape, before is_durable_fn was appended.
+#[repr(C)]
+struct StateStoreVtableV015 {
+    state: *mut c_void,
+    get_fn: usize,
+    set_fn: usize,
+    delete_fn: usize,
+    contains_key_fn: usize,
+    get_many_fn: usize,
+    set_many_fn: usize,
+    delete_many_fn: usize,
+    clear_store_fn: usize,
+    list_keys_fn: usize,
+    store_exists_fn: usize,
+    key_count_fn: usize,
+    sync_fn: usize,
+    drop_fn: usize,
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn drasi_plugin_metadata() -> *const PluginMetadata {
+    &METADATA
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn drasi_plugin_init() -> *mut c_void {
+    INIT_CALLED.store(true, Ordering::SeqCst);
+    std::ptr::null_mut()
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn old_abi_fixture_init_called() -> bool {
+    INIT_CALLED.load(Ordering::SeqCst)
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn old_abi_fixture_state_store_vtable_size() -> usize {
+    std::mem::size_of::<StateStoreVtableV015>()
+}

--- a/components/host-sdk/tests/integration_test.rs
+++ b/components/host-sdk/tests/integration_test.rs
@@ -2006,6 +2006,82 @@ async fn test_source_with_null_identity_provider() {
     assert_eq!(source.id(), "null-ip-test");
 }
 
+#[tokio::test]
+#[serial]
+async fn test_source_state_store_durability_cross_cdylib() {
+    struct EnvGuard(&'static str);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(self.0);
+        }
+    }
+
+    const MARKER_ENV: &str = "DRASI_MOCK_STATE_STORE_DURABILITY_MARKER";
+    let _env_guard = EnvGuard(MARKER_ENV);
+    let path = require_plugin("drasi-source-mock");
+    let plugin = load_plugin_from_path(
+        &path,
+        std::ptr::null_mut(),
+        callbacks::default_log_callback_fn(),
+        std::ptr::null_mut(),
+        callbacks::default_lifecycle_callback_fn(),
+    )
+    .expect("Should load mock source plugin");
+
+    let durable_source = plugin.source_plugins[0]
+        .create_source("durable-state-store-test", &serde_json::json!({}), false)
+        .await
+        .expect("Should create durable-store source");
+    let durable_marker = tempfile::NamedTempFile::new().expect("durable marker file");
+    std::env::set_var(MARKER_ENV, durable_marker.path());
+    let durable_temp = tempfile::tempdir().expect("durable temp directory");
+    let durable_store: std::sync::Arc<dyn drasi_lib::StateStoreProvider> = std::sync::Arc::new(
+        drasi_state_store_redb::RedbStateStoreProvider::new(durable_temp.path().join("state.redb"))
+            .expect("redb state store"),
+    );
+    let (durable_update_tx, _durable_update_rx) =
+        tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(16);
+    durable_source
+        .initialize(drasi_lib::context::SourceRuntimeContext {
+            instance_id: "durability-bridge-test".to_string(),
+            source_id: "durable-state-store-test".to_string(),
+            update_tx: durable_update_tx,
+            state_store: Some(durable_store),
+            identity_provider: None,
+            wal_provider: None,
+        })
+        .await;
+    assert_eq!(
+        std::fs::read_to_string(durable_marker.path()).expect("read durable marker"),
+        "true"
+    );
+
+    let volatile_source = plugin.source_plugins[0]
+        .create_source("volatile-state-store-test", &serde_json::json!({}), false)
+        .await
+        .expect("Should create volatile-store source");
+    let volatile_marker = tempfile::NamedTempFile::new().expect("volatile marker file");
+    std::env::set_var(MARKER_ENV, volatile_marker.path());
+    let volatile_store: std::sync::Arc<dyn drasi_lib::StateStoreProvider> =
+        std::sync::Arc::new(drasi_lib::MemoryStateStoreProvider::new());
+    let (volatile_update_tx, _volatile_update_rx) =
+        tokio::sync::mpsc::channel::<drasi_lib::component_graph::ComponentUpdate>(16);
+    volatile_source
+        .initialize(drasi_lib::context::SourceRuntimeContext {
+            instance_id: "durability-bridge-test".to_string(),
+            source_id: "volatile-state-store-test".to_string(),
+            update_tx: volatile_update_tx,
+            state_store: Some(volatile_store),
+            identity_provider: None,
+            wal_provider: None,
+        })
+        .await;
+    assert_eq!(
+        std::fs::read_to_string(volatile_marker.path()).expect("read volatile marker"),
+        "false"
+    );
+}
+
 /// Test that a source receives a non-null identity_provider through FFI.
 #[tokio::test]
 async fn test_source_with_identity_provider_injection() {

--- a/components/plugin-sdk/src/ffi/metadata.rs
+++ b/components/plugin-sdk/src/ffi/metadata.rs
@@ -54,7 +54,10 @@ use super::types::FfiStr;
 ///   lifecycle can notify dynamic sources after startup query subscriptions
 ///   have registered. The callback returns `FfiResult`, preserving source
 ///   failures across the ABI boundary (#774).
-pub const FFI_SDK_VERSION: &str = "0.15.0";
+/// - `0.16.0`: `StateStoreVtable` gained `is_durable_fn` so dynamic plugins
+///   observe the host provider's persistence capability instead of inheriting
+///   the trait's non-durable default (#896).
+pub const FFI_SDK_VERSION: &str = "0.16.0";
 
 /// The target triple this crate was compiled for.
 pub const TARGET_TRIPLE: &str = env!("TARGET_TRIPLE");

--- a/components/plugin-sdk/src/ffi/state_store_proxy.rs
+++ b/components/plugin-sdk/src/ffi/state_store_proxy.rs
@@ -34,6 +34,18 @@ pub struct FfiStateStoreProxy {
 unsafe impl Send for FfiStateStoreProxy {}
 unsafe impl Sync for FfiStateStoreProxy {}
 
+impl FfiStateStoreProxy {
+    /// Wrap a host-provided state-store vtable.
+    ///
+    /// # Safety
+    ///
+    /// `vtable` must be non-null, point to a fully initialized vtable, and remain
+    /// valid with its backing state for the lifetime of this proxy.
+    pub unsafe fn from_raw(vtable: *const StateStoreVtable) -> Self {
+        Self { vtable }
+    }
+}
+
 #[async_trait::async_trait]
 impl StateStoreProvider for FfiStateStoreProxy {
     async fn get(&self, store_id: &str, key: &str) -> StateStoreResult<Option<Vec<u8>>> {
@@ -171,6 +183,13 @@ impl StateStoreProvider for FfiStateStoreProxy {
             (vtable.sync_fn)(vtable.state)
                 .into_result()
                 .map_err(drasi_lib::StateStoreError::Other)
+        }
+    }
+
+    fn is_durable(&self) -> bool {
+        unsafe {
+            let vtable = &*self.vtable;
+            (vtable.is_durable_fn)(vtable.state)
         }
     }
 }

--- a/components/plugin-sdk/src/ffi/vtable_gen.rs
+++ b/components/plugin-sdk/src/ffi/vtable_gen.rs
@@ -2959,8 +2959,8 @@ fn build_source_runtime_context(
     let state_store: Option<Arc<dyn StateStoreProvider>> = if ffi_ctx.state_store.is_null() {
         None
     } else {
-        Some(Arc::new(FfiStateStoreProxy {
-            vtable: ffi_ctx.state_store,
+        Some(Arc::new(unsafe {
+            FfiStateStoreProxy::from_raw(ffi_ctx.state_store)
         }))
     };
     let identity_provider: Option<Arc<dyn drasi_lib::identity::IdentityProvider>> =
@@ -3005,8 +3005,8 @@ fn build_reaction_runtime_context(
     let state_store: Option<Arc<dyn StateStoreProvider>> = if ffi_ctx.state_store.is_null() {
         None
     } else {
-        Some(Arc::new(FfiStateStoreProxy {
-            vtable: ffi_ctx.state_store,
+        Some(Arc::new(unsafe {
+            FfiStateStoreProxy::from_raw(ffi_ctx.state_store)
         }))
     };
     let identity_provider: Option<Arc<dyn drasi_lib::identity::IdentityProvider>> =

--- a/components/plugin-sdk/src/ffi/vtables.rs
+++ b/components/plugin-sdk/src/ffi/vtables.rs
@@ -674,6 +674,10 @@ pub struct StateStoreVtable {
     pub sync_fn: extern "C" fn(state: *mut c_void) -> FfiResult,
     // Cleanup
     pub drop_fn: extern "C" fn(state: *mut c_void),
+    /// Whether the host provider persists state durably across restarts.
+    ///
+    /// Appended in SDK 0.16.0.
+    pub is_durable_fn: extern "C" fn(state: *mut c_void) -> bool,
 }
 
 unsafe impl Send for StateStoreVtable {}

--- a/components/sources/mock/src/mock.rs
+++ b/components/sources/mock/src/mock.rs
@@ -593,6 +593,15 @@ impl Source for MockSource {
     }
 
     async fn initialize(&self, context: drasi_lib::context::SourceRuntimeContext) {
+        if let (Ok(path), Some(provider)) = (
+            std::env::var("DRASI_MOCK_STATE_STORE_DURABILITY_MARKER"),
+            context.state_store.as_ref(),
+        ) {
+            if let Err(error) = std::fs::write(&path, provider.is_durable().to_string()) {
+                log::error!("failed to write state-store durability marker '{path}': {error}");
+            }
+        }
+
         // Test-only: exercise the FFI identity-provider clone/drop path across the plugin
         // boundary. Gated entirely behind the `DRASI_MOCK_IDENTITY_CLONE_STRESS` environment
         // variable (read only here) so no test-only knob leaks into the public config schema.


### PR DESCRIPTION
## Summary

- forward `StateStoreProvider::is_durable()` through `StateStoreVtable` and `FfiStateStoreProxy`
- bump the plugin FFI contract from `0.15.0` to `0.16.0` because the vtable is physically larger
- cover durable Redb (`true`) and volatile memory (`false`) through focused proxy tests and the real mock-source cdylib harness
- reject a physical `0.15.0` state-store vtable before plugin initialization instead of reading beyond the old layout

## Generic reproduction

1. Build a host `StateStoreVtable` around a provider whose `is_durable()` returns `true` (for example, Redb).
2. Pass that vtable through `FfiRuntimeContext` to a dynamically loaded source.
3. Query `is_durable()` from the plugin-side `FfiStateStoreProxy`.
4. Before this change, the proxy inherited the trait default and returned `false`; with this change it returns the host capability. A memory provider remains `false`.

This reproduction uses the generic SDK bridge and mock source only; it has no GitHub WorkGraph dependency.

## Stack and provenance

This is a clean SDK-only layer stacked on #903 (`agentofreality-source-lifecycle-abi`) at exact parent `fb891f1ee3109b885a55ab8e44d0c973e02d9e69`. #903 establishes mandatory metadata validation and ABI `0.15.0`; this PR advances the ABI to `0.16.0` for the `StateStoreVtable` layout change.

The behavior was selectively preserved from `eb777fa7966d04d93a4dabe6b22fbab6f75c1f3e` and the ABI correction from `487df4916faebe910267334ae137b4bf4cf68142`. Historical draft #742 remains untouched in stack 741 as implementation evidence and is not part of this branch's ancestry.

## ABI and behavior matrix

| Host SDK | Plugin SDK | Result |
|---|---|---|
| `0.16.x` | `0.16.x` | Accepted; durable providers report `true`, volatile providers report `false` |
| `0.16.x` | `0.15.x` | Rejected from metadata before plugin initialization; old vtable is physically smaller |
| `0.15.x` | `0.16.x` | Rejected by the major/minor compatibility gate |
| `0.16.x` | Missing metadata | Rejected before plugin initialization |

## Validation

- `cargo test -p drasi-host-sdk --lib state_store_bridge::tests`
- `cargo test -p drasi-host-sdk --test abi_compatibility_test`
- `cargo test -p drasi-host-sdk --test integration_test test_source_state_store_durability_cross_cdylib -- --exact --nocapture`
- `cargo test -p drasi-plugin-sdk --lib`
- `cargo test -p drasi-host-sdk --lib test_sdk_compatibility`
- `cargo clippy -p drasi-host-sdk -p drasi-plugin-sdk -p drasi-source-mock --all-targets -- -D warnings`
- `cargo +nightly fmt --all`

Fixes #896