### PR TITLE
fix(core): preserve nested aggregate lifecycle

### DIFF
--- a/components/indexes/garnet/src/result_index.rs
+++ b/components/indexes/garnet/src/result_index.rs
@@ -63,6 +63,28 @@ impl GarnetResultIndex {
 
 #[async_trait]
 impl AccumulatorIndex for GarnetResultIndex {
+    async fn is_empty(&self) -> Result<bool, IndexError> {
+        let prefix = format!("ari:{{{}}}:", self.query_id);
+        {
+            let guard = self.session_state.lock()?;
+            if guard
+                .as_ref()
+                .is_some_and(|buffer| buffer.contains_live_key_with_prefix(&prefix))
+            {
+                return Ok(false);
+            }
+        }
+
+        let pattern = format!("{prefix}*");
+        let mut con = self.connection.clone();
+        let mut keys = con
+            .scan_match::<_, String>(pattern)
+            .await
+            .map_err(IndexError::other)?;
+
+        Ok(keys.next_item().await.is_none())
+    }
+
     #[tracing::instrument(name = "ari::get", skip_all, err)]
     async fn get(
         &self,

--- a/components/indexes/garnet/src/session_state.rs
+++ b/components/indexes/garnet/src/session_state.rs
@@ -98,6 +98,19 @@ impl WriteBuffer {
         }
     }
 
+    pub fn contains_live_key_with_prefix(&self, prefix: &str) -> bool {
+        self.keys.iter().any(|(key, state)| {
+            key.starts_with(prefix)
+                && match state {
+                    KeyState::Deleted => false,
+                    KeyState::StringValue(_) => true,
+                    KeyState::Hash { fields } => fields.values().any(Option::is_some),
+                    KeyState::Set { added, .. } => !added.is_empty(),
+                    KeyState::SortedSet { added, .. } => !added.is_empty(),
+                }
+        })
+    }
+
     // --- String operations ---
 
     pub fn string_set(&mut self, key: String, value: Vec<u8>) {

--- a/components/indexes/garnet/tests/scenario_tests.rs
+++ b/components/indexes/garnet/tests/scenario_tests.rs
@@ -440,9 +440,10 @@ mod session {
 
     use drasi_core::{
         evaluation::functions::aggregation::ValueAccumulator,
+        index_cache::cached_result_index::CachedResultIndex,
         interface::{
             AccumulatorIndex, CheckpointStore, ElementIndex, FutureQueue, LazySortedSetStore,
-            PushType, ResultKey, ResultOwner, SessionControl,
+            PushType, ResultIndex, ResultKey, ResultOwner, SessionControl,
         },
         models::{Element, ElementMetadata, ElementPropertyMap, ElementReference},
     };
@@ -453,6 +454,57 @@ mod session {
     use futures::StreamExt;
     use ordered_float::OrderedFloat;
     use uuid::Uuid;
+
+    #[allow(clippy::unwrap_used)]
+    #[tokio::test]
+    async fn result_state_and_cardinality_follow_transaction_lifecycle() {
+        let redis = super::shared_redis().await;
+        let client = redis::Client::open(redis.url()).unwrap();
+        let connection = client.get_multiplexed_async_connection().await.unwrap();
+        let query_id = format!("test-{}", Uuid::new_v4());
+        let session_state = Arc::new(GarnetSessionState::new(connection.clone()));
+        let session_control = GarnetSessionControl::new(session_state.clone());
+        let result_index = Arc::new(GarnetResultIndex::new(&query_id, connection, session_state));
+        result_index.clear().await.unwrap();
+        let result_index = CachedResultIndex::new(result_index, 3).unwrap();
+        let key = ResultKey::GroupBy(Arc::new(vec![]));
+        let owner = ResultOwner::PartGroupCardinality(2);
+
+        session_control.begin().await.unwrap();
+        assert!(result_index.is_empty().await.unwrap());
+        result_index.ensure_state_version().await.unwrap();
+        assert!(!result_index.is_empty().await.unwrap());
+        result_index
+            .set(
+                key.clone(),
+                owner.clone(),
+                Some(ValueAccumulator::Count { value: 2 }),
+            )
+            .await
+            .unwrap();
+        session_control.rollback().unwrap();
+
+        session_control.begin().await.unwrap();
+        assert!(result_index.is_empty().await.unwrap());
+        result_index.ensure_state_version().await.unwrap();
+        result_index
+            .set(
+                key.clone(),
+                owner.clone(),
+                Some(ValueAccumulator::Count { value: 2 }),
+            )
+            .await
+            .unwrap();
+        session_control.commit().await.unwrap();
+
+        session_control.begin().await.unwrap();
+        result_index.ensure_state_version().await.unwrap();
+        assert!(matches!(
+            result_index.get(&key, &owner).await.unwrap(),
+            Some(ValueAccumulator::Count { value: 2 })
+        ));
+        session_control.rollback().unwrap();
+    }
 
     #[allow(clippy::unwrap_used)]
     #[tokio::test]

--- a/components/indexes/rocksdb/src/result_index.rs
+++ b/components/indexes/rocksdb/src/result_index.rs
@@ -73,6 +73,34 @@ impl RocksDbResultIndex {
 
 #[async_trait]
 impl AccumulatorIndex for RocksDbResultIndex {
+    async fn is_empty(&self) -> Result<bool, IndexError> {
+        let db = self.db.clone();
+        let session_state = self.session_state.clone();
+
+        task::spawn_blocking(move || {
+            let values_cf = db.cf_handle(VALUES_CF).expect("values cf not found");
+            let sets_cf = db.cf_handle(SETS_CF).expect("sorted-sets cf not found");
+
+            session_state.with_txn(|txn| {
+                let values_empty = txn
+                    .iterator_cf(&values_cf, IteratorMode::Start)
+                    .next()
+                    .transpose()
+                    .map_err(IndexError::other)?
+                    .is_none();
+                let sets_empty = txn
+                    .iterator_cf(&sets_cf, IteratorMode::Start)
+                    .next()
+                    .transpose()
+                    .map_err(IndexError::other)?
+                    .is_none();
+                Ok(values_empty && sets_empty)
+            })
+        })
+        .await
+        .map_err(IndexError::other)?
+    }
+
     #[tracing::instrument(name = "ari::get", skip_all, err)]
     async fn get(
         &self,

--- a/components/indexes/rocksdb/tests/scenario_tests.rs
+++ b/components/indexes/rocksdb/tests/scenario_tests.rs
@@ -400,9 +400,10 @@ mod session {
 
     use drasi_core::{
         evaluation::functions::aggregation::ValueAccumulator,
+        index_cache::cached_result_index::CachedResultIndex,
         interface::{
-            AccumulatorIndex, ElementIndex, FutureQueue, PushType, ResultKey, ResultOwner,
-            SessionControl,
+            AccumulatorIndex, ElementIndex, FutureQueue, PushType, ResultIndex, ResultKey,
+            ResultOwner, SessionControl,
         },
         models::{Element, ElementMetadata, ElementPropertyMap, ElementReference},
     };
@@ -413,6 +414,59 @@ mod session {
     };
     use serial_test::serial;
     use uuid::Uuid;
+
+    #[allow(clippy::unwrap_used)]
+    #[tokio::test]
+    #[serial]
+    async fn result_state_and_cardinality_follow_transaction_lifecycle() {
+        let url = format!("test-data/{}", Uuid::new_v4());
+        let query_id = format!("test-{}", Uuid::new_v4());
+        let options = RocksIndexOptions::new(true, false, RocksDbMemoryBudget::default());
+        let db = open_unified_db(&url, &query_id, &options).unwrap();
+        let session_state = Arc::new(RocksDbSessionState::new(db.clone()));
+        let result_index = Arc::new(RocksDbResultIndex::new(db, session_state.clone(), options));
+        let session_control = RocksDbSessionControl::new(session_state);
+        result_index.clear().await.unwrap();
+        let result_index = CachedResultIndex::new(result_index, 3).unwrap();
+        let key = ResultKey::GroupBy(Arc::new(vec![]));
+        let owner = ResultOwner::PartGroupCardinality(2);
+
+        session_control.begin().await.unwrap();
+        assert!(result_index.is_empty().await.unwrap());
+        result_index.ensure_state_version().await.unwrap();
+        result_index
+            .set(
+                key.clone(),
+                owner.clone(),
+                Some(ValueAccumulator::Count { value: 2 }),
+            )
+            .await
+            .unwrap();
+        session_control.rollback().unwrap();
+
+        session_control.begin().await.unwrap();
+        assert!(result_index.is_empty().await.unwrap());
+        result_index.ensure_state_version().await.unwrap();
+        result_index
+            .set(
+                key.clone(),
+                owner.clone(),
+                Some(ValueAccumulator::Count { value: 2 }),
+            )
+            .await
+            .unwrap();
+        session_control.commit().await.unwrap();
+
+        session_control.begin().await.unwrap();
+        result_index.ensure_state_version().await.unwrap();
+        assert!(matches!(
+            result_index.get(&key, &owner).await.unwrap(),
+            Some(ValueAccumulator::Count { value: 2 })
+        ));
+        session_control.rollback().unwrap();
+
+        let _ = std::fs::remove_dir_all(&url);
+    }
 
     #[allow(clippy::unwrap_used)]
     #[tokio::test]

--- a/core/src/evaluation/mod.rs
+++ b/core/src/evaluation/mod.rs
@@ -36,20 +36,34 @@ use crate::interface::{IndexError, MiddlewareError};
 #[derive(Debug)]
 pub enum EvaluationError {
     DivideByZero,
-    InvalidType { expected: String },
+    InvalidType {
+        expected: String,
+    },
     UnknownIdentifier(String),
     UnknownFunction(String), // Unknown Cypher function
     IndexError(IndexError),
     MiddlewareError(MiddlewareError),
     ParseError,
     InvalidContext,
-    OutOfRange { kind: OutOfRangeType },
+    OutOfRange {
+        kind: OutOfRangeType,
+    },
     OverflowError,
     FunctionError(FunctionError),
     CorruptData,
     InvalidArgument,
-    UnknownProperty { property_name: String },
-    FormatError { expected: String },
+    UnknownProperty {
+        property_name: String,
+    },
+    FormatError {
+        expected: String,
+    },
+    InvalidGroupCardinality {
+        part_num: usize,
+        count: i64,
+        before_contributes: bool,
+        after_contributes: bool,
+    },
 }
 
 #[derive(Debug)]

--- a/core/src/evaluation/parts/mod.rs
+++ b/core/src/evaluation/parts/mod.rs
@@ -225,6 +225,8 @@ impl QueryPartEvaluator {
                                         before_out,
                                         agg_after,
                                         agg_snapshot,
+                                        part_num,
+                                        None,
                                         change_context,
                                     )
                                     .await;
@@ -260,6 +262,8 @@ impl QueryPartEvaluator {
                             before_out,
                             after_out,
                             agg_snapshot,
+                            part_num,
+                            None,
                             change_context,
                         )
                         .await
@@ -363,15 +367,15 @@ impl QueryPartEvaluator {
                         if !default_before {
                             true
                         } else {
-                            let mut before_hash = SpookyHasher::default();
-                            before.hash(&mut before_hash);
-                            let before_hash = before_hash.finish();
+                            let before_hash = hash_variables_for_groupby(before);
                             match self
-                                .result_index
-                                .get(&result_key, &ResultOwner::PartCurrent(part_num))
+                                .read_signature_state(
+                                    &result_key,
+                                    &ResultOwner::PartCurrent(part_num),
+                                )
                                 .await?
                             {
-                                Some(ValueAccumulator::Signature(sig)) => sig == before_hash,
+                                Some(sig) => sig == before_hash,
                                 None => {
                                     self.result_index
                                         .set(
@@ -382,27 +386,23 @@ impl QueryPartEvaluator {
                                         .await?;
                                     false
                                 }
-                                _ => false,
                             }
                         }
                     }
                     None => false,
                 };
 
-                let mut after_hash = SpookyHasher::default();
-                after.hash(&mut after_hash);
-                let after_hash = after_hash.finish();
+                let after_hash = hash_variables_for_groupby(&after);
 
                 let should_apply = {
                     if !default_after {
                         true
                     } else {
                         match self
-                            .result_index
-                            .get(&result_key, &ResultOwner::PartDefault(part_num))
+                            .read_signature_state(&result_key, &ResultOwner::PartDefault(part_num))
                             .await?
                         {
-                            Some(ValueAccumulator::Signature(sig)) => {
+                            Some(sig) => {
                                 if sig == after_hash {
                                     self.result_index
                                         .set(
@@ -415,7 +415,6 @@ impl QueryPartEvaluator {
                                 sig != after_hash
                             }
                             None => true,
-                            _ => true,
                         }
                     }
                 };
@@ -538,13 +537,18 @@ impl QueryPartEvaluator {
                                         next_before,
                                         next_after,
                                         agg_snapshot,
+                                        part_num,
+                                        Some(OuterContributionTransition {
+                                            before: !before_filtered && should_revert,
+                                            after: false,
+                                        }),
                                         change_context,
                                     )
                                     .await;
                             }
                         }
 
-                        if before.is_some() && !before_filtered {
+                        if !before_filtered && should_revert {
                             return Ok(vec![QueryPartEvaluationContext::Removing {
                                 before: next_before.unwrap_or_default(),
                                 row_signature: 0,
@@ -576,6 +580,11 @@ impl QueryPartEvaluator {
                             next_before,
                             next_after,
                             agg_snapshot,
+                            part_num,
+                            Some(OuterContributionTransition {
+                                before: !before_filtered && should_revert,
+                                after: should_apply,
+                            }),
                             change_context,
                         )
                         .await?),
@@ -664,8 +673,26 @@ impl QueryPartEvaluator {
         before_out: Option<QueryVariables>,
         after_out: QueryVariables,
         snapshot: Option<QueryVariables>,
+        part_num: usize,
+        contribution: Option<OuterContributionTransition>,
         change_context: &ChangeContext,
     ) -> Result<Vec<QueryPartEvaluationContext>, EvaluationError> {
+        if let Some(contribution) = contribution {
+            return self
+                .reconcile_tracked_aggregate(
+                    part,
+                    grouping_keys,
+                    before_in,
+                    before_out,
+                    after_out,
+                    snapshot,
+                    part_num,
+                    contribution,
+                    change_context,
+                )
+                .await;
+        }
+
         if before_in.is_none() || before_out.is_none() {
             return Ok(vec![QueryPartEvaluationContext::Aggregation {
                 before: before_out,
@@ -731,4 +758,241 @@ impl QueryPartEvaluator {
             },
         ])
     }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn reconcile_tracked_aggregate(
+        &self,
+        part: &QueryPart,
+        grouping_keys: Vec<String>,
+        before_in: Option<QueryVariables>,
+        before_out: Option<QueryVariables>,
+        after_out: QueryVariables,
+        snapshot: Option<QueryVariables>,
+        part_num: usize,
+        contribution: OuterContributionTransition,
+        change_context: &ChangeContext,
+    ) -> Result<Vec<QueryPartEvaluationContext>, EvaluationError> {
+        if !contribution.before && !contribution.after {
+            return Ok(vec![QueryPartEvaluationContext::Noop]);
+        }
+
+        if contribution.before && contribution.after {
+            let before_out = before_out.ok_or(EvaluationError::InvalidContext)?;
+            if grouping_values_match(&grouping_keys, &before_out, &after_out) {
+                let key = ResultKey::groupby_from_variables(&grouping_keys, &after_out);
+                let cardinality = self
+                    .transition_group_cardinality(part_num, key, true, true)
+                    .await?;
+                return Ok(vec![QueryPartEvaluationContext::Aggregation {
+                    before: Some(before_out),
+                    after: after_out,
+                    grouping_keys,
+                    default_before: cardinality.before == 0,
+                    default_after: cardinality.after == 0,
+                    row_signature: 0,
+                }]);
+            }
+
+            let before_key = ResultKey::groupby_from_variables(&grouping_keys, &before_out);
+            let after_key = ResultKey::groupby_from_variables(&grouping_keys, &after_out);
+            let before_cardinality = self.read_group_cardinality(part_num, &before_key).await?;
+            let after_cardinality = self.read_group_cardinality(part_num, &after_key).await?;
+            if before_cardinality == 0 {
+                return Err(EvaluationError::InvalidGroupCardinality {
+                    part_num,
+                    count: before_cardinality,
+                    before_contributes: true,
+                    after_contributes: false,
+                });
+            }
+            let new_before_cardinality = before_cardinality - 1;
+            let new_after_cardinality = after_cardinality.checked_add(1).ok_or(
+                EvaluationError::InvalidGroupCardinality {
+                    part_num,
+                    count: after_cardinality,
+                    before_contributes: false,
+                    after_contributes: true,
+                },
+            )?;
+            self.write_group_cardinality(part_num, before_key, new_before_cardinality)
+                .await?;
+            self.write_group_cardinality(part_num, after_key, new_after_cardinality)
+                .await?;
+
+            let before_in = before_in.ok_or(EvaluationError::InvalidContext)?;
+            let mut source_context =
+                ExpressionEvaluationContext::new(&before_in, change_context.before_clock.clone());
+            source_context.set_side_effects(context::SideEffects::Snapshot);
+            let mut source_grouping_keys = Vec::new();
+            let source_after = self
+                .project(
+                    &source_context,
+                    &part.return_clause,
+                    &mut source_grouping_keys,
+                )
+                .await?;
+
+            return Ok(vec![
+                QueryPartEvaluationContext::Aggregation {
+                    before: snapshot,
+                    after: after_out,
+                    grouping_keys: grouping_keys.clone(),
+                    default_before: after_cardinality == 0,
+                    default_after: new_after_cardinality == 0,
+                    row_signature: 0,
+                },
+                QueryPartEvaluationContext::Aggregation {
+                    before: Some(before_out),
+                    after: source_after,
+                    grouping_keys,
+                    default_before: before_cardinality == 0,
+                    default_after: new_before_cardinality == 0,
+                    row_signature: 0,
+                },
+            ]);
+        }
+
+        if contribution.before {
+            let before_out = before_out.ok_or(EvaluationError::InvalidContext)?;
+            let key = ResultKey::groupby_from_variables(&grouping_keys, &before_out);
+            let cardinality = self
+                .transition_group_cardinality(part_num, key, true, false)
+                .await?;
+            return Ok(vec![QueryPartEvaluationContext::Aggregation {
+                before: Some(before_out),
+                after: after_out,
+                grouping_keys,
+                default_before: cardinality.before == 0,
+                default_after: cardinality.after == 0,
+                row_signature: 0,
+            }]);
+        }
+
+        let key = ResultKey::groupby_from_variables(&grouping_keys, &after_out);
+        let cardinality = self
+            .transition_group_cardinality(part_num, key, false, true)
+            .await?;
+        Ok(vec![QueryPartEvaluationContext::Aggregation {
+            before: snapshot.or(before_out),
+            after: after_out,
+            grouping_keys,
+            default_before: cardinality.before == 0,
+            default_after: cardinality.after == 0,
+            row_signature: 0,
+        }])
+    }
+
+    async fn transition_group_cardinality(
+        &self,
+        part_num: usize,
+        key: ResultKey,
+        before_contributes: bool,
+        after_contributes: bool,
+    ) -> Result<GroupCardinalityTransition, EvaluationError> {
+        let before = self.read_group_cardinality(part_num, &key).await?;
+        if before_contributes && before == 0 {
+            return Err(EvaluationError::InvalidGroupCardinality {
+                part_num,
+                count: before,
+                before_contributes,
+                after_contributes,
+            });
+        }
+
+        let delta = i64::from(after_contributes) - i64::from(before_contributes);
+        let after = before
+            .checked_add(delta)
+            .ok_or(EvaluationError::InvalidGroupCardinality {
+                part_num,
+                count: before,
+                before_contributes,
+                after_contributes,
+            })?;
+        if after < 0 {
+            return Err(EvaluationError::InvalidGroupCardinality {
+                part_num,
+                count: before,
+                before_contributes,
+                after_contributes,
+            });
+        }
+
+        self.write_group_cardinality(part_num, key, after).await?;
+        Ok(GroupCardinalityTransition { before, after })
+    }
+
+    async fn read_group_cardinality(
+        &self,
+        part_num: usize,
+        key: &ResultKey,
+    ) -> Result<i64, EvaluationError> {
+        match self
+            .result_index
+            .get(key, &ResultOwner::PartGroupCardinality(part_num))
+            .await?
+        {
+            Some(ValueAccumulator::Count { value }) if value >= 0 => Ok(value),
+            Some(_) => Err(EvaluationError::CorruptData),
+            None => Ok(0),
+        }
+    }
+
+    async fn read_signature_state(
+        &self,
+        key: &ResultKey,
+        owner: &ResultOwner,
+    ) -> Result<Option<u64>, EvaluationError> {
+        match self.result_index.get(key, owner).await? {
+            Some(ValueAccumulator::Signature(signature)) => Ok(Some(signature)),
+            Some(_) => Err(EvaluationError::CorruptData),
+            None => Ok(None),
+        }
+    }
+
+    async fn write_group_cardinality(
+        &self,
+        part_num: usize,
+        key: ResultKey,
+        count: i64,
+    ) -> Result<(), EvaluationError> {
+        let value = (count > 0).then_some(ValueAccumulator::Count { value: count });
+        self.result_index
+            .set(key, ResultOwner::PartGroupCardinality(part_num), value)
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct OuterContributionTransition {
+    before: bool,
+    after: bool,
+}
+
+struct GroupCardinalityTransition {
+    before: i64,
+    after: i64,
+}
+
+fn grouping_values_match(
+    grouping_keys: &[String],
+    before: &QueryVariables,
+    after: &QueryVariables,
+) -> bool {
+    grouping_keys.iter().all(
+        |key| match (before.get(key.as_str()), after.get(key.as_str())) {
+            (Some(before), Some(after)) => before.eq_for_groupby(after),
+            (None, None) => true,
+            _ => false,
+        },
+    )
+}
+
+fn hash_variables_for_groupby(variables: &QueryVariables) -> u64 {
+    let mut hasher = SpookyHasher::default();
+    for (name, value) in variables {
+        name.hash(&mut hasher);
+        value.hash_for_groupby(&mut hasher);
+    }
+    hasher.finish()
 }

--- a/core/src/evaluation/parts/tests.rs
+++ b/core/src/evaluation/parts/tests.rs
@@ -86,3 +86,59 @@ fn build_query(query: &str) -> Query {
     let parser = Arc::new(CypherParser::new(function_registry.clone()));
     parser.parse(query).unwrap()
 }
+
+#[tokio::test]
+async fn outer_group_cardinality_rejects_underflow_and_corrupt_state() {
+    use crate::{
+        evaluation::variable_value::VariableValue,
+        in_memory_index::in_memory_result_index::InMemoryResultIndex,
+        interface::{AccumulatorIndex, ResultKey, ResultOwner},
+    };
+
+    let registry = Arc::new(FunctionRegistry::new());
+    let result_index = Arc::new(InMemoryResultIndex::new());
+    let expression_evaluator = Arc::new(ExpressionEvaluator::new(registry, result_index.clone()));
+    let evaluator = QueryPartEvaluator::new(expression_evaluator, result_index.clone());
+    let key = ResultKey::GroupBy(Arc::new(vec![VariableValue::from("group")]));
+
+    let underflow = evaluator
+        .transition_group_cardinality(2, key.clone(), true, false)
+        .await;
+    assert!(matches!(
+        underflow,
+        Err(EvaluationError::InvalidGroupCardinality {
+            part_num: 2,
+            count: 0,
+            ..
+        })
+    ));
+
+    result_index
+        .set(
+            key.clone(),
+            ResultOwner::PartGroupCardinality(2),
+            Some(ValueAccumulator::Signature(1)),
+        )
+        .await
+        .unwrap();
+    let corrupt = evaluator
+        .transition_group_cardinality(2, key, false, true)
+        .await;
+    assert!(matches!(corrupt, Err(EvaluationError::CorruptData)));
+
+    for owner in [ResultOwner::PartCurrent(2), ResultOwner::PartDefault(2)] {
+        let key = ResultKey::GroupBy(Arc::new(vec![VariableValue::from("signature")]));
+        result_index
+            .set(
+                key.clone(),
+                owner.clone(),
+                Some(ValueAccumulator::Count { value: 1 }),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            evaluator.read_signature_state(&key, &owner).await,
+            Err(EvaluationError::CorruptData)
+        ));
+    }
+}

--- a/core/src/evaluation/parts/tests/multi_part.rs
+++ b/core/src/evaluation/parts/tests/multi_part.rs
@@ -517,7 +517,7 @@ async fn aggregating_part_to_aggregating_part_add_solution() {
               "my_avg" => json!(1.0)
             ],
             grouping_keys: vec!["Category".to_string()],
-            default_before: false,
+            default_before: true,
             default_after: false,
             row_signature: IGNORED_ROW_SIGNATURE,
         }]
@@ -544,7 +544,7 @@ async fn aggregating_part_to_aggregating_part_add_solution() {
               "my_avg" => json!(2.0)
             ],
             grouping_keys: vec!["Category".to_string()],
-            default_before: false,
+            default_before: true,
             default_after: false,
             row_signature: IGNORED_ROW_SIGNATURE,
         }]
@@ -1095,7 +1095,7 @@ async fn sequential_aggregations1() {
                 "total" => json!(1)
             ],
             grouping_keys: vec![],
-            default_before: false,
+            default_before: true,
             default_after: false,
             row_signature: IGNORED_ROW_SIGNATURE,
         }]
@@ -1261,7 +1261,7 @@ async fn sequential_aggregations2() {
                 "total" => json!(2)
             ],
             grouping_keys: vec![],
-            default_before: false,
+            default_before: true,
             default_after: false,
             row_signature: IGNORED_ROW_SIGNATURE,
         }]

--- a/core/src/in_memory_index/in_memory_result_index.rs
+++ b/core/src/in_memory_index/in_memory_result_index.rs
@@ -56,6 +56,10 @@ impl InMemoryResultIndex {
 
 #[async_trait]
 impl AccumulatorIndex for InMemoryResultIndex {
+    async fn is_empty(&self) -> Result<bool, IndexError> {
+        Ok(self.values.read().await.is_empty() && self.sorted_sets.read().await.is_empty())
+    }
+
     async fn get(
         &self,
         key: &ResultKey,

--- a/core/src/index_cache/cached_result_index.rs
+++ b/core/src/index_cache/cached_result_index.rs
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    hash::{Hash, Hasher},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use async_trait::async_trait;
-use caches::{lru::CacheError, Cache, DefaultHashBuilder, LRUCache};
-use hashers::builtin::DefaultHasher;
+use caches::lru::CacheError;
 use ordered_float::OrderedFloat;
-use tokio::sync::RwLock;
 
 use crate::{
     evaluation::functions::aggregation::ValueAccumulator,
@@ -33,38 +28,24 @@ use crate::{
 
 pub struct CachedResultIndex {
     inner: Arc<dyn ResultIndex>,
-
-    value_cache: Arc<RwLock<LRUCache<u64, ValueAccumulator, DefaultHashBuilder>>>,
-    set_count_cache: Arc<RwLock<LRUCache<(u64, OrderedFloat<f64>), isize, DefaultHashBuilder>>>,
 }
 
 impl CachedResultIndex {
-    pub fn new(inner: Arc<dyn ResultIndex>, cache_size: usize) -> Result<Self, CacheError> {
-        log::info!("using cached result index with cache size {cache_size}");
-
-        let value_cache = LRUCache::new(cache_size)?;
-        let set_count_cache = LRUCache::new(cache_size)?;
-
-        Ok(CachedResultIndex {
-            inner,
-            value_cache: Arc::new(RwLock::new(value_cache)),
-            set_count_cache: Arc::new(RwLock::new(set_count_cache)),
-        })
+    pub fn new(inner: Arc<dyn ResultIndex>, _cache_size: usize) -> Result<Self, CacheError> {
+        // This wrapper has no commit/rollback hook, so caching would expose
+        // accumulator values written by a transaction that later rolls back.
+        Ok(CachedResultIndex { inner })
     }
 }
 
 #[async_trait]
 impl AccumulatorIndex for CachedResultIndex {
+    async fn is_empty(&self) -> Result<bool, IndexError> {
+        self.inner.is_empty().await
+    }
+
     async fn clear(&self) -> Result<(), IndexError> {
-        self.inner.clear().await?;
-
-        let mut value_cache = self.value_cache.write().await;
-        value_cache.purge();
-
-        let mut set_count_cache = self.set_count_cache.write().await;
-        set_count_cache.purge();
-
-        Ok(())
+        self.inner.clear().await
     }
 
     async fn get(
@@ -72,22 +53,7 @@ impl AccumulatorIndex for CachedResultIndex {
         key: &ResultKey,
         owner: &ResultOwner,
     ) -> Result<Option<ValueAccumulator>, IndexError> {
-        let cache_key = get_hash_key(owner, key);
-
-        let mut cache = self.value_cache.write().await;
-        match cache.get(&cache_key) {
-            None => {
-                let value = self.inner.get(key, owner).await?;
-                match value {
-                    None => Ok(None),
-                    Some(v) => {
-                        _ = cache.put(cache_key, v.clone());
-                        Ok(Some(v))
-                    }
-                }
-            }
-            Some(v) => Ok(Some(v.clone())),
-        }
+        self.inner.get(key, owner).await
     }
 
     async fn set(
@@ -96,17 +62,7 @@ impl AccumulatorIndex for CachedResultIndex {
         owner: ResultOwner,
         value: Option<ValueAccumulator>,
     ) -> Result<(), IndexError> {
-        let cache_key = get_hash_key(&owner, &key);
-
-        self.inner.set(key, owner, value.clone()).await?;
-
-        let mut cache = self.value_cache.write().await;
-        match value {
-            None => _ = cache.remove(&cache_key),
-            Some(v) => _ = cache.put(cache_key, v),
-        };
-
-        Ok(())
+        self.inner.set(key, owner, value).await
     }
 }
 
@@ -125,17 +81,7 @@ impl LazySortedSetStore for CachedResultIndex {
         set_id: u64,
         value: OrderedFloat<f64>,
     ) -> Result<isize, IndexError> {
-        let cache_key = (set_id, value);
-
-        let mut cache = self.set_count_cache.write().await;
-        match cache.get(&cache_key) {
-            None => {
-                let value = self.inner.get_value_count(set_id, value).await?;
-                _ = cache.put(cache_key, value);
-                Ok(value)
-            }
-            Some(v) => Ok(*v),
-        }
+        self.inner.get_value_count(set_id, value).await
     }
 
     async fn increment_value_count(
@@ -144,19 +90,7 @@ impl LazySortedSetStore for CachedResultIndex {
         value: OrderedFloat<f64>,
         delta: isize,
     ) -> Result<(), IndexError> {
-        self.inner
-            .increment_value_count(set_id, value, delta)
-            .await?;
-
-        let cache_key = (set_id, value);
-        let mut cache = self.set_count_cache.write().await;
-
-        match cache.get_mut(&cache_key) {
-            None => _ = cache.put(cache_key, delta),
-            Some(v) => *v += delta,
-        }
-
-        Ok(())
+        self.inner.increment_value_count(set_id, value, delta).await
     }
 }
 
@@ -175,11 +109,4 @@ impl ResultSequenceCounter for CachedResultIndex {
     async fn get_sequence(&self) -> Result<ResultSequence, IndexError> {
         self.inner.get_sequence().await
     }
-}
-
-fn get_hash_key(owner: &ResultOwner, key: &ResultKey) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    owner.hash(&mut hasher);
-    key.hash(&mut hasher);
-    hasher.finish()
 }

--- a/core/src/interface/mod.rs
+++ b/core/src/interface/mod.rs
@@ -51,6 +51,7 @@ pub use result_index::ResultKey;
 pub use result_index::ResultOwner;
 pub use result_index::ResultSequence;
 pub use result_index::ResultSequenceCounter;
+pub use result_index::RESULT_INDEX_STATE_VERSION;
 pub use session_control::NoOpSessionControl;
 pub use session_control::SessionControl;
 pub use session_control::SessionGuard;

--- a/core/src/interface/result_index.rs
+++ b/core/src/interface/result_index.rs
@@ -25,10 +25,49 @@ use crate::evaluation::functions::aggregation::ValueAccumulator;
 
 use super::IndexError;
 
-pub trait ResultIndex: AccumulatorIndex + ResultSequenceCounter {}
+/// First explicit version for persisted accumulator and aggregate lifecycle semantics.
+pub const RESULT_INDEX_STATE_VERSION: u64 = 1;
+
+#[async_trait]
+pub trait ResultIndex: AccumulatorIndex + ResultSequenceCounter {
+    /// Ensures the accumulator store uses the current result-index semantics.
+    ///
+    /// A missing marker is initialized only for an empty store. Existing
+    /// markerless or incompatible state must be cleared and replayed.
+    async fn ensure_state_version(&self) -> Result<(), IndexError> {
+        let key = ResultKey::InputHash(0);
+        let owner = ResultOwner::QueryState;
+
+        match self.get(&key, &owner).await? {
+            Some(ValueAccumulator::Signature(RESULT_INDEX_STATE_VERSION)) => Ok(()),
+            Some(ValueAccumulator::Signature(version)) => Err(IndexError::other(
+                ResultIndexStateVersionError::UnsupportedVersion {
+                    expected: RESULT_INDEX_STATE_VERSION,
+                    actual: version,
+                },
+            )),
+            Some(_) => Err(IndexError::other(
+                ResultIndexStateVersionError::InvalidMarker,
+            )),
+            None if self.is_empty().await? => {
+                self.set(
+                    key,
+                    owner,
+                    Some(ValueAccumulator::Signature(RESULT_INDEX_STATE_VERSION)),
+                )
+                .await
+            }
+            None => Err(IndexError::other(
+                ResultIndexStateVersionError::MissingMarker,
+            )),
+        }
+    }
+}
 
 #[async_trait]
 pub trait AccumulatorIndex: LazySortedSetStore {
+    async fn is_empty(&self) -> Result<bool, IndexError>;
+
     async fn clear(&self) -> Result<(), IndexError>;
     async fn get(
         &self,
@@ -96,6 +135,8 @@ pub enum ResultOwner {
     Function(usize),
     PartCurrent(usize),
     PartDefault(usize),
+    PartGroupCardinality(usize),
+    QueryState,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -103,6 +144,18 @@ pub enum ResultKey {
     GroupBy(Arc<Vec<VariableValue>>),
     InputHash(u64),
     Element(ElementReference),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ResultIndexStateVersionError {
+    #[error(
+        "result index has no state-version marker but contains data; clear and replay the query index"
+    )]
+    MissingMarker,
+    #[error("result index state-version marker has an incompatible value")]
+    InvalidMarker,
+    #[error("unsupported result index state version {actual}; expected {expected}")]
+    UnsupportedVersion { expected: u64, actual: u64 },
 }
 
 impl ResultKey {
@@ -135,5 +188,52 @@ impl std::hash::Hash for ResultKey {
                 element_reference.hash(state);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::in_memory_index::in_memory_result_index::InMemoryResultIndex;
+
+    #[tokio::test]
+    async fn state_version_initializes_only_empty_indexes() {
+        let empty = InMemoryResultIndex::new();
+        empty.ensure_state_version().await.unwrap();
+        empty.ensure_state_version().await.unwrap();
+        assert!(!empty.is_empty().await.unwrap());
+
+        let markerless = InMemoryResultIndex::new();
+        markerless
+            .set(
+                ResultKey::InputHash(42),
+                ResultOwner::Function(1),
+                Some(ValueAccumulator::Count { value: 1 }),
+            )
+            .await
+            .unwrap();
+
+        let error = markerless.ensure_state_version().await.unwrap_err();
+        assert!(
+            matches!(&error, IndexError::Other(source) if source.to_string().contains("clear and replay"))
+        );
+    }
+
+    #[tokio::test]
+    async fn incompatible_state_version_is_rejected() {
+        let index = InMemoryResultIndex::new();
+        index
+            .set(
+                ResultKey::InputHash(0),
+                ResultOwner::QueryState,
+                Some(ValueAccumulator::Signature(RESULT_INDEX_STATE_VERSION + 1)),
+            )
+            .await
+            .unwrap();
+
+        let error = index.ensure_state_version().await.unwrap_err();
+        assert!(
+            matches!(&error, IndexError::Other(source) if source.to_string().contains("unsupported result index state version"))
+        );
     }
 }

--- a/core/src/query/continuous_query.rs
+++ b/core/src/query/continuous_query.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     interface::{
         ElementIndex, FutureQueue, FutureQueueConsumer, IndexError, MiddlewareError, QueryClock,
-        SessionControl, SessionGuard,
+        ResultIndex, SessionControl, SessionGuard,
     },
     middleware::SourceMiddlewarePipelineCollection,
     models::{Element, SourceChange},
@@ -66,6 +66,7 @@ pub struct ContinuousQuery {
     query: Arc<Query>,
     future_consumer_shutdown_request: Arc<Notify>,
     future_queue: Arc<dyn FutureQueue>,
+    result_index: Arc<dyn ResultIndex>,
     future_queue_task: Mutex<Option<JoinHandle<()>>>,
     change_lock: Mutex<()>,
     source_pipelines: SourceMiddlewarePipelineCollection,
@@ -82,6 +83,7 @@ impl ContinuousQuery {
         path_solver: Arc<MatchPathSolver>,
         part_evaluator: Arc<QueryPartEvaluator>,
         future_queue: Arc<dyn FutureQueue>,
+        result_index: Arc<dyn ResultIndex>,
         source_pipelines: SourceMiddlewarePipelineCollection,
         session_control: Arc<dyn SessionControl>,
     ) -> Self {
@@ -94,6 +96,7 @@ impl ContinuousQuery {
             query,
             future_consumer_shutdown_request: Arc::new(Notify::new()),
             future_queue,
+            result_index,
             future_queue_task: Mutex::new(None),
             change_lock: Mutex::new(()),
             source_pipelines,
@@ -108,6 +111,7 @@ impl ContinuousQuery {
     ) -> Result<Vec<QueryPartEvaluationContext>, EvaluationError> {
         let _lock = self.change_lock.lock().await;
         let guard = SessionGuard::begin(self.session_control.clone()).await?;
+        self.ensure_result_index_state().await?;
 
         let changes = self.execute_source_middleware(change).await?;
         let result = self.process_changes_inner(changes).await?;
@@ -134,6 +138,7 @@ impl ContinuousQuery {
     {
         let _lock = self.change_lock.lock().await;
         let guard = SessionGuard::begin(self.session_control.clone()).await?;
+        self.ensure_result_index_state().await?;
 
         let changes = self.execute_source_middleware(change).await?;
         let result = self.process_changes_inner(changes).await?;
@@ -154,6 +159,7 @@ impl ContinuousQuery {
     pub async fn process_due_futures(&self) -> Result<Option<DueFutureResult>, EvaluationError> {
         let _lock = self.change_lock.lock().await;
         let guard = SessionGuard::begin(self.session_control.clone()).await?;
+        self.ensure_result_index_state().await?;
 
         let future_ref = match self.future_queue.pop().await {
             Ok(Some(fr)) => fr,
@@ -170,6 +176,10 @@ impl ContinuousQuery {
         let results = self.process_changes_inner(changes).await?;
         guard.commit().await?;
         Ok(Some(DueFutureResult { results, source_id }))
+    }
+
+    async fn ensure_result_index_state(&self) -> Result<(), IndexError> {
+        self.result_index.ensure_state_version().await
     }
 
     /// Expose the ContinuousQuery's future queue for external polling.
@@ -848,11 +858,14 @@ impl CollapsedAggregationResults {
     ) -> Vec<(QueryPartEvaluationContext, ChangeContext)> {
         self.data
             .into_iter()
-            .map(|(after_key, (v, before_key))| {
+            .filter_map(|(after_key, (v, before_key))| {
+                if is_default_aggregation_noop(&v) {
+                    return None;
+                }
                 let mut change_context = change_context.clone();
                 change_context.before_grouping_hash = before_key;
                 change_context.after_grouping_hash = after_key;
-                (v, change_context)
+                Some((v, change_context))
             })
             .collect()
     }
@@ -860,26 +873,42 @@ impl CollapsedAggregationResults {
     fn into_result_vec(self) -> Vec<QueryPartEvaluationContext> {
         self.data
             .into_iter()
-            .map(|(after_key, (ctx, _))| match ctx {
-                QueryPartEvaluationContext::Aggregation {
-                    before,
-                    after,
-                    grouping_keys,
-                    default_before,
-                    default_after,
-                    ..
-                } => QueryPartEvaluationContext::Aggregation {
-                    before,
-                    after,
-                    grouping_keys,
-                    default_before,
-                    default_after,
-                    row_signature: after_key,
-                },
-                other => other,
+            .filter_map(|(after_key, (ctx, _))| {
+                if is_default_aggregation_noop(&ctx) {
+                    return None;
+                }
+                Some(match ctx {
+                    QueryPartEvaluationContext::Aggregation {
+                        before,
+                        after,
+                        grouping_keys,
+                        default_before,
+                        default_after,
+                        ..
+                    } => QueryPartEvaluationContext::Aggregation {
+                        before,
+                        after,
+                        grouping_keys,
+                        default_before,
+                        default_after,
+                        row_signature: after_key,
+                    },
+                    other => other,
+                })
             })
             .collect()
     }
+}
+
+fn is_default_aggregation_noop(context: &QueryPartEvaluationContext) -> bool {
+    matches!(
+        context,
+        QueryPartEvaluationContext::Aggregation {
+            default_before: true,
+            default_after: true,
+            ..
+        }
+    )
 }
 
 fn extract_grouping_value_hash(grouping_keys: &Vec<String>, variables: &QueryVariables) -> u64 {
@@ -907,7 +936,7 @@ mod collapsed_aggregation_tests {
     }
 
     #[test]
-    fn collapse_preserves_first_before_and_last_after_defaults() {
+    fn collapse_discards_add_then_remove() {
         let mut collapsed = CollapsedAggregationResults::new();
         collapsed.insert(QueryPartEvaluationContext::Aggregation {
             before: Some(variables("group-a", 0)),
@@ -927,6 +956,30 @@ mod collapsed_aggregation_tests {
         });
 
         let results = collapsed.into_result_vec();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn collapse_preserves_first_add_and_last_update() {
+        let mut collapsed = CollapsedAggregationResults::new();
+        collapsed.insert(QueryPartEvaluationContext::Aggregation {
+            before: Some(variables("group-a", 0)),
+            after: variables("group-a", 1),
+            grouping_keys: vec!["group".to_string()],
+            default_before: true,
+            default_after: false,
+            row_signature: 0,
+        });
+        collapsed.insert(QueryPartEvaluationContext::Aggregation {
+            before: Some(variables("group-a", 1)),
+            after: variables("group-a", 2),
+            grouping_keys: vec!["group".to_string()],
+            default_before: false,
+            default_after: false,
+            row_signature: 0,
+        });
+
+        let results = collapsed.into_result_vec();
         assert_eq!(results.len(), 1);
         assert!(matches!(
             &results[0],
@@ -934,9 +987,9 @@ mod collapsed_aggregation_tests {
                 before: Some(before),
                 after,
                 default_before: true,
-                default_after: true,
+                default_after: false,
                 ..
-            } if before == &variables("group-a", 0) && after == &variables("group-a", 1)
+            } if before == &variables("group-a", 0) && after == &variables("group-a", 2)
         ));
     }
 }

--- a/core/src/query/query_builder.rs
+++ b/core/src/query/query_builder.rs
@@ -244,6 +244,7 @@ impl QueryBuilder {
             path_solver,
             part_evaluator,
             future_queue,
+            result_index,
             source_pipelines,
             session_control,
         ))

--- a/core/src/query/tests/mod.rs
+++ b/core/src/query/tests/mod.rs
@@ -14,6 +14,7 @@
 
 mod aggregate_update_tests;
 mod chained_optional_tests;
+mod nested_aggregate_lifecycle_tests;
 mod retained_multi_source_tests;
 mod row_signature_tests;
 

--- a/core/src/query/tests/nested_aggregate_lifecycle_tests.rs
+++ b/core/src/query/tests/nested_aggregate_lifecycle_tests.rs
@@ -1,0 +1,457 @@
+// Copyright 2026 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap, sync::Arc};
+
+use drasi_query_cypher::CypherParser;
+use serde_json::json;
+
+use crate::{
+    evaluation::{
+        context::{QueryPartEvaluationContext, QueryVariables},
+        functions::{Count, Function, FunctionRegistry, ValueAccumulator},
+        variable_value::VariableValue,
+    },
+    in_memory_index::{
+        in_memory_element_index::InMemoryElementIndex, in_memory_future_queue::InMemoryFutureQueue,
+        in_memory_result_index::InMemoryResultIndex,
+    },
+    interface::{AccumulatorIndex, ResultIndex, ResultKey, ResultOwner},
+    models::{Element, ElementMetadata, ElementPropertyMap, ElementReference, SourceChange},
+    query::{ContinuousQuery, QueryBuilder},
+};
+
+const TEAM_SEAT_QUERY: &str = "
+MATCH (team:Team)-[:HAS_SEAT]->(seat:Seat)
+OPTIONAL MATCH (person:Person)-[:OCCUPIES]->(seat)
+WITH team, seat, count(person) AS personCount
+WITH team,
+  count(CASE WHEN personCount = 1 THEN 1 ELSE null END) AS filledSeatCount
+WHERE filledSeatCount <> team.declaredCount
+RETURN team.id AS teamId, filledSeatCount
+";
+
+const LATE_REPORT_QUERY: &str = "
+MATCH (team:Team)-[:HAS_SEAT]->(seat:Seat)
+OPTIONAL MATCH (person:Person)-[:OCCUPIES]->(seat)
+OPTIONAL MATCH (report:Report)-[:REPORT_FOR]->(person)
+OPTIONAL MATCH (review:Review)-[:REVIEWS]->(report)
+WITH team, seat, person, report, review,
+  count(team) AS basePathCount,
+  count(CASE WHEN person IS NOT NULL THEN 1 ELSE null END) AS structuralPathCount
+WITH team, seat, person,
+  count(CASE WHEN basePathCount <> 1 THEN 1 ELSE null END) AS invalidPathCount,
+  count(CASE WHEN structuralPathCount = 1 AND report IS NOT NULL
+    THEN 1 ELSE null END) AS reportCount,
+  count(CASE WHEN structuralPathCount = 1 AND review IS NOT NULL
+    THEN 1 ELSE null END) AS reviewCount,
+  count(CASE WHEN structuralPathCount = 1
+    AND NOT person.isActive
+    AND review.reportId = report.id
+    THEN 1 ELSE null END) AS validReportCount
+WITH team, seat,
+  count(CASE WHEN invalidPathCount = 0
+    AND reportCount = 1
+    AND reviewCount = 1
+    AND validReportCount = 1
+    THEN 1 ELSE null END) AS reviewedSeatCount
+WITH team,
+  count(CASE WHEN reviewedSeatCount = 1 THEN 1 ELSE null END) AS completedPersonCount
+WHERE completedPersonCount = team.declaredCount
+RETURN team.id AS teamId, completedPersonCount
+";
+
+struct MaterializedQuery {
+    query: ContinuousQuery,
+    rows: HashMap<u64, QueryVariables>,
+}
+
+impl MaterializedQuery {
+    async fn new(query_text: &str) -> Self {
+        let element_index = Arc::new(InMemoryElementIndex::new());
+        let result_index = Arc::new(InMemoryResultIndex::new());
+        Self::with_indexes(query_text, element_index, result_index).await
+    }
+
+    async fn with_indexes(
+        query_text: &str,
+        element_index: Arc<InMemoryElementIndex>,
+        result_index: Arc<InMemoryResultIndex>,
+    ) -> Self {
+        let functions = Arc::new(FunctionRegistry::new());
+        functions.register_function("count", Function::Aggregating(Arc::new(Count {})));
+        let parser = Arc::new(CypherParser::new(functions.clone()));
+        let query = QueryBuilder::new(query_text, parser)
+            .with_function_registry(functions)
+            .with_element_index(element_index.clone())
+            .with_archive_index(element_index)
+            .with_result_index(result_index)
+            .with_future_queue(Arc::new(InMemoryFutureQueue::new()))
+            .build()
+            .await;
+        Self {
+            query,
+            rows: HashMap::new(),
+        }
+    }
+
+    async fn process(&mut self, change: SourceChange) -> Vec<QueryPartEvaluationContext> {
+        let changes = self.query.process_source_change(change).await.unwrap();
+        for change in &changes {
+            match change {
+                QueryPartEvaluationContext::Adding {
+                    after,
+                    row_signature,
+                }
+                | QueryPartEvaluationContext::Updating {
+                    after,
+                    row_signature,
+                    ..
+                }
+                | QueryPartEvaluationContext::Aggregation {
+                    after,
+                    row_signature,
+                    ..
+                } => {
+                    self.rows.insert(*row_signature, after.clone());
+                }
+                QueryPartEvaluationContext::Removing { row_signature, .. } => {
+                    self.rows.remove(row_signature);
+                }
+                QueryPartEvaluationContext::Noop => {}
+            }
+        }
+        changes
+    }
+
+    fn integer(&self, field: &str) -> i64 {
+        assert_eq!(self.rows.len(), 1);
+        match self.rows.values().next().unwrap().get(field) {
+            Some(VariableValue::Integer(value)) => value.as_i64().unwrap(),
+            other => panic!("expected integer {field}, got {other:?}"),
+        }
+    }
+}
+
+fn node(id: &str, label: &str, effective_from: u64, properties: serde_json::Value) -> SourceChange {
+    SourceChange::Insert {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("test", id),
+                labels: Arc::new([Arc::from(label)]),
+                effective_from,
+            },
+            properties: ElementPropertyMap::from(properties),
+        },
+    }
+}
+
+fn update_node(
+    id: &str,
+    label: &str,
+    effective_from: u64,
+    properties: serde_json::Value,
+) -> SourceChange {
+    SourceChange::Update {
+        element: Element::Node {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("test", id),
+                labels: Arc::new([Arc::from(label)]),
+                effective_from,
+            },
+            properties: ElementPropertyMap::from(properties),
+        },
+    }
+}
+
+fn relation(id: &str, label: &str, effective_from: u64, from: &str, to: &str) -> SourceChange {
+    SourceChange::Insert {
+        element: Element::Relation {
+            metadata: ElementMetadata {
+                reference: ElementReference::new("test", id),
+                labels: Arc::new([Arc::from(label)]),
+                effective_from,
+            },
+            in_node: ElementReference::new("test", from),
+            out_node: ElementReference::new("test", to),
+            properties: ElementPropertyMap::from(json!({})),
+        },
+    }
+}
+
+fn delete(id: &str, effective_from: u64) -> SourceChange {
+    SourceChange::Delete {
+        metadata: ElementMetadata {
+            reference: ElementReference::new("test", id),
+            labels: Arc::new([]),
+            effective_from,
+        },
+    }
+}
+
+async fn insert_team_and_seats(subject: &mut MaterializedQuery) -> Vec<QueryPartEvaluationContext> {
+    let mut results = subject
+        .process(node(
+            "team",
+            "Team",
+            1,
+            json!({"id": "team", "declaredCount": 2}),
+        ))
+        .await;
+    results.extend(
+        subject
+            .process(node("seat-a", "Seat", 2, json!({"id": "a"})))
+            .await,
+    );
+    results.extend(
+        subject
+            .process(relation("team-seat-a", "HAS_SEAT", 3, "team", "seat-a"))
+            .await,
+    );
+    results.extend(
+        subject
+            .process(node("seat-b", "Seat", 4, json!({"id": "b"})))
+            .await,
+    );
+    results.extend(
+        subject
+            .process(relation("team-seat-b", "HAS_SEAT", 5, "team", "seat-b"))
+            .await,
+    );
+    results
+}
+
+async fn insert_person(
+    subject: &mut MaterializedQuery,
+    id: &str,
+    seat: &str,
+    effective_from: u64,
+) -> Vec<QueryPartEvaluationContext> {
+    subject
+        .process(node(
+            id,
+            "Person",
+            effective_from,
+            json!({"id": id, "isActive": true}),
+        ))
+        .await;
+    subject
+        .process(relation(
+            &format!("{id}-{seat}"),
+            "OCCUPIES",
+            effective_from + 1,
+            id,
+            seat,
+        ))
+        .await
+}
+
+#[tokio::test]
+async fn zero_inner_groups_emit_add_then_update_and_track_full_lifecycle() {
+    let mut subject = MaterializedQuery::new(TEAM_SEAT_QUERY).await;
+    let initial = insert_team_and_seats(&mut subject).await;
+
+    assert!(matches!(
+        initial.as_slice(),
+        [QueryPartEvaluationContext::Adding { .. }]
+    ));
+    assert_eq!(subject.integer("filledSeatCount"), 0);
+
+    let first_person = insert_person(&mut subject, "person-a", "seat-a", 6).await;
+    assert!(matches!(
+        first_person.as_slice(),
+        [QueryPartEvaluationContext::Updating { .. }]
+    ));
+    assert_eq!(subject.integer("filledSeatCount"), 1);
+
+    let second_person = insert_person(&mut subject, "person-b", "seat-b", 8).await;
+    assert!(matches!(
+        second_person.as_slice(),
+        [QueryPartEvaluationContext::Removing { .. }]
+    ));
+    assert!(subject.rows.is_empty());
+
+    let remove_person = subject.process(delete("person-b-seat-b", 10)).await;
+    assert!(matches!(
+        remove_person.as_slice(),
+        [QueryPartEvaluationContext::Adding { .. }]
+    ));
+    assert_eq!(subject.integer("filledSeatCount"), 1);
+
+    subject.process(delete("person-a-seat-a", 11)).await;
+    assert_eq!(subject.integer("filledSeatCount"), 0);
+
+    subject.process(delete("team-seat-b", 12)).await;
+    assert_eq!(
+        subject.integer("filledSeatCount"),
+        0,
+        "removing a non-last zero contributor must retain the outer group"
+    );
+
+    let remove_last = subject.process(delete("team-seat-a", 13)).await;
+    assert!(matches!(
+        remove_last.as_slice(),
+        [QueryPartEvaluationContext::Removing { .. }]
+    ));
+    assert!(subject.rows.is_empty());
+
+    let readd = subject
+        .process(relation("team-seat-a", "HAS_SEAT", 14, "team", "seat-a"))
+        .await;
+    assert!(matches!(
+        readd.as_slice(),
+        [QueryPartEvaluationContext::Adding { .. }]
+    ));
+    assert_eq!(subject.integer("filledSeatCount"), 0);
+}
+
+#[tokio::test]
+async fn retained_cardinality_survives_query_restart() {
+    let element_index = Arc::new(InMemoryElementIndex::new());
+    let result_index = Arc::new(InMemoryResultIndex::new());
+    let mut subject = MaterializedQuery::with_indexes(
+        TEAM_SEAT_QUERY,
+        element_index.clone(),
+        result_index.clone(),
+    )
+    .await;
+    insert_team_and_seats(&mut subject).await;
+    assert_eq!(subject.integer("filledSeatCount"), 0);
+    drop(subject);
+
+    let mut restarted =
+        MaterializedQuery::with_indexes(TEAM_SEAT_QUERY, element_index, result_index).await;
+    let first_person = insert_person(&mut restarted, "person-a", "seat-a", 6).await;
+    assert!(matches!(
+        first_person.as_slice(),
+        [QueryPartEvaluationContext::Updating { .. }]
+    ));
+    assert_eq!(restarted.integer("filledSeatCount"), 1);
+}
+
+async fn insert_team_and_person(subject: &mut MaterializedQuery) {
+    for change in [
+        node("team", "Team", 1, json!({"id": "team", "declaredCount": 1})),
+        node("seat", "Seat", 2, json!({"id": "seat"})),
+        relation("team-seat", "HAS_SEAT", 3, "team", "seat"),
+        node(
+            "person",
+            "Person",
+            4,
+            json!({"id": "person", "isActive": true}),
+        ),
+        relation("person-seat", "OCCUPIES", 5, "person", "seat"),
+    ] {
+        subject.process(change).await;
+    }
+}
+
+async fn insert_report_and_review(subject: &mut MaterializedQuery, effective_from: u64) {
+    for change in [
+        node("report", "Report", effective_from, json!({"id": "report"})),
+        relation(
+            "report-person",
+            "REPORT_FOR",
+            effective_from + 1,
+            "report",
+            "person",
+        ),
+        node(
+            "review",
+            "Review",
+            effective_from + 2,
+            json!({"id": "review", "reportId": "report"}),
+        ),
+        relation(
+            "review-report",
+            "REVIEWS",
+            effective_from + 3,
+            "review",
+            "report",
+        ),
+    ] {
+        subject.process(change).await;
+    }
+}
+
+#[tokio::test]
+async fn closed_person_converges_when_report_evidence_replays_later() {
+    let mut evidence_late = MaterializedQuery::new(LATE_REPORT_QUERY).await;
+    insert_team_and_person(&mut evidence_late).await;
+    evidence_late
+        .process(update_node(
+            "person",
+            "Person",
+            6,
+            json!({"id": "person", "isActive": false}),
+        ))
+        .await;
+    insert_report_and_review(&mut evidence_late, 7).await;
+
+    assert_eq!(evidence_late.integer("completedPersonCount"), 1);
+
+    let mut close_last = MaterializedQuery::new(LATE_REPORT_QUERY).await;
+    insert_team_and_person(&mut close_last).await;
+    insert_report_and_review(&mut close_last, 6).await;
+    close_last
+        .process(update_node(
+            "person",
+            "Person",
+            10,
+            json!({"id": "person", "isActive": false}),
+        ))
+        .await;
+
+    assert_eq!(close_last.rows, evidence_late.rows);
+}
+
+#[tokio::test]
+async fn processing_rejects_markerless_retained_accumulators() {
+    let element_index = Arc::new(InMemoryElementIndex::new());
+    let result_index = Arc::new(InMemoryResultIndex::new());
+    result_index
+        .set(
+            ResultKey::InputHash(42),
+            ResultOwner::Function(1),
+            Some(ValueAccumulator::Count { value: 1 }),
+        )
+        .await
+        .unwrap();
+
+    let functions = Arc::new(FunctionRegistry::new());
+    functions.register_function("count", Function::Aggregating(Arc::new(Count {})));
+    let parser = Arc::new(CypherParser::new(functions.clone()));
+    let query = QueryBuilder::new(TEAM_SEAT_QUERY, parser)
+        .with_function_registry(functions)
+        .with_element_index(element_index.clone())
+        .with_archive_index(element_index)
+        .with_result_index(result_index)
+        .with_future_queue(Arc::new(InMemoryFutureQueue::new()))
+        .build()
+        .await;
+
+    let error = query
+        .process_source_change(node(
+            "team",
+            "Team",
+            1,
+            json!({"id": "team", "declaredCount": 1}),
+        ))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, crate::evaluation::EvaluationError::IndexError(crate::interface::IndexError::Other(source))
+            if source.to_string().contains("clear and replay"))
+    );
+}

--- a/lib/src/queries/config_hash.rs
+++ b/lib/src/queries/config_hash.rs
@@ -33,6 +33,7 @@ use serde::Serialize;
 use crate::config::{
     QueryConfig, QueryJoinConfig, QueryJoinKeyConfig, QueryLanguage, SourceSubscriptionConfig,
 };
+use drasi_core::interface::RESULT_INDEX_STATE_VERSION;
 use drasi_core::models::SourceMiddlewareConfig;
 
 /// Minimal projection of `QueryConfig` containing only identity-defining fields.
@@ -53,6 +54,7 @@ use drasi_core::models::SourceMiddlewareConfig;
 ///     `storage_backend`, `recovery_policy`.
 #[derive(Serialize)]
 struct QueryIdentity<'a> {
+    result_index_state_version: u64,
     query: &'a str,
     query_language: &'a QueryLanguage,
     middleware: &'a [SourceMiddlewareConfig],
@@ -113,6 +115,13 @@ fn canonicalize_join(join: &QueryJoinConfig) -> JoinIdentity<'_> {
 /// and it is invariant under cosmetic reordering of `sources`, `joins`, a
 /// source's `nodes` / `relations`, and a join's `keys`.
 pub fn compute_config_hash(config: &QueryConfig) -> u64 {
+    compute_config_hash_for_result_index_version(config, RESULT_INDEX_STATE_VERSION)
+}
+
+fn compute_config_hash_for_result_index_version(
+    config: &QueryConfig,
+    result_index_state_version: u64,
+) -> u64 {
     let mut sources: Vec<SourceIdentity> = config.sources.iter().map(canonicalize_source).collect();
     sources.sort_by(|a, b| a.source_id.cmp(b.source_id));
 
@@ -123,6 +132,7 @@ pub fn compute_config_hash(config: &QueryConfig) -> u64 {
     });
 
     let identity = QueryIdentity {
+        result_index_state_version,
         query: &config.query,
         query_language: &config.query_language,
         middleware: &config.middleware,
@@ -174,6 +184,15 @@ mod tests {
             outbox_capacity: 1000,
             bootstrap_timeout_secs: 300,
         }
+    }
+
+    #[test]
+    fn result_index_state_version_changes_config_hash() {
+        let config = base();
+        assert_ne!(
+            compute_config_hash_for_result_index_version(&config, RESULT_INDEX_STATE_VERSION + 1),
+            compute_config_hash(&config)
+        );
     }
 
     #[test]

--- a/shared-tests/src/use_cases/incident_alert/mod.rs
+++ b/shared-tests/src/use_cases/incident_alert/mod.rs
@@ -627,7 +627,7 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
             &result,
             &QueryPartEvaluationContext::Aggregation {
                 default_before: false,
-                default_after: false,
+                default_after: true,
                 grouping_keys: vec![
                     "RegionName".into(),
                     "IncidentId".into(),
@@ -638,15 +638,15 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
                   "IncidentId" => VariableValue::from(json!("in1000")),
                   "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
                   "RegionName" => VariableValue::from(json!("SoCal")),
-                  "IncidentSeverity" => VariableValue::from(json!("critical")),
-                  "EmployeeCount" => VariableValue::from(json!(0))
+                  "IncidentSeverity" => VariableValue::from(json!("extreme")),
+                  "EmployeeCount" => VariableValue::from(json!(4))
                 )),
                 after: variablemap!(
                   "IncidentId" => VariableValue::from(json!("in1000")),
                   "IncidentDescription" => VariableValue::from(json!("Forest Fire")),
                   "RegionName" => VariableValue::from(json!("SoCal")),
-                  "IncidentSeverity" => VariableValue::from(json!("critical")),
-                  "EmployeeCount" => VariableValue::from(json!(4))
+                  "IncidentSeverity" => VariableValue::from(json!("extreme")),
+                  "EmployeeCount" => VariableValue::from(json!(0))
                 ),
                 row_signature: IGNORED_ROW_SIGNATURE,
             }
@@ -654,7 +654,7 @@ pub async fn incident_alert(config: &(impl QueryTestConfig + Send)) {
         assert!(contains_data(
             &result,
             &QueryPartEvaluationContext::Aggregation {
-                default_before: false,
+                default_before: true,
                 default_after: false,
                 grouping_keys: vec![
                     "RegionName".into(),


### PR DESCRIPTION
## Summary

Preserve a real zero-valued inner aggregate as a contributor when it crosses a second aggregation boundary. The outer group now emits an initial Add, updates normally, survives removal of a non-last zero contributor, and is removed only when its final contributor disappears.

This is a stacked change:

- Base: #904 (`agentofreality-fix-chained-optional-propagation`) at `b2970b174a8cf8e8a7052d10cca5b77d0e03ded0`
- #904 depends on #810
- This PR must remain based on #904 until the native stack is registered

Fixes #806

## Standalone reproduction

```cypher
MATCH (team:Team)-[:HAS_SEAT]->(seat:Seat)
OPTIONAL MATCH (person:Person)-[:OCCUPIES]->(seat)
WITH team, seat, count(person) AS personCount
WITH team,
  count(CASE WHEN personCount = 1 THEN 1 ELSE null END) AS filledSeatCount
WHERE filledSeatCount <> team.declaredCount
RETURN team.id AS teamId, filledSeatCount
```

Insert one team with `declaredCount: 2`, then two seats and their `HAS_SEAT` relationships. Before this fix, the valid outer `filledSeatCount: 0` row was omitted. Adding the first occupant then emitted an Update without a preceding Add. The regression test also removes a non-last empty seat, removes the last contributor, re-adds it, and restarts the query over retained state.

## Implementation

- Persist contributor cardinality per query part and outer grouping key through the existing `ResultIndex` API; no physical schema expansion.
- Derive aggregate default/current signatures with `hash_for_groupby`, matching live ElementReference grouping identity. A generic Team/Person/Report replay regression closes a person before Report/Review evidence arrives and verifies convergence with the opposite event order.
- Introduce result-index semantic state version `1`, the first explicit version on the current branch lineage. Direct Core use rejects markerless non-empty or incompatible state; `drasi-lib` includes the version in its config hash so retained deployments clear and rebootstrap deliberately.
- Keep result-index reads transaction-consistent by making `CachedResultIndex` delegate to its backend; it has no commit/rollback hook and therefore must not retain rolled-back values. This does not claim transactional behavior for `NoOpSessionControl`.
- Suppress collapsed add-then-remove default transitions while preserving real first-add and final-update transitions.

## Provenance and scope

The lifecycle implementation is extracted from original prototype `2f129f229f487611bebbba3c9270aca315642401`. The grouping-aware persisted-signature residual is extracted from `7be2e1bd895196c1e4fbf99a23dbbcbdb4abc8e8`.

The WorkGraph source pruning, positionless WAL, and recovery changes from `7be2e1bd` are intentionally excluded. This PR does not include #807 endpoint checking or #808/#809 clause/reparent work.

## Validation

- `cargo test -p drasi-core` — 767 passed
- `cargo test -p drasi-core query::tests::` — 24 passed on the default solver
- `cargo test -p drasi-core --features parallel_solver query::tests::` — 24 passed
- `cargo test -p drasi-core evaluation::parts::tests` — 25 passed
- `cargo test -p drasi-index-rocksdb --test scenario_tests result_state_and_cardinality_follow_transaction_lifecycle` — passed
- `cargo test -p drasi-index-rocksdb --test scenario_tests incident_alert` — passed
- `cargo test -p drasi-lib queries::config_hash::tests` — 26 passed
- `cargo test -p drasi-index-garnet --test scenario_tests --no-run` — compiled; not executed because it requires an external Redis-compatible service
- `cargo clippy -p drasi-core -p drasi-index-rocksdb -p drasi-index-garnet -p drasi-lib --all-targets -- -D warnings` — passed

An additional all-features clippy attempt was blocked while building the third-party `jq-sys` vendored oniguruma sources on macOS; the affected crates pass clippy with their default features.